### PR TITLE
15 - While/For Loops, Break/Continue, and range()

### DIFF
--- a/crates/sifr/tests/e2e/fail/break_outside_loop.sifr
+++ b/crates/sifr/tests/e2e/fail/break_outside_loop.sifr
@@ -1,0 +1,3 @@
+# expect-error: 'break' outside of loop
+def main():
+    break

--- a/crates/sifr/tests/e2e/fail/continue_outside_loop.sifr
+++ b/crates/sifr/tests/e2e/fail/continue_outside_loop.sifr
@@ -1,0 +1,3 @@
+# expect-error: 'continue' outside of loop
+def main():
+    continue

--- a/crates/sifr/tests/e2e/pass/break_continue.sifr
+++ b/crates/sifr/tests/e2e/pass/break_continue.sifr
@@ -1,0 +1,12 @@
+# expect-stdout: 12
+def main():
+    total: int = 0
+    i: int = 0
+    while i < 100:
+        i = i + 1
+        if i > 5:
+            break
+        if i == 3:
+            continue
+        total = total + i
+    print(total)

--- a/crates/sifr/tests/e2e/pass/for_range.sifr
+++ b/crates/sifr/tests/e2e/pass/for_range.sifr
@@ -1,0 +1,6 @@
+# expect-stdout: 45
+def main():
+    total: int = 0
+    for i in range(10):
+        total = total + i
+    print(total)

--- a/crates/sifr/tests/e2e/pass/for_range_start_end.sifr
+++ b/crates/sifr/tests/e2e/pass/for_range_start_end.sifr
@@ -1,0 +1,6 @@
+# expect-stdout: 28
+def main():
+    total: int = 0
+    for i in range(1, 8):
+        total = total + i
+    print(total)

--- a/crates/sifr/tests/e2e/pass/nested_loops.sifr
+++ b/crates/sifr/tests/e2e/pass/nested_loops.sifr
@@ -1,0 +1,7 @@
+# expect-stdout: 6
+def main():
+    count: int = 0
+    for i in range(3):
+        for j in range(2):
+            count = count + 1
+    print(count)

--- a/crates/sifr/tests/e2e/pass/while_loop.sifr
+++ b/crates/sifr/tests/e2e/pass/while_loop.sifr
@@ -1,0 +1,8 @@
+# expect-stdout: 55
+def main():
+    total: int = 0
+    i: int = 1
+    while i <= 10:
+        total = total + i
+        i = i + 1
+    print(total)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -104,9 +104,13 @@ impl RustEmitter {
 
     fn emit_stmt(&mut self, stmt: &HirStmt) {
         match stmt {
-            HirStmt::Let { name, ty, value, .. } => {
+            HirStmt::Let { name, ty, value, is_mutable } => {
                 self.write_indent();
-                self.write("let ");
+                if *is_mutable {
+                    self.write("let mut ");
+                } else {
+                    self.write("let ");
+                }
                 self.write(name);
                 self.write(": ");
                 self.write(&ty.rust_type());
@@ -175,6 +179,38 @@ impl RustEmitter {
                 }
 
                 self.writeln("}");
+            }
+            HirStmt::While { condition, body } => {
+                self.write_indent();
+                self.write("while ");
+                self.emit_expr(condition);
+                self.write(" {\n");
+                self.indent += 1;
+                for s in body {
+                    self.emit_stmt(s);
+                }
+                self.indent -= 1;
+                self.writeln("}");
+            }
+            HirStmt::For { target, iter, body, .. } => {
+                self.write_indent();
+                self.write("for ");
+                self.write(target);
+                self.write(" in ");
+                self.emit_expr(iter);
+                self.write(" {\n");
+                self.indent += 1;
+                for s in body {
+                    self.emit_stmt(s);
+                }
+                self.indent -= 1;
+                self.writeln("}");
+            }
+            HirStmt::Break => {
+                self.writeln("break;");
+            }
+            HirStmt::Continue => {
+                self.writeln("continue;");
             }
             HirStmt::Pass => {
                 // No-op in Rust
@@ -307,6 +343,11 @@ impl RustEmitter {
                 self.write(" } else { ");
                 self.emit_expr(else_expr);
                 self.write(" }");
+            }
+            HirExpr::RangeLiteral { start, end, .. } => {
+                self.emit_expr(start);
+                self.write("..");
+                self.emit_expr(end);
             }
         }
     }

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -54,6 +54,22 @@ pub enum HirStmt {
         elif_clauses: Vec<(HirExpr, Vec<HirStmt>)>,
         else_body: Option<Vec<HirStmt>>,
     },
+    /// While loop
+    While {
+        condition: HirExpr,
+        body: Vec<HirStmt>,
+    },
+    /// For loop
+    For {
+        target: String,
+        target_ty: Type,
+        iter: HirExpr,
+        body: Vec<HirStmt>,
+    },
+    /// Break statement
+    Break,
+    /// Continue statement
+    Continue,
     /// Pass (no-op)
     Pass,
 }
@@ -115,6 +131,12 @@ pub enum HirExpr {
         else_expr: Box<HirExpr>,
         ty: Type,
     },
+    /// Range literal: range(end) or range(start, end)
+    RangeLiteral {
+        start: Box<HirExpr>,
+        end: Box<HirExpr>,
+        ty: Type,
+    },
 }
 
 impl HirExpr {
@@ -132,7 +154,8 @@ impl HirExpr {
             | Self::Compare { ty, .. }
             | Self::BoolOp { ty, .. }
             | Self::Call { ty, .. }
-            | Self::IfExpr { ty, .. } => ty,
+            | Self::IfExpr { ty, .. }
+            | Self::RangeLiteral { ty, .. } => ty,
         }
     }
 }

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -36,6 +36,8 @@ struct LowerCtx {
     scope: Scope,
     /// Collected errors
     errors: Vec<LoweringError>,
+    /// Loop nesting depth (for break/continue validation)
+    loop_depth: usize,
 }
 
 impl LowerCtx {
@@ -44,6 +46,7 @@ impl LowerCtx {
             functions: HashMap::new(),
             scope: Scope::new(),
             errors: Vec::new(),
+            loop_depth: 0,
         }
     }
 
@@ -53,6 +56,10 @@ impl LowerCtx {
             line: None,
             col: None,
         });
+    }
+
+    fn in_loop(&self) -> bool {
+        self.loop_depth > 0
     }
 }
 
@@ -193,9 +200,25 @@ fn lower_stmt(stmt: &Stmt, func_type: &FunctionType, ctx: &mut LowerCtx) -> Opti
             Some(HirStmt::Expr { expr })
         }
         Stmt::If(if_stmt) => lower_if(if_stmt, func_type, ctx),
+        Stmt::While(while_stmt) => lower_while(while_stmt, func_type, ctx),
+        Stmt::For(for_stmt) => lower_for(for_stmt, func_type, ctx),
+        Stmt::Break(_) => {
+            if !ctx.in_loop() {
+                ctx.error("'break' outside of loop".to_string());
+                return None;
+            }
+            Some(HirStmt::Break)
+        }
+        Stmt::Continue(_) => {
+            if !ctx.in_loop() {
+                ctx.error("'continue' outside of loop".to_string());
+                return None;
+            }
+            Some(HirStmt::Continue)
+        }
         Stmt::Pass(_) => Some(HirStmt::Pass),
         _ => {
-            ctx.error(format!("unsupported statement type"));
+            ctx.error("unsupported statement type".to_string());
             None
         }
     }
@@ -337,6 +360,57 @@ fn lower_if(if_stmt: &StmtIf, func_type: &FunctionType, ctx: &mut LowerCtx) -> O
         then_body,
         elif_clauses,
         else_body,
+    })
+}
+
+fn lower_while(while_stmt: &StmtWhile, func_type: &FunctionType, ctx: &mut LowerCtx) -> Option<HirStmt> {
+    let condition = lower_expr(&while_stmt.test, ctx)?;
+
+    ctx.scope.push();
+    ctx.loop_depth += 1;
+    let body = lower_stmts(&while_stmt.body, func_type, ctx);
+    ctx.loop_depth -= 1;
+    ctx.scope.pop();
+
+    Some(HirStmt::While { condition, body })
+}
+
+fn lower_for(for_stmt: &StmtFor, func_type: &FunctionType, ctx: &mut LowerCtx) -> Option<HirStmt> {
+    // Lower the iterable expression
+    let iter_expr = lower_expr(&for_stmt.iter, ctx)?;
+    let iter_ty = iter_expr.ty().clone();
+
+    // Determine the element type from the iterable
+    let elem_ty = iter_ty.iterable_element_type().unwrap_or_else(|| {
+        ctx.error(format!(
+            "cannot iterate over type '{}'",
+            iter_ty.display_name()
+        ));
+        Type::Any
+    });
+
+    // Extract the target variable name
+    let target_name = match for_stmt.target.as_ref() {
+        Expr::Name(n) => n.id.to_string(),
+        _ => {
+            ctx.error("for loop target must be a simple name".to_string());
+            return None;
+        }
+    };
+
+    // Create a new scope for the loop body, define the loop variable
+    ctx.scope.push();
+    ctx.scope.define(target_name.clone(), elem_ty.clone());
+    ctx.loop_depth += 1;
+    let body = lower_stmts(&for_stmt.body, func_type, ctx);
+    ctx.loop_depth -= 1;
+    ctx.scope.pop();
+
+    Some(HirStmt::For {
+        target: target_name,
+        target_ty: elem_ty,
+        iter: iter_expr,
+        body,
     })
 }
 
@@ -546,6 +620,11 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         }
     };
 
+    // Special handling for range() built-in
+    if func_name == "range" {
+        return lower_range_call(call, ctx);
+    }
+
     let ft = ctx.functions.get(&func_name).cloned().or_else(|| {
         ctx.error(format!("undefined function: '{}'", func_name));
         None
@@ -599,6 +678,60 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         args,
         ty: *ft.return_type,
     })
+}
+
+fn lower_range_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    let args: Vec<_> = call.arguments.args.iter().collect();
+
+    match args.len() {
+        1 => {
+            // range(end) -> 0..end
+            let end = lower_expr(args[0], ctx)?;
+            if end.ty() != &Type::Int {
+                ctx.error(format!(
+                    "range() argument must be 'int', got '{}'",
+                    end.ty().display_name()
+                ));
+                return None;
+            }
+            Some(HirExpr::RangeLiteral {
+                start: Box::new(HirExpr::IntLiteral(0)),
+                end: Box::new(end),
+                ty: Type::Range,
+            })
+        }
+        2 => {
+            // range(start, end) -> start..end
+            let start = lower_expr(args[0], ctx)?;
+            let end = lower_expr(args[1], ctx)?;
+            if start.ty() != &Type::Int {
+                ctx.error(format!(
+                    "range() start argument must be 'int', got '{}'",
+                    start.ty().display_name()
+                ));
+                return None;
+            }
+            if end.ty() != &Type::Int {
+                ctx.error(format!(
+                    "range() end argument must be 'int', got '{}'",
+                    end.ty().display_name()
+                ));
+                return None;
+            }
+            Some(HirExpr::RangeLiteral {
+                start: Box::new(start),
+                end: Box::new(end),
+                ty: Type::Range,
+            })
+        }
+        _ => {
+            ctx.error(format!(
+                "range() takes 1 or 2 arguments, got {}",
+                args.len()
+            ));
+            None
+        }
+    }
 }
 
 fn lower_if_expr(if_expr: &ExprIf, ctx: &mut LowerCtx) -> Option<HirExpr> {
@@ -680,6 +813,71 @@ mod tests {
     fn test_copy_type_no_move() {
         let module = lower_source(
             "def main():\n    x: int = 42\n    print(x)\n    print(x)\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+    }
+
+    #[test]
+    fn test_while_loop() {
+        let module = lower_source(
+            "def main():\n    i: int = 0\n    while i < 10:\n        i = i + 1\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+        // Body should contain a Let and a While
+        assert!(module.functions[0].body.len() >= 2);
+        assert!(matches!(module.functions[0].body[1], HirStmt::While { .. }));
+    }
+
+    #[test]
+    fn test_for_range() {
+        let module = lower_source(
+            "def main():\n    for i in range(10):\n        print(i)\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+        assert!(matches!(module.functions[0].body[0], HirStmt::For { .. }));
+    }
+
+    #[test]
+    fn test_for_range_start_end() {
+        let module = lower_source(
+            "def main():\n    for i in range(1, 5):\n        print(i)\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+        assert!(matches!(module.functions[0].body[0], HirStmt::For { .. }));
+    }
+
+    #[test]
+    fn test_break_outside_loop() {
+        let result = lower_source(
+            "def main():\n    break\n"
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("'break' outside of loop")));
+    }
+
+    #[test]
+    fn test_continue_outside_loop() {
+        let result = lower_source(
+            "def main():\n    continue\n"
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("'continue' outside of loop")));
+    }
+
+    #[test]
+    fn test_break_inside_loop() {
+        let module = lower_source(
+            "def main():\n    while True:\n        break\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+    }
+
+    #[test]
+    fn test_nested_loops() {
+        let module = lower_source(
+            "def main():\n    for i in range(3):\n        for j in range(2):\n            print(i)\n"
         ).unwrap();
         assert_eq!(module.functions.len(), 1);
     }

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -15,6 +15,8 @@ pub enum Type {
     None,
     /// Function type with parameter types and return type
     Function(FunctionType),
+    /// Range type (maps to `std::ops::Range<i64>` in Rust)
+    Range,
     /// Explicit opt-out of type checking
     Any,
     /// Bottom type (function that never returns)
@@ -50,7 +52,7 @@ impl Type {
     /// - `Function` is `Copy` (function pointers).
     pub fn ownership(&self) -> OwnershipKind {
         match self {
-            Self::Int | Self::Float | Self::Bool | Self::None | Self::Never => OwnershipKind::Copy,
+            Self::Int | Self::Float | Self::Bool | Self::None | Self::Never | Self::Range => OwnershipKind::Copy,
             Self::Function(_) => OwnershipKind::Copy,
             Self::Str | Self::Any => OwnershipKind::Move,
         }
@@ -65,6 +67,7 @@ impl Type {
             Self::Str => "str",
             Self::None => "None",
             Self::Function(_) => "function",
+            Self::Range => "range",
             Self::Any => "Any",
             Self::Never => "Never",
         }
@@ -78,6 +81,7 @@ impl Type {
             Self::Bool => "bool".to_string(),
             Self::Str => "String".to_string(),
             Self::None => "()".to_string(),
+            Self::Range => "std::ops::Range<i64>".to_string(),
             Self::Any => "Box<dyn std::any::Any>".to_string(),
             Self::Never => "!".to_string(),
             Self::Function(ft) => {
@@ -91,6 +95,14 @@ impl Type {
     /// Check if this type is a numeric type (int or float).
     pub fn is_numeric(&self) -> bool {
         matches!(self, Self::Int | Self::Float)
+    }
+
+    /// Returns the element type if this type is iterable, or None otherwise.
+    pub fn iterable_element_type(&self) -> Option<Type> {
+        match self {
+            Self::Range => Some(Type::Int),
+            _ => None,
+        }
     }
 
     /// Check if a value of type `self` can be assigned to a target of type `target`.

--- a/issues/14-m2-control-flow-and-data-structures.md
+++ b/issues/14-m2-control-flow-and-data-structures.md
@@ -1,0 +1,265 @@
+## 📄 Product Requirements & Solution Design Template
+
+---
+
+### 🧭 1. Product Requirements
+
+#### **Title**
+
+M2: Control Flow and Data Structures
+
+---
+
+#### **Objective / Problem Statement**
+
+The Sifr compiler (M1) can compile simple programs with functions, if/else, and primitives to native binaries. However, it cannot express loops or work with compound data types (lists, dicts, tuples). Without these, Sifr programs cannot process collections, iterate over data, or implement real algorithms. M2 adds the control flow and data structure primitives needed to write meaningful programs.
+
+---
+
+#### **Constraints**
+
+| Constraint | Rationale |
+| --- | --- |
+| Must emit valid Rust source code | Continues M1's Rust emission strategy |
+| New types must integrate with existing ownership model | Move-by-default for compound types (list, dict, tuple), copy for primitives |
+| Generic type parameters for collections (list[T], dict[K,V]) | Type safety for collection elements |
+| Backward compatible with M1 programs | Existing .sifr programs must continue to compile |
+| Built entirely by AI agents | Comprehensive test coverage at every layer |
+
+---
+
+#### **Business Goals & Success Criteria (KPIs)**
+
+| Metric | Baseline (Today) | Target (Post-launch) |
+| --- | --- | --- |
+| Loop constructs | 0 (no while/for) | while and for loops compile and run correctly |
+| Data structure types | 0 (only primitives) | list[T], dict[K,V], tuple[T,...] all work |
+| String operations | Only concatenation | len(), upper(), lower(), split(), strip(), f-strings |
+| Collection operations | None | Indexing, slicing, in operator, append, len |
+| Test coverage | M1 tests passing | M2 tests added at all 4 layers |
+
+---
+
+#### **Scope**
+
+##### ✅ Features In
+
+1. `while` loop with break/continue
+2. `for` loop over ranges and iterables (lists)
+3. `range()` built-in function
+4. `list[T]` type with literal syntax, append, len, indexing
+5. `dict[K, V]` type with literal syntax, key access, len
+6. `tuple[T, ...]` type with literal syntax, indexing
+7. String methods: `.len()`, `.upper()`, `.lower()`, `.split()`, `.strip()`
+8. f-string formatting (`f"Hello {name}"`)
+9. `in` operator for membership testing (lists, dicts, strings)
+10. Indexing and slicing (`my_list[0]`, `my_list[1:3]`)
+11. Tuple unpacking / multiple assignment (`a, b = 1, 2`)
+12. `len()` built-in function for all collection types
+
+##### ❌ Features Out
+
+| Feature | Reason for Exclusion |
+| --- | --- |
+| List/dict comprehensions | Deferred to M6 (closures needed) |
+| Nested generics (list[list[int]]) | Deferred to M6 |
+| Custom iterators (__iter__/__next__) | Deferred to M6 |
+| Set type | Deferred to M7 (stdlib) |
+| enumerate(), zip(), map(), filter() | Deferred to M6 |
+
+---
+
+#### **Users / Stakeholders, Use-Cases & Dependencies**
+
+| Persona | Use-Case / Benefit | Dependencies | **AC-ID** |
+| --- | --- | --- | --- |
+| Sifr developer | Write programs with loops to process data | Loop lowering + codegen | AC-1 |
+| Sifr developer | Use lists, dicts, tuples to model data | Collection type system + codegen | AC-2 |
+| Sifr developer | Format strings with f-strings | String operation codegen | AC-3 |
+| Sifr developer | Index and slice collections | Indexing/slicing lowering + codegen | AC-4 |
+| AI agent | Run `cargo test` to verify M2 correctness | Test suite extended | AC-5 |
+
+---
+
+### **Acceptance Criteria**
+
+| **AC-ID** | Persona | Criterion *(Given / When / Then)* |
+| --- | --- | --- |
+| AC-1 | Developer | **Given** a `.sifr` file with while and for loops **When** running `sifr run` **Then** the program executes loops correctly and produces expected output |
+| AC-2 | Developer | **Given** a `.sifr` file using list[int], dict[str,int], tuple[int,str] **When** running `sifr build` **Then** a native binary is produced that correctly creates, modifies, and reads collections |
+| AC-3 | Developer | **Given** a `.sifr` file with f-strings and string methods **When** running `sifr run` **Then** strings are formatted and manipulated correctly |
+| AC-4 | Developer | **Given** a `.sifr` file with indexing (list[0]), slicing (list[1:3]), and `in` operator **When** running `sifr run` **Then** correct values are returned |
+| AC-5 | AI Agent | **Given** the full codebase **When** running `cargo test` **Then** all M1 + M2 tests pass |
+
+---
+
+## 🧠 2. Solution Design
+
+### **2.1 Functional Requirements**
+
+* Parse `while` and `for` loop syntax from Python AST
+* Parse `list[T]`, `dict[K,V]`, `tuple[T,...]` type annotations
+* Parse list/dict/tuple literal expressions
+* Parse f-string expressions
+* Parse indexing (`x[0]`) and slicing (`x[1:3]`) expressions
+* Parse `in` operator in boolean context
+* Parse `break` and `continue` statements
+* Parse tuple unpacking assignments (`a, b = 1, 2`)
+* Type-check collection operations (element types, key types)
+* Type-check loop variables (infer from iterable element type)
+* Generate Rust code for all new constructs
+* Extend ownership model: list, dict, tuple are Move types
+
+---
+
+### **2.2 Non-Functional Requirements**
+
+| ID | Requirement |
+| --- | --- |
+| NFR-1 | Programs with loops (< 200 lines) compile in under 5 seconds |
+| NFR-2 | All M1 tests continue to pass (backward compatibility) |
+| NFR-3 | New tests run in under 60 seconds via `cargo test` |
+| NFR-4 | No new compiler warnings on stable Rust |
+
+---
+
+### **2.3 High-Level Architecture**
+
+No new crates needed. M2 extends existing crates:
+
+```
+sifr_type_system  -- Add List(T), Dict(K,V), Tuple(T...) types
+        ↓
+sifr_hir          -- Add While, For, Break, Continue HIR nodes
+        ↓                Add collection literal, indexing, slicing, method call HIR nodes
+sifr_codegen      -- Add Rust codegen for loops, collections, f-strings
+        ↓
+sifr_driver       -- No changes needed (pipeline unchanged)
+sifr (CLI)        -- No changes needed
+```
+
+---
+
+### **2.4 Detailed Component Design**
+
+**📦 sifr_type_system extensions**
+
+New type variants:
+- `Type::List(Box<Type>)` — `list[T]` → `Vec<T>`
+- `Type::Dict(Box<Type>, Box<Type>)` — `dict[K,V]` → `HashMap<K,V>`
+- `Type::Tuple(Vec<Type>)` — `tuple[A,B,C]` → `(A,B,C)`
+
+New type checking:
+- Indexing: `list[int]` indexed by `int` returns `T`
+- Dict access: `dict[K,V]` accessed by `K` returns `V`
+- Tuple indexing: `tuple[A,B]` indexed by literal int returns the positional type
+- `in` operator: returns `bool` for list/dict/str membership
+- `len()`: returns `int` for list/dict/tuple/str
+- Method calls: `.append(T)` on list, `.upper()` on str, etc.
+
+Ownership:
+- `List`, `Dict`, `Tuple` are all `Move` types
+- Iterating over a list borrows it (for loop)
+
+**⚙️ sifr_hir extensions**
+
+New HIR statements:
+- `HirStmt::While { condition, body }` — while loop
+- `HirStmt::For { target, iter, body }` — for loop
+- `HirStmt::Break` — break statement
+- `HirStmt::Continue` — continue statement
+
+New HIR expressions:
+- `HirExpr::ListLiteral { elements, ty }` — `[1, 2, 3]`
+- `HirExpr::DictLiteral { keys, values, ty }` — `{"a": 1, "b": 2}`
+- `HirExpr::TupleLiteral { elements, ty }` — `(1, "hello")`
+- `HirExpr::Index { object, index, ty }` — `x[0]`
+- `HirExpr::Slice { object, lower, upper, ty }` — `x[1:3]`
+- `HirExpr::MethodCall { object, method, args, ty }` — `x.append(1)`
+- `HirExpr::FStringLiteral { parts, ty }` — `f"Hello {name}"`
+- `HirExpr::RangeLiteral { start, end, ty }` — `range(n)` / `range(a, b)`
+- `HirExpr::ContainsOp { left, right, ty }` — `x in collection`
+
+New lowering:
+- `lower_while` — Lower while loop with break/continue
+- `lower_for` — Lower for loop, infer loop variable type from iterable
+- `lower_list_literal` — Lower list display, infer element type
+- `lower_dict_literal` — Lower dict display, infer key/value types
+- `lower_tuple_literal` — Lower tuple display
+- `lower_subscript` — Lower indexing and slicing
+- `lower_attribute` — Lower method calls on types
+- `lower_fstring` — Lower f-string parts
+- `lower_tuple_unpack` — Lower tuple unpacking assignments
+
+**🗄️ sifr_codegen extensions**
+
+New Rust generation:
+- `while condition { body }` — direct mapping
+- `for target in iter { body }` — direct mapping with `.iter()` for borrowed iteration
+- `break;` / `continue;` — direct mapping
+- `vec![1, 2, 3]` — list literal
+- `HashMap::from([("a", 1)])` — dict literal (with `use std::collections::HashMap;`)
+- `(1, "hello".to_string())` — tuple literal
+- `x[0]` / `x.get("key")` — indexing
+- `x[1..3].to_vec()` — slicing
+- `x.push(val)` — append
+- `x.len()` — len
+- `format!("Hello {}", name)` — f-string
+- `0..n` / `a..b` — range
+- `x.contains(&val)` / `x.contains_key(&val)` — in operator
+
+---
+
+### **2.5 Data Model**
+
+Not applicable (compiler, no database).
+
+---
+
+### **2.6 API Integration**
+
+Not applicable for M2.
+
+---
+
+### **2.7 Error Handling & Monitoring**
+
+* Type mismatch on collection element types (e.g., `list[int]` with `str` element)
+* Index out of bounds is a runtime error (Rust panics)
+* Wrong key type for dict access
+* Method not found on type
+* Break/continue outside of loop
+* Tuple unpacking length mismatch
+
+---
+
+### **2.8 Deployment Plan**
+
+* Same as M1 -- distributed as `sifr` binary via `cargo install`
+
+---
+
+### **2.9 Trade-offs & Alternatives**
+
+| Option Considered | Pros | Cons | Rationale for Final Choice |
+| --- | --- | --- | --- |
+| Implement for-loop as while-loop desugar | Simpler HIR | Loses semantic info, harder codegen | Keep for-loop as first-class HIR node |
+| Use Vec<Box<dyn Any>> for untyped lists | Simpler type system | No type safety | Use Vec<T> with generic type tracking |
+| Implement slicing as method call | Consistent with methods | Less Pythonic | Keep subscript syntax, map to Rust slice |
+
+---
+
+### **2.10 Testing Strategy** *(mapped to ACs)*
+
+| **AC-ID** | Test Layer | Happy-Path Check | Non-Happy / Edge Check | Tooling & Automation | Pass/Fail Gate |
+| --- | --- | --- | --- | --- | --- |
+| AC-1 | E2E (Layer 3) | while_loop.sifr, for_loop.sifr compile and run | break/continue in nested loops, infinite loop guard | cargo test --test e2e | All pass |
+| AC-2 | E2E + Snapshot | list_ops.sifr, dict_ops.sifr, tuple_ops.sifr | Empty collections, type mismatch errors | insta + e2e | All pass |
+| AC-3 | E2E + Snapshot | fstring.sifr, string_methods.sifr | Empty string, special chars | insta + e2e | All pass |
+| AC-4 | E2E + Snapshot | indexing.sifr, slicing.sifr, in_operator.sifr | Negative index, out of bounds | insta + e2e | All pass |
+| AC-5 | All layers | cargo test passes | No regressions in M1 tests | cargo test | Exit code 0 |
+
+**Additional NFR Tests**
+
+* Backward compatibility: all M1 E2E tests still pass
+* Performance: compilation of 200-line program with loops < 5s

--- a/issues/15-while-for-loops-and-range.md
+++ b/issues/15-while-for-loops-and-range.md
@@ -1,0 +1,45 @@
+## While/For Loops, Break/Continue, and range()
+
+#### **Current Situation**
+
+- The Sifr compiler (M1) supports functions, if/else, primitives, and basic expressions but has no loop constructs.
+- Programs cannot iterate over data or repeat operations, severely limiting what can be expressed.
+- The ruff-forked parser already supports `while`, `for`, `break`, `continue` AST nodes from Python syntax, but the HIR, type system, and codegen do not handle them.
+
+#### **Desired Situation**
+
+- `while` loops compile and run correctly, including nested loops.
+- `for` loops over `range()` compile and run correctly.
+- `break` and `continue` statements work inside loops.
+- `range(n)` and `range(start, end)` are supported as built-in functions.
+- Loop variables in `for` loops are automatically typed as `int` when iterating over a range.
+- Errors are reported for `break`/`continue` used outside of loops.
+- E2E tests verify all loop constructs produce correct output.
+
+#### **Suggested Solution**
+
+1. **sifr_type_system** changes:
+   - Add `Type::Range` variant (maps to Rust `std::ops::Range<i64>`)
+   - Add `range` to built-in functions in type checking
+
+2. **sifr_hir** changes:
+   - Add `HirStmt::While { condition: HirExpr, body: Vec<HirStmt> }`
+   - Add `HirStmt::For { target: String, target_ty: Type, iter: HirExpr, body: Vec<HirStmt> }`
+   - Add `HirStmt::Break` and `HirStmt::Continue`
+   - Add `HirExpr::RangeLiteral { start: Option<Box<HirExpr>>, end: Box<HirExpr>, ty: Type }`
+   - Implement `lower_while`: lower condition + body, push/pop scope for body
+   - Implement `lower_for`: lower iterable, infer target type from iterable element type, define target in scope, lower body
+   - Implement `lower_break` / `lower_continue`: validate inside loop context
+   - Track loop nesting depth in `LowerCtx` for break/continue validation
+   - Register `range` as built-in function
+
+3. **sifr_codegen** changes:
+   - Emit `while condition { body }` for while loops
+   - Emit `for target in start..end { body }` for for-range loops
+   - Emit `break;` and `continue;`
+   - Emit `start..end` for range literals
+
+4. **Tests:**
+   - Unit tests for loop lowering and type inference
+   - E2E pass tests: while_loop.sifr, for_loop.sifr, for_range.sifr, nested_loops.sifr, break_continue.sifr
+   - E2E fail tests: break_outside_loop.sifr, continue_outside_loop.sifr

--- a/issues/16-list-dict-tuple-types.md
+++ b/issues/16-list-dict-tuple-types.md
@@ -1,0 +1,67 @@
+## List, Dict, and Tuple Types with Collection Operations
+
+#### **Current Situation**
+
+- The Sifr type system only supports primitive types (int, float, bool, str, None) and functions.
+- There are no compound data types for modeling collections of data.
+- Programs cannot create lists, dictionaries, or tuples, making it impossible to work with structured data.
+- The ruff-forked parser already supports list/dict/tuple literal syntax and subscript expressions from Python, but the HIR, type system, and codegen do not handle them.
+
+#### **Desired Situation**
+
+- `list[T]` type works with literal syntax (`[1, 2, 3]`), type annotations, `append()`, `len()`, and indexing.
+- `dict[K, V]` type works with literal syntax (`{"a": 1}`), type annotations, key access, `len()`.
+- `tuple[A, B, ...]` type works with literal syntax (`(1, "hello")`), type annotations, and positional indexing.
+- All collection types are Move types (consistent with ownership model).
+- `len()` built-in works on all collections and strings.
+- Type inference works for collection literals (e.g., `[1, 2, 3]` infers `list[int]`).
+- For loops can iterate over lists (in addition to ranges from Task 1).
+- `in` operator works for membership testing on lists, dicts, and strings.
+- Indexing (`x[0]`) and slicing (`x[1:3]`) work on lists and strings.
+- E2E tests verify all collection operations.
+
+#### **Suggested Solution**
+
+1. **sifr_type_system** changes:
+   - Add `Type::List(Box<Type>)` — maps to `Vec<T>`
+   - Add `Type::Dict(Box<Type>, Box<Type>)` — maps to `HashMap<K, V>`
+   - Add `Type::Tuple(Vec<Type>)` — maps to `(A, B, C)`
+   - Update `ownership()`: List, Dict, Tuple are Move types
+   - Update `rust_type()`: generate `Vec<T>`, `HashMap<K, V>`, `(A, B, C)`
+   - Update `display_name()`: show `list[int]`, `dict[str, int]`, `tuple[int, str]`
+   - Update `is_assignable_to()`: structural subtyping for collections
+   - Add type checking for indexing (list by int, dict by key type, tuple by literal int)
+   - Add type checking for `in` operator (returns bool)
+   - Add type checking for method calls (append, len, etc.)
+
+2. **sifr_hir** changes:
+   - Add `HirExpr::ListLiteral { elements: Vec<HirExpr>, ty: Type }`
+   - Add `HirExpr::DictLiteral { keys: Vec<HirExpr>, values: Vec<HirExpr>, ty: Type }`
+   - Add `HirExpr::TupleLiteral { elements: Vec<HirExpr>, ty: Type }`
+   - Add `HirExpr::Index { object: Box<HirExpr>, index: Box<HirExpr>, ty: Type }`
+   - Add `HirExpr::Slice { object: Box<HirExpr>, lower: Option<Box<HirExpr>>, upper: Option<Box<HirExpr>>, ty: Type }`
+   - Add `HirExpr::MethodCall { object: Box<HirExpr>, method: String, args: Vec<HirExpr>, ty: Type }`
+   - Add `HirExpr::ContainsOp { element: Box<HirExpr>, collection: Box<HirExpr>, ty: Type }`
+   - Implement lowering for list/dict/tuple literals with element type inference
+   - Implement lowering for subscript (indexing + slicing)
+   - Implement lowering for attribute access (method calls)
+   - Implement lowering for `in` operator (Compare node with `In` op)
+   - Resolve `list[T]`, `dict[K,V]`, `tuple[A,B]` type annotations
+   - Update for-loop lowering to support iterating over lists (infer element type)
+   - Register `len` as built-in function
+
+3. **sifr_codegen** changes:
+   - Emit `vec![elem1, elem2, ...]` for list literals
+   - Emit `std::collections::HashMap::from([(k1, v1), ...])` for dict literals
+   - Emit `(elem1, elem2, ...)` for tuple literals
+   - Emit `x[index]` for list/tuple indexing, `x[key].clone()` or `x.get(&key)` for dict
+   - Emit `x[lower..upper].to_vec()` for slicing
+   - Emit `x.push(val)` for append, `x.len()` for len
+   - Emit `x.contains(&val)` for list/string `in`, `x.contains_key(&key)` for dict `in`
+   - Emit `for target in collection.iter() { body }` for list iteration
+   - Add `use std::collections::HashMap;` when dicts are used
+
+4. **Tests:**
+   - Unit tests for collection type checking and inference
+   - E2E pass tests: list_ops.sifr, dict_ops.sifr, tuple_ops.sifr, collection_iteration.sifr, indexing.sifr, in_operator.sifr
+   - E2E fail tests: list_type_mismatch.sifr, wrong_index_type.sifr, dict_wrong_key.sifr

--- a/issues/17-string-ops-fstrings-tuple-unpacking.md
+++ b/issues/17-string-ops-fstrings-tuple-unpacking.md
@@ -1,0 +1,44 @@
+## String Operations, F-strings, and Tuple Unpacking
+
+#### **Current Situation**
+
+- Strings in Sifr only support concatenation (`+` operator) and basic print.
+- There are no string methods (len, upper, lower, split, strip).
+- There are no f-strings for string formatting.
+- There is no tuple unpacking / multiple assignment syntax.
+- These are essential for writing readable, practical programs.
+
+#### **Desired Situation**
+
+- String methods work: `.len()`, `.upper()`, `.lower()`, `.split()`, `.strip()`, `.startswith()`, `.endswith()`.
+- F-string formatting works: `f"Hello {name}, you are {age} years old"`.
+- Tuple unpacking works: `a, b = 1, 2` and `a, b = get_pair()`.
+- All features have proper type checking and produce correct Rust code.
+- E2E tests verify all string operations and tuple unpacking.
+
+#### **Suggested Solution**
+
+1. **sifr_type_system** changes:
+   - Add method resolution for `Str` type: `.len() -> int`, `.upper() -> str`, `.lower() -> str`, `.split(sep: str) -> list[str]`, `.strip() -> str`, `.startswith(prefix: str) -> bool`, `.endswith(suffix: str) -> bool`
+   - Add method resolution for `List` type: `.len() -> int`, `.append(T) -> None`
+   - Add method resolution for `Dict` type: `.len() -> int`, `.keys() -> list[K]`, `.values() -> list[V]`
+   - Create a method resolution system that maps (Type, method_name) -> (param_types, return_type)
+
+2. **sifr_hir** changes:
+   - Add `HirExpr::FString { parts: Vec<FStringPart>, ty: Type }` where `FStringPart` is either `Literal(String)` or `Expr(HirExpr)`
+   - Add `HirStmt::TupleUnpack { targets: Vec<(String, Type)>, value: HirExpr }` for multiple assignment
+   - Implement `lower_fstring`: parse f-string parts, type-check interpolated expressions
+   - Implement `lower_tuple_unpack`: validate target count matches tuple length, define variables in scope
+   - Extend method call lowering with the method resolution system
+
+3. **sifr_codegen** changes:
+   - Emit `format!("...", expr1, expr2)` for f-strings
+   - Emit `.len()`, `.to_uppercase()`, `.to_lowercase()`, `.split(sep).collect::<Vec<_>>()`, `.trim()`, `.starts_with(prefix)`, `.ends_with(suffix)` for string methods
+   - Emit `let (a, b) = expr;` for tuple unpacking
+   - Emit `.len()`, `.push(val)` for list methods
+   - Emit `.len()`, `.keys().cloned().collect()`, `.values().cloned().collect()` for dict methods
+
+4. **Tests:**
+   - Unit tests for method resolution and f-string type checking
+   - E2E pass tests: string_methods.sifr, fstring.sifr, tuple_unpacking.sifr
+   - E2E fail tests: wrong_method_args.sifr, tuple_unpack_mismatch.sifr


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/15

#### **Changes**

* Add `Type::Range` to the type system with `iterable_element_type()` method
* Add `HirStmt::While`, `HirStmt::For`, `HirStmt::Break`, `HirStmt::Continue` to HIR
* Add `HirExpr::RangeLiteral` for `range(n)` and `range(start, end)` expressions
* Implement AST-to-HIR lowering for while/for loops with proper scope management
* Track loop nesting depth in `LowerCtx` for break/continue validation
* Handle `range()` as a special built-in call (1 or 2 int arguments)
* Generate correct Rust code: `while`, `for..in`, `break`, `continue`, `start..end`
* Emit `let mut` for mutable variables (previously all were `let`)
* Add 5 E2E pass tests: while_loop, for_range, for_range_start_end, nested_loops, break_continue
* Add 2 E2E fail tests: break_outside_loop, continue_outside_loop
* Add 7 unit tests for loop lowering logic
* Add M2 Epic PRDS and task descriptions

Made with [Cursor](https://cursor.com)