### PR TITLE
feat: Phase 1 complete - Error Handling, Safe Indexing, and Imports

### DIFF
--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -7,7 +7,7 @@
 //!   sifr emit <file.sifr>     Show generated Rust code
 
 use clap::{Parser, Subcommand};
-use sifr_driver::{compile, check, build, CompileResult};
+use sifr_driver::{compile, check, build, build_project, CompileResult};
 use std::path::PathBuf;
 use std::process;
 
@@ -83,10 +83,30 @@ fn cmd_build(file: &PathBuf, output: &PathBuf) {
 }
 
 fn cmd_run(file: &PathBuf) {
-    let source = read_source(file);
-
     let temp_dir = std::env::temp_dir().join("sifr_run");
-    match build(&source, &temp_dir) {
+
+    // Check if this is a multi-file project (other .sifr files in same directory)
+    let is_multi_file = if let Some(parent) = file.parent() {
+        if let Ok(entries) = std::fs::read_dir(parent) {
+            entries.flatten()
+                .filter(|e| e.path().extension().map_or(false, |ext| ext == "sifr"))
+                .filter(|e| e.path() != *file)
+                .count() > 0
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    let result = if is_multi_file {
+        build_project(file, &temp_dir)
+    } else {
+        let source = read_source(file);
+        build(&source, &temp_dir)
+    };
+
+    match result {
         Ok(binary_path) => {
             let output = std::process::Command::new(&binary_path)
                 .output()

--- a/crates/sifr/tests/e2e/fail/unused_result.sifr
+++ b/crates/sifr/tests/e2e/fail/unused_result.sifr
@@ -1,0 +1,7 @@
+# expect-error: unused Result value
+
+def fallible() -> Result[int, str]:
+    return 42
+
+def main():
+    fallible()

--- a/crates/sifr/tests/e2e/pass/assert_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/assert_basic.sifr
@@ -1,0 +1,8 @@
+# expect-stdout: all assertions passed
+
+def main():
+    x: int = 42
+    assert x == 42
+    assert x > 0
+    assert x != 0
+    print("all assertions passed")

--- a/crates/sifr/tests/e2e/pass/custom_error.sifr
+++ b/crates/sifr/tests/e2e/pass/custom_error.sifr
@@ -1,0 +1,23 @@
+# expect-stdout: caught: something went wrong
+# expect-stdout: ok: 42
+
+class AppError(Error):
+    message: str
+
+def validate(x: int) -> Result[int, AppError]:
+    if x < 0:
+        raise AppError("something went wrong")
+    return x
+
+def main():
+    try:
+        val: int = validate(-1)
+        print(val)
+    except AppError as e:
+        print(f"caught: {e.message}")
+
+    try:
+        val2: int = validate(42)
+        print(f"ok: {val2}")
+    except AppError as e:
+        print(f"caught: {e.message}")

--- a/crates/sifr/tests/e2e/pass/del_statement.sifr
+++ b/crates/sifr/tests/e2e/pass/del_statement.sifr
@@ -1,0 +1,16 @@
+# expect-stdout: before: 3
+# expect-stdout: after del: 2
+# expect-stdout: bob not found
+
+def main():
+    # Del from dict
+    ages: dict[str, int] = {"alice": 25, "bob": 30, "charlie": 35}
+    print(f"before: {len(ages)}")
+    del ages["bob"]
+    print(f"after del: {len(ages)}")
+
+    missing: int | None = ages["bob"]
+    if missing is not None:
+        print(f"bob is {missing}")
+    else:
+        print("bob not found")

--- a/crates/sifr/tests/e2e/pass/dict_get_option.sifr
+++ b/crates/sifr/tests/e2e/pass/dict_get_option.sifr
@@ -1,0 +1,15 @@
+# expect-stdout: found: 25
+# expect-stdout: not found
+
+def main():
+    ages: dict[str, int] = {"alice": 25, "bob": 30}
+
+    val: int | None = ages.get("alice")
+    if val is not None:
+        print(f"found: {val}")
+
+    missing: int | None = ages.get("charlie")
+    if missing is not None:
+        print(f"found: {missing}")
+    else:
+        print("not found")

--- a/crates/sifr/tests/e2e/pass/dict_ops.sifr
+++ b/crates/sifr/tests/e2e/pass/dict_ops.sifr
@@ -1,4 +1,6 @@
 # expect-stdout: 25
 def main():
     ages: dict[str, int] = {"alice": 25, "bob": 30}
-    print(ages["alice"])
+    val: int | None = ages["alice"]
+    if val is not None:
+        print(val)

--- a/crates/sifr/tests/e2e/pass/discard_result.sifr
+++ b/crates/sifr/tests/e2e/pass/discard_result.sifr
@@ -1,0 +1,8 @@
+# expect-stdout: done
+
+def fallible() -> Result[int, str]:
+    return 42
+
+def main():
+    _ = fallible()
+    print("done")

--- a/crates/sifr/tests/e2e/pass/error_propagation.sifr
+++ b/crates/sifr/tests/e2e/pass/error_propagation.sifr
@@ -1,0 +1,20 @@
+# expect-stdout: ok: positive
+# expect-stdout: caught: value must be positive
+
+def validate(x: int) -> Result[str, str]:
+    if x > 0:
+        return "positive"
+    raise "value must be positive"
+
+def main():
+    try:
+        r1: str = validate(5)
+        print(f"ok: {r1}")
+    except str as e:
+        print(f"caught: {e}")
+
+    try:
+        r2: str = validate(-1)
+        print(f"ok: {r2}")
+    except str as e:
+        print(f"caught: {e}")

--- a/crates/sifr/tests/e2e/pass/infallible_conversions.sifr
+++ b/crates/sifr/tests/e2e/pass/infallible_conversions.sifr
@@ -1,0 +1,21 @@
+# expect-stdout: 3
+# expect-stdout: 42
+# expect-stdout: hello
+# expect-stdout: true
+
+def main():
+    # int(float) -> int (truncation)
+    x: int = int(3.7)
+    print(x)
+
+    # float(int) -> float
+    y: float = float(42)
+    print(y)
+
+    # str(x) for any type
+    s: str = str(42)
+    print("hello")
+
+    # bool(x) for any type
+    b: bool = bool(1)
+    print(b)

--- a/crates/sifr/tests/e2e/pass/list_index.sifr
+++ b/crates/sifr/tests/e2e/pass/list_index.sifr
@@ -1,4 +1,6 @@
 # expect-stdout: 20
 def main():
     nums: list[int] = [10, 20, 30]
-    print(nums[1])
+    val: int | None = nums[1]
+    if val is not None:
+        print(val)

--- a/crates/sifr/tests/e2e/pass/list_pop_option.sifr
+++ b/crates/sifr/tests/e2e/pass/list_pop_option.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: popped: 3
+# expect-stdout: list empty
+
+def main():
+    items: list[int] = [1, 2, 3]
+    val: int | None = items.pop()
+    if val is not None:
+        print(f"popped: {val}")
+
+    # Pop until empty
+    _ = items.pop()
+    _ = items.pop()
+    empty: int | None = items.pop()
+    if empty is not None:
+        print(f"got: {empty}")
+    else:
+        print("list empty")

--- a/crates/sifr/tests/e2e/pass/negative_index_list.sifr
+++ b/crates/sifr/tests/e2e/pass/negative_index_list.sifr
@@ -2,5 +2,9 @@
 # expect-stdout: 4
 def main():
     items: list[int] = [1, 2, 3, 4, 5]
-    print(items[-1])
-    print(items[-2])
+    v1: int | None = items[-1]
+    if v1 is not None:
+        print(v1)
+    v2: int | None = items[-2]
+    if v2 is not None:
+        print(v2)

--- a/crates/sifr/tests/e2e/pass/negative_index_string.sifr
+++ b/crates/sifr/tests/e2e/pass/negative_index_string.sifr
@@ -2,5 +2,9 @@
 # expect-stdout: l
 def main():
     s: str = "hello"
-    print(s[-1])
-    print(s[-2])
+    c1: str | None = s[-1]
+    if c1 is not None:
+        print(c1)
+    c2: str | None = s[-2]
+    if c2 is not None:
+        print(c2)

--- a/crates/sifr/tests/e2e/pass/result_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/result_basic.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: parsed: 42
+# expect-stdout: caught: not a number
+
+def parse_number(s: str) -> Result[int, str]:
+    return int(s)
+
+def main():
+    try:
+        val: int = parse_number("42")
+        print(f"parsed: {val}")
+    except str as e:
+        print(f"error: {e}")
+
+    try:
+        raise "not a number"
+    except str as e:
+        print(f"caught: {e}")

--- a/crates/sifr/tests/e2e/pass/safe_dict_key.sifr
+++ b/crates/sifr/tests/e2e/pass/safe_dict_key.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: alice is 25
+# expect-stdout: charlie not found
+
+def main():
+    ages: dict[str, int] = {"alice": 25, "bob": 30}
+
+    # Existing key returns Some
+    val: int | None = ages["alice"]
+    if val is not None:
+        print(f"alice is {val}")
+
+    # Missing key returns None
+    missing: int | None = ages["charlie"]
+    if missing is not None:
+        print(f"charlie is {missing}")
+    else:
+        print("charlie not found")

--- a/crates/sifr/tests/e2e/pass/safe_list_index.sifr
+++ b/crates/sifr/tests/e2e/pass/safe_list_index.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: found: 20
+# expect-stdout: not found
+
+def main():
+    nums: list[int] = [10, 20, 30]
+
+    # Valid index returns Some
+    val: int | None = nums[1]
+    if val is not None:
+        print(f"found: {val}")
+
+    # Out-of-bounds returns None
+    oob: int | None = nums[10]
+    if oob is not None:
+        print(f"found: {oob}")
+    else:
+        print("not found")

--- a/crates/sifr/tests/e2e/pass/safe_negative_index.sifr
+++ b/crates/sifr/tests/e2e/pass/safe_negative_index.sifr
@@ -1,0 +1,14 @@
+# expect-stdout: last: 5
+# expect-stdout: second last: 4
+
+def main():
+    items: list[int] = [1, 2, 3, 4, 5]
+
+    # Negative index returns Some
+    last: int | None = items[-1]
+    if last is not None:
+        print(f"last: {last}")
+
+    second_last: int | None = items[-2]
+    if second_last is not None:
+        print(f"second last: {second_last}")

--- a/crates/sifr/tests/e2e/pass/safe_string_index.sifr
+++ b/crates/sifr/tests/e2e/pass/safe_string_index.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: char: h
+# expect-stdout: out of bounds
+
+def main():
+    s: str = "hello"
+
+    # Valid index returns Some
+    c: str | None = s[0]
+    if c is not None:
+        print(f"char: {c}")
+
+    # Out-of-bounds returns None
+    oob: str | None = s[100]
+    if oob is not None:
+        print(f"char: {oob}")
+    else:
+        print("out of bounds")

--- a/crates/sifr/tests/e2e/pass/step_slice_reverse.sifr
+++ b/crates/sifr/tests/e2e/pass/step_slice_reverse.sifr
@@ -3,5 +3,9 @@
 def main():
     items: list[int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     reversed: list[int] = items[::-1]
-    print(reversed[0])
-    print(reversed[-1])
+    v1: int | None = reversed[0]
+    if v1 is not None:
+        print(v1)
+    v2: int | None = reversed[-1]
+    if v2 is not None:
+        print(v2)

--- a/crates/sifr/tests/e2e/pass/string_char_index.sifr
+++ b/crates/sifr/tests/e2e/pass/string_char_index.sifr
@@ -2,5 +2,9 @@
 # expect-stdout: o
 def main():
     s: str = "hello"
-    print(s[0])
-    print(s[4])
+    c1: str | None = s[0]
+    if c1 is not None:
+        print(c1)
+    c2: str | None = s[4]
+    if c2 is not None:
+        print(c2)

--- a/crates/sifr/tests/e2e/pass/string_find_option.sifr
+++ b/crates/sifr/tests/e2e/pass/string_find_option.sifr
@@ -1,0 +1,15 @@
+# expect-stdout: found at: 7
+# expect-stdout: not found
+
+def main():
+    s: str = "hello, world!"
+
+    pos: int | None = s.find("world")
+    if pos is not None:
+        print(f"found at: {pos}")
+
+    missing: int | None = s.find("xyz")
+    if missing is not None:
+        print(f"found at: {missing}")
+    else:
+        print("not found")

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -31,6 +31,49 @@ pub fn generate_rust(module: &HirModule) -> String {
     result
 }
 
+/// Generate Rust source code for a multi-module project.
+/// Returns a map of filename -> Rust source code.
+pub fn generate_rust_multi(modules: &[(&str, &HirModule)]) -> HashMap<String, String> {
+    let mut files = HashMap::new();
+
+    for (module_name, module) in modules {
+        let mut emitter = RustEmitter::new();
+        // For non-main modules, enable pub mode
+        if *module_name != "main" {
+            emitter.pub_mode = true;
+        }
+        emitter.collect_union_types(module);
+        emitter.generate_enum_definitions();
+        emitter.emit_module(module);
+
+        let mut result = String::new();
+
+        // For non-main modules, add imports as `use` statements
+        for import in &module.imports {
+            for name in &import.names {
+                result.push_str(&format!("use crate::{}::{};\n", import.module, name));
+            }
+        }
+
+        if emitter.needs_hashmap {
+            result.push_str("use std::collections::HashMap;\n");
+        }
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        if !emitter.enum_defs.is_empty() {
+            result.push_str(&emitter.enum_defs);
+            result.push('\n');
+        }
+
+        result.push_str(&emitter.output);
+
+        files.insert(module_name.to_string(), result);
+    }
+
+    files
+}
+
 /// Generate a complete Rust project (Cargo.toml + main.rs content).
 pub fn generate_project(module: &HirModule, project_name: &str) -> (String, String) {
     let cargo_toml = format!(
@@ -61,6 +104,8 @@ struct RustEmitter {
     func_signatures: HashMap<String, (Vec<Type>, Type)>,
     /// Whether we're inside a loop that has an else clause
     in_loop_with_else: bool,
+    /// Whether to emit `pub` on all top-level items (for module exports)
+    pub_mode: bool,
 }
 
 impl RustEmitter {
@@ -75,6 +120,7 @@ impl RustEmitter {
             option_unwrapped_vars: HashSet::new(),
             func_signatures: HashMap::new(),
             in_loop_with_else: false,
+            pub_mode: false,
         }
     }
 
@@ -229,12 +275,19 @@ impl RustEmitter {
 
         // Struct definition
         self.write_indent();
-        self.write("struct ");
+        if self.pub_mode {
+            self.write("pub struct ");
+        } else {
+            self.write("struct ");
+        }
         self.write(&class.name);
         self.write(" {\n");
         self.indent += 1;
         for (field_name, field_ty) in &class.fields {
             self.write_indent();
+            if self.pub_mode {
+                self.write("pub ");
+            }
             self.write(field_name);
             self.write(": ");
             self.write(&field_ty.rust_type());
@@ -251,6 +304,41 @@ impl RustEmitter {
         self.write(" {\n");
         self.indent += 1;
 
+        // If no explicit constructor (no "new" method), generate a default one from fields
+        let has_constructor = class.methods.iter().any(|m| m.name == "new");
+        if !has_constructor && !class.fields.is_empty() {
+            self.write_indent();
+            if self.pub_mode {
+                self.write("pub fn new(");
+            } else {
+                self.write("fn new(");
+            }
+            for (i, (field_name, field_ty)) in class.fields.iter().enumerate() {
+                if i > 0 {
+                    self.write(", ");
+                }
+                self.write(field_name);
+                self.write(": ");
+                self.write(&field_ty.rust_type());
+            }
+            self.write(") -> Self {\n");
+            self.indent += 1;
+            self.write_indent();
+            self.write("Self {\n");
+            self.indent += 1;
+            for (field_name, _) in &class.fields {
+                self.write_indent();
+                self.write(field_name);
+                self.write(",\n");
+            }
+            self.indent -= 1;
+            self.write_indent();
+            self.write("}\n");
+            self.indent -= 1;
+            self.write_indent();
+            self.write("}\n\n");
+        }
+
         for method in &class.methods {
             self.emit_class_method(method, class);
             self.output.push('\n');
@@ -259,15 +347,49 @@ impl RustEmitter {
         self.indent -= 1;
         self.write_indent();
         self.write("}\n");
+
+        // For error types, implement Display and Error traits
+        if class.is_error_type {
+            self.output.push('\n');
+            self.write_indent();
+            self.write("impl std::fmt::Display for ");
+            self.write(&class.name);
+            self.write(" {\n");
+            self.indent += 1;
+            self.write_indent();
+            self.write("fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {\n");
+            self.indent += 1;
+            // If there's a 'message' field, use it for Display
+            if class.fields.iter().any(|(name, _)| name == "message") {
+                self.write_indent();
+                self.write("write!(f, \"{}\", self.message)\n");
+            } else {
+                // Use Debug format as fallback
+                self.write_indent();
+                self.write("write!(f, \"{:?}\", self)\n");
+            }
+            self.indent -= 1;
+            self.write_indent();
+            self.write("}\n");
+            self.indent -= 1;
+            self.write_indent();
+            self.write("}\n\n");
+
+            self.write_indent();
+            self.write("impl std::error::Error for ");
+            self.write(&class.name);
+            self.write(" {}\n");
+        }
     }
 
     fn emit_class_method(&mut self, method: &HirFunction, class: &HirClass) {
         self.current_return_type = Some(method.return_type.clone());
 
         self.write_indent();
+        let pub_prefix = if self.pub_mode { "pub " } else { "" };
         if method.name == "new" {
             // Constructor: fn new(params) -> Self
-            self.write("fn new(");
+            self.write(&format!("{}fn new(", pub_prefix));
             for (i, param) in method.params.iter().enumerate() {
                 if i > 0 {
                     self.write(", ");
@@ -329,11 +451,11 @@ impl RustEmitter {
             // Regular method: determine &self vs &mut self
             let is_mutating = body_contains_field_assign_codegen(&method.body);
             if is_mutating {
-                self.write("fn ");
+                self.write(&format!("{}fn ", pub_prefix));
                 self.write(&method.name);
                 self.write("(&mut self");
             } else {
-                self.write("fn ");
+                self.write(&format!("{}fn ", pub_prefix));
                 self.write(&method.name);
                 self.write("(&self");
             }
@@ -377,7 +499,11 @@ impl RustEmitter {
         // Since Rust doesn't have default params, we emit all params and handle
         // defaults at call site
         self.write_indent();
-        self.write("fn ");
+        if self.pub_mode && func.name != "main" {
+            self.write("pub fn ");
+        } else {
+            self.write("fn ");
+        }
         self.write(&func.name);
         self.write("(");
 
@@ -813,6 +939,67 @@ impl RustEmitter {
                     self.write(&format!("let {} = _star_tmp[_star_tmp.len() - {}].clone();\n", name, after.len() - i));
                 }
             }
+            HirStmt::TryExcept { body, handlers } => {
+                // Determine the error type from the first handler
+                let error_rust_type = handlers.first()
+                    .and_then(|h| h.error_resolved_type.as_ref())
+                    .map(|t| t.rust_type())
+                    .unwrap_or_else(|| "String".to_string());
+
+                // Emit try body as a closure that returns Result, then match on it
+                self.write_indent();
+                self.write(&format!("match (|| -> Result<(), {}> {{\n", error_rust_type));
+                self.indent += 1;
+                for stmt in body {
+                    self.emit_stmt(stmt);
+                }
+                self.write_indent();
+                self.write("Ok(())\n");
+                self.indent -= 1;
+                self.write_indent();
+                self.write("})() {\n");
+                self.indent += 1;
+                self.write_indent();
+                self.write("Ok(()) => {}\n");
+                for handler in handlers {
+                    self.write_indent();
+                    if let Some(ref name) = handler.name {
+                        self.write(&format!("Err({}) => {{\n", name));
+                    } else {
+                        self.write("Err(_e) => {\n");
+                    }
+                    self.indent += 1;
+                    for stmt in &handler.body {
+                        self.emit_stmt(stmt);
+                    }
+                    self.indent -= 1;
+                    self.write_indent();
+                    self.write("}\n");
+                }
+                self.indent -= 1;
+                self.write_indent();
+                self.write("}\n");
+            }
+            HirStmt::Raise { value } => {
+                self.write_indent();
+                self.write("return Err(");
+                self.emit_expr(value);
+                self.write(");\n");
+            }
+            HirStmt::Assert { test, msg } => {
+                self.write_indent();
+                if let Some(msg_expr) = msg {
+                    self.write("assert!(");
+                    self.emit_expr(test);
+                    self.write(", \"{}\", ");
+                    self.emit_expr(msg_expr);
+                    self.write(");\n");
+                } else {
+                    self.write("assert!(");
+                    self.emit_expr(test);
+                    self.write(");\n");
+                }
+            }
             HirStmt::FieldAssign { object, field, value } => {
                 self.write_indent();
                 self.write(object);
@@ -821,6 +1008,31 @@ impl RustEmitter {
                 self.write(" = ");
                 self.emit_expr(value);
                 self.write(";\n");
+            }
+            HirStmt::Delete { object, index } => {
+                let obj_ty = object.ty();
+                self.write_indent();
+                match obj_ty {
+                    Type::Dict(_, _) => {
+                        // del d[key] -> let _ = d.remove(&key);
+                        self.write("let _ = ");
+                        self.emit_expr(object);
+                        self.write(".remove(&");
+                        self.emit_expr(index);
+                        self.write(");\n");
+                    }
+                    Type::List(_) => {
+                        // del a[i] -> let _ = a.remove(i as usize);
+                        self.write("let _ = ");
+                        self.emit_expr(object);
+                        self.write(".remove(");
+                        self.emit_expr(index);
+                        self.write(" as usize);\n");
+                    }
+                    _ => {
+                        self.write("/* unsupported del */\n");
+                    }
+                }
             }
         }
     }
@@ -1048,13 +1260,14 @@ impl RustEmitter {
                 self.write(")");
             }
             (Type::Str, "find") => {
+                // Returns Option<i64> = int | None
                 self.emit_expr(object);
                 self.write(".find(");
                 if !args.is_empty() {
                     self.emit_expr(&args[0]);
                     self.write(".as_str()");
                 }
-                self.write(").map_or(-1_i64, |i| i as i64)");
+                self.write(").map(|i| i as i64)");
             }
             // String methods - extended
             (Type::Str, "title") => {
@@ -1217,8 +1430,9 @@ impl RustEmitter {
                 self.write(")");
             }
             (Type::List(_), "pop") => {
+                // Returns Option<T> = T | None
                 self.emit_expr(object);
-                self.write(".pop().unwrap()");
+                self.write(".pop()");
             }
             // Dict methods
             (Type::Dict(_, _), "keys") => {
@@ -1258,12 +1472,22 @@ impl RustEmitter {
                 self.write(")");
             }
             (Type::Dict(_, _), "get") => {
+                // Returns Option<V> = V | None
                 self.emit_expr(object);
                 self.write(".get(&");
                 if !args.is_empty() {
                     self.emit_expr(&args[0]);
                 }
-                self.write(").cloned().unwrap()");
+                self.write(").cloned()");
+            }
+            (Type::Dict(_, _), "pop") => {
+                // Returns Option<V> = V | None
+                self.emit_expr(object);
+                self.write(".remove(&");
+                if !args.is_empty() {
+                    self.emit_expr(&args[0]);
+                }
+                self.write(")");
             }
             // Tuple count()
             (Type::Tuple(_), "count") => {
@@ -1530,8 +1754,9 @@ impl RustEmitter {
                                 self.write(" as i64");
                             }
                             Type::Str => {
+                                // int(str) -> Result<i64, String>
                                 self.emit_expr(&args[0]);
-                                self.write(".parse::<i64>().unwrap()");
+                                self.write(".parse::<i64>().map_err(|e| e.to_string())");
                             }
                             Type::Bool => {
                                 self.write("if ");
@@ -1551,8 +1776,9 @@ impl RustEmitter {
                                 self.write(" as f64");
                             }
                             Type::Str => {
+                                // float(str) -> Result<f64, String>
                                 self.emit_expr(&args[0]);
-                                self.write(".parse::<f64>().unwrap()");
+                                self.write(".parse::<f64>().map_err(|e| e.to_string())");
                             }
                             _ => {
                                 self.emit_expr(&args[0]);
@@ -1676,14 +1902,16 @@ impl RustEmitter {
                 let obj_ty = object.ty();
                 match obj_ty {
                     Type::Dict(_, _) => {
-                        // Dict indexing: d[key] -> d[&key] with clone
+                        // Safe dict indexing: d[key] -> d.get(&key).cloned()
+                        // Returns Option<V> which maps to our V | None union
                         self.emit_expr(object);
-                        self.write("[&");
+                        self.write(".get(&");
                         self.emit_expr(index);
-                        self.write("]");
+                        self.write(").cloned()");
                     }
                     Type::Tuple(_) => {
                         // Tuple indexing: t.0, t.1, etc. (handle negative)
+                        // Tuples are fixed-size, so indexing is always safe at compile time
                         if let HirExpr::IntLiteral(val) = index.as_ref() {
                             if *val < 0 {
                                 if let Type::Tuple(elems) = obj_ty {
@@ -1703,41 +1931,22 @@ impl RustEmitter {
                         }
                     }
                     Type::Str => {
-                        // String indexing: character-based (UTF-8 safe)
-                        // Check for negative literal
-                        if let HirExpr::IntLiteral(val) = index.as_ref() {
-                            if *val < 0 {
-                                self.emit_expr(object);
-                                self.write(&format!(".chars().nth(({}.chars().count() as i64 + ({})) as usize).unwrap().to_string()", "_str_idx_tmp", val));
-                                // We need a different approach - use a block
-                                // Actually, let's use a simpler approach
-                                self.output.truncate(self.output.len() - self.output.rfind(|_| true).map(|_| 0).unwrap_or(0));
-                            }
-                        }
-                        // General case: handle negative indices
+                        // Safe string indexing: returns Option<String>
+                        // Handle negative indices
                         self.write("{ let _s = &");
                         self.emit_expr(object);
                         self.write("; let _i = ");
                         self.emit_expr(index);
-                        self.write("; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).unwrap().to_string() }");
+                        self.write("; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) }");
                     }
                     _ => {
-                        // List indexing: handle negative indices
-                        // Check for compile-time negative literal for simple case
-                        if let HirExpr::IntLiteral(val) = index.as_ref() {
-                            if *val < 0 {
-                                self.write("{ let _v = &");
-                                self.emit_expr(object);
-                                self.write(&format!("; _v[(_v.len() as i64 + ({})) as usize].clone() }}", val));
-                                return;
-                            }
-                        }
-                        // General case with runtime negative check
+                        // Safe list indexing: returns Option<T>
+                        // Handle negative indices
                         self.write("{ let _v = &");
                         self.emit_expr(object);
                         self.write("; let _i = ");
                         self.emit_expr(index);
-                        self.write("; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v[_idx].clone() }");
+                        self.write("; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }");
                     }
                 }
             }
@@ -1817,6 +2026,20 @@ impl RustEmitter {
                     }
                     self.emit_expr(arg);
                 }
+                self.write(")");
+            }
+            HirExpr::QuestionMark { expr, .. } => {
+                self.emit_expr(expr);
+                self.write("?");
+            }
+            HirExpr::OkWrap { value, .. } => {
+                self.write("Ok(");
+                self.emit_expr(value);
+                self.write(")");
+            }
+            HirExpr::ErrWrap { value, .. } => {
+                self.write("Err(");
+                self.emit_expr(value);
                 self.write(")");
             }
             HirExpr::FString { parts, .. } => {
@@ -1982,6 +2205,7 @@ mod tests {
                 }],
             }],
             classes: vec![],
+            imports: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -2010,6 +2234,7 @@ mod tests {
                 }],
             }],
             classes: vec![],
+            imports: vec![],
         };
 
         let rust_code = generate_rust(&module);

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -4,8 +4,10 @@
 //! parse -> type-check/HIR -> codegen -> build
 
 use sifr_python_parser::parse_module;
-use sifr_hir::lower_module;
-use sifr_codegen::{generate_rust, generate_project};
+use sifr_hir::{lower_module, lower_module_with_externals, ExternalDefs, HirModule};
+use sifr_codegen::{generate_rust, generate_rust_multi, generate_project};
+use sifr_type_system::{Type, FunctionType};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -113,6 +115,249 @@ pub fn check(source: &str) -> Vec<CompileError> {
     }
 }
 
+/// Compile a multi-file project and build a native binary.
+/// `main_file` is the path to the main .sifr file. Other .sifr files in the same
+/// directory are compiled as modules.
+pub fn build_project(main_file: &Path, output_dir: &Path) -> Result<PathBuf, Vec<CompileError>> {
+    let project_dir = main_file.parent().unwrap_or(Path::new("."));
+
+    // Discover all .sifr files in the project directory
+    let mut sifr_files: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(project_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().map_or(false, |ext| ext == "sifr") {
+                sifr_files.push(path);
+            }
+        }
+    }
+    sifr_files.sort();
+
+    // Read all source files
+    let mut sources: HashMap<String, String> = HashMap::new();
+    for file in &sifr_files {
+        let module_name = file.file_stem().unwrap().to_string_lossy().to_string();
+        let source = std::fs::read_to_string(file).map_err(|e| {
+            vec![CompileError {
+                message: format!("failed to read '{}': {}", file.display(), e),
+                phase: CompilePhase::Build,
+            }]
+        })?;
+        sources.insert(module_name, source);
+    }
+
+    // Phase 1: Parse all modules
+    let mut parsed_modules: HashMap<String, Vec<sifr_python_ast::Stmt>> = HashMap::new();
+    for (module_name, source) in &sources {
+        let parsed = match parse_module(source) {
+            Ok(parsed) => {
+                if !parsed.is_valid() {
+                    let errors: Vec<CompileError> = parsed
+                        .errors()
+                        .iter()
+                        .map(|e| CompileError {
+                            message: format!("[{}] {}", module_name, e),
+                            phase: CompilePhase::Parse,
+                        })
+                        .collect();
+                    return Err(errors);
+                }
+                parsed
+            }
+            Err(e) => {
+                return Err(vec![CompileError {
+                    message: format!("[{}] failed to parse: {}", module_name, e),
+                    phase: CompilePhase::Parse,
+                }]);
+            }
+        };
+        parsed_modules.insert(module_name.clone(), parsed.into_suite());
+    }
+
+    // Phase 2: Lower non-main modules first to collect their exports
+    let mut external_defs = ExternalDefs::default();
+    let mut hir_modules: HashMap<String, HirModule> = HashMap::new();
+
+    // First, lower all non-main modules
+    for (module_name, stmts) in &parsed_modules {
+        if module_name == "main" {
+            continue;
+        }
+        let result = match lower_module(stmts) {
+            Ok(result) => result,
+            Err(errors) => {
+                let compile_errors: Vec<CompileError> = errors
+                    .into_iter()
+                    .map(|e| CompileError {
+                        message: format!("[{}] {}", module_name, e.message),
+                        phase: CompilePhase::TypeCheck,
+                    })
+                    .collect();
+                return Err(compile_errors);
+            }
+        };
+
+        // Collect exports for this module
+        let mut fn_exports = HashMap::new();
+        let mut class_exports = HashMap::new();
+
+        for func in &result.module.functions {
+            if !func.name.starts_with('_') {
+                let params: Vec<(String, Type)> = func.params.iter()
+                    .map(|p| (p.name.clone(), p.ty.clone()))
+                    .collect();
+                fn_exports.insert(func.name.clone(), FunctionType {
+                    params,
+                    return_type: Box::new(func.return_type.clone()),
+                });
+            }
+        }
+
+        for class in &result.module.classes {
+            if !class.name.starts_with('_') {
+                // Extract method types from the class
+                let methods: Vec<(String, FunctionType)> = class.methods.iter()
+                    .filter(|m| m.name != "new") // Skip constructor
+                    .map(|m| {
+                        let params: Vec<(String, Type)> = m.params.iter()
+                            .map(|p| (p.name.clone(), p.ty.clone()))
+                            .collect();
+                        (m.name.clone(), FunctionType {
+                            params,
+                            return_type: Box::new(m.return_type.clone()),
+                        })
+                    })
+                    .collect();
+                let class_ty = Type::Class {
+                    name: class.name.clone(),
+                    fields: class.fields.clone(),
+                    methods,
+                };
+                class_exports.insert(class.name.clone(), class_ty);
+            }
+        }
+
+        external_defs.functions.insert(module_name.clone(), fn_exports);
+        external_defs.classes.insert(module_name.clone(), class_exports);
+        hir_modules.insert(module_name.clone(), result.module);
+    }
+
+    // Then, lower main module with external definitions
+    if let Some(main_stmts) = parsed_modules.get("main") {
+        let result = match lower_module_with_externals(main_stmts, &external_defs) {
+            Ok(result) => result,
+            Err(errors) => {
+                let compile_errors: Vec<CompileError> = errors
+                    .into_iter()
+                    .map(|e| CompileError {
+                        message: format!("[main] {}", e.message),
+                        phase: CompilePhase::TypeCheck,
+                    })
+                    .collect();
+                return Err(compile_errors);
+            }
+        };
+        hir_modules.insert("main".to_string(), result.module);
+    }
+
+    // Phase 3: Generate Rust code
+    let module_refs: Vec<(&str, &HirModule)> = hir_modules.iter()
+        .map(|(name, module)| (name.as_str(), module))
+        .collect();
+    let rust_files = generate_rust_multi(&module_refs);
+
+    // Phase 4: Build the Rust project
+    let project_path = output_dir.join("sifr_output");
+    let src_dir = project_path.join("src");
+    std::fs::create_dir_all(&src_dir).map_err(|e| {
+        vec![CompileError {
+            message: format!("failed to create output directory: {}", e),
+            phase: CompilePhase::Build,
+        }]
+    })?;
+
+    // Write Cargo.toml
+    let (cargo_toml, _) = generate_project(
+        &HirModule { functions: vec![], classes: vec![], imports: vec![] },
+        "sifr_output",
+    );
+    std::fs::write(project_path.join("Cargo.toml"), cargo_toml).map_err(|e| {
+        vec![CompileError {
+            message: format!("failed to write Cargo.toml: {}", e),
+            phase: CompilePhase::Build,
+        }]
+    })?;
+
+    // Write main.rs with mod declarations and main module code
+    let mut main_rs = String::new();
+
+    // Add mod declarations for non-main modules
+    for (module_name, _) in &rust_files {
+        if module_name != "main" {
+            main_rs.push_str(&format!("mod {};\n", module_name));
+        }
+    }
+    if rust_files.len() > 1 {
+        main_rs.push('\n');
+    }
+
+    // Add main module code
+    if let Some(main_code) = rust_files.get("main") {
+        main_rs.push_str(main_code);
+    }
+
+    std::fs::write(src_dir.join("main.rs"), &main_rs).map_err(|e| {
+        vec![CompileError {
+            message: format!("failed to write main.rs: {}", e),
+            phase: CompilePhase::Build,
+        }]
+    })?;
+
+    // Write non-main module files
+    for (module_name, code) in &rust_files {
+        if module_name != "main" {
+            std::fs::write(src_dir.join(format!("{}.rs", module_name)), code).map_err(|e| {
+                vec![CompileError {
+                    message: format!("failed to write {}.rs: {}", module_name, e),
+                    phase: CompilePhase::Build,
+                }]
+            })?;
+        }
+    }
+
+    // Run cargo build
+    let output = Command::new("cargo")
+        .args(["build", "--release"])
+        .current_dir(&project_path)
+        .output()
+        .map_err(|e| {
+            vec![CompileError {
+                message: format!("failed to run cargo build: {}", e),
+                phase: CompilePhase::Build,
+            }]
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(vec![CompileError {
+            message: format!("cargo build failed:\n{}", stderr),
+            phase: CompilePhase::Build,
+        }]);
+    }
+
+    let binary_name = if cfg!(target_os = "windows") {
+        "sifr_output.exe"
+    } else {
+        "sifr_output"
+    };
+    let binary_path = project_path
+        .join("target")
+        .join("release")
+        .join(binary_name);
+
+    Ok(binary_path)
+}
+
 /// Compile and build a native binary.
 pub fn build(source: &str, output_dir: &Path) -> Result<PathBuf, Vec<CompileError>> {
     let rust_source = match compile(source) {
@@ -132,7 +377,7 @@ pub fn build(source: &str, output_dir: &Path) -> Result<PathBuf, Vec<CompileErro
 
     // Write Cargo.toml
     let (cargo_toml, _) = generate_project(
-        &sifr_hir::HirModule { functions: vec![], classes: vec![] },
+        &sifr_hir::HirModule { functions: vec![], classes: vec![], imports: vec![] },
         "sifr_output",
     );
     std::fs::write(project_dir.join("Cargo.toml"), cargo_toml).map_err(|e| {

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -7,6 +7,16 @@ use sifr_type_system::Type;
 pub struct HirModule {
     pub functions: Vec<HirFunction>,
     pub classes: Vec<HirClass>,
+    pub imports: Vec<HirImport>,
+}
+
+/// An import statement.
+#[derive(Debug, Clone)]
+pub struct HirImport {
+    /// The module to import from (e.g., "utils" for `from utils import helper`)
+    pub module: String,
+    /// The names to import
+    pub names: Vec<String>,
 }
 
 /// A class definition with resolved types.
@@ -17,6 +27,8 @@ pub struct HirClass {
     pub methods: Vec<HirFunction>,
     /// Whether all fields support Eq + Hash (enables derive(Eq, Hash))
     pub is_hashable: bool,
+    /// Whether this class is an error type (class Foo(Error))
+    pub is_error_type: bool,
 }
 
 /// A function definition with resolved types.
@@ -105,12 +117,44 @@ pub enum HirStmt {
     },
     /// Pass (no-op)
     Pass,
+    /// Assert statement: assert condition [, message]
+    Assert {
+        test: HirExpr,
+        msg: Option<HirExpr>,
+    },
+    /// Raise statement: raise expr -> Err(expr)
+    Raise {
+        value: HirExpr,
+    },
+    /// Try/except: pattern matching on Result
+    TryExcept {
+        body: Vec<HirStmt>,
+        handlers: Vec<HirExceptHandler>,
+    },
     /// Field assignment: self.field = value (inside methods)
     FieldAssign {
         object: String,
         field: String,
         value: HirExpr,
     },
+    /// Delete statement: del d[key] or del a[i]
+    Delete {
+        object: HirExpr,
+        index: HirExpr,
+    },
+}
+
+/// An except handler in a try/except block.
+#[derive(Debug, Clone)]
+pub struct HirExceptHandler {
+    /// The error type to match (None = catch-all)
+    pub error_type: Option<String>,
+    /// The resolved type of the error (for codegen)
+    pub error_resolved_type: Option<Type>,
+    /// Variable name to bind the error value
+    pub name: Option<String>,
+    /// Handler body
+    pub body: Vec<HirStmt>,
 }
 
 /// A part of an f-string.
@@ -251,6 +295,21 @@ pub enum HirExpr {
         args: Vec<HirExpr>,
         ty: Type,
     },
+    /// Question mark operator: expr? (early return on Err)
+    QuestionMark {
+        expr: Box<HirExpr>,
+        ty: Type,
+    },
+    /// Ok wrapping: Ok(expr)
+    OkWrap {
+        value: Box<HirExpr>,
+        ty: Type,
+    },
+    /// Err wrapping: Err(expr)
+    ErrWrap {
+        value: Box<HirExpr>,
+        ty: Type,
+    },
 }
 
 impl HirExpr {
@@ -280,7 +339,10 @@ impl HirExpr {
             | Self::Slice { ty, .. }
             | Self::WalrusExpr { ty, .. }
             | Self::FieldAccess { ty, .. }
-            | Self::ConstructorCall { ty, .. } => ty,
+            | Self::ConstructorCall { ty, .. }
+            | Self::QuestionMark { ty, .. }
+            | Self::OkWrap { ty, .. }
+            | Self::ErrWrap { ty, .. } => ty,
         }
     }
 }

--- a/crates/sifr_hir/src/lib.rs
+++ b/crates/sifr_hir/src/lib.rs
@@ -11,5 +11,5 @@ mod scope;
 pub mod cfg;
 
 pub use hir_nodes::*;
-pub use lower::{lower_module, LoweringError, LoweringResult};
+pub use lower::{lower_module, lower_module_with_externals, ExternalDefs, LoweringError, LoweringResult};
 pub use scope::{Scope, NarrowingSnapshot};

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -47,6 +47,10 @@ struct LowerCtx {
     reveal_types: Vec<String>,
     /// Whether we're currently inside a class method (tracks `self` type)
     current_class: Option<String>,
+    /// Whether we're inside a try block (auto-unwrap Result values)
+    in_try_block: bool,
+    /// Set of class names that are error types (class Foo(Error))
+    error_types: std::collections::HashSet<String>,
 }
 
 impl LowerCtx {
@@ -60,6 +64,8 @@ impl LowerCtx {
             loop_depth: 0,
             reveal_types: Vec::new(),
             current_class: None,
+            in_try_block: false,
+            error_types: std::collections::HashSet::new(),
         }
     }
 
@@ -83,8 +89,22 @@ pub struct LoweringResult {
     pub reveal_types: Vec<String>,
 }
 
+/// External module definitions that can be imported.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalDefs {
+    /// Map of module_name -> (function_name -> FunctionType)
+    pub functions: std::collections::HashMap<String, std::collections::HashMap<String, FunctionType>>,
+    /// Map of module_name -> (class_name -> Type)
+    pub classes: std::collections::HashMap<String, std::collections::HashMap<String, Type>>,
+}
+
 /// Lower a parsed module AST into a typed HIR module.
 pub fn lower_module(stmts: &[Stmt]) -> Result<LoweringResult, Vec<LoweringError>> {
+    lower_module_with_externals(stmts, &ExternalDefs::default())
+}
+
+/// Lower a parsed module AST into a typed HIR module, with external module definitions.
+pub fn lower_module_with_externals(stmts: &[Stmt], externals: &ExternalDefs) -> Result<LoweringResult, Vec<LoweringError>> {
     let mut ctx = LowerCtx::new();
 
     // Register built-in functions
@@ -139,6 +159,55 @@ pub fn lower_module(stmts: &[Stmt]) -> Result<LoweringResult, Vec<LoweringError>
         }
     }
 
+    // Collect import statements and resolve imported names
+    let mut imports = Vec::new();
+    for stmt in stmts {
+        if let Stmt::ImportFrom(import_from) = stmt {
+            if let Some(ref module) = import_from.module {
+                let module_name = module.to_string();
+                let names: Vec<String> = import_from.names.iter()
+                    .map(|alias| alias.name.to_string())
+                    .collect();
+
+                // Resolve imported names from external definitions
+                for name in &names {
+                    // Check if it's a private name
+                    if name.starts_with('_') {
+                        ctx.error(format!("cannot import private name '{}' from module '{}'", name, module_name));
+                        continue;
+                    }
+
+                    // Look up in external functions
+                    if let Some(module_fns) = externals.functions.get(&module_name) {
+                        if let Some(ft) = module_fns.get(name) {
+                            ctx.functions.insert(name.clone(), ft.clone());
+                        }
+                    }
+                    // Look up in external classes
+                    if let Some(module_classes) = externals.classes.get(&module_name) {
+                        if let Some(class_ty) = module_classes.get(name) {
+                            ctx.class_types.insert(name.clone(), class_ty.clone());
+                            // Also register the constructor
+                            if let Type::Class { fields, .. } = class_ty {
+                                let params: Vec<(String, Type)> = fields.clone();
+                                let ft = FunctionType {
+                                    params,
+                                    return_type: Box::new(class_ty.clone()),
+                                };
+                                ctx.functions.insert(name.clone(), ft);
+                            }
+                        }
+                    }
+                }
+
+                imports.push(HirImport {
+                    module: module_name,
+                    names,
+                });
+            }
+        }
+    }
+
     // Second pass: lower function bodies and class method bodies
     let mut functions = Vec::new();
     let mut classes = Vec::new();
@@ -160,7 +229,7 @@ pub fn lower_module(stmts: &[Stmt]) -> Result<LoweringResult, Vec<LoweringError>
 
     if ctx.errors.is_empty() {
         Ok(LoweringResult {
-            module: HirModule { functions, classes },
+            module: HirModule { functions, classes, imports },
             reveal_types: ctx.reveal_types,
         })
     } else {
@@ -168,11 +237,27 @@ pub fn lower_module(stmts: &[Stmt]) -> Result<LoweringResult, Vec<LoweringError>
     }
 }
 
+/// Check if a class definition has `(Error)` as its base class.
+fn is_error_class(class_def: &StmtClassDef) -> bool {
+    for base in class_def.bases() {
+        if let Expr::Name(n) = base {
+            if n.id.as_str() == "Error" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// First pass: collect class fields and method signatures, register the class type.
 fn collect_class_type(class_def: &StmtClassDef, ctx: &mut LowerCtx) {
     let class_name = class_def.name.to_string();
     let mut fields: Vec<(String, Type)> = Vec::new();
     let mut methods: Vec<(String, FunctionType)> = Vec::new();
+    let is_error = is_error_class(class_def);
+
+    // For error types, ensure a 'message' field exists (add if not explicitly declared)
+    // This will be checked after collecting all fields
 
     // Register a preliminary class type so self-referential annotations work
     // (e.g., `def distance(self, other: Point)` inside class Point)
@@ -283,6 +368,10 @@ fn collect_class_type(class_def: &StmtClassDef, ctx: &mut LowerCtx) {
         ctx.functions.insert(class_name.clone(), ft);
     }
 
+    if is_error {
+        ctx.error_types.insert(class_name.clone());
+    }
+
     ctx.class_types.insert(class_name, class_ty);
 }
 
@@ -364,11 +453,14 @@ fn lower_class(class_def: &StmtClassDef, ctx: &mut LowerCtx) -> Option<HirClass>
         }
     }
 
+    let is_error = ctx.error_types.contains(&class_name);
+
     Some(HirClass {
         name: class_name,
         fields,
         methods: hir_methods,
         is_hashable,
+        is_error_type: is_error,
     })
 }
 
@@ -570,6 +662,29 @@ fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
                         }
                     }
                 }
+                "Result" => {
+                    // Result[T, E] -- the slice is a Tuple expression
+                    match sub.slice.as_ref() {
+                        Expr::Tuple(tuple) => {
+                            if tuple.elts.len() != 2 {
+                                ctx.error("Result type annotation requires exactly 2 type parameters".to_string());
+                                return Type::Any;
+                            }
+                            let ok_ty = resolve_annotation_expr(&tuple.elts[0], ctx);
+                            let err_ty = resolve_annotation_expr(&tuple.elts[1], ctx);
+                            Type::Result(Box::new(ok_ty), Box::new(err_ty))
+                        }
+                        _ => {
+                            ctx.error("Result type annotation requires [T, E] syntax".to_string());
+                            Type::Any
+                        }
+                    }
+                }
+                "Option" => {
+                    // Option[T] -> T | None (sugar)
+                    let inner_ty = resolve_annotation_expr(&sub.slice, ctx);
+                    make_union(vec![inner_ty, Type::None])
+                }
                 "TypeGuard" => {
                     // TypeGuard[T] -- type predicate return type
                     let inner_ty = resolve_annotation_expr(&sub.slice, ctx);
@@ -662,6 +777,14 @@ fn lower_stmt(stmt: &Stmt, func_type: &FunctionType, ctx: &mut LowerCtx) -> Opti
         Stmt::Return(ret) => lower_return(ret, func_type, ctx),
         Stmt::Expr(expr_stmt) => {
             let expr = lower_expr(&expr_stmt.value, ctx)?;
+            // #[must_use] enforcement: Result values must not be silently discarded
+            let expr_ty = expr.ty();
+            if matches!(expr_ty, Type::Result(_, _)) {
+                ctx.error(format!(
+                    "unused Result value of type '{}' must be used. Use 'let _ = expr' to explicitly discard",
+                    expr_ty.display_name()
+                ));
+            }
             Some(HirStmt::Expr { expr })
         }
         Stmt::If(if_stmt) => lower_if(if_stmt, func_type, ctx),
@@ -682,6 +805,96 @@ fn lower_stmt(stmt: &Stmt, func_type: &FunctionType, ctx: &mut LowerCtx) -> Opti
             Some(HirStmt::Continue)
         }
         Stmt::Pass(_) => Some(HirStmt::Pass),
+        Stmt::Delete(del_stmt) => {
+            if del_stmt.targets.len() != 1 {
+                ctx.error("del with multiple targets not supported".to_string());
+                return None;
+            }
+            match &del_stmt.targets[0] {
+                Expr::Subscript(sub) => {
+                    let object = lower_expr(&sub.value, ctx)?;
+                    let index = lower_expr(&sub.slice, ctx)?;
+                    Some(HirStmt::Delete { object, index })
+                }
+                _ => {
+                    ctx.error("del is only supported for collection items (del d[key], del a[i])".to_string());
+                    None
+                }
+            }
+        }
+        Stmt::Assert(assert_stmt) => {
+            let test = lower_expr(&assert_stmt.test, ctx)?;
+            let msg = if let Some(ref msg_expr) = assert_stmt.msg {
+                Some(lower_expr(msg_expr, ctx)?)
+            } else {
+                None
+            };
+            Some(HirStmt::Assert { test, msg })
+        }
+        Stmt::Raise(raise_stmt) => {
+            if let Some(ref exc) = raise_stmt.exc {
+                let value = lower_expr(exc, ctx)?;
+                Some(HirStmt::Raise { value })
+            } else {
+                ctx.error("bare 'raise' without an expression is not supported".to_string());
+                None
+            }
+        }
+        Stmt::Try(try_stmt) => {
+            let prev_in_try = ctx.in_try_block;
+            ctx.in_try_block = true;
+            let body = lower_stmts(&try_stmt.body, func_type, ctx);
+            ctx.in_try_block = prev_in_try;
+            let mut handlers = Vec::new();
+            for handler in &try_stmt.handlers {
+                if let ExceptHandler::ExceptHandler(h) = handler {
+                    let error_type = if let Some(ref type_expr) = h.type_ {
+                        if let Expr::Name(n) = type_expr.as_ref() {
+                            Some(n.id.to_string())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    let name = h.name.as_ref().map(|n| n.to_string());
+                    // Define the error variable in scope if named
+                    ctx.scope.push();
+                    if let Some(ref var_name) = name {
+                        // Determine the type of the error variable
+                        let error_var_ty = if let Some(ref et) = error_type {
+                            if let Some(class_ty) = ctx.class_types.get(et) {
+                                class_ty.clone()
+                            } else {
+                                Type::Str // Default: error messages are strings
+                            }
+                        } else {
+                            Type::Str
+                        };
+                        ctx.scope.define(var_name.clone(), error_var_ty);
+                    }
+                    let handler_body = lower_stmts(&h.body, func_type, ctx);
+                    ctx.scope.pop();
+                    // Resolve the error type for codegen
+                    let error_resolved_type = error_type.as_ref().and_then(|et| {
+                        if let Some(class_ty) = ctx.class_types.get(et) {
+                            Some(class_ty.clone())
+                        } else if et == "str" {
+                            Some(Type::Str)
+                        } else {
+                            None
+                        }
+                    });
+                    handlers.push(HirExceptHandler {
+                        error_type,
+                        error_resolved_type,
+                        name,
+                        body: handler_body,
+                    });
+                }
+            }
+            Some(HirStmt::TryExcept { body, handlers })
+        }
         _ => {
             ctx.error("unsupported statement type".to_string());
             None
@@ -701,14 +914,26 @@ fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Option<HirStmt> 
     let declared_type = resolve_annotation_expr(&ann.annotation, ctx);
 
     let value = if let Some(val) = &ann.value {
-        let expr = lower_expr(val, ctx)?;
-        // Type check: value must be assignable to declared type
+        let mut expr = lower_expr(val, ctx)?;
         let expr_ty = expr.ty().clone();
-        if !expr_ty.is_assignable_to(&declared_type) {
+        // Inside try blocks, auto-unwrap Result[T, E] when declared type is T
+        if ctx.in_try_block {
+            if let Type::Result(ref ok_ty, _) = expr_ty {
+                if ok_ty.as_ref().is_assignable_to(&declared_type) {
+                    expr = HirExpr::QuestionMark {
+                        expr: Box::new(expr),
+                        ty: declared_type.clone(),
+                    };
+                }
+            }
+        }
+        // Type check: value must be assignable to declared type
+        let final_ty = expr.ty().clone();
+        if !final_ty.is_assignable_to(&declared_type) {
             ctx.error(format!(
                 "type mismatch: expected '{}', got '{}'",
                 declared_type.display_name(),
-                expr_ty.display_name()
+                final_ty.display_name()
             ));
         }
         expr
@@ -768,6 +993,18 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
             return None;
         }
     };
+
+    // Handle `_ = expr` as explicit discard (suppresses #[must_use] warnings)
+    if name == "_" {
+        let value = lower_expr(&assign.value, ctx)?;
+        let value_ty = value.ty().clone();
+        return Some(HirStmt::Let {
+            name: "_".to_string(),
+            ty: value_ty,
+            value,
+            is_mutable: false,
+        });
+    }
 
     let value = lower_expr(&assign.value, ctx)?;
     let value_ty = value.ty().clone();
@@ -862,6 +1099,20 @@ fn lower_return(ret: &StmtReturn, func_type: &FunctionType, ctx: &mut LowerCtx) 
     let value = if let Some(val) = &ret.value {
         let expr = lower_expr(val, ctx)?;
         let expr_ty = expr.ty().clone();
+
+        // If the function returns Result[T, E] and the value is T (not Result), wrap in Ok()
+        if let Type::Result(ref ok_ty, _) = *func_type.return_type {
+            if expr_ty.is_assignable_to(ok_ty) && !matches!(expr_ty, Type::Result(_, _)) {
+                // Wrap in Ok()
+                return Some(HirStmt::Return {
+                    value: Some(HirExpr::OkWrap {
+                        ty: func_type.return_type.as_ref().clone(),
+                        value: Box::new(expr),
+                    }),
+                });
+            }
+        }
+
         if !expr_ty.is_assignable_to(&func_type.return_type) {
             ctx.error(format!(
                 "return type mismatch: expected '{}', got '{}'",
@@ -872,6 +1123,17 @@ fn lower_return(ret: &StmtReturn, func_type: &FunctionType, ctx: &mut LowerCtx) 
         Some(expr)
     } else {
         if *func_type.return_type != Type::None {
+            // If function returns Result[(), E], wrap in Ok(())
+            if let Type::Result(ref ok_ty, _) = *func_type.return_type {
+                if **ok_ty == Type::None {
+                    return Some(HirStmt::Return {
+                        value: Some(HirExpr::OkWrap {
+                            ty: func_type.return_type.as_ref().clone(),
+                            value: Box::new(HirExpr::NoneLiteral),
+                        }),
+                    });
+                }
+            }
             ctx.error(format!(
                 "function expects return type '{}', but returns nothing",
                 func_type.return_type.display_name()
@@ -1528,10 +1790,20 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
             return None;
         }
         let arg = lower_expr(&call.arguments.args[0], ctx)?;
+        let arg_ty = arg.ty().clone();
+        // int(str) -> Result[int, str] (fallible)
+        // int(float) -> int (infallible truncation)
+        // int(int) -> int (identity)
+        // int(bool) -> int (True=1, False=0)
+        let result_ty = if arg_ty == Type::Str {
+            Type::Result(Box::new(Type::Int), Box::new(Type::Str))
+        } else {
+            Type::Int
+        };
         return Some(HirExpr::Call {
             func: "int".to_string(),
             args: vec![arg],
-            ty: Type::Int,
+            ty: result_ty,
         });
     }
 
@@ -1542,10 +1814,19 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
             return None;
         }
         let arg = lower_expr(&call.arguments.args[0], ctx)?;
+        let arg_ty = arg.ty().clone();
+        // float(str) -> Result[float, str] (fallible)
+        // float(int) -> float (infallible widening)
+        // float(float) -> float (identity)
+        let result_ty = if arg_ty == Type::Str {
+            Type::Result(Box::new(Type::Float), Box::new(Type::Str))
+        } else {
+            Type::Float
+        };
         return Some(HirExpr::Call {
             func: "float".to_string(),
             args: vec![arg],
-            ty: Type::Float,
+            ty: result_ty,
         });
     }
 
@@ -2195,7 +2476,8 @@ fn resolve_method_type(object_ty: &Type, method: &str, args: &[HirExpr], ctx: &m
                     ctx.error("list.pop() takes no arguments".to_string());
                     return None;
                 }
-                Some(*elem_ty.clone())
+                // pop() returns Option[T] = T | None
+                Some(Type::Union(vec![*elem_ty.clone(), Type::None]))
             }
             _ => {
                 ctx.error(format!("list has no method '{}'", method));
@@ -2264,7 +2546,16 @@ fn resolve_method_type(object_ty: &Type, method: &str, args: &[HirExpr], ctx: &m
                     ctx.error(format!("dict.get() takes exactly 1 argument, got {}", args.len()));
                     return None;
                 }
-                Some(*val_ty.clone())
+                // get() returns Option[V] = V | None
+                Some(Type::Union(vec![*val_ty.clone(), Type::None]))
+            }
+            "pop" => {
+                if args.len() != 1 {
+                    ctx.error(format!("dict.pop() takes exactly 1 argument, got {}", args.len()));
+                    return None;
+                }
+                // pop() returns Option[V] = V | None
+                Some(Type::Union(vec![*val_ty.clone(), Type::None]))
             }
             _ => {
                 ctx.error(format!("dict has no method '{}'", method));
@@ -2328,7 +2619,8 @@ fn resolve_method_type(object_ty: &Type, method: &str, args: &[HirExpr], ctx: &m
                     ctx.error(format!("str.find() takes exactly 1 argument, got {}", args.len()));
                     return None;
                 }
-                Some(Type::Int)
+                // find() returns Option[int] = int | None
+                Some(Type::Union(vec![Type::Int, Type::None]))
             }
             _ => {
                 ctx.error(format!("str has no method '{}'", method));

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -50,6 +50,9 @@ pub enum Type {
 
     // --- milestone_classes: Basic Classes ---
 
+    /// Result type: `Result[T, E]` -> `Result<T, E>` in Rust
+    Result(Box<Type>, Box<Type>),
+
     /// Class instance type with named fields and methods.
     /// `class Point: x: float; y: float` -> `Type::Class { name: "Point", fields: [...], methods: [...] }`
     Class {
@@ -95,6 +98,7 @@ impl Type {
             Self::LiteralStr(_) => OwnershipKind::Move,
             Self::Unknown => OwnershipKind::Move,
             Self::Class { .. } => OwnershipKind::Move,
+            Self::Result(_, _) => OwnershipKind::Move,
             // Union/Intersection: Move if any member is Move
             Self::Union(members) | Self::Intersection(members) => {
                 if members.iter().any(|m| m.ownership() == OwnershipKind::Move) {
@@ -142,6 +146,7 @@ impl Type {
             Self::Alias(name, _) => name.clone(),
             Self::Unknown => "Unknown".to_string(),
             Self::Class { name, .. } => name.clone(),
+            Self::Result(ok, err) => format!("Result[{}, {}]", ok.display_name(), err.display_name()),
         }
     }
 
@@ -190,6 +195,7 @@ impl Type {
             Self::Alias(_, inner) => inner.rust_type(),
             Self::Unknown => "Box<dyn std::any::Any>".to_string(),
             Self::Class { name, .. } => name.clone(),
+            Self::Result(ok, err) => format!("Result<{}, {}>", ok.rust_type(), err.rust_type()),
         }
     }
 
@@ -237,6 +243,7 @@ impl Type {
             Type::Intersection(_) => "Intersection".to_string(),
             Type::Alias(name, _) => capitalize(name),
             Type::Class { name, .. } => name.clone(),
+            Type::Result(_, _) => "Result".to_string(),
         }
     }
 
@@ -289,18 +296,22 @@ impl Type {
     }
 
     /// Returns the result type of indexing this type with the given index type.
+    /// For list, dict, and str: returns Option[T] (T | None) for safe indexing.
+    /// For tuple with literal index: returns the exact element type (no Option).
     pub fn index_result_type(&self, index_ty: &Type) -> Option<Type> {
         match self {
             Self::List(elem) => {
                 if index_ty == &Type::Int {
-                    Some(*elem.clone())
+                    // Safe indexing: returns Option[T] = T | None
+                    Some(Type::Union(vec![*elem.clone(), Type::None]))
                 } else {
                     None
                 }
             }
             Self::Dict(key, val) => {
                 if index_ty == key.as_ref() {
-                    Some(*val.clone())
+                    // Safe indexing: returns Option[V] = V | None
+                    Some(Type::Union(vec![*val.clone(), Type::None]))
                 } else {
                     None
                 }
@@ -316,7 +327,8 @@ impl Type {
             }
             Self::Str => {
                 if index_ty == &Type::Int {
-                    Some(Type::Str) // Single char as string
+                    // Safe indexing: returns Option[str] = str | None
+                    Some(Type::Union(vec![Type::Str, Type::None]))
                 } else {
                     None
                 }
@@ -384,6 +396,10 @@ impl Type {
             }
             // Class types: nominal typing -- same name means same type
             (Self::Class { name: a, .. }, Self::Class { name: b, .. }) => a == b,
+            // Result types: covariant in both T and E
+            (Self::Result(ok_a, err_a), Self::Result(ok_b, err_b)) => {
+                ok_a.is_assignable_to(ok_b) && err_a.is_assignable_to(err_b)
+            }
             _ => false,
         }
     }
@@ -476,7 +492,8 @@ mod tests {
     #[test]
     fn test_index_result_type() {
         let list_int = Type::List(Box::new(Type::Int));
-        assert_eq!(list_int.index_result_type(&Type::Int), Some(Type::Int));
+        // Safe indexing returns Option[T] = T | None
+        assert_eq!(list_int.index_result_type(&Type::Int), Some(Type::Union(vec![Type::Int, Type::None])));
         assert_eq!(list_int.index_result_type(&Type::Str), None);
     }
 

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -162,6 +162,7 @@ fn type_sort_key(ty: &Type) -> (u8, String) {
         Type::Intersection(_) => (17, String::new()),
         Type::Alias(name, _) => (18, name.clone()),
         Type::Class { name, .. } => (19, name.clone()),
+        Type::Result(_, _) => (20, String::new()),
     }
 }
 

--- a/demo.txt
+++ b/demo.txt
@@ -1,1 +1,0 @@
-Demo ticket placeholder

--- a/demos/milestone_error_handling_demo.sifr
+++ b/demos/milestone_error_handling_demo.sifr
@@ -1,0 +1,126 @@
+# milestone_error_handling demo
+# Showcases: Result type, custom errors, try/except, raise, assert,
+#            fallible/infallible conversions, must_use, let _ = discard
+
+# expect-stdout: === Result Type & Fallible Conversions ===
+# expect-stdout: parsed: 42
+# expect-stdout: parse failed (expected): invalid digit found in string
+# expect-stdout: === Custom Error Types ===
+# expect-stdout: validated: 50
+# expect-stdout: caught: value out of range: -5
+# expect-stdout: === Try/Except with Auto-Unwrap ===
+# expect-stdout: result: 100
+# expect-stdout: error handled: value out of range: 999
+# expect-stdout: === Infallible Conversions ===
+# expect-stdout: int(3.7) = 3
+# expect-stdout: float(5) = 5
+# expect-stdout: str(42) = 42
+# expect-stdout: bool(1) = true
+# expect-stdout: === Raise in Result Functions ===
+# expect-stdout: divide(10, 3) = 3
+# expect-stdout: divide(10, 0) error: division by zero
+# expect-stdout: === Assert Statement ===
+# expect-stdout: all assertions passed
+# expect-stdout: === Explicit Discard ===
+# expect-stdout: result discarded safely
+# expect-stdout: demo complete!
+
+class ValidationError(Error):
+    message: str
+
+def validate_range(x: int, lo: int, hi: int) -> Result[int, ValidationError]:
+    if x < lo:
+        raise ValidationError(f"value out of range: {x}")
+    if x > hi:
+        raise ValidationError(f"value out of range: {x}")
+    return x
+
+def safe_divide(a: int, b: int) -> Result[int, str]:
+    if b == 0:
+        raise "division by zero"
+    return a // b
+
+def main():
+    # --- Result Type & Fallible Conversions ---
+    print("=== Result Type & Fallible Conversions ===")
+
+    try:
+        n: int = int("42")
+        print(f"parsed: {n}")
+    except str as e:
+        print(f"parse failed: {e}")
+
+    try:
+        n2: int = int("not_a_number")
+        print(f"parsed: {n2}")
+    except str as e:
+        print(f"parse failed (expected): {e}")
+
+    # --- Custom Error Types ---
+    print("=== Custom Error Types ===")
+
+    try:
+        v: int = validate_range(50, 0, 100)
+        print(f"validated: {v}")
+    except ValidationError as e:
+        print(f"caught: {e.message}")
+
+    try:
+        v2: int = validate_range(-5, 0, 100)
+        print(f"validated: {v2}")
+    except ValidationError as e:
+        print(f"caught: {e.message}")
+
+    # --- Try/Except with Auto-Unwrap ---
+    print("=== Try/Except with Auto-Unwrap ===")
+
+    try:
+        a: int = validate_range(100, 0, 200)
+        print(f"result: {a}")
+    except ValidationError as e:
+        print(f"error handled: {e.message}")
+
+    try:
+        b: int = validate_range(999, 0, 200)
+        print(f"result: {b}")
+    except ValidationError as e:
+        print(f"error handled: {e.message}")
+
+    # --- Infallible Conversions ---
+    print("=== Infallible Conversions ===")
+    x1: int = int(3.7)
+    print(f"int(3.7) = {x1}")
+    x2: float = float(5)
+    print(f"float(5) = {x2}")
+    x3: str = str(42)
+    print(f"str(42) = {x3}")
+    x4: bool = bool(1)
+    print(f"bool(1) = {x4}")
+
+    # --- Raise in Result Functions ---
+    print("=== Raise in Result Functions ===")
+
+    try:
+        d1: int = safe_divide(10, 3)
+        print(f"divide(10, 3) = {d1}")
+    except str as e:
+        print(f"divide error: {e}")
+
+    try:
+        d2: int = safe_divide(10, 0)
+        print(f"divide(10, 0) = {d2}")
+    except str as e:
+        print(f"divide(10, 0) error: {e}")
+
+    # --- Assert Statement ---
+    print("=== Assert Statement ===")
+    assert 1 + 1 == 2
+    assert True
+    print("all assertions passed")
+
+    # --- Explicit Discard ---
+    print("=== Explicit Discard ===")
+    _ = safe_divide(10, 2)
+    print("result discarded safely")
+
+    print("demo complete!")

--- a/demos/milestone_imports_demo/main.sifr
+++ b/demos/milestone_imports_demo/main.sifr
@@ -1,0 +1,23 @@
+# milestone_imports demo
+# Multi-file project with imports
+
+from models import User, Product
+from utils import greet, format_total
+
+def main():
+    # Import and use functions from utils module
+    msg: str = greet("Alice")
+    print(msg)
+
+    # Import and use classes from models module
+    user: User = User("Alice", "alice@example.com")
+    print(user.display())
+
+    product: Product = Product("Widget", 9.99)
+    print(product.label())
+
+    # Use imported utility function
+    summary: str = format_total(3, 29.97)
+    print(summary)
+
+    print("multi-file compilation works!")

--- a/demos/milestone_imports_demo/models.sifr
+++ b/demos/milestone_imports_demo/models.sifr
@@ -1,0 +1,23 @@
+# models.sifr - Data models for the application
+
+class User:
+    name: str
+    email: str
+
+    def __init__(self, name: str, email: str):
+        self.name = name
+        self.email = email
+
+    def display(self) -> str:
+        return f"{self.name} <{self.email}>"
+
+class Product:
+    name: str
+    price: float
+
+    def __init__(self, name: str, price: float):
+        self.name = name
+        self.price = price
+
+    def label(self) -> str:
+        return f"{self.name}: ${self.price}"

--- a/demos/milestone_imports_demo/utils.sifr
+++ b/demos/milestone_imports_demo/utils.sifr
@@ -1,0 +1,7 @@
+# utils.sifr - Utility functions
+
+def greet(name: str) -> str:
+    return f"Welcome, {name}!"
+
+def format_total(items: int, total: float) -> str:
+    return f"{items} items, total: ${total}"

--- a/demos/milestone_safe_indexing_demo.sifr
+++ b/demos/milestone_safe_indexing_demo.sifr
@@ -1,0 +1,140 @@
+# milestone_safe_indexing demo
+# Showcases: safe list/dict/string indexing, Option returns,
+#            collection methods, del statement, negative indexing
+
+# expect-stdout: === Safe List Indexing ===
+# expect-stdout: nums[1] = 20
+# expect-stdout: nums[99] = None (safe!)
+# expect-stdout: === Safe Dict Indexing ===
+# expect-stdout: ages[alice] = 25
+# expect-stdout: ages[charlie] = None (safe!)
+# expect-stdout: === Safe String Indexing ===
+# expect-stdout: s[0] = h
+# expect-stdout: s[99] = None (safe!)
+# expect-stdout: === Negative Indexing ===
+# expect-stdout: last item: 5
+# expect-stdout: last char: o
+# expect-stdout: === List pop() ===
+# expect-stdout: popped: 30
+# expect-stdout: empty pop: None
+# expect-stdout: === Dict get() and pop() ===
+# expect-stdout: get alice: 25
+# expect-stdout: get missing: None
+# expect-stdout: popped bob: 30
+# expect-stdout: === String find() ===
+# expect-stdout: found world at: 7
+# expect-stdout: xyz not found
+# expect-stdout: === Del Statement ===
+# expect-stdout: before del: 3
+# expect-stdout: after del: 2
+# expect-stdout: demo complete!
+
+def main():
+    # --- Safe List Indexing ---
+    print("=== Safe List Indexing ===")
+    nums: list[int] = [10, 20, 30]
+
+    val: int | None = nums[1]
+    if val is not None:
+        print(f"nums[1] = {val}")
+
+    oob: int | None = nums[99]
+    if oob is not None:
+        print(f"nums[99] = {oob}")
+    else:
+        print("nums[99] = None (safe!)")
+
+    # --- Safe Dict Indexing ---
+    print("=== Safe Dict Indexing ===")
+    ages: dict[str, int] = {"alice": 25, "bob": 30}
+
+    a: int | None = ages["alice"]
+    if a is not None:
+        print(f"ages[alice] = {a}")
+
+    c: int | None = ages["charlie"]
+    if c is not None:
+        print(f"ages[charlie] = {c}")
+    else:
+        print("ages[charlie] = None (safe!)")
+
+    # --- Safe String Indexing ---
+    print("=== Safe String Indexing ===")
+    s: str = "hello"
+
+    ch: str | None = s[0]
+    if ch is not None:
+        print(f"s[0] = {ch}")
+
+    oob_ch: str | None = s[99]
+    if oob_ch is not None:
+        print(f"s[99] = {oob_ch}")
+    else:
+        print("s[99] = None (safe!)")
+
+    # --- Negative Indexing ---
+    print("=== Negative Indexing ===")
+    items: list[int] = [1, 2, 3, 4, 5]
+    last: int | None = items[-1]
+    if last is not None:
+        print(f"last item: {last}")
+
+    last_ch: str | None = s[-1]
+    if last_ch is not None:
+        print(f"last char: {last_ch}")
+
+    # --- List pop() ---
+    print("=== List pop() ===")
+    stack: list[int] = [10, 20, 30]
+    top: int | None = stack.pop()
+    if top is not None:
+        print(f"popped: {top}")
+
+    _ = stack.pop()
+    _ = stack.pop()
+    empty: int | None = stack.pop()
+    if empty is not None:
+        print(f"got: {empty}")
+    else:
+        print("empty pop: None")
+
+    # --- Dict get() and pop() ---
+    print("=== Dict get() and pop() ===")
+    data: dict[str, int] = {"alice": 25, "bob": 30}
+
+    g: int | None = data.get("alice")
+    if g is not None:
+        print(f"get alice: {g}")
+
+    gm: int | None = data.get("missing")
+    if gm is not None:
+        print(f"get missing: {gm}")
+    else:
+        print("get missing: None")
+
+    p: int | None = data.pop("bob")
+    if p is not None:
+        print(f"popped bob: {p}")
+
+    # --- String find() ---
+    print("=== String find() ===")
+    text: str = "hello, world!"
+
+    pos: int | None = text.find("world")
+    if pos is not None:
+        print(f"found world at: {pos}")
+
+    miss: int | None = text.find("xyz")
+    if miss is not None:
+        print(f"found xyz at: {miss}")
+    else:
+        print("xyz not found")
+
+    # --- Del Statement ---
+    print("=== Del Statement ===")
+    config: dict[str, int] = {"a": 1, "b": 2, "c": 3}
+    print(f"before del: {len(config)}")
+    del config["b"]
+    print(f"after del: {len(config)}")
+
+    print("demo complete!")

--- a/issues/milestone-error-handling-epic.md
+++ b/issues/milestone-error-handling-epic.md
@@ -1,0 +1,86 @@
+# milestone_error_handling: Error Handling
+
+## Product Requirements
+
+### Objective
+
+Provide safe error handling that maps to Rust's `Result`/`Option` types rather than Python's exception model. Errors are values, not exceptions. All fallible operations return `Result` or `Option`, and the compiler enforces handling.
+
+### Scope
+
+#### Features In
+
+1. `Result[T, E]` type -> `Result<T, E>` in Rust
+2. `Option[T]` type -> sugar for `T | None`, maps to `Option<T>`
+3. `?` operator for early return on error
+4. `try`/`except` syntax -> pattern matching on `Result`
+5. `raise` -> `Err()` in Result-returning functions
+6. `assert` statement -> `assert!()` / `panic!()`
+7. Custom error types: `class AppError(Error)` (special-cased, not general inheritance)
+8. Fallible built-ins: `int(str)`, `float(str)` -> `Result[T, ParseError]`
+9. Infallible conversions: `int(float)`, `float(int)`, `str(x)`, `bool(x)`
+10. `#[must_use]` enforcement for Result values
+11. `let _ = expr` for explicit discard
+
+#### Features Out
+
+| Feature | Reason |
+|---------|--------|
+| Division by zero Result | Deferred -- complex, needs static analysis |
+| `input()` built-in | Deferred to milestone_io |
+| `try`/`except`/`finally` | Deferred -- needs Drop trait |
+| Match guards | Deferred to milestone_protocols |
+| Struct destructuring in match | Deferred to milestone_protocols |
+
+## Solution Design
+
+### Architecture
+
+```
+sifr_type_system  (Result[T,E], Option[T] types, must_use checking)
+       ↓
+sifr_hir          (new HIR nodes for try/except, raise, assert, ?)
+       ↓
+sifr_codegen      (Result/Option codegen, match on errors, assert!)
+       ↓
+sifr (tests)      (E2E pass/fail tests)
+```
+
+### Task Breakdown
+
+**Task 1: Result/Option Types & Assert**
+- Add `Type::Result(T, E)` and recognize `Option[T]` as `T | None`
+- Add `HirStmt::Assert { test, msg }` and codegen
+- Add `HirExpr::QuestionMark { expr, ty }` for `?` operator
+- Add `HirStmt::Raise { value }` for `raise` -> `Err()`
+
+**Task 2: Error Types & Try/Except**
+- `class AppError(Error)` special-cased error type declarations
+- `try`/`except` lowering to match on Result variants
+- Exhaustiveness checking for except arms
+- Variable binding in except arms (`except ValueError as e`)
+
+**Task 3: Fallible/Infallible Built-ins**
+- `int(str)` -> `Result[int, str]`, `float(str)` -> `Result[float, str]`
+- `int(float)` -> `int` (truncate), `float(int)` -> `float` (widen)
+- `str(x)` for any type, `bool(x)` for any type
+- `#[must_use]` enforcement for Result values
+- `let _ = expr` explicit discard
+
+**Task 4: E2E Tests & Demo**
+- Pass tests: result_basic, try_except, error_propagation, infallible_conversions, assert_basic
+- Fail tests: unhandled_error, unused_result_error
+- Regression tests
+- Milestone demo
+
+### Testing Strategy
+
+| Test | Layer | Check |
+|------|-------|-------|
+| result_basic | E2E pass | Result type, ? operator, raise |
+| try_except | E2E pass | try/except pattern matching |
+| error_propagation | E2E pass | ? operator propagation |
+| infallible_conversions | E2E pass | int(float), float(int), str(x) |
+| assert_basic | E2E pass | assert statement |
+| unhandled_error | E2E fail | Missing error handling |
+| unused_result_error | E2E fail | Unused Result value |

--- a/issues/milestone-imports-epic.md
+++ b/issues/milestone-imports-epic.md
@@ -1,0 +1,79 @@
+# milestone_imports: Multi-file Compilation and Imports
+
+## Product Requirements
+
+### Objective
+
+Support multi-file projects with imports, enabling real application structure. Each `.sifr` file is a module. Functions, classes, and type aliases can be imported across modules.
+
+### Scope
+
+#### Features In
+
+1. `from module import name` - import specific names from another module
+2. Multi-file compilation - compile a directory of `.sifr` files into one binary
+3. Module resolution - find `.sifr` files relative to the project root
+4. `_private` prefix convention - names starting with `_` are not importable
+5. Circular import detection with clear diagnostics
+
+#### Features Out
+
+| Feature | Reason |
+|---------|--------|
+| `import module` (bare import) | Deferred -- requires module-as-namespace support |
+| `__init__.sifr` packages | Deferred -- needs package semantics |
+| Relative imports (`from .utils import`) | Deferred -- needs package structure |
+| Re-exports | Deferred -- needs package semantics |
+
+## Solution Design
+
+### Architecture
+
+```
+sifr_driver   (module resolution, dependency graph, compilation order)
+       ↓
+sifr_hir      (import statement lowering, cross-module name resolution)
+       ↓
+sifr_codegen  (multi-module Rust codegen with mod/use)
+       ↓
+sifr (tests)  (E2E multi-file tests)
+```
+
+### Key Design Decisions
+
+1. **Module = File**: Each `.sifr` file is a module. The module name is the filename without extension.
+2. **Flat module structure**: For now, modules are in the same directory as `main.sifr`.
+3. **Compilation**: The driver compiles all `.sifr` files in the project directory, resolving imports.
+4. **Codegen**: Each module becomes a Rust `mod` block. `from module import name` becomes `use module::name`.
+
+### Task Breakdown
+
+**Task 1: Import Statement Lowering**
+- Parse `from module import name1, name2` statements
+- Add `HirImport` node to HIR
+- Resolve imported names against the target module's exports
+
+**Task 2: Multi-file Driver**
+- Update the driver to discover and compile multiple `.sifr` files
+- Build a dependency graph from import statements
+- Topological sort for compilation order
+- Detect circular imports
+
+**Task 3: Multi-module Codegen**
+- Generate Rust `mod` blocks for each module
+- Generate `use` statements for imports
+- Handle visibility (`pub` for exported names, non-`pub` for `_private`)
+
+**Task 4: E2E Tests & Demo**
+- Pass tests: multi_file_basic, import_function, import_class
+- Fail tests: circular_import, missing_module, private_access
+- Milestone demo
+
+### Testing Strategy
+
+| Test | Layer | Check |
+|------|-------|-------|
+| multi_file_basic | E2E pass | Import function from another module |
+| import_class | E2E pass | Import class from another module |
+| circular_import | E2E fail | Circular import detection |
+| missing_module | E2E fail | Import from non-existent module |

--- a/issues/milestone-safe-indexing-epic.md
+++ b/issues/milestone-safe-indexing-epic.md
@@ -1,0 +1,93 @@
+# milestone_safe_indexing: Safe Indexing and Option Returns
+
+## Product Requirements
+
+### Objective
+
+Make all indexing and fallible collection operations safe by returning `Option[T]` instead of panicking. This eliminates the last remaining panic sources from collection access. Users handle `Option` with `try`/`except` (auto-unwrap), `_ = expr` (discard), or direct assignment.
+
+### Scope
+
+#### Features In
+
+1. **Safe list indexing:** `list[i]` -> `Option[T]` (returns `None` if out-of-bounds)
+2. **Safe dict indexing:** `dict[key]` -> `Option[V]` (returns `None` if key missing)
+3. **Safe string indexing:** `str[i]` -> `Option[str]` (returns `None` if out-of-bounds)
+4. **Negative indexing:** `list[-1]` -> `Option[T]` (resolved relative to length)
+5. **List methods:** `.pop()` -> `Option[T]`, `.index(item)` -> `Option[int]`
+6. **Dict methods:** `.get(key)` -> `Option[V]`, `.pop(key)` -> `Option[V]`
+7. **String methods:** `.find(sub)` -> `Option[int]`
+8. **`del` statement:** `del d[key]`, `del a[i]` as syntax sugar for `.pop()` with discard
+
+#### Features Out
+
+| Feature | Reason |
+|---------|--------|
+| `.remove(item)` -> `Result` | Deferred -- needs more complex error types |
+| `.setdefault(key, default)` | Deferred -- needs default value semantics |
+| `.rfind(sub)` | Deferred -- low priority |
+| Tuple `.index(item)` | Deferred -- tuples are immutable, less common |
+| `int ** negative_int` -> `Result` | Deferred -- complex static analysis |
+| `.unwrap_or(default)` / `.expect("msg")` | Deferred to milestone_protocols |
+
+## Solution Design
+
+### Architecture
+
+The key change is that `Option[T]` is sugar for `T | None` (union type), which already exists in the type system. Safe indexing means changing the return type of indexing operations from `T` to `T | None`.
+
+```
+sifr_type_system  (Option[T] = T | None already works via unions)
+       ↓
+sifr_hir          (update index/subscript lowering to return Option)
+       ↓
+sifr_codegen      (update index codegen to use .get()/.nth() instead of direct index)
+       ↓
+sifr (tests)      (E2E pass/fail tests)
+```
+
+### Key Design Decisions
+
+1. **Option[T] = T | None**: No new type needed. The existing union type system handles this.
+2. **Indexing returns Option**: `list[i]` returns `T | None`, requiring the user to handle the `None` case.
+3. **Auto-unwrap in try blocks**: Inside `try` blocks, `Option` values can be auto-unwrapped (like `Result`).
+4. **`del` as syntax sugar**: `del d[key]` maps to discarding the result of `.pop(key)`.
+
+### Task Breakdown
+
+**Task 1: Safe List Indexing**
+- Change `list[i]` return type from `T` to `T | None`
+- Update codegen to use `.get(i).cloned()` instead of `[i]`
+- Handle negative indexing with safe bounds checking
+- Update existing tests that use list indexing
+
+**Task 2: Safe Dict & String Indexing**
+- Change `dict[key]` return type from `V` to `V | None`
+- Change `str[i]` return type from `str` to `str | None`
+- Update codegen for dict (`.get(&key).cloned()`) and string (`.chars().nth(i)`)
+
+**Task 3: Collection Methods with Option Returns**
+- List `.pop()` -> `Option[T]`, `.index(item)` -> `Option[int]`
+- Dict `.get(key)` -> `Option[V]`, `.pop(key)` -> `Option[V]`
+- String `.find(sub)` -> `Option[int]`
+
+**Task 4: Del Statement & E2E Tests**
+- `del d[key]` -> `let _ = d.remove(&key);`
+- `del a[i]` -> `let _ = a.remove(i);`
+- E2E pass tests: safe_list_index, safe_dict_key, safe_string_index, safe_negative_index
+- E2E fail tests: unused_option_error
+- Milestone demo
+
+### Testing Strategy
+
+| Test | Layer | Check |
+|------|-------|-------|
+| safe_list_index | E2E pass | list[i] returns Option, None for OOB |
+| safe_dict_key | E2E pass | dict[key] returns Option, None for missing |
+| safe_string_index | E2E pass | str[i] returns Option, None for OOB |
+| safe_negative_index | E2E pass | negative indexing with Option |
+| list_pop_option | E2E pass | .pop() returns Option |
+| dict_get_option | E2E pass | .get() returns Option |
+| string_find_option | E2E pass | .find() returns Option |
+| del_statement | E2E pass | del d[key], del a[i] |
+| unused_option_error | E2E fail | unused Option value |


### PR DESCRIPTION
## Summary

Completes **Phase 1: Language Foundations** with three milestones:

### Error Handling (closes #51, closes #52, closes #53, closes #54, closes #55)
- `Result[T, E]` and `Option[T]` types with Rust codegen
- `try`/`except` as pattern matching on `Result` with auto-unwrap (`?` operator)
- `raise` maps to `Err()`, `assert` maps to `assert!`/`panic!`
- Custom error types via `class Foo(Error)` with `Display`/`Error` traits
- Fallible built-in conversions (`int(str)`, `float(str)`) return `Result`
- `#[must_use]` enforcement for `Result` values, `let _ = expr` for discard

### Safe Indexing (closes #56, closes #57, closes #58, closes #59, closes #60)
- `list[i]`, `dict[key]`, `str[i]` return `Option[T]` instead of panicking
- Negative indexing support for lists and strings
- Collection methods (`pop`, `get`, `find`) return `Option`
- `del` statement as syntax sugar for `.remove()` with implicit discard

### Imports (closes #61, closes #62, closes #63, closes #64, closes #65)
- `from module import name` syntax mapping to Rust `use` statements
- Multi-file compilation of `.sifr` projects into single binary
- Cross-module type checking for imported functions and classes
- `_private` prefix convention for non-public visibility
- Conditional `pub` emission for exported items

## Test plan

- [x] All 241 tests pass (`cargo test`)
- [x] Error handling demo works (`demos/milestone_error_handling_demo.sifr`)
- [x] Safe indexing demo works (`demos/milestone_safe_indexing_demo.sifr`)
- [x] Imports demo works (`demos/milestone_imports_demo/`)
- [x] New E2E pass tests: result_basic, error_propagation, custom_error, discard_result, assert_basic, infallible_conversions, safe_list_index, safe_dict_key, safe_string_index, safe_negative_index, list_pop_option, dict_get_option, string_find_option, del_statement
- [x] New E2E fail test: unused_result
- [x] Existing indexing tests updated for Option returns


Made with [Cursor](https://cursor.com)