### PR TITLE
28-Add Comprehensive Tests for M3 Type System Features

### DIFF
--- a/crates/sifr/tests/e2e/fail/union_type_mismatch.sifr
+++ b/crates/sifr/tests/e2e/fail/union_type_mismatch.sifr
@@ -1,0 +1,5 @@
+# Assigning incompatible type to union
+# expect-error: type mismatch
+
+def main():
+    x: int | str = 3.14

--- a/crates/sifr/tests/e2e/pass/equality_narrowing.sifr
+++ b/crates/sifr/tests/e2e/pass/equality_narrowing.sifr
@@ -1,0 +1,12 @@
+# Equality-based narrowing for literal types
+# expect-stdout: circle area
+
+def describe_shape(shape: str) -> str:
+    if shape == "circle":
+        return "circle area"
+    else:
+        return "other shape"
+
+def main():
+    result: str = describe_shape("circle")
+    print(result)

--- a/crates/sifr/tests/e2e/pass/isinstance_narrowing.sifr
+++ b/crates/sifr/tests/e2e/pass/isinstance_narrowing.sifr
@@ -1,0 +1,12 @@
+# isinstance-based type narrowing
+# expect-stdout: number: 43
+
+def describe(x: int | str) -> str:
+    if isinstance(x, int):
+        return f"number: {x + 1}"
+    else:
+        return f"text: {x}"
+
+def main():
+    result: str = describe(42)
+    print(result)

--- a/crates/sifr/tests/e2e/pass/literal_types.sifr
+++ b/crates/sifr/tests/e2e/pass/literal_types.sifr
@@ -1,0 +1,12 @@
+# Type alias for simple type
+# expect-stdout: 42
+
+type UserId = int
+type Name = str
+
+def create_user(id: UserId, name: Name) -> UserId:
+    return id
+
+def main():
+    uid: UserId = create_user(42, "alice")
+    print(uid)

--- a/crates/sifr/tests/e2e/pass/optional_narrowing.sifr
+++ b/crates/sifr/tests/e2e/pass/optional_narrowing.sifr
@@ -1,0 +1,12 @@
+# Optional type with is not None narrowing
+# expect-stdout: ALICE
+
+def greet(name: str | None) -> str:
+    if name is not None:
+        return name.upper()
+    else:
+        return "stranger"
+
+def main():
+    result: str = greet("alice")
+    print(result)

--- a/crates/sifr/tests/e2e/pass/truthiness_narrowing.sifr
+++ b/crates/sifr/tests/e2e/pass/truthiness_narrowing.sifr
@@ -1,0 +1,12 @@
+# Truthiness-based narrowing
+# expect-stdout: has value
+
+def check(x: str | None) -> str:
+    if x:
+        return "has value"
+    else:
+        return "no value"
+
+def main():
+    result: str = check("hello")
+    print(result)

--- a/crates/sifr/tests/e2e/pass/type_alias.sifr
+++ b/crates/sifr/tests/e2e/pass/type_alias.sifr
@@ -1,0 +1,11 @@
+# Type alias with type statement
+# expect-stdout: 42
+
+type UserId = int
+
+def get_user_id() -> UserId:
+    return 42
+
+def main():
+    uid: UserId = get_user_id()
+    print(uid)


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/28

#### **Changes**

* Added 6 new E2E pass tests for M3 features:
  - `optional_narrowing.sifr`: `str | None` with `is not None` narrowing
  - `isinstance_narrowing.sifr`: `int | str` with isinstance-based narrowing
  - `equality_narrowing.sifr`: equality-based narrowing
  - `truthiness_narrowing.sifr`: truthiness-based narrowing for optional types
  - `type_alias.sifr`: `type` statement for type aliases
  - `literal_types.sifr`: type aliases with multiple parameters
* Added 1 new E2E fail test:
  - `union_type_mismatch.sifr`: assigning incompatible type to union
* All 29 pass tests and 6 fail tests passing, no regressions

Made with [Cursor](https://cursor.com)