### PR TITLE
25-Build Narrowing Engine and Control Flow Graph

### DIFF
--- a/crates/sifr_hir/src/cfg.rs
+++ b/crates/sifr_hir/src/cfg.rs
@@ -1,0 +1,198 @@
+//! Control Flow Graph for type narrowing.
+//!
+//! Inspired by TypeScript's binder, this module builds a control flow graph
+//! during HIR lowering. Each statement/expression gets a FlowNode that
+//! tracks how variable types change through branches.
+
+use sifr_type_system::Type;
+
+/// Unique identifier for a flow node.
+pub type FlowNodeId = usize;
+
+/// A node in the control flow graph.
+#[derive(Debug, Clone)]
+pub enum FlowNode {
+    /// Entry point of a function.
+    Start,
+    /// A variable assignment that establishes or changes a type.
+    Assignment {
+        var: String,
+        ty: Type,
+        antecedent: FlowNodeId,
+    },
+    /// A conditional branch point (if/elif/while condition).
+    Condition {
+        /// The antecedent before the condition is evaluated.
+        antecedent: FlowNodeId,
+        /// Flow node for the true branch.
+        true_branch: FlowNodeId,
+        /// Flow node for the false branch.
+        false_branch: FlowNodeId,
+    },
+    /// A join point where multiple branches merge (after if/else, loop exit).
+    Label {
+        antecedents: Vec<FlowNodeId>,
+    },
+    /// Unreachable code (after return, break, continue, or exhaustive narrowing).
+    Unreachable,
+}
+
+/// The control flow graph, built during HIR lowering.
+#[derive(Debug, Clone)]
+pub struct ControlFlowGraph {
+    /// Arena of flow nodes.
+    nodes: Vec<FlowNode>,
+    /// The current flow node (where we're "at" during lowering).
+    current: FlowNodeId,
+}
+
+impl ControlFlowGraph {
+    /// Create a new CFG with a Start node.
+    pub fn new() -> Self {
+        let mut cfg = Self {
+            nodes: Vec::new(),
+            current: 0,
+        };
+        let start = cfg.add_node(FlowNode::Start);
+        cfg.current = start;
+        cfg
+    }
+
+    /// Add a node to the graph and return its ID.
+    pub fn add_node(&mut self, node: FlowNode) -> FlowNodeId {
+        let id = self.nodes.len();
+        self.nodes.push(node);
+        id
+    }
+
+    /// Get the current flow node ID.
+    pub fn current(&self) -> FlowNodeId {
+        self.current
+    }
+
+    /// Set the current flow node.
+    pub fn set_current(&mut self, id: FlowNodeId) {
+        self.current = id;
+    }
+
+    /// Record a variable assignment at the current point.
+    pub fn record_assignment(&mut self, var: String, ty: Type) -> FlowNodeId {
+        let antecedent = self.current;
+        let id = self.add_node(FlowNode::Assignment {
+            var,
+            ty,
+            antecedent,
+        });
+        self.current = id;
+        id
+    }
+
+    /// Create a condition branch point. Returns (true_branch_start, false_branch_start).
+    pub fn branch(&mut self) -> (FlowNodeId, FlowNodeId) {
+        let antecedent = self.current;
+        let true_start = self.add_node(FlowNode::Label {
+            antecedents: vec![antecedent],
+        });
+        let false_start = self.add_node(FlowNode::Label {
+            antecedents: vec![antecedent],
+        });
+        let _cond = self.add_node(FlowNode::Condition {
+            antecedent,
+            true_branch: true_start,
+            false_branch: false_start,
+        });
+        (true_start, false_start)
+    }
+
+    /// Create a join point merging multiple branches.
+    pub fn join(&mut self, branches: Vec<FlowNodeId>) -> FlowNodeId {
+        let id = self.add_node(FlowNode::Label {
+            antecedents: branches,
+        });
+        self.current = id;
+        id
+    }
+
+    /// Mark the current point as unreachable.
+    pub fn mark_unreachable(&mut self) -> FlowNodeId {
+        let id = self.add_node(FlowNode::Unreachable);
+        self.current = id;
+        id
+    }
+
+    /// Get a reference to a flow node by ID.
+    pub fn get_node(&self, id: FlowNodeId) -> Option<&FlowNode> {
+        self.nodes.get(id)
+    }
+
+    /// Get the number of nodes in the graph.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Check if the graph is empty (shouldn't happen, always has Start).
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+}
+
+impl Default for ControlFlowGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cfg_new_has_start() {
+        let cfg = ControlFlowGraph::new();
+        assert_eq!(cfg.len(), 1);
+        assert_eq!(cfg.current(), 0);
+        assert!(matches!(cfg.get_node(0), Some(FlowNode::Start)));
+    }
+
+    #[test]
+    fn test_cfg_assignment() {
+        let mut cfg = ControlFlowGraph::new();
+        let id = cfg.record_assignment("x".to_string(), Type::Int);
+        assert_eq!(id, 1);
+        assert_eq!(cfg.current(), 1);
+        if let Some(FlowNode::Assignment { var, ty, antecedent }) = cfg.get_node(1) {
+            assert_eq!(var, "x");
+            assert_eq!(*ty, Type::Int);
+            assert_eq!(*antecedent, 0); // points to Start
+        } else {
+            panic!("Expected Assignment node");
+        }
+    }
+
+    #[test]
+    fn test_cfg_branch_and_join() {
+        let mut cfg = ControlFlowGraph::new();
+        let (true_start, false_start) = cfg.branch();
+        assert!(true_start > 0);
+        assert!(false_start > 0);
+
+        // Simulate work in true branch
+        cfg.set_current(true_start);
+        let true_end = cfg.record_assignment("x".to_string(), Type::Int);
+
+        // Simulate work in false branch
+        cfg.set_current(false_start);
+        let false_end = cfg.record_assignment("x".to_string(), Type::Str);
+
+        // Join
+        let join = cfg.join(vec![true_end, false_end]);
+        assert_eq!(cfg.current(), join);
+    }
+
+    #[test]
+    fn test_cfg_unreachable() {
+        let mut cfg = ControlFlowGraph::new();
+        let id = cfg.mark_unreachable();
+        assert!(matches!(cfg.get_node(id), Some(FlowNode::Unreachable)));
+    }
+}

--- a/crates/sifr_hir/src/lib.rs
+++ b/crates/sifr_hir/src/lib.rs
@@ -8,7 +8,8 @@
 mod hir_nodes;
 mod lower;
 mod scope;
+pub mod cfg;
 
 pub use hir_nodes::*;
 pub use lower::{lower_module, LoweringError};
-pub use scope::Scope;
+pub use scope::{Scope, NarrowingSnapshot};

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -1,26 +1,47 @@
 //! Scope-based name resolution for Sifr.
+//!
+//! Supports type narrowing: variables can have a `narrowed_type` that
+//! differs from their `declared_type` within control flow branches.
 
 use sifr_type_system::{Type, OwnershipKind};
 use std::collections::HashMap;
 
-/// Tracks variable state for ownership.
+/// Tracks variable state for ownership and narrowing.
 #[derive(Debug, Clone)]
 pub struct VarInfo {
+    /// The declared type (from annotation or inference).
     pub ty: Type,
+    /// The narrowed type (from control flow analysis). None means not narrowed.
+    pub narrowed_type: Option<Type>,
+    /// Whether the variable has been moved.
     pub is_moved: bool,
 }
+
+impl VarInfo {
+    /// Get the effective type (narrowed if available, otherwise declared).
+    pub fn effective_type(&self) -> &Type {
+        self.narrowed_type.as_ref().unwrap_or(&self.ty)
+    }
+}
+
+/// A snapshot of the narrowing state for all variables in scope.
+/// Used to save/restore narrowing at branch points.
+pub type NarrowingSnapshot = Vec<(String, Option<Type>)>;
 
 /// A scope for name resolution.
 #[derive(Debug, Clone)]
 pub struct Scope {
     /// Stack of scope frames (innermost last).
     frames: Vec<HashMap<String, VarInfo>>,
+    /// Type alias registry.
+    type_aliases: HashMap<String, Type>,
 }
 
 impl Scope {
     pub fn new() -> Self {
         Self {
             frames: vec![HashMap::new()],
+            type_aliases: HashMap::new(),
         }
     }
 
@@ -37,7 +58,7 @@ impl Scope {
     /// Define a variable in the current (innermost) scope.
     pub fn define(&mut self, name: String, ty: Type) {
         if let Some(frame) = self.frames.last_mut() {
-            frame.insert(name, VarInfo { ty, is_moved: false });
+            frame.insert(name, VarInfo { ty, narrowed_type: None, is_moved: false });
         }
     }
 
@@ -83,6 +104,70 @@ impl Scope {
                 return;
             }
         }
+    }
+
+    // --- Narrowing support ---
+
+    /// Set the narrowed type for a variable.
+    pub fn narrow_var(&mut self, name: &str, narrowed_type: Type) {
+        for frame in self.frames.iter_mut().rev() {
+            if let Some(info) = frame.get_mut(name) {
+                info.narrowed_type = Some(narrowed_type);
+                return;
+            }
+        }
+    }
+
+    /// Clear the narrowed type for a variable (restore to declared type).
+    pub fn clear_narrowing(&mut self, name: &str) {
+        for frame in self.frames.iter_mut().rev() {
+            if let Some(info) = frame.get_mut(name) {
+                info.narrowed_type = None;
+                return;
+            }
+        }
+    }
+
+    /// Save the current narrowing state for all variables in scope.
+    /// Used before entering a branch.
+    pub fn save_narrowing_state(&self) -> NarrowingSnapshot {
+        let mut snapshot = Vec::new();
+        for frame in &self.frames {
+            for (name, info) in frame {
+                snapshot.push((name.clone(), info.narrowed_type.clone()));
+            }
+        }
+        snapshot
+    }
+
+    /// Restore narrowing state from a snapshot.
+    /// Used after exiting a branch to restore the state before the branch.
+    pub fn restore_narrowing_state(&mut self, snapshot: &NarrowingSnapshot) {
+        for (name, narrowed) in snapshot {
+            for frame in self.frames.iter_mut().rev() {
+                if let Some(info) = frame.get_mut(name) {
+                    info.narrowed_type = narrowed.clone();
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Get the effective type of a variable (narrowed if available, otherwise declared).
+    pub fn effective_type(&self, name: &str) -> Option<&Type> {
+        self.lookup(name).map(|info| info.effective_type())
+    }
+
+    // --- Type alias support ---
+
+    /// Register a type alias.
+    pub fn define_type_alias(&mut self, name: String, ty: Type) {
+        self.type_aliases.insert(name, ty);
+    }
+
+    /// Look up a type alias.
+    pub fn lookup_type_alias(&self, name: &str) -> Option<&Type> {
+        self.type_aliases.get(name)
     }
 }
 
@@ -134,5 +219,51 @@ mod tests {
         let moved = scope.mark_moved("x");
         assert!(!moved); // Int is Copy, not moved
         assert!(!scope.is_moved("x"));
+    }
+
+    // --- M3: Narrowing tests ---
+
+    #[test]
+    fn test_narrowing() {
+        let mut scope = Scope::new();
+        let union_type = Type::Union(vec![Type::Int, Type::Str]);
+        scope.define("x".to_string(), union_type.clone());
+
+        // Before narrowing, effective type is declared type
+        assert_eq!(scope.effective_type("x"), Some(&union_type));
+
+        // Narrow to Int
+        scope.narrow_var("x", Type::Int);
+        assert_eq!(scope.effective_type("x"), Some(&Type::Int));
+
+        // Clear narrowing
+        scope.clear_narrowing("x");
+        assert_eq!(scope.effective_type("x"), Some(&union_type));
+    }
+
+    #[test]
+    fn test_narrowing_save_restore() {
+        let mut scope = Scope::new();
+        let union_type = Type::Union(vec![Type::Int, Type::Str]);
+        scope.define("x".to_string(), union_type.clone());
+
+        // Save state before branch
+        let snapshot = scope.save_narrowing_state();
+
+        // Narrow in branch
+        scope.narrow_var("x", Type::Int);
+        assert_eq!(scope.effective_type("x"), Some(&Type::Int));
+
+        // Restore state
+        scope.restore_narrowing_state(&snapshot);
+        assert_eq!(scope.effective_type("x"), Some(&union_type));
+    }
+
+    #[test]
+    fn test_type_alias() {
+        let mut scope = Scope::new();
+        scope.define_type_alias("UserId".to_string(), Type::Int);
+        assert_eq!(scope.lookup_type_alias("UserId"), Some(&Type::Int));
+        assert_eq!(scope.lookup_type_alias("Unknown"), None);
     }
 }

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -12,8 +12,10 @@ pub mod literal;
 pub use types::{Type, FunctionType, OwnershipKind};
 pub use check::{type_check_binary_op, type_check_unary_op, type_check_comparison, type_check_bool_op};
 pub use infer::infer_literal_type;
+pub mod narrow;
 pub use union::{make_union, subtract_from_union, intersect_with_union, remove_none_from_union, union_contains, union_contains_none};
 pub use literal::{LiteralValue, widen as widen_literal};
+pub use narrow::{NarrowingCondition, narrow_type};
 
 /// A type error produced during type checking.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sifr_type_system/src/narrow.rs
+++ b/crates/sifr_type_system/src/narrow.rs
@@ -1,0 +1,317 @@
+//! Type narrowing engine for control-flow-based type refinement.
+//!
+//! Inspired by TypeScript's checker narrowing and ty's intersection-based narrowing.
+//! Given a type and a condition, produces the narrowed type for the then-branch
+//! (condition is true) or else-branch (condition is false).
+
+use crate::literal::LiteralValue;
+use crate::types::Type;
+use crate::union::{intersect_with_union, make_union, remove_none_from_union, subtract_from_union};
+
+/// A condition that can narrow a variable's type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NarrowingCondition {
+    /// Truthiness check: `if x:` -- narrows out None and falsy types
+    Truthiness(String),
+    /// None identity check: `if x is None:`
+    IsNone(String),
+    /// Not-None identity check: `if x is not None:`
+    IsNotNone(String),
+    /// isinstance check: `if isinstance(x, int):`
+    IsInstance(String, Type),
+    /// Equality check: `if x == "GET":`
+    Equality(String, LiteralValue),
+    /// Type predicate: user-defined guard function returned true
+    TypePredicate(String, Type),
+    /// Negation: the opposite of a condition
+    Not(Box<NarrowingCondition>),
+    /// Conjunction: all conditions are true
+    And(Vec<NarrowingCondition>),
+    /// Disjunction: at least one condition is true
+    Or(Vec<NarrowingCondition>),
+}
+
+impl NarrowingCondition {
+    /// Get the variable name being narrowed, if this is a simple condition.
+    pub fn var_name(&self) -> Option<&str> {
+        match self {
+            NarrowingCondition::Truthiness(name)
+            | NarrowingCondition::IsNone(name)
+            | NarrowingCondition::IsNotNone(name)
+            | NarrowingCondition::IsInstance(name, _)
+            | NarrowingCondition::Equality(name, _)
+            | NarrowingCondition::TypePredicate(name, _) => Some(name),
+            NarrowingCondition::Not(inner) => inner.var_name(),
+            NarrowingCondition::And(_) | NarrowingCondition::Or(_) => None,
+        }
+    }
+}
+
+/// Narrow a type based on a condition being true or false.
+///
+/// - `ty`: the current type of the variable
+/// - `condition`: the narrowing condition
+/// - `is_true`: whether we're in the then-branch (true) or else-branch (false)
+///
+/// Returns the narrowed type.
+pub fn narrow_type(ty: &Type, condition: &NarrowingCondition, is_true: bool) -> Type {
+    match condition {
+        NarrowingCondition::Truthiness(_) => {
+            if is_true {
+                // Truthy: remove None from the type
+                narrow_truthiness(ty)
+            } else {
+                // Falsy: could be None, 0, "", False, empty collections
+                // For now, just narrow to None if it's in the union
+                narrow_falsiness(ty)
+            }
+        }
+        NarrowingCondition::IsNone(_) => {
+            if is_true {
+                // x is None -> x: None
+                Type::None
+            } else {
+                // x is not None -> remove None
+                remove_none_from_union(ty)
+            }
+        }
+        NarrowingCondition::IsNotNone(_) => {
+            if is_true {
+                // x is not None -> remove None
+                remove_none_from_union(ty)
+            } else {
+                // x is None
+                Type::None
+            }
+        }
+        NarrowingCondition::IsInstance(_, target_type) => {
+            if is_true {
+                // isinstance(x, int) is true -> narrow to int
+                intersect_with_union(ty, target_type)
+            } else {
+                // isinstance(x, int) is false -> remove int
+                subtract_from_union(ty, target_type)
+            }
+        }
+        NarrowingCondition::Equality(_, value) => {
+            if is_true {
+                // x == "GET" -> narrow to LiteralStr("GET")
+                value.to_type()
+            } else {
+                // x != "GET" -> remove that literal (if applicable)
+                subtract_from_union(ty, &value.to_type())
+            }
+        }
+        NarrowingCondition::TypePredicate(_, target_type) => {
+            if is_true {
+                target_type.clone()
+            } else {
+                subtract_from_union(ty, target_type)
+            }
+        }
+        NarrowingCondition::Not(inner) => {
+            // Negate: swap is_true
+            narrow_type(ty, inner, !is_true)
+        }
+        NarrowingCondition::And(conditions) => {
+            if is_true {
+                // All conditions are true: apply each narrowing in sequence
+                let mut result = ty.clone();
+                for cond in conditions {
+                    result = narrow_type(&result, cond, true);
+                }
+                result
+            } else {
+                // At least one is false: union of each individual false-narrowing
+                // This is an approximation; for now, return the original type
+                ty.clone()
+            }
+        }
+        NarrowingCondition::Or(conditions) => {
+            if is_true {
+                // At least one is true: union of each individual true-narrowing
+                let narrowed: Vec<Type> = conditions
+                    .iter()
+                    .map(|c| narrow_type(ty, c, true))
+                    .collect();
+                make_union(narrowed)
+            } else {
+                // All are false: apply each false-narrowing in sequence
+                let mut result = ty.clone();
+                for cond in conditions {
+                    result = narrow_type(&result, cond, false);
+                }
+                result
+            }
+        }
+    }
+}
+
+/// Narrow a type for truthiness (remove None and falsy singletons).
+fn narrow_truthiness(ty: &Type) -> Type {
+    match ty {
+        Type::Union(members) => {
+            let truthy: Vec<Type> = members
+                .iter()
+                .filter(|m| !is_always_falsy(m))
+                .cloned()
+                .collect();
+            make_union(truthy)
+        }
+        other => {
+            if is_always_falsy(other) {
+                Type::Never
+            } else {
+                other.clone()
+            }
+        }
+    }
+}
+
+/// Narrow a type for falsiness (keep only None and falsy types).
+fn narrow_falsiness(ty: &Type) -> Type {
+    match ty {
+        Type::Union(members) => {
+            let falsy: Vec<Type> = members
+                .iter()
+                .filter(|m| can_be_falsy(m))
+                .cloned()
+                .collect();
+            make_union(falsy)
+        }
+        other => {
+            if can_be_falsy(other) {
+                other.clone()
+            } else {
+                Type::Never
+            }
+        }
+    }
+}
+
+/// Check if a type is always falsy.
+fn is_always_falsy(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::None | Type::LiteralBool(false) | Type::LiteralInt(0)
+    ) || matches!(ty, Type::LiteralStr(s) if s.is_empty())
+}
+
+/// Check if a type can be falsy (has falsy values in its domain).
+fn can_be_falsy(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::None
+            | Type::Bool
+            | Type::Int
+            | Type::Float
+            | Type::Str
+            | Type::LiteralBool(false)
+            | Type::LiteralInt(0)
+    ) || matches!(ty, Type::LiteralStr(s) if s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_isinstance_narrowing_true() {
+        let ty = make_union(vec![Type::Int, Type::Str]);
+        let cond = NarrowingCondition::IsInstance("x".to_string(), Type::Int);
+        let result = narrow_type(&ty, &cond, true);
+        assert_eq!(result, Type::Int);
+    }
+
+    #[test]
+    fn test_isinstance_narrowing_false() {
+        let ty = make_union(vec![Type::Int, Type::Str]);
+        let cond = NarrowingCondition::IsInstance("x".to_string(), Type::Int);
+        let result = narrow_type(&ty, &cond, false);
+        assert_eq!(result, Type::Str);
+    }
+
+    #[test]
+    fn test_is_none_narrowing() {
+        let ty = make_union(vec![Type::Str, Type::None]);
+        let cond = NarrowingCondition::IsNone("x".to_string());
+        assert_eq!(narrow_type(&ty, &cond, true), Type::None);
+        assert_eq!(narrow_type(&ty, &cond, false), Type::Str);
+    }
+
+    #[test]
+    fn test_is_not_none_narrowing() {
+        let ty = make_union(vec![Type::Str, Type::None]);
+        let cond = NarrowingCondition::IsNotNone("x".to_string());
+        assert_eq!(narrow_type(&ty, &cond, true), Type::Str);
+        assert_eq!(narrow_type(&ty, &cond, false), Type::None);
+    }
+
+    #[test]
+    fn test_truthiness_narrowing() {
+        let ty = make_union(vec![Type::Str, Type::None]);
+        let cond = NarrowingCondition::Truthiness("x".to_string());
+        let result = narrow_type(&ty, &cond, true);
+        assert_eq!(result, Type::Str); // None removed
+    }
+
+    #[test]
+    fn test_equality_narrowing() {
+        let ty = Type::Str;
+        let cond = NarrowingCondition::Equality("x".to_string(), LiteralValue::Str("GET".to_string()));
+        let result = narrow_type(&ty, &cond, true);
+        assert_eq!(result, Type::LiteralStr("GET".to_string()));
+    }
+
+    #[test]
+    fn test_equality_narrowing_false() {
+        let ty = make_union(vec![
+            Type::LiteralStr("GET".to_string()),
+            Type::LiteralStr("POST".to_string()),
+        ]);
+        let cond = NarrowingCondition::Equality("x".to_string(), LiteralValue::Str("GET".to_string()));
+        let result = narrow_type(&ty, &cond, false);
+        assert_eq!(result, Type::LiteralStr("POST".to_string()));
+    }
+
+    #[test]
+    fn test_type_predicate_narrowing() {
+        let ty = make_union(vec![Type::Int, Type::Str]);
+        let cond = NarrowingCondition::TypePredicate("x".to_string(), Type::Str);
+        assert_eq!(narrow_type(&ty, &cond, true), Type::Str);
+        assert_eq!(narrow_type(&ty, &cond, false), Type::Int);
+    }
+
+    #[test]
+    fn test_not_negation() {
+        let ty = make_union(vec![Type::Int, Type::Str]);
+        let inner = NarrowingCondition::IsInstance("x".to_string(), Type::Int);
+        let cond = NarrowingCondition::Not(Box::new(inner));
+        // Not(isinstance(x, int)) true -> isinstance false -> Str
+        assert_eq!(narrow_type(&ty, &cond, true), Type::Str);
+        // Not(isinstance(x, int)) false -> isinstance true -> Int
+        assert_eq!(narrow_type(&ty, &cond, false), Type::Int);
+    }
+
+    #[test]
+    fn test_isinstance_three_types() {
+        let ty = make_union(vec![Type::Bool, Type::Int, Type::Str]);
+        let cond = NarrowingCondition::IsInstance("x".to_string(), Type::Int);
+        assert_eq!(narrow_type(&ty, &cond, true), Type::Int);
+        // False branch: Bool and Str remain
+        let false_result = narrow_type(&ty, &cond, false);
+        assert_eq!(false_result, make_union(vec![Type::Bool, Type::Str]));
+    }
+
+    #[test]
+    fn test_narrow_unknown_with_isinstance() {
+        let ty = Type::Unknown;
+        let cond = NarrowingCondition::IsInstance("x".to_string(), Type::Int);
+        // Unknown narrowed with isinstance(x, int) -> Int
+        let result = narrow_type(&ty, &cond, true);
+        assert_eq!(result, Type::Int);
+        // False branch: Unknown minus Int is still Unknown
+        let false_result = narrow_type(&ty, &cond, false);
+        assert_eq!(false_result, Type::Unknown);
+    }
+}

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -41,6 +41,8 @@ pub fn union_contains(union: &Type, ty: &Type) -> bool {
 /// the else branch has `x: str`.
 pub fn subtract_from_union(union: &Type, to_remove: &Type) -> Type {
     match union {
+        // Unknown minus a specific type is still Unknown (we can't enumerate what's left)
+        Type::Unknown => Type::Unknown,
         Type::Union(members) => {
             let remaining: Vec<Type> = members
                 .iter()
@@ -65,6 +67,8 @@ pub fn subtract_from_union(union: &Type, to_remove: &Type) -> Type {
 /// the then-branch has `x: int`.
 pub fn intersect_with_union(union: &Type, target: &Type) -> Type {
     match union {
+        // Unknown can be narrowed to anything via isinstance
+        Type::Unknown => target.clone(),
         Type::Union(members) => {
             let matching: Vec<Type> = members
                 .iter()


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/25

#### **Changes**

* Created `narrow.rs` in sifr_type_system: `NarrowingCondition` enum and `narrow_type()` function supporting truthiness, isinstance, equality, is None/is not None, type predicates, negation, conjunction, and disjunction
* Created `cfg.rs` in sifr_hir: `ControlFlowGraph` with `FlowNode` types (Start, Assignment, Condition, Label, Unreachable) for tracking control flow during HIR lowering
* Updated `scope.rs`: Added `narrowed_type` to `VarInfo`, `save_narrowing_state()`/`restore_narrowing_state()` for branch handling, type alias registry, `effective_type()` method
* Fixed `Unknown` type handling in `intersect_with_union` and `subtract_from_union`
* 96 tests passing (68 type system + 28 HIR), all existing E2E tests still pass

Made with [Cursor](https://cursor.com)