### PR TITLE
Add f-strings, tuple unpacking, and string operations

### DIFF
--- a/crates/sifr/tests/e2e/pass/fstring_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/fstring_basic.sifr
@@ -1,0 +1,7 @@
+# F-string basic interpolation
+# expect-stdout: Hello, Alice! You are 30 years old.
+def main():
+    name: str = "Alice"
+    age: int = 30
+    msg: str = f"Hello, {name}! You are {age} years old."
+    print(msg)

--- a/crates/sifr/tests/e2e/pass/fstring_expr.sifr
+++ b/crates/sifr/tests/e2e/pass/fstring_expr.sifr
@@ -1,0 +1,6 @@
+# F-string with expressions
+# expect-stdout: 2 + 3 = 5
+def main():
+    a: int = 2
+    b: int = 3
+    print(f"{a} + {b} = {a + b}")

--- a/crates/sifr/tests/e2e/pass/string_ops.sifr
+++ b/crates/sifr/tests/e2e/pass/string_ops.sifr
@@ -1,0 +1,6 @@
+# String operations
+# expect-stdout: HELLO
+def main():
+    s: str = "hello"
+    upper: str = s.upper()
+    print(upper)

--- a/crates/sifr/tests/e2e/pass/tuple_unpack.sifr
+++ b/crates/sifr/tests/e2e/pass/tuple_unpack.sifr
@@ -1,0 +1,7 @@
+# Tuple unpacking
+# expect-stdout: 1\nhello
+def main():
+    pair: tuple[int, str] = (1, "hello")
+    x, y = pair
+    print(x)
+    print(y)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -226,6 +226,19 @@ impl RustEmitter {
             HirStmt::Pass => {
                 // No-op in Rust
             }
+            HirStmt::TupleUnpack { targets, value } => {
+                self.write_indent();
+                self.write("let (");
+                for (i, (name, _ty)) in targets.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write(name);
+                }
+                self.write(") = ");
+                self.emit_expr(value);
+                self.write(";\n");
+            }
         }
     }
 
@@ -575,6 +588,37 @@ impl RustEmitter {
                         self.write(")");
                     }
                 }
+            }
+            HirExpr::FString { parts, .. } => {
+                // Build the format string and collect expressions
+                let mut format_str = String::new();
+                let mut exprs: Vec<&HirExpr> = Vec::new();
+                for part in parts {
+                    match part {
+                        HirFStringPart::Literal(s) => {
+                            // Escape braces in the literal for Rust's format!
+                            for ch in s.chars() {
+                                match ch {
+                                    '{' => format_str.push_str("{{"),
+                                    '}' => format_str.push_str("}}"),
+                                    _ => format_str.push(ch),
+                                }
+                            }
+                        }
+                        HirFStringPart::Expr(expr) => {
+                            format_str.push_str("{}");
+                            exprs.push(expr);
+                        }
+                    }
+                }
+                self.write("format!(\"");
+                self.write(&format_str);
+                self.write("\"");
+                for expr in &exprs {
+                    self.write(", ");
+                    self.emit_expr(expr);
+                }
+                self.write(")");
             }
         }
     }

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -70,8 +70,22 @@ pub enum HirStmt {
     Break,
     /// Continue statement
     Continue,
+    /// Tuple unpacking: a, b = expr
+    TupleUnpack {
+        targets: Vec<(String, Type)>,
+        value: HirExpr,
+    },
     /// Pass (no-op)
     Pass,
+}
+
+/// A part of an f-string.
+#[derive(Debug, Clone)]
+pub enum HirFStringPart {
+    /// A literal string part
+    Literal(String),
+    /// An interpolated expression
+    Expr(HirExpr),
 }
 
 /// A typed expression.
@@ -172,6 +186,11 @@ pub enum HirExpr {
         collection: Box<HirExpr>,
         ty: Type,
     },
+    /// F-string: f"Hello {name}"
+    FString {
+        parts: Vec<HirFStringPart>,
+        ty: Type,
+    },
 }
 
 impl HirExpr {
@@ -196,7 +215,8 @@ impl HirExpr {
             | Self::TupleLiteral { ty, .. }
             | Self::Index { ty, .. }
             | Self::MethodCall { ty, .. }
-            | Self::ContainsOp { ty, .. } => ty,
+            | Self::ContainsOp { ty, .. }
+            | Self::FString { ty, .. } => ty,
         }
     }
 }

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -322,6 +322,11 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
         return None;
     }
 
+    // Handle tuple unpacking: a, b = expr
+    if let Expr::Tuple(tuple) = &assign.targets[0] {
+        return lower_tuple_unpack_assign(tuple, &assign.value, ctx);
+    }
+
     let name = match &assign.targets[0] {
         Expr::Name(n) => n.id.to_string(),
         _ => {
@@ -489,6 +494,7 @@ fn lower_expr(expr: &Expr, ctx: &mut LowerCtx) -> Option<HirExpr> {
         Expr::Tuple(tuple) => lower_tuple_literal(tuple, ctx),
         Expr::Subscript(sub) => lower_subscript(sub, ctx),
         Expr::Attribute(attr) => lower_attribute(attr, ctx),
+        Expr::FString(fstring) => lower_fstring(fstring, ctx),
         _ => {
             ctx.error("unsupported expression type".to_string());
             None
@@ -805,6 +811,88 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         func: func_name,
         args,
         ty: *ft.return_type,
+    })
+}
+
+fn lower_fstring(fstring: &ExprFString, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    let mut parts = Vec::new();
+
+    for part in &fstring.value {
+        match part {
+            sifr_python_ast::FStringPart::Literal(s) => {
+                parts.push(HirFStringPart::Literal(s.to_string()));
+            }
+            sifr_python_ast::FStringPart::FString(fs) => {
+                for element in fs.elements.iter() {
+                    match element {
+                        FStringElement::Literal(lit) => {
+                            parts.push(HirFStringPart::Literal(lit.value.to_string()));
+                        }
+                        FStringElement::Expression(expr_elem) => {
+                            let expr = lower_expr(&expr_elem.expression, ctx)?;
+                            parts.push(HirFStringPart::Expr(expr));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Some(HirExpr::FString {
+        parts,
+        ty: Type::Str,
+    })
+}
+
+fn lower_tuple_unpack_assign(tuple: &ExprTuple, value: &Expr, ctx: &mut LowerCtx) -> Option<HirStmt> {
+    // Extract target names
+    let mut target_names = Vec::new();
+    for elt in &tuple.elts {
+        match elt {
+            Expr::Name(n) => target_names.push(n.id.to_string()),
+            _ => {
+                ctx.error("tuple unpacking target must be a simple name".to_string());
+                return None;
+            }
+        }
+    }
+
+    // Lower the value expression
+    let value_expr = lower_expr(value, ctx)?;
+    let value_ty = value_expr.ty().clone();
+
+    // Check that the value is a tuple with matching length
+    let elem_types = match &value_ty {
+        Type::Tuple(elems) => {
+            if elems.len() != target_names.len() {
+                ctx.error(format!(
+                    "tuple unpacking: expected {} values, got {}",
+                    target_names.len(),
+                    elems.len()
+                ));
+                return None;
+            }
+            elems.clone()
+        }
+        _ => {
+            ctx.error(format!(
+                "cannot unpack non-tuple type '{}'",
+                value_ty.display_name()
+            ));
+            return None;
+        }
+    };
+
+    // Define variables in scope
+    let mut targets = Vec::new();
+    for (name, ty) in target_names.into_iter().zip(elem_types.into_iter()) {
+        ctx.scope.define(name.clone(), ty.clone());
+        targets.push((name, ty));
+    }
+
+    Some(HirStmt::TupleUnpack {
+        targets,
+        value: value_expr,
     })
 }
 
@@ -1318,5 +1406,54 @@ mod tests {
             "def main():\n    for i in range(3):\n        for j in range(2):\n            print(i)\n"
         ).unwrap();
         assert_eq!(module.functions.len(), 1);
+    }
+
+    #[test]
+    fn test_fstring_basic() {
+        let module = lower_source(
+            "def main():\n    name: str = \"Alice\"\n    msg: str = f\"Hello, {name}!\"\n    print(msg)\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+        // Should have 3 statements: let name, let msg, print
+        assert_eq!(module.functions[0].body.len(), 3);
+    }
+
+    #[test]
+    fn test_fstring_with_expression() {
+        let module = lower_source(
+            "def main():\n    a: int = 2\n    b: int = 3\n    print(f\"{a} + {b} = {a + b}\")\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+    }
+
+    #[test]
+    fn test_tuple_unpack() {
+        let module = lower_source(
+            "def main():\n    pair: tuple[int, str] = (1, \"hello\")\n    x, y = pair\n    print(x)\n"
+        ).unwrap();
+        assert_eq!(module.functions.len(), 1);
+        // Should have: let pair, tuple_unpack, print
+        assert!(module.functions[0].body.len() >= 3);
+        assert!(matches!(module.functions[0].body[1], HirStmt::TupleUnpack { .. }));
+    }
+
+    #[test]
+    fn test_tuple_unpack_wrong_count() {
+        let result = lower_source(
+            "def main():\n    pair: tuple[int, str] = (1, \"hello\")\n    x, y, z = pair\n"
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("expected 3 values, got 2")));
+    }
+
+    #[test]
+    fn test_tuple_unpack_non_tuple() {
+        let result = lower_source(
+            "def main():\n    x: int = 42\n    a, b = x\n"
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.message.contains("cannot unpack non-tuple")));
     }
 }


### PR DESCRIPTION
## Summary
- Implements f-string support with expression interpolation, lowered to Rust's `format!()` macro
- Adds tuple unpacking assignments (`a, b = tuple_expr`) with type checking for element count and non-tuple errors
- Adds string operations E2E test
- Includes comprehensive unit tests for f-string lowering, tuple unpacking, and error cases
- New E2E tests: `fstring_basic`, `fstring_expr`, `tuple_unpack`, `string_ops`

Closes #17

## Test plan
- [x] All existing tests pass (`cargo test` - 0 failures)
- [x] New unit tests for f-string lowering and tuple unpacking
- [x] E2E tests verify compilation and runtime output
- [x] Manual verification with `sifr run` for all new test files


Made with [Cursor](https://cursor.com)