### PR TITLE
feat: milestone_codegen_quality - improve Rust codegen idiomaticity

### DIFF
--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -106,6 +106,8 @@ struct RustEmitter {
     in_loop_with_else: bool,
     /// Whether to emit `pub` on all top-level items (for module exports)
     pub_mode: bool,
+    /// Set of variable names that are mutated in the current function body
+    mutated_vars: HashSet<String>,
 }
 
 impl RustEmitter {
@@ -121,6 +123,7 @@ impl RustEmitter {
             func_signatures: HashMap::new(),
             in_loop_with_else: false,
             pub_mode: false,
+            mutated_vars: HashSet::new(),
         }
     }
 
@@ -385,6 +388,9 @@ impl RustEmitter {
     fn emit_class_method(&mut self, method: &HirFunction, class: &HirClass) {
         self.current_return_type = Some(method.return_type.clone());
 
+        // Pre-scan: collect mutated variables so we know which need `mut`
+        self.mutated_vars = collect_mutated_vars(&method.body);
+
         self.write_indent();
         let pub_prefix = if self.pub_mode { "pub " } else { "" };
         if method.name == "new" {
@@ -489,11 +495,15 @@ impl RustEmitter {
         }
 
         self.current_return_type = None;
+        self.mutated_vars.clear();
     }
 
     fn emit_function(&mut self, func: &HirFunction) {
         // Track the current function's return type for Option wrapping
         self.current_return_type = Some(func.return_type.clone());
+
+        // Pre-scan: collect mutated variables so we know which need `mut`
+        self.mutated_vars = collect_mutated_vars(&func.body);
 
         // Function signature -- only emit params without defaults, or all params
         // Since Rust doesn't have default params, we emit all params and handle
@@ -510,6 +520,10 @@ impl RustEmitter {
         for (i, param) in func.params.iter().enumerate() {
             if i > 0 {
                 self.write(", ");
+            }
+            // Emit `mut` for parameters that are mutated in the body
+            if self.mutated_vars.contains(&param.name) {
+                self.write("mut ");
             }
             self.write(&param.name);
             self.write(": ");
@@ -538,13 +552,15 @@ impl RustEmitter {
         self.writeln("}");
 
         self.current_return_type = None;
+        self.mutated_vars.clear();
     }
 
     fn emit_stmt(&mut self, stmt: &HirStmt) {
         match stmt {
-            HirStmt::Let { name, ty, value, is_mutable } => {
+            HirStmt::Let { name, ty, value, is_mutable: _ } => {
                 self.write_indent();
-                if *is_mutable {
+                // Only emit `mut` if the variable is actually mutated later
+                if self.mutated_vars.contains(name) {
                     self.write("let mut ");
                 } else {
                     self.write("let ");
@@ -584,8 +600,8 @@ impl RustEmitter {
                         match var_ty {
                             Type::Str => {
                                 self.write(name);
-                                self.write(".push_str(&");
-                                self.emit_expr(value);
+                                self.write(".push_str(");
+                                self.emit_str_ref_expr(value);
                                 self.write(");\n");
                                 return;
                             }
@@ -992,7 +1008,7 @@ impl RustEmitter {
                     self.write("assert!(");
                     self.emit_expr(test);
                     self.write(", \"{}\", ");
-                    self.emit_expr(msg_expr);
+                    self.emit_display_expr(msg_expr);
                     self.write(");\n");
                 } else {
                     self.write("assert!(");
@@ -1017,8 +1033,8 @@ impl RustEmitter {
                         // del d[key] -> let _ = d.remove(&key);
                         self.write("let _ = ");
                         self.emit_expr(object);
-                        self.write(".remove(&");
-                        self.emit_expr(index);
+                        self.write(".remove(");
+                        self.emit_key_ref_expr(index);
                         self.write(");\n");
                     }
                     Type::List(_) => {
@@ -1224,8 +1240,7 @@ impl RustEmitter {
                 self.emit_expr(object);
                 self.write(".starts_with(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
-                    self.write(".as_str()");
+                    self.emit_str_ref_expr(&args[0]);
                 }
                 self.write(")");
             }
@@ -1233,8 +1248,7 @@ impl RustEmitter {
                 self.emit_expr(object);
                 self.write(".ends_with(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
-                    self.write(".as_str()");
+                    self.emit_str_ref_expr(&args[0]);
                 }
                 self.write(")");
             }
@@ -1244,18 +1258,17 @@ impl RustEmitter {
                     self.write(".split_whitespace().map(|s| s.to_string()).collect::<Vec<String>>()");
                 } else {
                     self.write(".split(");
-                    self.emit_expr(&args[0]);
-                    self.write(".as_str()).map(|s| s.to_string()).collect::<Vec<String>>()");
+                    self.emit_str_ref_expr(&args[0]);
+                    self.write(").map(|s| s.to_string()).collect::<Vec<String>>()");
                 }
             }
             (Type::Str, "replace") => {
                 self.emit_expr(object);
                 self.write(".replace(");
                 if args.len() >= 2 {
-                    self.emit_expr(&args[0]);
-                    self.write(".as_str(), ");
-                    self.emit_expr(&args[1]);
-                    self.write(".as_str()");
+                    self.emit_str_ref_expr(&args[0]);
+                    self.write(", ");
+                    self.emit_str_ref_expr(&args[1]);
                 }
                 self.write(")");
             }
@@ -1264,8 +1277,7 @@ impl RustEmitter {
                 self.emit_expr(object);
                 self.write(".find(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
-                    self.write(".as_str()");
+                    self.emit_str_ref_expr(&args[0]);
                 }
                 self.write(").map(|i| i as i64)");
             }
@@ -1328,17 +1340,16 @@ impl RustEmitter {
                 // Python: "sep".join(items) -> Rust: items.join("sep")
                 if !args.is_empty() {
                     self.emit_expr(&args[0]);
-                    self.write(".join(&");
-                    self.emit_expr(object);
+                    self.write(".join(");
+                    self.emit_str_ref_expr(object);
                     self.write(")");
                 }
             }
             (Type::Str, "count") => {
                 self.emit_expr(object);
-                self.write(".matches(&");
+                self.write(".matches(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
-                    self.write(" as &str");
+                    self.emit_str_ref_expr(&args[0]);
                 }
                 self.write(").count() as i64");
             }
@@ -1465,27 +1476,27 @@ impl RustEmitter {
             }
             (Type::Dict(_, _), "contains") => {
                 self.emit_expr(object);
-                self.write(".contains_key(&");
+                self.write(".contains_key(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
+                    self.emit_key_ref_expr(&args[0]);
                 }
                 self.write(")");
             }
             (Type::Dict(_, _), "get") => {
                 // Returns Option<V> = V | None
                 self.emit_expr(object);
-                self.write(".get(&");
+                self.write(".get(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
+                    self.emit_key_ref_expr(&args[0]);
                 }
                 self.write(").cloned()");
             }
             (Type::Dict(_, _), "pop") => {
                 // Returns Option<V> = V | None
                 self.emit_expr(object);
-                self.write(".remove(&");
+                self.write(".remove(");
                 if !args.is_empty() {
-                    self.emit_expr(&args[0]);
+                    self.emit_key_ref_expr(&args[0]);
                 }
                 self.write(")");
             }
@@ -1571,10 +1582,16 @@ impl RustEmitter {
             HirExpr::BinOp { left, op, right, ty } => {
                 // Special handling for string concatenation
                 if op == "+" && *ty == Type::Str {
-                    self.write("format!(\"{}{}\", ");
-                    self.emit_expr(left);
-                    self.write(", ");
-                    self.emit_expr(right);
+                    // Flatten chained string concatenation into a single format! call
+                    let mut parts: Vec<&HirExpr> = Vec::new();
+                    collect_string_concat_parts(left, &mut parts);
+                    collect_string_concat_parts(right, &mut parts);
+                    let placeholders: String = parts.iter().map(|_| "{}").collect::<Vec<_>>().join("");
+                    self.write(&format!("format!(\"{}\"", placeholders));
+                    for part in &parts {
+                        self.write(", ");
+                        self.emit_expr(part);
+                    }
                     self.write(")");
                 } else if op == "//" {
                     // Floor division
@@ -1686,20 +1703,22 @@ impl RustEmitter {
                 if func == "print" {
                     // Map print() to println!
                     if args.is_empty() {
-                        self.write("println!(\"{}\", \"\")");
+                        self.write("println!()");
+                    } else if let HirExpr::FString { parts, .. } = &args[0] {
+                        // Inline f-string directly into println! to avoid double-format
+                        self.emit_fstring_macro("println!", parts);
                     } else if matches!(args[0].ty(), Type::Class { .. }) {
                         // Use Debug format for class instances
                         self.write("println!(\"{:?}\", ");
                         self.emit_expr(&args[0]);
                         self.write(")");
-                    } else if is_option_type(args[0].ty()) {
-                        // Option<T>: display inner value or "None"
+                    } else {
+                        // Use emit_display_expr for all other cases:
+                        // - Option<T> gets map_or wrapping
+                        // - String literals omit .to_string()
+                        // - Everything else emits normally
                         self.write("println!(\"{}\", ");
                         self.emit_display_expr(&args[0]);
-                        self.write(")");
-                    } else {
-                        self.write("println!(\"{}\", ");
-                        self.emit_expr(&args[0]);
                         self.write(")");
                     };
                 } else if func == "isinstance" {
@@ -1877,7 +1896,7 @@ impl RustEmitter {
             }
             HirExpr::DictLiteral { keys, values, .. } => {
                 self.needs_hashmap = true;
-                self.write("std::collections::HashMap::from([");
+                self.write("HashMap::from([");
                 for (i, (key, val)) in keys.iter().zip(values.iter()).enumerate() {
                     if i > 0 {
                         self.write(", ");
@@ -1910,8 +1929,8 @@ impl RustEmitter {
                         // Safe dict indexing: d[key] -> d.get(&key).cloned()
                         // Returns Option<V> which maps to our V | None union
                         self.emit_expr(object);
-                        self.write(".get(&");
-                        self.emit_expr(index);
+                        self.write(".get(");
+                        self.emit_key_ref_expr(index);
                         self.write(").cloned()");
                     }
                     Type::Tuple(_) => {
@@ -1963,15 +1982,15 @@ impl RustEmitter {
                 match coll_ty {
                     Type::Dict(_, _) => {
                         self.emit_expr(collection);
-                        self.write(".contains_key(&");
-                        self.emit_expr(element);
+                        self.write(".contains_key(");
+                        self.emit_key_ref_expr(element);
                         self.write(")");
                     }
                     Type::Str => {
                         self.emit_expr(collection);
-                        self.write(".contains(&");
-                        self.emit_expr(element);
-                        self.write(" as &str)");
+                        self.write(".contains(");
+                        self.emit_str_ref_expr(element);
+                        self.write(")");
                     }
                     _ => {
                         // List: collection.contains(&element)
@@ -2048,47 +2067,81 @@ impl RustEmitter {
                 self.write(")");
             }
             HirExpr::FString { parts, .. } => {
-                // Build the format string and collect expressions
-                let mut format_str = String::new();
-                let mut exprs: Vec<&HirExpr> = Vec::new();
-                for part in parts {
-                    match part {
-                        HirFStringPart::Literal(s) => {
-                            // Escape braces in the literal for Rust's format!
-                            for ch in s.chars() {
-                                match ch {
-                                    '{' => format_str.push_str("{{"),
-                                    '}' => format_str.push_str("}}"),
-                                    _ => format_str.push(ch),
-                                }
-                            }
-                        }
-                        HirFStringPart::Expr(expr) => {
-                            format_str.push_str("{}");
-                            exprs.push(expr);
+                self.emit_fstring_macro("format!", parts);
+            }
+        }
+    }
+
+    /// Emit an f-string as a Rust format macro call (format!, println!, etc.).
+    /// This avoids the double-format pattern `println!("{}", format!(...))`.
+    fn emit_fstring_macro(&mut self, macro_name: &str, parts: &[HirFStringPart]) {
+        let mut format_str = String::new();
+        let mut exprs: Vec<&HirExpr> = Vec::new();
+        for part in parts {
+            match part {
+                HirFStringPart::Literal(s) => {
+                    // Escape braces in the literal for Rust's format!
+                    for ch in s.chars() {
+                        match ch {
+                            '{' => format_str.push_str("{{"),
+                            '}' => format_str.push_str("}}"),
+                            _ => format_str.push(ch),
                         }
                     }
                 }
-                self.write("format!(\"");
-                self.write(&format_str);
-                self.write("\"");
-                for expr in &exprs {
-                    self.write(", ");
-                    self.emit_display_expr(expr);
+                HirFStringPart::Expr(expr) => {
+                    format_str.push_str("{}");
+                    exprs.push(expr);
                 }
-                self.write(")");
             }
+        }
+        self.write(macro_name);
+        self.write("(\"");
+        self.write(&format_str);
+        self.write("\"");
+        for expr in &exprs {
+            self.write(", ");
+            self.emit_display_expr(expr);
+        }
+        self.write(")");
+    }
+
+    /// Emit an expression as a HashMap key reference.
+    /// String literals are emitted directly (e.g., `"key"`) since HashMap::get accepts &str via Borrow.
+    /// Other expressions are emitted with `&` prefix (e.g., `&var`).
+    fn emit_key_ref_expr(&mut self, expr: &HirExpr) {
+        if let HirExpr::StringLiteral(val) = expr {
+            self.write(&format!("{:?}", val));
+        } else {
+            self.write("&");
+            self.emit_expr(expr);
+        }
+    }
+
+    /// Emit an expression as a `&str` reference.
+    /// String literals are emitted directly (e.g., `"hello"`).
+    /// Other string expressions are emitted with `.as_str()` (e.g., `s.as_str()`).
+    fn emit_str_ref_expr(&mut self, expr: &HirExpr) {
+        if let HirExpr::StringLiteral(val) = expr {
+            self.write(&format!("{:?}", val));
+        } else {
+            self.emit_expr(expr);
+            self.write(".as_str()");
         }
     }
 
     /// Emit an expression suitable for use inside format!/println! contexts.
     /// Wraps Option<T> expressions so they display as the inner value or "None".
+    /// Omits `.to_string()` on string literals since format macros accept &str.
     fn emit_display_expr(&mut self, expr: &HirExpr) {
         if is_option_type(expr.ty()) {
             // Wrap: expr.map_or("None".to_string(), |_v| format!("{}", _v))
             self.write("(");
             self.emit_expr(expr);
             self.write(").map_or(\"None\".to_string(), |_v| format!(\"{}\", _v))");
+        } else if let HirExpr::StringLiteral(val) = expr {
+            // In display contexts, string literals don't need .to_string()
+            self.write(&format!("{:?}", val));
         } else {
             self.emit_expr(expr);
         }
@@ -2196,9 +2249,156 @@ fn detect_is_none_var(expr: &HirExpr) -> Option<String> {
     None
 }
 
+/// Collect all parts of a chained string concatenation (`a + b + c`).
+/// Recursively flattens nested BinOp::Add on strings into a flat list of expressions.
+fn collect_string_concat_parts<'a>(expr: &'a HirExpr, parts: &mut Vec<&'a HirExpr>) {
+    if let HirExpr::BinOp { left, op, right, ty } = expr {
+        if op == "+" && *ty == Type::Str {
+            collect_string_concat_parts(left, parts);
+            collect_string_concat_parts(right, parts);
+            return;
+        }
+    }
+    parts.push(expr);
+}
+
 /// Check if a method body contains any field assignments (self.field = ...).
 fn body_contains_field_assign_codegen(stmts: &[HirStmt]) -> bool {
     stmts.iter().any(|s| matches!(s, HirStmt::FieldAssign { .. }))
+}
+
+/// Mutating methods that require the receiver variable to be `mut`.
+const MUTATING_METHODS: &[&str] = &[
+    "append", "extend", "insert", "clear", "reverse", "sort", "pop", "remove",
+    "push_str", "update",
+];
+
+/// Collect the set of variable names that are mutated in a function body.
+/// A variable is mutated if it appears in:
+/// - `HirStmt::Assign` (reassignment)
+/// - `HirStmt::AugAssign` (augmented assignment like +=)
+/// - `HirStmt::Expr` containing a `MethodCall` on the variable with a mutating method
+/// - `HirStmt::Delete` on the variable
+fn collect_mutated_vars(stmts: &[HirStmt]) -> HashSet<String> {
+    let mut mutated = HashSet::new();
+    collect_mutated_vars_inner(stmts, &mut mutated);
+    mutated
+}
+
+fn collect_mutated_vars_inner(stmts: &[HirStmt], mutated: &mut HashSet<String>) {
+    for stmt in stmts {
+        match stmt {
+            HirStmt::Assign { name, .. } => {
+                mutated.insert(name.clone());
+            }
+            HirStmt::AugAssign { name, .. } => {
+                mutated.insert(name.clone());
+            }
+            HirStmt::Expr { expr } => {
+                collect_mutated_vars_in_expr(expr, mutated);
+            }
+            HirStmt::Let { value, .. } => {
+                // Scan the value expression for mutating method calls
+                collect_mutated_vars_in_expr(value, mutated);
+            }
+            HirStmt::Return { value: Some(expr) } => {
+                collect_mutated_vars_in_expr(expr, mutated);
+            }
+            HirStmt::If { condition, then_body, elif_clauses, else_body } => {
+                collect_mutated_vars_in_expr(condition, mutated);
+                collect_mutated_vars_inner(then_body, mutated);
+                for (cond, body) in elif_clauses {
+                    collect_mutated_vars_in_expr(cond, mutated);
+                    collect_mutated_vars_inner(body, mutated);
+                }
+                if let Some(body) = else_body {
+                    collect_mutated_vars_inner(body, mutated);
+                }
+            }
+            HirStmt::While { condition, body, else_body } => {
+                collect_mutated_vars_in_expr(condition, mutated);
+                collect_mutated_vars_inner(body, mutated);
+                if let Some(eb) = else_body {
+                    collect_mutated_vars_inner(eb, mutated);
+                }
+            }
+            HirStmt::For { body, else_body, .. } => {
+                collect_mutated_vars_inner(body, mutated);
+                if let Some(eb) = else_body {
+                    collect_mutated_vars_inner(eb, mutated);
+                }
+            }
+            HirStmt::TryExcept { body, handlers } => {
+                collect_mutated_vars_inner(body, mutated);
+                for handler in handlers {
+                    collect_mutated_vars_inner(&handler.body, mutated);
+                }
+            }
+            HirStmt::Delete { object, .. } => {
+                if let HirExpr::Name { name, .. } = object {
+                    mutated.insert(name.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_mutated_vars_in_expr(expr: &HirExpr, mutated: &mut HashSet<String>) {
+    match expr {
+        HirExpr::MethodCall { object, method, args, .. } => {
+            if MUTATING_METHODS.contains(&method.as_str()) {
+                if let HirExpr::Name { name, .. } = object.as_ref() {
+                    mutated.insert(name.clone());
+                }
+            }
+            // Recurse into sub-expressions
+            collect_mutated_vars_in_expr(object, mutated);
+            for arg in args {
+                collect_mutated_vars_in_expr(arg, mutated);
+            }
+        }
+        HirExpr::Call { args, .. } => {
+            for arg in args {
+                collect_mutated_vars_in_expr(arg, mutated);
+            }
+        }
+        HirExpr::BinOp { left, right, .. } => {
+            collect_mutated_vars_in_expr(left, mutated);
+            collect_mutated_vars_in_expr(right, mutated);
+        }
+        HirExpr::UnaryOp { operand, .. } => {
+            collect_mutated_vars_in_expr(operand, mutated);
+        }
+        HirExpr::Compare { left, comparators, .. } => {
+            collect_mutated_vars_in_expr(left, mutated);
+            for c in comparators {
+                collect_mutated_vars_in_expr(c, mutated);
+            }
+        }
+        HirExpr::BoolOp { values, .. } => {
+            for v in values {
+                collect_mutated_vars_in_expr(v, mutated);
+            }
+        }
+        HirExpr::IfExpr { condition, then_expr, else_expr, .. } => {
+            collect_mutated_vars_in_expr(condition, mutated);
+            collect_mutated_vars_in_expr(then_expr, mutated);
+            collect_mutated_vars_in_expr(else_expr, mutated);
+        }
+        HirExpr::Index { object, index, .. } => {
+            collect_mutated_vars_in_expr(object, mutated);
+            collect_mutated_vars_in_expr(index, mutated);
+        }
+        HirExpr::FString { parts, .. } => {
+            for part in parts {
+                if let HirFStringPart::Expr(e) = part {
+                    collect_mutated_vars_in_expr(e, mutated);
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -2258,5 +2458,305 @@ mod tests {
         let rust_code = generate_rust(&module);
         assert!(rust_code.contains("fn add(a: i64, b: i64) -> i64"));
         assert!(rust_code.contains("return a + b;"));
+    }
+
+    // --- Codegen Quality Tests ---
+
+    #[test]
+    fn test_no_unnecessary_mut() {
+        // Variable that is never reassigned should NOT have `mut`
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![
+                    HirStmt::Let {
+                        name: "x".to_string(),
+                        ty: Type::Int,
+                        value: HirExpr::IntLiteral(42),
+                        is_mutable: true, // HIR says mutable, but codegen should ignore
+                    },
+                    HirStmt::Expr {
+                        expr: HirExpr::Call {
+                            func: "print".to_string(),
+                            args: vec![HirExpr::Name { name: "x".to_string(), ty: Type::Int }],
+                            ty: Type::None,
+                        },
+                    },
+                ],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("let x: i64"), "should emit `let x` without mut");
+        assert!(!rust_code.contains("let mut x"), "should NOT emit `let mut x`");
+    }
+
+    #[test]
+    fn test_mut_on_reassigned_variable() {
+        // Variable that IS reassigned should have `mut`
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![
+                    HirStmt::Let {
+                        name: "x".to_string(),
+                        ty: Type::Int,
+                        value: HirExpr::IntLiteral(0),
+                        is_mutable: true,
+                    },
+                    HirStmt::Assign {
+                        name: "x".to_string(),
+                        value: HirExpr::IntLiteral(1),
+                    },
+                ],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("let mut x: i64"), "should emit `let mut x` for reassigned var");
+    }
+
+    #[test]
+    fn test_println_fstring_inlined() {
+        // print(f"hello {name}") should emit println!("hello {}", name) not println!("{}", format!(...))
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![
+                    HirStmt::Let {
+                        name: "name".to_string(),
+                        ty: Type::Str,
+                        value: HirExpr::StringLiteral("World".to_string()),
+                        is_mutable: false,
+                    },
+                    HirStmt::Expr {
+                        expr: HirExpr::Call {
+                            func: "print".to_string(),
+                            args: vec![HirExpr::FString {
+                                parts: vec![
+                                    HirFStringPart::Literal("Hello, ".to_string()),
+                                    HirFStringPart::Expr(HirExpr::Name { name: "name".to_string(), ty: Type::Str }),
+                                    HirFStringPart::Literal("!".to_string()),
+                                ],
+                                ty: Type::Str,
+                            }],
+                            ty: Type::None,
+                        },
+                    },
+                ],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("println!(\"Hello, {}!\", name)"), "should inline f-string into println!");
+        assert!(!rust_code.contains("format!(\"Hello, {}!\""), "should NOT have standalone format! inside println!");
+    }
+
+    #[test]
+    fn test_no_tostring_in_println() {
+        // print("hello") should emit println!("{}", "hello") not println!("{}", "hello".to_string())
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![HirStmt::Expr {
+                    expr: HirExpr::Call {
+                        func: "print".to_string(),
+                        args: vec![HirExpr::StringLiteral("hello".to_string())],
+                        ty: Type::None,
+                    },
+                }],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("println!(\"{}\", \"hello\")"), "should emit string literal without .to_string()");
+        assert!(!rust_code.contains("\"hello\".to_string()"), "should NOT have .to_string() in println context");
+    }
+
+    #[test]
+    fn test_hashmap_short_name() {
+        // Dict literal should use HashMap::from not std::collections::HashMap::from
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![HirStmt::Let {
+                    name: "d".to_string(),
+                    ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                    value: HirExpr::DictLiteral {
+                        keys: vec![HirExpr::StringLiteral("a".to_string())],
+                        values: vec![HirExpr::IntLiteral(1)],
+                        ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                    },
+                    is_mutable: false,
+                }],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("use std::collections::HashMap;"), "should have HashMap import");
+        assert!(rust_code.contains("HashMap::from("), "should use short HashMap::from");
+        assert!(!rust_code.contains("std::collections::HashMap::from("), "should NOT use fully qualified HashMap::from");
+        assert!(rust_code.contains("HashMap<String, i64>"), "type annotation should use short HashMap");
+    }
+
+    #[test]
+    fn test_dict_get_string_literal_key() {
+        // d["key"] should emit d.get("key") not d.get(&"key".to_string())
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![
+                    HirStmt::Let {
+                        name: "d".to_string(),
+                        ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                        value: HirExpr::DictLiteral {
+                            keys: vec![HirExpr::StringLiteral("key".to_string())],
+                            values: vec![HirExpr::IntLiteral(1)],
+                            ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                        },
+                        is_mutable: false,
+                    },
+                    HirStmt::Let {
+                        name: "v".to_string(),
+                        ty: Type::Union(vec![Type::Int, Type::None]),
+                        value: HirExpr::Index {
+                            object: Box::new(HirExpr::Name {
+                                name: "d".to_string(),
+                                ty: Type::Dict(Box::new(Type::Str), Box::new(Type::Int)),
+                            }),
+                            index: Box::new(HirExpr::StringLiteral("key".to_string())),
+                            ty: Type::Union(vec![Type::Int, Type::None]),
+                        },
+                        is_mutable: false,
+                    },
+                ],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains(".get(\"key\")"), "should emit .get(\"key\") for string literal key");
+        assert!(!rust_code.contains("&\"key\".to_string()"), "should NOT have &\"key\".to_string()");
+    }
+
+    #[test]
+    fn test_string_concat_flattened() {
+        // "a" + "b" + "c" should emit format!("{}{}{}", ...) not nested format!
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![HirStmt::Let {
+                    name: "s".to_string(),
+                    ty: Type::Str,
+                    value: HirExpr::BinOp {
+                        left: Box::new(HirExpr::BinOp {
+                            left: Box::new(HirExpr::StringLiteral("a".to_string())),
+                            op: "+".to_string(),
+                            right: Box::new(HirExpr::StringLiteral("b".to_string())),
+                            ty: Type::Str,
+                        }),
+                        op: "+".to_string(),
+                        right: Box::new(HirExpr::StringLiteral("c".to_string())),
+                        ty: Type::Str,
+                    },
+                    is_mutable: false,
+                }],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("format!(\"{}{}{}\","), "should flatten into single format! with 3 placeholders");
+        assert_eq!(rust_code.matches("format!").count(), 1, "should have exactly one format! call");
+    }
+
+    #[test]
+    fn test_mut_on_mutating_method_call() {
+        // Variable with .push() call should have `mut`
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![
+                    HirStmt::Let {
+                        name: "items".to_string(),
+                        ty: Type::List(Box::new(Type::Int)),
+                        value: HirExpr::ListLiteral {
+                            elements: vec![HirExpr::IntLiteral(1)],
+                            ty: Type::List(Box::new(Type::Int)),
+                        },
+                        is_mutable: true,
+                    },
+                    HirStmt::Expr {
+                        expr: HirExpr::MethodCall {
+                            object: Box::new(HirExpr::Name {
+                                name: "items".to_string(),
+                                ty: Type::List(Box::new(Type::Int)),
+                            }),
+                            method: "append".to_string(),
+                            args: vec![HirExpr::IntLiteral(2)],
+                            ty: Type::None,
+                        },
+                    },
+                ],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("let mut items"), "should emit `let mut items` for variable with .push()");
+    }
+
+    #[test]
+    fn test_empty_print() {
+        // print() should emit println!() not println!("{}", "")
+        let module = HirModule {
+            functions: vec![HirFunction {
+                name: "main".to_string(),
+                params: vec![],
+                return_type: Type::None,
+                body: vec![HirStmt::Expr {
+                    expr: HirExpr::Call {
+                        func: "print".to_string(),
+                        args: vec![],
+                        ty: Type::None,
+                    },
+                }],
+            }],
+            classes: vec![],
+            imports: vec![],
+        };
+
+        let rust_code = generate_rust(&module);
+        assert!(rust_code.contains("println!()"), "should emit println!() for empty print");
+        assert!(!rust_code.contains(r#"println!("{}", "")"#), "should NOT emit println with empty string arg");
     }
 }

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -162,7 +162,7 @@ impl Type {
             Self::Str => "String".to_string(),
             Self::None => "()".to_string(),
             Self::List(elem) => format!("Vec<{}>", elem.rust_type()),
-            Self::Dict(key, val) => format!("std::collections::HashMap<{}, {}>", key.rust_type(), val.rust_type()),
+            Self::Dict(key, val) => format!("HashMap<{}, {}>", key.rust_type(), val.rust_type()),
             Self::Tuple(elems) => {
                 let parts: Vec<String> = elems.iter().map(Self::rust_type).collect();
                 format!("({})", parts.join(", "))
@@ -469,7 +469,7 @@ mod tests {
         let dict_str_int = Type::Dict(Box::new(Type::Str), Box::new(Type::Int));
         assert_eq!(dict_str_int.ownership(), OwnershipKind::Move);
         assert_eq!(dict_str_int.display_name(), "dict[str, int]");
-        assert_eq!(dict_str_int.rust_type(), "std::collections::HashMap<String, i64>");
+        assert_eq!(dict_str_int.rust_type(), "HashMap<String, i64>");
     }
 
     #[test]

--- a/demos/milestone_classes_demo.rs
+++ b/demos/milestone_classes_demo.rs
@@ -29,8 +29,8 @@ impl Point {
     }
 
     fn distance(&self, other: &Point) -> f64 {
-        let mut dx: f64 = self.x - other.x;
-        let mut dy: f64 = self.y - other.y;
+        let dx: f64 = self.x - other.x;
+        let dy: f64 = self.y - other.y;
         return ((dx * dx) + (dy * dy) as f64).powf(0.5_f64 as f64);
     }
 
@@ -109,37 +109,37 @@ impl Color {
 fn describe_shape(shape: CircleOrSquare) {
     match shape {
         CircleOrSquare::Circle(shape) => {
-            println!("{}", format!("Circle: radius={}", shape.radius));
+            println!("Circle: radius={}", shape.radius);
         }
         CircleOrSquare::Square(shape) => {
-            println!("{}", format!("Square: side={}", shape.side));
+            println!("Square: side={}", shape.side);
         }
     }
 }
 
 fn main() {
-    println!("{}", "=== Basic Class ===".to_string());
-    let mut origin: Point = Point::new(0.0_f64, 0.0_f64);
-    let mut target: Point = Point::new(3.0_f64, 4.0_f64);
-    let mut d: f64 = origin.distance(&target);
-    println!("{}", format!("Distance from origin to (3,4): {}", d));
-    println!("{}", "=== Methods ===".to_string());
-    let mut rect: Rectangle = Rectangle::new(5.0_f64, 3.0_f64);
-    println!("{}", format!("Rectangle area: {}", rect.area()));
-    println!("{}", format!("Rectangle perimeter: {}", rect.perimeter()));
-    println!("{}", "=== Field Access ===".to_string());
-    println!("{}", format!("Rectangle width: {}", rect.width));
-    println!("{}", format!("Rectangle height: {}", rect.height));
-    println!("{}", "=== Union + isinstance ===".to_string());
-    let mut c: Circle = Circle::new(10.0_f64);
-    let mut s: Square = Square::new(7.0_f64);
+    println!("{}", "=== Basic Class ===");
+    let origin: Point = Point::new(0.0_f64, 0.0_f64);
+    let target: Point = Point::new(3.0_f64, 4.0_f64);
+    let d: f64 = origin.distance(&target);
+    println!("Distance from origin to (3,4): {}", d);
+    println!("{}", "=== Methods ===");
+    let rect: Rectangle = Rectangle::new(5.0_f64, 3.0_f64);
+    println!("Rectangle area: {}", rect.area());
+    println!("Rectangle perimeter: {}", rect.perimeter());
+    println!("{}", "=== Field Access ===");
+    println!("Rectangle width: {}", rect.width);
+    println!("Rectangle height: {}", rect.height);
+    println!("{}", "=== Union + isinstance ===");
+    let c: Circle = Circle::new(10.0_f64);
+    let s: Square = Square::new(7.0_f64);
     describe_shape(CircleOrSquare::Circle(c));
     describe_shape(CircleOrSquare::Square(s));
-    println!("{}", "=== Hash ===".to_string());
-    let mut red: Color = Color::new(255_i64, 0_i64, 0_i64);
-    let mut also_red: Color = Color::new(255_i64, 0_i64, 0_i64);
-    let mut h1: i64 = { use std::hash::{Hash, Hasher}; let mut _h = std::collections::hash_map::DefaultHasher::new(); red.hash(&mut _h); _h.finish() as i64 };
-    let mut h2: i64 = { use std::hash::{Hash, Hasher}; let mut _h = std::collections::hash_map::DefaultHasher::new(); also_red.hash(&mut _h); _h.finish() as i64 };
-    println!("{}", format!("Same color same hash: {}", h1 == h2));
-    println!("{}", "=== Done ===".to_string());
+    println!("{}", "=== Hash ===");
+    let red: Color = Color::new(255_i64, 0_i64, 0_i64);
+    let also_red: Color = Color::new(255_i64, 0_i64, 0_i64);
+    let h1: i64 = { use std::hash::{Hash, Hasher}; let mut _h = std::collections::hash_map::DefaultHasher::new(); red.hash(&mut _h); _h.finish() as i64 };
+    let h2: i64 = { use std::hash::{Hash, Hasher}; let mut _h = std::collections::hash_map::DefaultHasher::new(); also_red.hash(&mut _h); _h.finish() as i64 };
+    println!("Same color same hash: {}", h1 == h2);
+    println!("{}", "=== Done ===");
 }

--- a/demos/milestone_codegen_quality_demo.rs
+++ b/demos/milestone_codegen_quality_demo.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+
+fn main() {
+    let x: i64 = 42_i64;
+    println!("Immutable x = {}", x);
+    let mut counter: i64 = 0_i64;
+    counter = counter + 1_i64;
+    counter = counter + 1_i64;
+    println!("Mutable counter = {}", counter);
+    let mut items: Vec<i64> = vec![1_i64, 2_i64, 3_i64];
+    items.push(4_i64);
+    println!("List after append: length = {}", items.len() as i64);
+    let name: String = "Sifr".to_string();
+    let version: i64 = 2_i64;
+    println!("Welcome to {} v{}!", name, version);
+    println!("{}", "hello world");
+    let lang: String = "sifr-lang".to_string();
+    println!("Starts with sifr: {}", lang.starts_with("sifr"));
+    println!("Ends with lang: {}", lang.ends_with("lang"));
+    let replaced: String = lang.replace("sifr", "SIFR");
+    println!("Replaced: {}", replaced);
+    let csv: String = "a,b,c".to_string();
+    let parts: Vec<String> = csv.split(",").map(|s| s.to_string()).collect::<Vec<String>>();
+    println!("Split count: {}", parts.len() as i64);
+    let ages: HashMap<String, i64> = HashMap::from([("alice".to_string(), 25_i64), ("bob".to_string(), 30_i64), ("charlie".to_string(), 35_i64)]);
+    let alice_age: Option<i64> = ages.get("alice").cloned();
+    if let Some(alice_age) = alice_age {
+        println!("Alice is {} years old", alice_age);
+    }
+    let has_bob: bool = ages.contains_key("bob");
+    println!("Has bob: {}", has_bob);
+    let greeting: String = format!("{}{}{}{}", "Hello".to_string(), ", ".to_string(), "World".to_string(), "!".to_string());
+    println!("Greeting: {}", greeting);
+    println!("{}", "All codegen quality improvements verified!");
+}

--- a/demos/milestone_codegen_quality_demo.sifr
+++ b/demos/milestone_codegen_quality_demo.sifr
@@ -1,0 +1,70 @@
+# ============================================================
+# Sifr Codegen Quality Demo
+# Showcases all codegen quality improvements:
+# 1. No unnecessary `mut` on immutable variables
+# 2. F-strings inlined directly into println! (no double format!)
+# 3. String literals clean in display contexts (no .to_string())
+# 4. String method args use literals directly (no .to_string().as_str())
+# 5. HashMap lookups with string literal keys (no &"key".to_string())
+# 6. Flattened string concatenation (single format! call)
+# ============================================================
+
+def main():
+    # --- 1. Immutable vs mutable variables ---
+    # `x` is never reassigned -> no `mut`
+    x: int = 42
+    print(f"Immutable x = {x}")
+
+    # `counter` IS reassigned -> `mut`
+    counter: int = 0
+    counter = counter + 1
+    counter = counter + 1
+    print(f"Mutable counter = {counter}")
+
+    # `items` has a mutating method call (.append) -> `mut`
+    items: list[int] = [1, 2, 3]
+    items.append(4)
+    print(f"List after append: length = {items.len()}")
+
+    # --- 2. F-strings inlined into println! ---
+    name: str = "Sifr"
+    version: int = 2
+    # Emits: println!("Welcome to {} v{}!", name, version)
+    print(f"Welcome to {name} v{version}!")
+
+    # --- 3. String literals in print without .to_string() ---
+    # Emits: println!("{}", "hello world")
+    print("hello world")
+
+    # --- 4. String methods with literal args ---
+    lang: str = "sifr-lang"
+    # Emits: lang.starts_with("sifr")
+    print(f"Starts with sifr: {lang.startswith('sifr')}")
+    print(f"Ends with lang: {lang.endswith('lang')}")
+
+    # Emits: lang.replace("sifr", "SIFR")
+    replaced: str = lang.replace("sifr", "SIFR")
+    print(f"Replaced: {replaced}")
+
+    # Emits: csv.split(",")
+    csv: str = "a,b,c"
+    parts: list[str] = csv.split(",")
+    print(f"Split count: {parts.len()}")
+
+    # --- 5. HashMap with string literal keys ---
+    ages: dict[str, int] = {"alice": 25, "bob": 30, "charlie": 35}
+    # Emits: ages.get("alice")
+    alice_age: int | None = ages["alice"]
+    if alice_age is not None:
+        print(f"Alice is {alice_age} years old")
+
+    # Emits: ages.contains_key("bob")
+    has_bob: bool = "bob" in ages
+    print(f"Has bob: {has_bob}")
+
+    # --- 6. Flattened string concatenation ---
+    greeting: str = "Hello" + ", " + "World" + "!"
+    # Emits: format!("{}{}{}{}", ...)
+    print(f"Greeting: {greeting}")
+
+    print("All codegen quality improvements verified!")

--- a/demos/milestone_control_flow_demo.rs
+++ b/demos/milestone_control_flow_demo.rs
@@ -11,16 +11,16 @@ fn sum_range(n: i64) -> i64 {
 fn fizzbuzz(n: i64) {
     for i in 1_i64..n + 1_i64 {
         if i % 15_i64 == 0_i64 {
-            println!("{}", "FizzBuzz".to_string());
+            println!("{}", "FizzBuzz");
         }
         if i % 3_i64 == 0_i64 {
             if i % 5_i64 != 0_i64 {
-                println!("{}", "Fizz".to_string());
+                println!("{}", "Fizz");
             }
         }
         if i % 5_i64 == 0_i64 {
             if i % 3_i64 != 0_i64 {
-                println!("{}", "Buzz".to_string());
+                println!("{}", "Buzz");
             }
         }
         if i % 3_i64 != 0_i64 {
@@ -37,23 +37,23 @@ fn countdown(n: i64) {
         println!("{}", i);
         i = i - 1_i64;
     }
-    println!("{}", "Go!".to_string());
+    println!("{}", "Go!");
 }
 
 fn main() {
-    println!("{}", format!("=== While Loop: Countdown ==="));
+    println!("=== While Loop: Countdown ===");
     countdown(5_i64);
-    println!("{}", format!("=== For Loop: Sum of 0..9 ==="));
-    let mut s: i64 = sum_range(10_i64);
-    println!("{}", format!("Sum of range(10) = {}", s));
-    println!("{}", format!("=== Nested Loops: Multiplication Table ==="));
+    println!("=== For Loop: Sum of 0..9 ===");
+    let s: i64 = sum_range(10_i64);
+    println!("Sum of range(10) = {}", s);
+    println!("=== Nested Loops: Multiplication Table ===");
     for i in 1_i64..4_i64 {
         for j in 1_i64..4_i64 {
-            let mut product: i64 = i * j;
-            println!("{}", format!("{} x {} = {}", i, j, product));
+            let product: i64 = i * j;
+            println!("{} x {} = {}", i, j, product);
         }
     }
-    println!("{}", format!("=== Break/Continue ==="));
+    println!("=== Break/Continue ===");
     let mut i: i64 = 0_i64;
     while i < 10_i64 {
         i = i + 1_i64;
@@ -65,49 +65,49 @@ fn main() {
         }
         println!("{}", i);
     }
-    println!("{}", format!("=== Lists ==="));
-    let mut nums: Vec<i64> = vec![10_i64, 20_i64, 30_i64, 40_i64, 50_i64];
-    println!("{}", format!("Length: {}", nums.len() as i64));
-    println!("{}", format!("First: {}", ({ let _v = &nums; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
-    println!("{}", format!("Last: {}", ({ let _v = &nums; let _i = 4_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
+    println!("=== Lists ===");
+    let nums: Vec<i64> = vec![10_i64, 20_i64, 30_i64, 40_i64, 50_i64];
+    println!("Length: {}", nums.len() as i64);
+    println!("First: {}", ({ let _v = &nums; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
+    println!("Last: {}", ({ let _v = &nums; let _i = 4_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
     let mut total: i64 = 0_i64;
     for n in nums.iter().cloned() {
         total = total + n;
     }
-    println!("{}", format!("Sum: {}", total));
+    println!("Sum: {}", total);
     let mut fruits: Vec<String> = vec!["apple".to_string(), "banana".to_string()];
     fruits.push("cherry".to_string());
-    println!("{}", format!("Fruits count: {}", fruits.len() as i64));
-    println!("{}", format!("=== Dict ==="));
-    let mut ages: std::collections::HashMap<String, i64> = std::collections::HashMap::from([("Alice".to_string(), 30_i64), ("Bob".to_string(), 25_i64), ("Charlie".to_string(), 35_i64)]);
-    println!("{}", format!("Alice is {} years old", (ages.get(&"Alice".to_string()).cloned()).map_or("None".to_string(), |_v| format!("{}", _v))));
-    println!("{}", format!("Bob is {} years old", (ages.get(&"Bob".to_string()).cloned()).map_or("None".to_string(), |_v| format!("{}", _v))));
-    println!("{}", format!("=== In Operator ==="));
-    let mut numbers: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
-    let mut found: bool = numbers.contains(&3_i64);
-    println!("{}", format!("3 in list: {}", found));
-    let mut missing: bool = numbers.contains(&9_i64);
-    println!("{}", format!("9 in list: {}", missing));
-    println!("{}", format!("=== Tuples ==="));
-    let mut point: (i64, i64, String) = (10_i64, 20_i64, "origin".to_string());
-    println!("{}", format!("Tuple length: {}", 3_i64));
-    println!("{}", format!("=== Tuple Unpacking ==="));
-    let mut pair: (String, i64) = ("Sifr".to_string(), 2025_i64);
+    println!("Fruits count: {}", fruits.len() as i64);
+    println!("=== Dict ===");
+    let ages: HashMap<String, i64> = HashMap::from([("Alice".to_string(), 30_i64), ("Bob".to_string(), 25_i64), ("Charlie".to_string(), 35_i64)]);
+    println!("Alice is {} years old", (ages.get("Alice").cloned()).map_or("None".to_string(), |_v| format!("{}", _v)));
+    println!("Bob is {} years old", (ages.get("Bob").cloned()).map_or("None".to_string(), |_v| format!("{}", _v)));
+    println!("=== In Operator ===");
+    let numbers: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
+    let found: bool = numbers.contains(&3_i64);
+    println!("3 in list: {}", found);
+    let missing: bool = numbers.contains(&9_i64);
+    println!("9 in list: {}", missing);
+    println!("=== Tuples ===");
+    let point: (i64, i64, String) = (10_i64, 20_i64, "origin".to_string());
+    println!("Tuple length: {}", 3_i64);
+    println!("=== Tuple Unpacking ===");
+    let pair: (String, i64) = ("Sifr".to_string(), 2025_i64);
     let (name, year) = pair;
-    println!("{}", format!("{} was born in {}", name, year));
-    println!("{}", format!("=== F-Strings ==="));
-    let mut a: i64 = 7_i64;
-    let mut b: i64 = 8_i64;
-    println!("{}", format!("{} * {} = {}", a, b, a * b));
-    println!("{}", format!("Is {} > {}? {}", a, b, a > b));
-    println!("{}", format!("=== String Operations ==="));
-    let mut greeting: String = "  Hello, World!  ".to_string();
+    println!("{} was born in {}", name, year);
+    println!("=== F-Strings ===");
+    let a: i64 = 7_i64;
+    let b: i64 = 8_i64;
+    println!("{} * {} = {}", a, b, a * b);
+    println!("Is {} > {}? {}", a, b, a > b);
+    println!("=== String Operations ===");
+    let greeting: String = "  Hello, World!  ".to_string();
     println!("{}", greeting.trim().to_string());
     println!("{}", greeting.trim().to_string().to_uppercase());
     println!("{}", greeting.trim().to_string().to_lowercase());
-    let mut lang: String = "sifr-lang".to_string();
-    println!("{}", format!("Starts with 'sifr': {}", lang.starts_with("sifr".to_string().as_str())));
-    println!("{}", format!("Ends with 'lang': {}", lang.ends_with("lang".to_string().as_str())));
-    println!("{}", format!("=== FizzBuzz (1-15) ==="));
+    let lang: String = "sifr-lang".to_string();
+    println!("Starts with 'sifr': {}", lang.starts_with("sifr"));
+    println!("Ends with 'lang': {}", lang.ends_with("lang"));
+    println!("=== FizzBuzz (1-15) ===");
     fizzbuzz(15_i64);
 }

--- a/demos/milestone_core_language_demo.rs
+++ b/demos/milestone_core_language_demo.rs
@@ -16,7 +16,7 @@ fn fibonacci(n: i64) -> i64 {
 }
 
 fn greet(name: String) -> String {
-    return format!("{}{}", format!("{}{}", "Hello, ".to_string(), name), "!".to_string());
+    return format!("{}{}{}", "Hello, ".to_string(), name, "!".to_string());
 }
 
 fn classify(x: i64) -> String {
@@ -44,27 +44,27 @@ fn is_even(n: i64) -> bool {
 }
 
 fn main() {
-    let mut x: i64 = 42_i64;
-    let mut pi: f64 = 3.14_f64;
-    let mut flag: bool = true;
-    let mut name: String = "Sifr".to_string();
-    let mut sum: i64 = x + 8_i64;
-    let mut product: i64 = double(sum);
+    let x: i64 = 42_i64;
+    let pi: f64 = 3.14_f64;
+    let flag: bool = true;
+    let name: String = "Sifr".to_string();
+    let sum: i64 = x + 8_i64;
+    let product: i64 = double(sum);
     println!("{}", product);
-    let mut fact: i64 = factorial(5_i64);
+    let fact: i64 = factorial(5_i64);
     println!("{}", fact);
-    let mut fib: i64 = fibonacci(10_i64);
+    let fib: i64 = fibonacci(10_i64);
     println!("{}", fib);
-    let mut msg: String = greet(name);
+    let msg: String = greet(name);
     println!("{}", msg);
-    let mut label: String = classify(x);
+    let label: String = classify(x);
     println!("{}", label);
-    let mut neg_label: String = classify(-7_i64);
+    let neg_label: String = classify(-7_i64);
     println!("{}", neg_label);
-    let mut zero_label: String = classify(0_i64);
+    let zero_label: String = classify(0_i64);
     println!("{}", zero_label);
-    let mut even: bool = is_even(4_i64);
+    let even: bool = is_even(4_i64);
     println!("{}", even);
-    let mut odd: bool = is_even(7_i64);
+    let odd: bool = is_even(7_i64);
     println!("{}", odd);
 }

--- a/demos/milestone_ergonomics_demo.rs
+++ b/demos/milestone_ergonomics_demo.rs
@@ -5,13 +5,13 @@ fn demo_augmented_assign() {
     x += 5_i64;
     x -= 2_i64;
     x *= 3_i64;
-    println!("{}", format!("Augmented assign result: {}", x));
+    println!("Augmented assign result: {}", x);
     let mut s: String = "Hello".to_string();
-    s.push_str(&" World".to_string());
-    println!("{}", format!("String +=: {}", s));
+    s.push_str(" World");
+    println!("String +=: {}", s);
     let mut items: Vec<i64> = vec![1_i64, 2_i64];
     items.extend(vec![3_i64, 4_i64]);
-    println!("{}", format!("List += length: {}", items.len() as i64));
+    println!("List += length: {}", items.len() as i64);
 }
 
 fn classify(n: i64) -> String {
@@ -23,102 +23,102 @@ fn greet(name: String, greeting: String, punctuation: String) -> String {
 }
 
 fn demo_negative_indexing() {
-    let mut items: Vec<i64> = vec![10_i64, 20_i64, 30_i64, 40_i64, 50_i64];
-    println!("{}", format!("Last element: {}", ({ let _v = &items; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
-    println!("{}", format!("Second to last: {}", ({ let _v = &items; let _i = -2_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
-    let mut s: String = "Sifr".to_string();
-    println!("{}", format!("Last char: {}", ({ let _s = &s; let _i = -1_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) }).map_or("None".to_string(), |_v| format!("{}", _v))));
+    let items: Vec<i64> = vec![10_i64, 20_i64, 30_i64, 40_i64, 50_i64];
+    println!("Last element: {}", ({ let _v = &items; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
+    println!("Second to last: {}", ({ let _v = &items; let _i = -2_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
+    let s: String = "Sifr".to_string();
+    println!("Last char: {}", ({ let _s = &s; let _i = -1_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) }).map_or("None".to_string(), |_v| format!("{}", _v)));
 }
 
 fn demo_step_slicing() {
-    let mut nums: Vec<i64> = vec![0_i64, 1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64, 7_i64, 8_i64, 9_i64];
-    let mut evens: Vec<i64> = { let _v = &nums; let _len = _v.len() as i64; let _step = 2_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = Vec::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_v[_i].clone()); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_v[_i as usize].clone()); _i += _step; } }; _result };
-    println!("{}", format!("Evens: {} elements", evens.len() as i64));
-    let mut reversed: Vec<i64> = { let _v = &nums; let _len = _v.len() as i64; let _step = -1_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = Vec::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_v[_i].clone()); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_v[_i as usize].clone()); _i += _step; } }; _result };
-    println!("{}", format!("Reversed first: {}, last: {}", ({ let _v = &reversed; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)), ({ let _v = &reversed; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
-    let mut s: String = "abcdefgh".to_string();
-    println!("{}", format!("Every other char: {}", { let _s: Vec<char> = s.chars().collect(); let _len = _s.len() as i64; let _step = 2_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = String::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_s[_i]); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_s[_i as usize]); _i += _step; } }; _result }));
-    println!("{}", format!("Reversed string: {}", { let _s: Vec<char> = s.chars().collect(); let _len = _s.len() as i64; let _step = -1_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = String::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_s[_i]); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_s[_i as usize]); _i += _step; } }; _result }));
+    let nums: Vec<i64> = vec![0_i64, 1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64, 7_i64, 8_i64, 9_i64];
+    let evens: Vec<i64> = { let _v = &nums; let _len = _v.len() as i64; let _step = 2_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = Vec::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_v[_i].clone()); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_v[_i as usize].clone()); _i += _step; } }; _result };
+    println!("Evens: {} elements", evens.len() as i64);
+    let reversed: Vec<i64> = { let _v = &nums; let _len = _v.len() as i64; let _step = -1_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = Vec::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_v[_i].clone()); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_v[_i as usize].clone()); _i += _step; } }; _result };
+    println!("Reversed first: {}, last: {}", ({ let _v = &reversed; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)), ({ let _v = &reversed; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
+    let s: String = "abcdefgh".to_string();
+    println!("Every other char: {}", { let _s: Vec<char> = s.chars().collect(); let _len = _s.len() as i64; let _step = 2_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = String::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_s[_i]); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_s[_i as usize]); _i += _step; } }; _result });
+    println!("Reversed string: {}", { let _s: Vec<char> = s.chars().collect(); let _len = _s.len() as i64; let _step = -1_i64; let _start = if _step > 0 { 0 } else { (_len - 1) as usize }; let _stop = if _step > 0 { _len as usize } else { 0_usize.wrapping_sub(1) }; let mut _result = String::new(); if _step > 0 { let mut _i = _start; while _i < _stop { _result.push(_s[_i]); _i += _step as usize; } } else { let mut _i = _start as i64; let _stop_i = _stop as i64; while _i > _stop_i { _result.push(_s[_i as usize]); _i += _step; } }; _result });
 }
 
 fn demo_string_methods() {
-    let mut s: String = "hello world".to_string();
-    println!("{}", format!("Replace: {}", s.replace("world".to_string().as_str(), "Sifr".to_string().as_str())));
-    println!("{}", format!("Starts with 'hello': {}", s.starts_with("hello".to_string().as_str())));
-    println!("{}", format!("Ends with 'world': {}", s.ends_with("world".to_string().as_str())));
-    println!("{}", format!("Title: {}", s.split_whitespace().map(|w| { let mut c = w.chars(); match c.next() { None => String::new(), Some(f) => f.to_uppercase().to_string() + &c.as_str().to_lowercase() } }).collect::<Vec<_>>().join(" ")));
-    println!("{}", format!("Is alpha: {}", !"abc".to_string().is_empty() && "abc".to_string().chars().all(|c| c.is_alphabetic())));
-    println!("{}", format!("Is digit: {}", !"123".to_string().is_empty() && "123".to_string().chars().all(|c| c.is_ascii_digit())));
-    let mut separator: String = ", ".to_string();
-    let mut items: Vec<String> = vec!["a".to_string(), "b".to_string(), "c".to_string()];
-    println!("{}", format!("Join: {}", items.join(&separator)));
+    let s: String = "hello world".to_string();
+    println!("Replace: {}", s.replace("world", "Sifr"));
+    println!("Starts with 'hello': {}", s.starts_with("hello"));
+    println!("Ends with 'world': {}", s.ends_with("world"));
+    println!("Title: {}", s.split_whitespace().map(|w| { let mut c = w.chars(); match c.next() { None => String::new(), Some(f) => f.to_uppercase().to_string() + &c.as_str().to_lowercase() } }).collect::<Vec<_>>().join(" "));
+    println!("Is alpha: {}", !"abc".to_string().is_empty() && "abc".to_string().chars().all(|c| c.is_alphabetic()));
+    println!("Is digit: {}", !"123".to_string().is_empty() && "123".to_string().chars().all(|c| c.is_ascii_digit()));
+    let separator: String = ", ".to_string();
+    let items: Vec<String> = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+    println!("Join: {}", items.join(separator.as_str()));
 }
 
 fn demo_list_methods() {
     let mut items: Vec<i64> = vec![3_i64, 1_i64, 4_i64, 1_i64, 5_i64];
     items.push(9_i64);
-    println!("{}", format!("After append: length={}", items.len() as i64));
-    println!("{}", format!("Count of 1: {}", items.iter().filter(|x| **x == 1_i64).count() as i64));
-    println!("{}", format!("Contains 4: {}", items.contains(&4_i64)));
+    println!("After append: length={}", items.len() as i64);
+    println!("Count of 1: {}", items.iter().filter(|x| **x == 1_i64).count() as i64);
+    println!("Contains 4: {}", items.contains(&4_i64));
     let mut copy: Vec<i64> = items.clone();
     copy.reverse();
-    println!("{}", format!("Reversed copy first: {}", ({ let _v = &copy; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v))));
+    println!("Reversed copy first: {}", ({ let _v = &copy; let _i = 0_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }).map_or("None".to_string(), |_v| format!("{}", _v)));
 }
 
 fn demo_dict_methods() {
-    let mut d: std::collections::HashMap<String, i64> = std::collections::HashMap::from([("a".to_string(), 1_i64), ("b".to_string(), 2_i64), ("c".to_string(), 3_i64)]);
-    println!("{}", format!("Dict contains 'a': {}", d.contains_key(&"a".to_string())));
-    println!("{}", format!("Dict length: {}", d.len() as i64));
+    let mut d: HashMap<String, i64> = HashMap::from([("a".to_string(), 1_i64), ("b".to_string(), 2_i64), ("c".to_string(), 3_i64)]);
+    println!("Dict contains 'a': {}", d.contains_key("a"));
+    println!("Dict length: {}", d.len() as i64);
     d.clear();
-    println!("{}", format!("After clear: {}", d.len() as i64));
+    println!("After clear: {}", d.len() as i64);
 }
 
 fn demo_chained_comparisons() {
-    let mut x: i64 = 5_i64;
+    let x: i64 = 5_i64;
     if (1_i64 < x && x < 10_i64) {
-        println!("{}", "5 is between 1 and 10".to_string());
+        println!("{}", "5 is between 1 and 10");
     }
-    let mut y: i64 = 15_i64;
+    let y: i64 = 15_i64;
     if (1_i64 < y && y < 10_i64) {
-        println!("{}", "This won't print".to_string());
+        println!("{}", "This won't print");
     } else {
-        println!("{}", "15 is NOT between 1 and 10".to_string());
+        println!("{}", "15 is NOT between 1 and 10");
     }
 }
 
 fn demo_string_multiply() {
     println!("{}", "=".to_string().repeat(30_i64 as usize));
-    println!("{}", "  String Multiplication Demo".to_string());
+    println!("{}", "  String Multiplication Demo");
     println!("{}", "-".to_string().repeat(30_i64 as usize));
 }
 
 fn demo_star_unpacking() {
-    let mut items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
+    let items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
     let _star_tmp = items.clone();
     let first = _star_tmp[0].clone();
     let rest = _star_tmp[1..].to_vec();
-    println!("{}", format!("First: {}, Rest length: {}", first, rest.len() as i64));
+    println!("First: {}, Rest length: {}", first, rest.len() as i64);
 }
 
 fn demo_loop_else() {
-    let mut items: Vec<i64> = vec![2_i64, 4_i64, 6_i64, 8_i64];
-    let mut target: i64 = 5_i64;
+    let items: Vec<i64> = vec![2_i64, 4_i64, 6_i64, 8_i64];
+    let target: i64 = 5_i64;
     let mut _broke = false;
     for item in items.iter().cloned() {
         if item == target {
-            println!("{}", "Found target!".to_string());
+            println!("{}", "Found target!");
             _broke = true;
             break;
         }
     }
     if !_broke {
-        println!("{}", "Target not found in list (loop else)".to_string());
+        println!("{}", "Target not found in list (loop else)");
     }
 }
 
 fn demo_power() {
-    println!("{}", format!("2 ** 10 = {}", 2_i64.pow(10_i64 as u32)));
-    println!("{}", format!("3 ** 3 = {}", 3_i64.pow(3_i64 as u32)));
+    println!("2 ** 10 = {}", 2_i64.pow(10_i64 as u32));
+    println!("3 ** 3 = {}", 3_i64.pow(3_i64 as u32));
 }
 
 fn divmod(a: i64, b: i64) -> (i64, i64) {
@@ -126,10 +126,10 @@ fn divmod(a: i64, b: i64) -> (i64, i64) {
 }
 
 fn demo_walrus() {
-    let mut items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64, 7_i64, 8_i64, 9_i64, 10_i64];
+    let items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64, 6_i64, 7_i64, 8_i64, 9_i64, 10_i64];
     let n: i64 = items.len() as i64;
     if n > 5_i64 {
-        println!("{}", format!("List has {} items (more than 5)", n));
+        println!("List has {} items (more than 5)", n);
     }
 }
 
@@ -137,15 +137,15 @@ fn placeholder() {
 }
 
 fn demo_builtins() {
-    println!("{}", format!("abs(-42) = {}", (-42_i64).abs()));
-    println!("{}", format!("round(3.7) = {}", 3.7_f64.round() as i64));
-    println!("{}", format!("repr(42) = {}", format!("{:?}", 42_i64)));
+    println!("abs(-42) = {}", (-42_i64).abs());
+    println!("round(3.7) = {}", 3.7_f64.round() as i64);
+    println!("repr(42) = {}", format!("{:?}", 42_i64));
 }
 
 fn main() {
     demo_augmented_assign();
-    println!("{}", format!("classify(5): {}", classify(5_i64)));
-    println!("{}", format!("classify(-3): {}", classify(-3_i64)));
+    println!("classify(5): {}", classify(5_i64));
+    println!("classify(-3): {}", classify(-3_i64));
     println!("{}", greet("Alice".to_string(), "Hello".to_string(), "!".to_string()));
     println!("{}", greet("Bob".to_string(), "Hi".to_string(), "!".to_string()));
     println!("{}", greet("Charlie".to_string(), "Hey".to_string(), "?".to_string()));
@@ -160,9 +160,9 @@ fn main() {
     demo_loop_else();
     demo_power();
     let (q, r) = divmod(17_i64, 5_i64);
-    println!("{}", format!("17 divmod 5: quotient={}, remainder={}", q, r));
+    println!("17 divmod 5: quotient={}, remainder={}", q, r);
     demo_walrus();
     placeholder();
     demo_builtins();
-    println!("{}", "All milestone_ergonomics features working!".to_string());
+    println!("{}", "All milestone_ergonomics features working!");
 }

--- a/demos/milestone_error_handling_demo.rs
+++ b/demos/milestone_error_handling_demo.rs
@@ -38,105 +38,105 @@ fn safe_divide(a: i64, b: i64) -> Result<i64, String> {
 }
 
 fn main() {
-    println!("{}", "=== Result Type & Fallible Conversions ===".to_string());
+    println!("{}", "=== Result Type & Fallible Conversions ===");
     match (|| -> Result<(), String> {
-        let mut n: i64 = "42".to_string().parse::<i64>().map_err(|e| e.to_string())?;
-        println!("{}", format!("parsed: {}", n));
+        let n: i64 = "42".to_string().parse::<i64>().map_err(|e| e.to_string())?;
+        println!("parsed: {}", n);
         Ok(())
     })() {
         Ok(()) => {}
         Err(e) => {
-            println!("{}", format!("parse failed: {}", e));
-        }
-    }
-    match (|| -> Result<(), String> {
-        let mut n2: i64 = "not_a_number".to_string().parse::<i64>().map_err(|e| e.to_string())?;
-        println!("{}", format!("parsed: {}", n2));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("parse failed (expected): {}", e));
-        }
-    }
-    println!("{}", "=== Custom Error Types ===".to_string());
-    match (|| -> Result<(), ValidationError> {
-        let mut v: i64 = validate_range(50_i64, 0_i64, 100_i64)?;
-        println!("{}", format!("validated: {}", v));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("caught: {}", e.message));
-        }
-    }
-    match (|| -> Result<(), ValidationError> {
-        let mut v2: i64 = validate_range(-5_i64, 0_i64, 100_i64)?;
-        println!("{}", format!("validated: {}", v2));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("caught: {}", e.message));
-        }
-    }
-    println!("{}", "=== Try/Except with Auto-Unwrap ===".to_string());
-    match (|| -> Result<(), ValidationError> {
-        let mut a: i64 = validate_range(100_i64, 0_i64, 200_i64)?;
-        println!("{}", format!("result: {}", a));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("error handled: {}", e.message));
-        }
-    }
-    match (|| -> Result<(), ValidationError> {
-        let mut b: i64 = validate_range(999_i64, 0_i64, 200_i64)?;
-        println!("{}", format!("result: {}", b));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("error handled: {}", e.message));
-        }
-    }
-    println!("{}", "=== Infallible Conversions ===".to_string());
-    let mut x1: i64 = 3.7_f64 as i64;
-    println!("{}", format!("int(3.7) = {}", x1));
-    let mut x2: f64 = 5_i64 as f64;
-    println!("{}", format!("float(5) = {}", x2));
-    let mut x3: String = format!("{}", 42_i64);
-    println!("{}", format!("str(42) = {}", x3));
-    let mut x4: bool = 1_i64 != 0;
-    println!("{}", format!("bool(1) = {}", x4));
-    println!("{}", "=== Raise in Result Functions ===".to_string());
-    match (|| -> Result<(), String> {
-        let mut d1: i64 = safe_divide(10_i64, 3_i64)?;
-        println!("{}", format!("divide(10, 3) = {}", d1));
-        Ok(())
-    })() {
-        Ok(()) => {}
-        Err(e) => {
-            println!("{}", format!("divide error: {}", e));
+            println!("parse failed: {}", e);
         }
     }
     match (|| -> Result<(), String> {
-        let mut d2: i64 = safe_divide(10_i64, 0_i64)?;
-        println!("{}", format!("divide(10, 0) = {}", d2));
+        let n2: i64 = "not_a_number".to_string().parse::<i64>().map_err(|e| e.to_string())?;
+        println!("parsed: {}", n2);
         Ok(())
     })() {
         Ok(()) => {}
         Err(e) => {
-            println!("{}", format!("divide(10, 0) error: {}", e));
+            println!("parse failed (expected): {}", e);
         }
     }
-    println!("{}", "=== Assert Statement ===".to_string());
+    println!("{}", "=== Custom Error Types ===");
+    match (|| -> Result<(), ValidationError> {
+        let v: i64 = validate_range(50_i64, 0_i64, 100_i64)?;
+        println!("validated: {}", v);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("caught: {}", e.message);
+        }
+    }
+    match (|| -> Result<(), ValidationError> {
+        let v2: i64 = validate_range(-5_i64, 0_i64, 100_i64)?;
+        println!("validated: {}", v2);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("caught: {}", e.message);
+        }
+    }
+    println!("{}", "=== Try/Except with Auto-Unwrap ===");
+    match (|| -> Result<(), ValidationError> {
+        let a: i64 = validate_range(100_i64, 0_i64, 200_i64)?;
+        println!("result: {}", a);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("error handled: {}", e.message);
+        }
+    }
+    match (|| -> Result<(), ValidationError> {
+        let b: i64 = validate_range(999_i64, 0_i64, 200_i64)?;
+        println!("result: {}", b);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("error handled: {}", e.message);
+        }
+    }
+    println!("{}", "=== Infallible Conversions ===");
+    let x1: i64 = 3.7_f64 as i64;
+    println!("int(3.7) = {}", x1);
+    let x2: f64 = 5_i64 as f64;
+    println!("float(5) = {}", x2);
+    let x3: String = format!("{}", 42_i64);
+    println!("str(42) = {}", x3);
+    let x4: bool = 1_i64 != 0;
+    println!("bool(1) = {}", x4);
+    println!("{}", "=== Raise in Result Functions ===");
+    match (|| -> Result<(), String> {
+        let d1: i64 = safe_divide(10_i64, 3_i64)?;
+        println!("divide(10, 3) = {}", d1);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("divide error: {}", e);
+        }
+    }
+    match (|| -> Result<(), String> {
+        let d2: i64 = safe_divide(10_i64, 0_i64)?;
+        println!("divide(10, 0) = {}", d2);
+        Ok(())
+    })() {
+        Ok(()) => {}
+        Err(e) => {
+            println!("divide(10, 0) error: {}", e);
+        }
+    }
+    println!("{}", "=== Assert Statement ===");
     assert!(1_i64 + 1_i64 == 2_i64);
     assert!(true);
-    println!("{}", "all assertions passed".to_string());
-    println!("{}", "=== Explicit Discard ===".to_string());
+    println!("{}", "all assertions passed");
+    println!("{}", "=== Explicit Discard ===");
     let _: Result<i64, String> = safe_divide(10_i64, 2_i64);
-    println!("{}", "result discarded safely".to_string());
-    println!("{}", "demo complete!".to_string());
+    println!("{}", "result discarded safely");
+    println!("{}", "demo complete!");
 }

--- a/demos/milestone_safe_indexing_demo.rs
+++ b/demos/milestone_safe_indexing_demo.rs
@@ -1,98 +1,98 @@
 use std::collections::HashMap;
 
 fn main() {
-    println!("{}", "=== Safe List Indexing ===".to_string());
-    let mut nums: Vec<i64> = vec![10_i64, 20_i64, 30_i64];
-    let mut val: Option<i64> = { let _v = &nums; let _i = 1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
+    println!("{}", "=== Safe List Indexing ===");
+    let nums: Vec<i64> = vec![10_i64, 20_i64, 30_i64];
+    let val: Option<i64> = { let _v = &nums; let _i = 1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
     if let Some(val) = val {
-        println!("{}", format!("nums[1] = {}", val));
+        println!("nums[1] = {}", val);
     }
-    let mut oob: Option<i64> = { let _v = &nums; let _i = 99_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
+    let oob: Option<i64> = { let _v = &nums; let _i = 99_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
     if let Some(oob) = oob {
-        println!("{}", format!("nums[99] = {}", oob));
+        println!("nums[99] = {}", oob);
     } else {
-        println!("{}", "nums[99] = None (safe!)".to_string());
+        println!("{}", "nums[99] = None (safe!)");
     }
-    println!("{}", "=== Safe Dict Indexing ===".to_string());
-    let mut ages: std::collections::HashMap<String, i64> = std::collections::HashMap::from([("alice".to_string(), 25_i64), ("bob".to_string(), 30_i64)]);
-    let mut a: Option<i64> = ages.get(&"alice".to_string()).cloned();
+    println!("{}", "=== Safe Dict Indexing ===");
+    let ages: HashMap<String, i64> = HashMap::from([("alice".to_string(), 25_i64), ("bob".to_string(), 30_i64)]);
+    let a: Option<i64> = ages.get("alice").cloned();
     if let Some(a) = a {
-        println!("{}", format!("ages[alice] = {}", a));
+        println!("ages[alice] = {}", a);
     }
-    let mut c: Option<i64> = ages.get(&"charlie".to_string()).cloned();
+    let c: Option<i64> = ages.get("charlie").cloned();
     if let Some(c) = c {
-        println!("{}", format!("ages[charlie] = {}", c));
+        println!("ages[charlie] = {}", c);
     } else {
-        println!("{}", "ages[charlie] = None (safe!)".to_string());
+        println!("{}", "ages[charlie] = None (safe!)");
     }
-    println!("{}", "=== Safe String Indexing ===".to_string());
-    let mut s: String = "hello".to_string();
-    let mut ch: Option<String> = { let _s = &s; let _i = 0_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
+    println!("{}", "=== Safe String Indexing ===");
+    let s: String = "hello".to_string();
+    let ch: Option<String> = { let _s = &s; let _i = 0_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
     if let Some(ch) = ch {
-        println!("{}", format!("s[0] = {}", ch));
+        println!("s[0] = {}", ch);
     }
-    let mut oob_ch: Option<String> = { let _s = &s; let _i = 99_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
+    let oob_ch: Option<String> = { let _s = &s; let _i = 99_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
     if let Some(oob_ch) = oob_ch {
-        println!("{}", format!("s[99] = {}", oob_ch));
+        println!("s[99] = {}", oob_ch);
     } else {
-        println!("{}", "s[99] = None (safe!)".to_string());
+        println!("{}", "s[99] = None (safe!)");
     }
-    println!("{}", "=== Negative Indexing ===".to_string());
-    let mut items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
-    let mut last: Option<i64> = { let _v = &items; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
+    println!("{}", "=== Negative Indexing ===");
+    let items: Vec<i64> = vec![1_i64, 2_i64, 3_i64, 4_i64, 5_i64];
+    let last: Option<i64> = { let _v = &items; let _i = -1_i64; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() };
     if let Some(last) = last {
-        println!("{}", format!("last item: {}", last));
+        println!("last item: {}", last);
     }
-    let mut last_ch: Option<String> = { let _s = &s; let _i = -1_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
+    let last_ch: Option<String> = { let _s = &s; let _i = -1_i64; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) };
     if let Some(last_ch) = last_ch {
-        println!("{}", format!("last char: {}", last_ch));
+        println!("last char: {}", last_ch);
     }
-    println!("{}", "=== List pop() ===".to_string());
+    println!("{}", "=== List pop() ===");
     let mut stack: Vec<i64> = vec![10_i64, 20_i64, 30_i64];
-    let mut top: Option<i64> = stack.pop();
+    let top: Option<i64> = stack.pop();
     if let Some(top) = top {
-        println!("{}", format!("popped: {}", top));
+        println!("popped: {}", top);
     }
     let _: Option<i64> = stack.pop();
     let _: Option<i64> = stack.pop();
-    let mut empty: Option<i64> = stack.pop();
+    let empty: Option<i64> = stack.pop();
     if let Some(empty) = empty {
-        println!("{}", format!("got: {}", empty));
+        println!("got: {}", empty);
     } else {
-        println!("{}", "empty pop: None".to_string());
+        println!("{}", "empty pop: None");
     }
-    println!("{}", "=== Dict get() and pop() ===".to_string());
-    let mut data: std::collections::HashMap<String, i64> = std::collections::HashMap::from([("alice".to_string(), 25_i64), ("bob".to_string(), 30_i64)]);
-    let mut g: Option<i64> = data.get(&"alice".to_string()).cloned();
+    println!("{}", "=== Dict get() and pop() ===");
+    let mut data: HashMap<String, i64> = HashMap::from([("alice".to_string(), 25_i64), ("bob".to_string(), 30_i64)]);
+    let g: Option<i64> = data.get("alice").cloned();
     if let Some(g) = g {
-        println!("{}", format!("get alice: {}", g));
+        println!("get alice: {}", g);
     }
-    let mut gm: Option<i64> = data.get(&"missing".to_string()).cloned();
+    let gm: Option<i64> = data.get("missing").cloned();
     if let Some(gm) = gm {
-        println!("{}", format!("get missing: {}", gm));
+        println!("get missing: {}", gm);
     } else {
-        println!("{}", "get missing: None".to_string());
+        println!("{}", "get missing: None");
     }
-    let mut p: Option<i64> = data.remove(&"bob".to_string());
+    let p: Option<i64> = data.remove("bob");
     if let Some(p) = p {
-        println!("{}", format!("popped bob: {}", p));
+        println!("popped bob: {}", p);
     }
-    println!("{}", "=== String find() ===".to_string());
-    let mut text: String = "hello, world!".to_string();
-    let mut pos: Option<i64> = text.find("world".to_string().as_str()).map(|i| i as i64);
+    println!("{}", "=== String find() ===");
+    let text: String = "hello, world!".to_string();
+    let pos: Option<i64> = text.find("world").map(|i| i as i64);
     if let Some(pos) = pos {
-        println!("{}", format!("found world at: {}", pos));
+        println!("found world at: {}", pos);
     }
-    let mut miss: Option<i64> = text.find("xyz".to_string().as_str()).map(|i| i as i64);
+    let miss: Option<i64> = text.find("xyz").map(|i| i as i64);
     if let Some(miss) = miss {
-        println!("{}", format!("found xyz at: {}", miss));
+        println!("found xyz at: {}", miss);
     } else {
-        println!("{}", "xyz not found".to_string());
+        println!("{}", "xyz not found");
     }
-    println!("{}", "=== Del Statement ===".to_string());
-    let mut config: std::collections::HashMap<String, i64> = std::collections::HashMap::from([("a".to_string(), 1_i64), ("b".to_string(), 2_i64), ("c".to_string(), 3_i64)]);
-    println!("{}", format!("before del: {}", config.len() as i64));
-    let _ = config.remove(&"b".to_string());
-    println!("{}", format!("after del: {}", config.len() as i64));
-    println!("{}", "demo complete!".to_string());
+    println!("{}", "=== Del Statement ===");
+    let mut config: HashMap<String, i64> = HashMap::from([("a".to_string(), 1_i64), ("b".to_string(), 2_i64), ("c".to_string(), 3_i64)]);
+    println!("before del: {}", config.len() as i64);
+    let _ = config.remove("b");
+    println!("after del: {}", config.len() as i64);
+    println!("{}", "demo complete!");
 }

--- a/demos/milestone_type_system_demo.rs
+++ b/demos/milestone_type_system_demo.rs
@@ -45,16 +45,16 @@ fn find_user(name: String) -> Option<String> {
 }
 
 fn main() {
-    let mut uid: i64 = create_user(42_i64, "alice".to_string());
+    let uid: i64 = create_user(42_i64, "alice".to_string());
     println!("{}", uid);
     println!("{}", handle_command("start".to_string()));
     println!("{}", handle_command("stop".to_string()));
     println!("{}", describe(IntOrStr::Int(42_i64)));
     println!("{}", describe(IntOrStr::Str("hello".to_string())));
-    let mut user: Option<String> = find_user("alice".to_string());
+    let user: Option<String> = find_user("alice".to_string());
     if let Some(user) = user {
         println!("{}", user);
     } else {
-        println!("{}", "not found".to_string());
+        println!("{}", "not found");
     }
 }


### PR DESCRIPTION
## Summary

- **Remove unnecessary `mut`**: Pre-scan function bodies to detect which variables are actually reassigned or have mutating method calls (`.push()`, `.pop()`, `.sort()`, etc.). Only emit `let mut` for those variables (~60 fewer unnecessary `mut` annotations).
- **Inline f-strings into `println!`**: `print(f"...")` now emits `println!("...", args)` directly instead of `println!("{}", format!(...))` (~40 fewer redundant `format!` calls).
- **Clean string literals in display contexts**: String literals inside `println!`/`format!` no longer get `.to_string()` appended (~20 fewer redundant conversions).
- **Clean string method arguments**: Methods like `starts_with`, `ends_with`, `split`, `replace`, `find` accept string literals directly instead of `"lit".to_string().as_str()` (~10 occurrences fixed).
- **Simplified HashMap lookups**: Dict access with string literal keys emits `d.get("key")` instead of `d.get(&"key".to_string())` (~10 fewer unnecessary allocations).
- **Flattened string concatenation**: Chained `+` on strings emits a single `format!("{}{}{}", a, b, c)` instead of nested `format!` calls.
- **Bonus**: `HashMap` type annotations and constructors now use short `HashMap` name with import instead of fully qualified `std::collections::HashMap`.

## Test plan

- [x] All 76 E2E tests pass (no regressions)
- [x] 9 new unit tests in `sifr_codegen` covering each pattern
- [x] All 7 single-file demos re-emitted and verified for clean idiomatic Rust
- [x] All demos compile and run with correct output
- [x] Milestone demo (`milestone_codegen_quality_demo.sifr`) showcases all improvements


Made with [Cursor](https://cursor.com)