### PR TITLE
24-Extend Type Enum with Union, Literal, Unknown, and Alias Variants

### DIFF
--- a/crates/sifr_type_system/src/infer.rs
+++ b/crates/sifr_type_system/src/infer.rs
@@ -23,7 +23,7 @@ pub enum LiteralKind {
     None,
 }
 
-/// Resolve a type annotation name (e.g., "int", "str") to a Type.
+/// Resolve a type annotation name (e.g., "int", "str", "Unknown") to a Type.
 pub fn resolve_type_annotation(name: &str) -> Option<Type> {
     match name {
         "int" => Some(Type::Int),
@@ -32,6 +32,8 @@ pub fn resolve_type_annotation(name: &str) -> Option<Type> {
         "str" => Some(Type::Str),
         "None" => Some(Type::None),
         "Any" => Some(Type::Any),
+        "Unknown" => Some(Type::Unknown),
+        "Never" => Some(Type::Never),
         _ => None,
     }
 }
@@ -57,6 +59,8 @@ mod tests {
         assert_eq!(resolve_type_annotation("bool"), Some(Type::Bool));
         assert_eq!(resolve_type_annotation("None"), Some(Type::None));
         assert_eq!(resolve_type_annotation("Any"), Some(Type::Any));
+        assert_eq!(resolve_type_annotation("Unknown"), Some(Type::Unknown));
+        assert_eq!(resolve_type_annotation("Never"), Some(Type::Never));
         assert_eq!(resolve_type_annotation("unknown"), None);
     }
 }

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -6,10 +6,14 @@
 mod types;
 mod check;
 pub mod infer;
+pub mod union;
+pub mod literal;
 
 pub use types::{Type, FunctionType, OwnershipKind};
 pub use check::{type_check_binary_op, type_check_unary_op, type_check_comparison, type_check_bool_op};
 pub use infer::infer_literal_type;
+pub use union::{make_union, subtract_from_union, intersect_with_union, remove_none_from_union, union_contains, union_contains_none};
+pub use literal::{LiteralValue, widen as widen_literal};
 
 /// A type error produced during type checking.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sifr_type_system/src/literal.rs
+++ b/crates/sifr_type_system/src/literal.rs
@@ -1,0 +1,165 @@
+//! Literal type handling and widening.
+//!
+//! Literal types represent specific values used as types:
+//! - `LiteralInt(42)` -- the type of exactly the value 42
+//! - `LiteralStr("GET")` -- the type of exactly the string "GET"
+//! - `LiteralBool(true)` -- the type of exactly the value true
+//!
+//! Literal types widen to their base type at mutable assignment
+//! (like TypeScript's fresh literal behavior).
+
+use crate::types::Type;
+
+/// Widen a literal type to its base type.
+///
+/// - `LiteralInt(42)` -> `Int`
+/// - `LiteralStr("GET")` -> `Str`
+/// - `LiteralBool(true)` -> `Bool`
+/// - Non-literal types are returned unchanged.
+pub fn widen(ty: &Type) -> Type {
+    match ty {
+        Type::LiteralInt(_) => Type::Int,
+        Type::LiteralStr(_) => Type::Str,
+        Type::LiteralBool(_) => Type::Bool,
+        Type::Union(members) => {
+            let widened: Vec<Type> = members.iter().map(widen).collect();
+            crate::union::make_union(widened)
+        }
+        other => other.clone(),
+    }
+}
+
+/// Get the base type of a literal type (or the type itself if not a literal).
+pub fn base_type(ty: &Type) -> Type {
+    match ty {
+        Type::LiteralInt(_) => Type::Int,
+        Type::LiteralStr(_) => Type::Str,
+        Type::LiteralBool(_) => Type::Bool,
+        other => other.clone(),
+    }
+}
+
+/// Check if a type is a literal type.
+pub fn is_literal(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::LiteralInt(_) | Type::LiteralStr(_) | Type::LiteralBool(_)
+    )
+}
+
+/// Check if a literal value matches a literal type.
+pub fn literal_matches(ty: &Type, value: &LiteralValue) -> bool {
+    match (ty, value) {
+        (Type::LiteralInt(expected), LiteralValue::Int(actual)) => expected == actual,
+        (Type::LiteralStr(expected), LiteralValue::Str(actual)) => expected == actual,
+        (Type::LiteralBool(expected), LiteralValue::Bool(actual)) => expected == actual,
+        // Base types accept any literal of that kind
+        (Type::Int, LiteralValue::Int(_)) => true,
+        (Type::Str, LiteralValue::Str(_)) => true,
+        (Type::Bool, LiteralValue::Bool(_)) => true,
+        _ => false,
+    }
+}
+
+/// A concrete literal value (used in narrowing conditions).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum LiteralValue {
+    Int(i64),
+    Str(String),
+    Bool(bool),
+}
+
+impl LiteralValue {
+    /// Convert a literal value to its corresponding literal type.
+    pub fn to_type(&self) -> Type {
+        match self {
+            LiteralValue::Int(v) => Type::LiteralInt(*v),
+            LiteralValue::Str(v) => Type::LiteralStr(v.clone()),
+            LiteralValue::Bool(v) => Type::LiteralBool(*v),
+        }
+    }
+}
+
+impl std::fmt::Display for LiteralValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LiteralValue::Int(v) => write!(f, "{v}"),
+            LiteralValue::Str(v) => write!(f, "\"{v}\""),
+            LiteralValue::Bool(v) => write!(f, "{v}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_widen_literal_int() {
+        assert_eq!(widen(&Type::LiteralInt(42)), Type::Int);
+    }
+
+    #[test]
+    fn test_widen_literal_str() {
+        assert_eq!(widen(&Type::LiteralStr("GET".to_string())), Type::Str);
+    }
+
+    #[test]
+    fn test_widen_literal_bool() {
+        assert_eq!(widen(&Type::LiteralBool(true)), Type::Bool);
+    }
+
+    #[test]
+    fn test_widen_non_literal() {
+        assert_eq!(widen(&Type::Int), Type::Int);
+        assert_eq!(widen(&Type::Str), Type::Str);
+    }
+
+    #[test]
+    fn test_base_type() {
+        assert_eq!(base_type(&Type::LiteralInt(42)), Type::Int);
+        assert_eq!(base_type(&Type::Int), Type::Int);
+    }
+
+    #[test]
+    fn test_is_literal() {
+        assert!(is_literal(&Type::LiteralInt(42)));
+        assert!(is_literal(&Type::LiteralStr("GET".to_string())));
+        assert!(is_literal(&Type::LiteralBool(true)));
+        assert!(!is_literal(&Type::Int));
+        assert!(!is_literal(&Type::Str));
+    }
+
+    #[test]
+    fn test_literal_matches() {
+        assert!(literal_matches(
+            &Type::LiteralInt(42),
+            &LiteralValue::Int(42)
+        ));
+        assert!(!literal_matches(
+            &Type::LiteralInt(42),
+            &LiteralValue::Int(99)
+        ));
+        assert!(literal_matches(&Type::Int, &LiteralValue::Int(42)));
+    }
+
+    #[test]
+    fn test_literal_value_to_type() {
+        assert_eq!(LiteralValue::Int(42).to_type(), Type::LiteralInt(42));
+        assert_eq!(
+            LiteralValue::Str("GET".to_string()).to_type(),
+            Type::LiteralStr("GET".to_string())
+        );
+        assert_eq!(LiteralValue::Bool(true).to_type(), Type::LiteralBool(true));
+    }
+
+    #[test]
+    fn test_widen_union_of_literals() {
+        let u = Type::Union(vec![
+            Type::LiteralStr("GET".to_string()),
+            Type::LiteralStr("POST".to_string()),
+        ]);
+        // Widening a union of literals should produce the base type
+        assert_eq!(widen(&u), Type::Str);
+    }
+}

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -27,6 +27,26 @@ pub enum Type {
     Any,
     /// Bottom type (function that never returns)
     Never,
+
+    // --- M3: Advanced Type System ---
+
+    /// Union type: value is one of several types (`int | str`)
+    /// Members are normalized: flattened, deduplicated, sorted.
+    Union(Vec<Type>),
+    /// Intersection type: value satisfies all types (internal, for narrowing)
+    Intersection(Vec<Type>),
+    /// Literal integer type: a specific int value as a type (`42`)
+    LiteralInt(i64),
+    /// Literal string type: a specific string value as a type (`"GET"`)
+    LiteralStr(String),
+    /// Literal boolean type: a specific bool value as a type (`True`)
+    LiteralBool(bool),
+    /// Type alias reference (resolved during checking)
+    Alias(String, Box<Type>),
+    /// Safe top type: accepts any value but must be narrowed before use.
+    /// Unlike `Any` which opts out of type checking, `Unknown` forces
+    /// the programmer to prove the type before operating on it.
+    Unknown,
 }
 
 /// Represents a function's type signature.
@@ -59,8 +79,21 @@ impl Type {
     pub fn ownership(&self) -> OwnershipKind {
         match self {
             Self::Int | Self::Float | Self::Bool | Self::None | Self::Never | Self::Range => OwnershipKind::Copy,
+            Self::LiteralInt(_) | Self::LiteralBool(_) => OwnershipKind::Copy,
             Self::Function(_) => OwnershipKind::Copy,
             Self::Str | Self::Any | Self::List(_) | Self::Dict(_, _) | Self::Tuple(_) => OwnershipKind::Move,
+            Self::LiteralStr(_) => OwnershipKind::Move,
+            Self::Unknown => OwnershipKind::Move,
+            // Union/Intersection: Move if any member is Move
+            Self::Union(members) | Self::Intersection(members) => {
+                if members.iter().any(|m| m.ownership() == OwnershipKind::Move) {
+                    OwnershipKind::Move
+                } else {
+                    OwnershipKind::Copy
+                }
+            }
+            // Alias: delegate to the underlying type
+            Self::Alias(_, inner) => inner.ownership(),
         }
     }
 
@@ -82,10 +115,28 @@ impl Type {
             Self::Range => "range".to_string(),
             Self::Any => "Any".to_string(),
             Self::Never => "Never".to_string(),
+            Self::Union(members) => {
+                let parts: Vec<String> = members.iter().map(Self::display_name).collect();
+                parts.join(" | ")
+            }
+            Self::Intersection(members) => {
+                let parts: Vec<String> = members.iter().map(Self::display_name).collect();
+                parts.join(" & ")
+            }
+            Self::LiteralInt(v) => format!("{v}"),
+            Self::LiteralStr(v) => format!("\"{v}\""),
+            Self::LiteralBool(v) => {
+                if *v { "True".to_string() } else { "False".to_string() }
+            }
+            Self::Alias(name, _) => name.clone(),
+            Self::Unknown => "Unknown".to_string(),
         }
     }
 
     /// Returns the Rust type name for code generation.
+    ///
+    /// For union types, this returns a generated enum name.
+    /// The actual enum definition is emitted by the codegen phase.
     pub fn rust_type(&self) -> String {
         match self {
             Self::Int => "i64".to_string(),
@@ -107,12 +158,111 @@ impl Type {
                 let ret = ft.return_type.rust_type();
                 format!("fn({}) -> {}", params.join(", "), ret)
             }
+            // Literal types map to their base Rust type
+            Self::LiteralInt(_) => "i64".to_string(),
+            Self::LiteralStr(_) => "String".to_string(),
+            Self::LiteralBool(_) => "bool".to_string(),
+            // Union: special case for T | None -> Option<T>
+            Self::Union(members) => {
+                let non_none: Vec<&Type> = members.iter().filter(|m| !matches!(m, Type::None)).collect();
+                let has_none = members.iter().any(|m| matches!(m, Type::None));
+                if has_none && non_none.len() == 1 {
+                    // T | None -> Option<T>
+                    format!("Option<{}>", non_none[0].rust_type())
+                } else {
+                    // General union -> generated enum name
+                    self.union_enum_name()
+                }
+            }
+            Self::Intersection(_) => "Box<dyn std::any::Any>".to_string(),
+            Self::Alias(_, inner) => inner.rust_type(),
+            Self::Unknown => "Box<dyn std::any::Any>".to_string(),
+        }
+    }
+
+    /// Generate a Rust enum name for a union type.
+    ///
+    /// E.g., `int | str` -> `IntOrStr`, `int | str | bool` -> `IntOrStrOrBool`
+    pub fn union_enum_name(&self) -> String {
+        match self {
+            Self::Union(members) => {
+                let parts: Vec<String> = members
+                    .iter()
+                    .map(|m| Self::type_to_enum_variant_prefix(m))
+                    .collect();
+                parts.join("Or")
+            }
+            _ => self.rust_type(),
+        }
+    }
+
+    /// Get the enum variant name for a type when it appears in a union enum.
+    pub fn union_variant_name(&self) -> String {
+        Self::type_to_enum_variant_prefix(self)
+    }
+
+    /// Helper: map a type to a PascalCase name for enum variant/name generation.
+    fn type_to_enum_variant_prefix(ty: &Type) -> String {
+        match ty {
+            Type::Int => "Int".to_string(),
+            Type::Float => "Float".to_string(),
+            Type::Bool => "Bool".to_string(),
+            Type::Str => "Str".to_string(),
+            Type::None => "None".to_string(),
+            Type::LiteralInt(v) => format!("LitInt{v}"),
+            Type::LiteralStr(v) => format!("Lit{}", capitalize(v)),
+            Type::LiteralBool(v) => format!("Lit{}", if *v { "True" } else { "False" }),
+            Type::List(_) => "List".to_string(),
+            Type::Dict(_, _) => "Dict".to_string(),
+            Type::Tuple(_) => "Tuple".to_string(),
+            Type::Range => "Range".to_string(),
+            Type::Function(_) => "Fn".to_string(),
+            Type::Unknown => "Unknown".to_string(),
+            Type::Any => "Any".to_string(),
+            Type::Never => "Never".to_string(),
+            Type::Union(_) => "Union".to_string(),
+            Type::Intersection(_) => "Intersection".to_string(),
+            Type::Alias(name, _) => capitalize(name),
         }
     }
 
     /// Check if this type is a numeric type (int or float).
     pub fn is_numeric(&self) -> bool {
-        matches!(self, Self::Int | Self::Float)
+        matches!(self, Self::Int | Self::Float | Self::LiteralInt(_))
+    }
+
+    /// Check if this type is a union type.
+    pub fn is_union(&self) -> bool {
+        matches!(self, Self::Union(_))
+    }
+
+    /// Check if this type is a literal type.
+    pub fn is_literal(&self) -> bool {
+        matches!(
+            self,
+            Self::LiteralInt(_) | Self::LiteralStr(_) | Self::LiteralBool(_)
+        )
+    }
+
+    /// Check if this type is the Unknown type.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+
+    /// Get the members of a union type, or a single-element vec for non-unions.
+    pub fn union_members(&self) -> Vec<Type> {
+        match self {
+            Self::Union(members) => members.clone(),
+            other => vec![other.clone()],
+        }
+    }
+
+    /// Resolve an alias to its underlying type.
+    pub fn resolve_alias(&self) -> &Type {
+        match self {
+            Self::Alias(_, inner) => inner.resolve_alias(),
+            other => other,
+        }
     }
 
     /// Returns the element type if this type is iterable, or None otherwise.
@@ -173,19 +323,46 @@ impl Type {
 
     /// Check if a value of type `self` can be assigned to a target of type `target`.
     pub fn is_assignable_to(&self, target: &Type) -> bool {
-        if self == target {
+        // Resolve aliases
+        let source = self.resolve_alias();
+        let target_resolved = target.resolve_alias();
+
+        if source == target_resolved {
             return true;
         }
         // Any is compatible with everything
-        if matches!(self, Self::Any) || matches!(target, Self::Any) {
+        if matches!(source, Self::Any) || matches!(target_resolved, Self::Any) {
             return true;
         }
         // Never is assignable to everything
-        if matches!(self, Self::Never) {
+        if matches!(source, Self::Never) {
             return true;
         }
+        // Unknown accepts any value (but operations on it are restricted)
+        if matches!(target_resolved, Self::Unknown) {
+            return true;
+        }
+        // Literal types are assignable to their base types
+        match (source, target_resolved) {
+            (Self::LiteralInt(_), Self::Int) => return true,
+            (Self::LiteralStr(_), Self::Str) => return true,
+            (Self::LiteralBool(_), Self::Bool) => return true,
+            _ => {}
+        }
+        // Source is assignable to a union target if assignable to any member
+        if let Self::Union(target_members) = target_resolved {
+            if target_members.iter().any(|m| source.is_assignable_to(m)) {
+                return true;
+            }
+        }
+        // Union source is assignable to target if ALL members are assignable
+        if let Self::Union(source_members) = source {
+            if source_members.iter().all(|m| m.is_assignable_to(target_resolved)) {
+                return true;
+            }
+        }
         // Structural subtyping for collections
-        match (self, target) {
+        match (source, target_resolved) {
             (Self::List(a), Self::List(b)) => a.is_assignable_to(b),
             (Self::Dict(ak, av), Self::Dict(bk, bv)) => ak.is_assignable_to(bk) && av.is_assignable_to(bv),
             (Self::Tuple(a), Self::Tuple(b)) => {
@@ -193,6 +370,15 @@ impl Type {
             }
             _ => false,
         }
+    }
+}
+
+/// Capitalize the first letter of a string.
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
     }
 }
 
@@ -276,5 +462,120 @@ mod tests {
         let list_int = Type::List(Box::new(Type::Int));
         assert_eq!(list_int.index_result_type(&Type::Int), Some(Type::Int));
         assert_eq!(list_int.index_result_type(&Type::Str), None);
+    }
+
+    // --- M3: Union type tests ---
+
+    #[test]
+    fn test_union_display_name() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert_eq!(u.display_name(), "int | str");
+    }
+
+    #[test]
+    fn test_literal_display_name() {
+        assert_eq!(Type::LiteralInt(42).display_name(), "42");
+        assert_eq!(Type::LiteralStr("GET".to_string()).display_name(), "\"GET\"");
+        assert_eq!(Type::LiteralBool(true).display_name(), "True");
+        assert_eq!(Type::LiteralBool(false).display_name(), "False");
+    }
+
+    #[test]
+    fn test_unknown_display_name() {
+        assert_eq!(Type::Unknown.display_name(), "Unknown");
+    }
+
+    #[test]
+    fn test_literal_assignable_to_base() {
+        assert!(Type::LiteralInt(42).is_assignable_to(&Type::Int));
+        assert!(Type::LiteralStr("GET".to_string()).is_assignable_to(&Type::Str));
+        assert!(Type::LiteralBool(true).is_assignable_to(&Type::Bool));
+    }
+
+    #[test]
+    fn test_literal_not_assignable_to_wrong_base() {
+        assert!(!Type::LiteralInt(42).is_assignable_to(&Type::Str));
+        assert!(!Type::LiteralStr("GET".to_string()).is_assignable_to(&Type::Int));
+    }
+
+    #[test]
+    fn test_assignable_to_union() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert!(Type::Int.is_assignable_to(&u));
+        assert!(Type::Str.is_assignable_to(&u));
+        assert!(!Type::Bool.is_assignable_to(&u));
+    }
+
+    #[test]
+    fn test_union_assignable_to_target() {
+        // Union is assignable to target only if ALL members are assignable
+        let u = Type::Union(vec![Type::Int, Type::Int]);
+        assert!(u.is_assignable_to(&Type::Int));
+
+        let u2 = Type::Union(vec![Type::Int, Type::Str]);
+        assert!(!u2.is_assignable_to(&Type::Int));
+    }
+
+    #[test]
+    fn test_anything_assignable_to_unknown() {
+        assert!(Type::Int.is_assignable_to(&Type::Unknown));
+        assert!(Type::Str.is_assignable_to(&Type::Unknown));
+        assert!(Type::Bool.is_assignable_to(&Type::Unknown));
+    }
+
+    #[test]
+    fn test_union_rust_type_option() {
+        let optional_str = Type::Union(vec![Type::None, Type::Str]);
+        assert_eq!(optional_str.rust_type(), "Option<String>");
+    }
+
+    #[test]
+    fn test_union_rust_type_enum() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert_eq!(u.rust_type(), "IntOrStr");
+    }
+
+    #[test]
+    fn test_union_ownership() {
+        // Union with Move member -> Move
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert_eq!(u.ownership(), OwnershipKind::Move);
+        // Union with only Copy members -> Copy
+        let u2 = Type::Union(vec![Type::Int, Type::Bool]);
+        assert_eq!(u2.ownership(), OwnershipKind::Copy);
+    }
+
+    #[test]
+    fn test_alias_resolves() {
+        let alias = Type::Alias("UserId".to_string(), Box::new(Type::Int));
+        assert_eq!(alias.display_name(), "UserId");
+        assert_eq!(alias.rust_type(), "i64");
+        assert!(alias.is_assignable_to(&Type::Int));
+    }
+
+    #[test]
+    fn test_literal_is_numeric() {
+        assert!(Type::LiteralInt(42).is_numeric());
+        assert!(!Type::LiteralStr("x".to_string()).is_numeric());
+    }
+
+    #[test]
+    fn test_is_union() {
+        assert!(Type::Union(vec![Type::Int, Type::Str]).is_union());
+        assert!(!Type::Int.is_union());
+    }
+
+    #[test]
+    fn test_is_literal() {
+        assert!(Type::LiteralInt(42).is_literal());
+        assert!(Type::LiteralStr("x".to_string()).is_literal());
+        assert!(Type::LiteralBool(true).is_literal());
+        assert!(!Type::Int.is_literal());
+    }
+
+    #[test]
+    fn test_never_assignable_to_union() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert!(Type::Never.is_assignable_to(&u));
     }
 }

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -1,0 +1,285 @@
+//! Union type construction, normalization, and operations.
+//!
+//! Union types represent "one of several types" (e.g., `int | str`).
+//! They are normalized: flattened (no nested unions), deduplicated,
+//! and sorted for consistent comparison.
+
+use crate::types::Type;
+
+/// Construct a union type from a list of member types.
+///
+/// Applies normalization:
+/// 1. Flatten nested unions
+/// 2. Deduplicate
+/// 3. Sort for consistent ordering
+/// 4. If only one type remains, return it directly (no single-element union)
+/// 5. If empty, return Never
+pub fn make_union(types: Vec<Type>) -> Type {
+    let mut members = Vec::new();
+    flatten_into(&mut members, types);
+    deduplicate(&mut members);
+    sort_members(&mut members);
+
+    match members.len() {
+        0 => Type::Never,
+        1 => members.into_iter().next().unwrap(),
+        _ => Type::Union(members),
+    }
+}
+
+/// Check if `ty` is a member of the union (or equal to a non-union type).
+pub fn union_contains(union: &Type, ty: &Type) -> bool {
+    match union {
+        Type::Union(members) => members.iter().any(|m| m == ty || member_contains(m, ty)),
+        other => other == ty,
+    }
+}
+
+/// Remove a type from a union, returning the remaining type.
+///
+/// Used for narrowing: if `x: int | str` and we know `x` is `int`,
+/// the else branch has `x: str`.
+pub fn subtract_from_union(union: &Type, to_remove: &Type) -> Type {
+    match union {
+        Type::Union(members) => {
+            let remaining: Vec<Type> = members
+                .iter()
+                .filter(|m| !types_overlap(m, to_remove))
+                .cloned()
+                .collect();
+            make_union(remaining)
+        }
+        other => {
+            if types_overlap(other, to_remove) {
+                Type::Never
+            } else {
+                other.clone()
+            }
+        }
+    }
+}
+
+/// Filter a union to only include types that overlap with `target`.
+///
+/// Used for narrowing: if `x: int | str | bool` and `isinstance(x, int)`,
+/// the then-branch has `x: int`.
+pub fn intersect_with_union(union: &Type, target: &Type) -> Type {
+    match union {
+        Type::Union(members) => {
+            let matching: Vec<Type> = members
+                .iter()
+                .filter(|m| types_overlap(m, target))
+                .cloned()
+                .collect();
+            make_union(matching)
+        }
+        other => {
+            if types_overlap(other, target) {
+                other.clone()
+            } else {
+                Type::Never
+            }
+        }
+    }
+}
+
+/// Check if a type is assignable to a union (i.e., assignable to at least one member).
+pub fn is_assignable_to_union(ty: &Type, union_members: &[Type]) -> bool {
+    union_members.iter().any(|m| ty.is_assignable_to(m))
+}
+
+/// Check if a union type is assignable to a target (all members must be assignable).
+pub fn union_is_assignable_to(union_members: &[Type], target: &Type) -> bool {
+    union_members.iter().all(|m| m.is_assignable_to(target))
+}
+
+/// Remove `None` from a union, returning the remaining type.
+/// Used for `is not None` narrowing.
+pub fn remove_none_from_union(union: &Type) -> Type {
+    subtract_from_union(union, &Type::None)
+}
+
+/// Check if a union contains None.
+pub fn union_contains_none(ty: &Type) -> bool {
+    union_contains(ty, &Type::None)
+}
+
+// --- Internal helpers ---
+
+/// Flatten nested unions into a flat list.
+fn flatten_into(out: &mut Vec<Type>, types: Vec<Type>) {
+    for ty in types {
+        match ty {
+            Type::Union(inner) => flatten_into(out, inner),
+            other => out.push(other),
+        }
+    }
+}
+
+/// Remove duplicate types.
+fn deduplicate(types: &mut Vec<Type>) {
+    let mut seen = Vec::new();
+    types.retain(|ty| {
+        if seen.contains(ty) {
+            false
+        } else {
+            seen.push(ty.clone());
+            true
+        }
+    });
+}
+
+/// Sort types for consistent ordering.
+/// Order: None, Bool, Int, Float, Str, LiteralBool, LiteralInt, LiteralStr,
+///        List, Dict, Tuple, Range, Function, Unknown, Any, Never, Union, Intersection, Alias
+fn sort_members(types: &mut Vec<Type>) {
+    types.sort_by_key(|ty| type_sort_key(ty));
+}
+
+fn type_sort_key(ty: &Type) -> (u8, String) {
+    match ty {
+        Type::None => (0, String::new()),
+        Type::Bool => (1, String::new()),
+        Type::Int => (2, String::new()),
+        Type::Float => (3, String::new()),
+        Type::Str => (4, String::new()),
+        Type::LiteralBool(v) => (5, format!("{v}")),
+        Type::LiteralInt(v) => (6, format!("{v}")),
+        Type::LiteralStr(v) => (7, v.clone()),
+        Type::List(_) => (8, String::new()),
+        Type::Dict(_, _) => (9, String::new()),
+        Type::Tuple(_) => (10, String::new()),
+        Type::Range => (11, String::new()),
+        Type::Function(_) => (12, String::new()),
+        Type::Unknown => (13, String::new()),
+        Type::Any => (14, String::new()),
+        Type::Never => (15, String::new()),
+        Type::Union(_) => (16, String::new()),
+        Type::Intersection(_) => (17, String::new()),
+        Type::Alias(name, _) => (18, name.clone()),
+    }
+}
+
+/// Check if a member type contains a target type (for literal-to-base matching).
+fn member_contains(member: &Type, target: &Type) -> bool {
+    match (member, target) {
+        (Type::Int, Type::LiteralInt(_)) => true,
+        (Type::Str, Type::LiteralStr(_)) => true,
+        (Type::Bool, Type::LiteralBool(_)) => true,
+        _ => false,
+    }
+}
+
+/// Check if two types overlap (share possible values).
+fn types_overlap(a: &Type, b: &Type) -> bool {
+    if a == b {
+        return true;
+    }
+    match (a, b) {
+        // Literal types overlap with their base types
+        (Type::LiteralInt(_), Type::Int) | (Type::Int, Type::LiteralInt(_)) => true,
+        (Type::LiteralStr(_), Type::Str) | (Type::Str, Type::LiteralStr(_)) => true,
+        (Type::LiteralBool(_), Type::Bool) | (Type::Bool, Type::LiteralBool(_)) => true,
+        // Any overlaps with everything
+        (Type::Any, _) | (_, Type::Any) => true,
+        // Union: overlap if any member overlaps
+        (Type::Union(members), other) | (other, Type::Union(members)) => {
+            members.iter().any(|m| types_overlap(m, other))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_union_basic() {
+        let u = make_union(vec![Type::Int, Type::Str]);
+        assert_eq!(u, Type::Union(vec![Type::Int, Type::Str]));
+    }
+
+    #[test]
+    fn test_make_union_single_element() {
+        let u = make_union(vec![Type::Int]);
+        assert_eq!(u, Type::Int);
+    }
+
+    #[test]
+    fn test_make_union_empty() {
+        let u = make_union(vec![]);
+        assert_eq!(u, Type::Never);
+    }
+
+    #[test]
+    fn test_make_union_dedup() {
+        let u = make_union(vec![Type::Int, Type::Str, Type::Int]);
+        assert_eq!(u, Type::Union(vec![Type::Int, Type::Str]));
+    }
+
+    #[test]
+    fn test_make_union_flatten() {
+        let inner = Type::Union(vec![Type::Str, Type::Bool]);
+        let u = make_union(vec![Type::Int, inner]);
+        assert_eq!(u, Type::Union(vec![Type::Bool, Type::Int, Type::Str]));
+    }
+
+    #[test]
+    fn test_make_union_sorted() {
+        let u = make_union(vec![Type::Str, Type::Int, Type::None]);
+        assert_eq!(u, Type::Union(vec![Type::None, Type::Int, Type::Str]));
+    }
+
+    #[test]
+    fn test_subtract_from_union() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        let result = subtract_from_union(&u, &Type::Int);
+        assert_eq!(result, Type::Str);
+    }
+
+    #[test]
+    fn test_subtract_none_from_optional() {
+        let u = Type::Union(vec![Type::None, Type::Str]);
+        let result = remove_none_from_union(&u);
+        assert_eq!(result, Type::Str);
+    }
+
+    #[test]
+    fn test_intersect_with_union() {
+        let u = Type::Union(vec![Type::Bool, Type::Int, Type::Str]);
+        let result = intersect_with_union(&u, &Type::Int);
+        assert_eq!(result, Type::Int);
+    }
+
+    #[test]
+    fn test_union_contains() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        assert!(union_contains(&u, &Type::Int));
+        assert!(union_contains(&u, &Type::Str));
+        assert!(!union_contains(&u, &Type::Bool));
+    }
+
+    #[test]
+    fn test_union_contains_none() {
+        let u = Type::Union(vec![Type::None, Type::Str]);
+        assert!(union_contains_none(&u));
+        let u2 = Type::Union(vec![Type::Int, Type::Str]);
+        assert!(!union_contains_none(&u2));
+    }
+
+    #[test]
+    fn test_is_assignable_to_union() {
+        let members = vec![Type::Int, Type::Str];
+        assert!(is_assignable_to_union(&Type::Int, &members));
+        assert!(is_assignable_to_union(&Type::Str, &members));
+        assert!(!is_assignable_to_union(&Type::Bool, &members));
+    }
+
+    #[test]
+    fn test_literal_overlap_with_base() {
+        let u = Type::Union(vec![Type::Int, Type::Str]);
+        let result = intersect_with_union(&u, &Type::LiteralInt(42));
+        assert_eq!(result, Type::Int);
+    }
+}


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/24

#### **Changes**

* Extended `Type` enum with 7 new variants: `Union`, `Intersection`, `LiteralInt`, `LiteralStr`, `LiteralBool`, `Alias`, and `Unknown`
* Created `union.rs` module with union construction, normalization (flatten, dedup, sort), subtraction, intersection, and membership checks
* Created `literal.rs` module with literal type handling, widening, and `LiteralValue` enum
* Updated `is_assignable_to()` with union subtyping rules, literal-to-base assignability, and `Unknown` acceptance
* Updated `ownership()`, `display_name()`, `rust_type()` for all new variants
* Special case: `T | None` maps to `Option<T>` in Rust codegen, other unions map to generated enum names
* Added `Unknown` and `Never` to `resolve_type_annotation()`
* 57 unit tests all passing, all existing E2E tests still pass

Made with [Cursor](https://cursor.com)