### PR TITLE
fix: Phase 3 codegen quality polish (milestone_codegen_quality_v3)

### DIFF
--- a/.cursor/plans/sifr_compiler_architecture_fa3c10ee.plan.md
+++ b/.cursor/plans/sifr_compiler_architecture_fa3c10ee.plan.md
@@ -225,7 +225,7 @@ flowchart TD
     milestone_protocols --> milestone_inheritance --> milestone_generics
     milestone_generics --> milestone_generators --> milestone_decorators --> milestone_core_stdlib
     milestone_core_stdlib --> milestone_test_runner --> milestone_ext_collections --> milestone_ext_stdlib
-    milestone_ext_stdlib --> milestone_async --> milestone_web_db --> milestone_data_processing
+    milestone_ext_stdlib --> milestone_codegen_quality_v3 --> milestone_async --> milestone_web_db --> milestone_data_processing
     milestone_data_processing --> milestone_metaprogramming --> milestone_ffi --> milestone_package_mgmt --> milestone_dev_tooling --> milestone_ecosystem
 ```
 
@@ -2222,6 +2222,35 @@ Depends on milestone_core_stdlib: needs `sifr.io` for test file discovery and `s
 
 ---
 
+## milestone_codegen_quality_v3: Phase 3 Codegen Polish
+
+**Goal:** Clean up the emitted Rust code from Phase 3 stdlib modules. Eliminate redundant allocations, unnecessary clones, and improve the idiomatic quality of generated code for all stdlib function calls.
+
+### Quality Issues
+
+1. **Redundant `.to_string()` on string literal args** — stdlib functions that accept `&str` receive `"literal".to_string()` instead of `"literal"` directly
+2. **Redundant `.clone()` on `vec![...]` literals** — set operations clone freshly-created vecs
+3. **`json_dumps` emits `.clone()` instead of `serde_json::to_string`** — incorrect serialization
+4. **`set_intersection` re-creates second set inside filter closure** — O(n*m) allocation instead of O(n+m)
+5. **`re_replace` uses `.to_string().as_str()`** — unnecessary String allocation
+6. **Hash/encoding functions use `.to_string().as_bytes()`** — should use `.as_bytes()` directly on literals
+
+### Implementation
+
+Add `emit_expr_as_str_ref` helper to `RustEmitter` that emits bare `"literal"` for string literals and `&expr` for variables. Update all stdlib codegen call sites.
+
+### Definition of Done (milestone_codegen_quality_v3)
+
+- All stdlib function calls emit clean, idiomatic Rust without redundant allocations
+- String literals passed directly to Rust APIs that accept `&str` / `AsRef<str>`
+- Vec literals not cloned unnecessarily in set operations
+- `json_dumps` uses `serde_json::to_string`
+- `set_intersection` hoists second arg before filter
+- All existing E2E tests pass (no regressions)
+- All Phase 3 demos produce identical output with cleaner Rust
+
+---
+
 ## milestone_async: Async Runtime
 
 **Goal:** Add async/await language support. This is a language feature milestone -- it adds the async primitives that milestone_web_db (web, database) builds on.
@@ -2747,6 +2776,7 @@ PHASE 3 - Standard Library:
   milestone_test_runner:  Test Runner                -> sifr test, assertions, discovery, parallel
   milestone_ext_collections:  Extended Collections       -> frozenset, Counter, defaultdict, bytes, bytearray
   milestone_ext_stdlib:  Extended Stdlib            -> math, time, random, regex, hash, encoding, stream, log
+  milestone_codegen_quality_v3:  Phase 3 Codegen Polish  -> Remove redundant .to_string() on literals, .clone() on vec literals, fix json_dumps, hoist set_intersection args, clean re_replace/hash/encoding codegen
 
 PHASE 4 - Ecosystem:
   milestone_async:  Async Runtime              -> async/await, tokio, tasks, async streams

--- a/crates/sifr/tests/e2e/pass/stdlib_json.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_json.sifr
@@ -6,9 +6,9 @@ def main():
     data: str = json_loads("{\"name\":\"sifr\"}")
     print(data)
 
-    # Dumps (for now, just returns the string)
+    # Dumps serializes to JSON (strings get quoted)
     output: str = json_dumps("hello")
     print(output)
 
 # expect-stdout: {"name":"sifr"}
-# expect-stdout: hello
+# expect-stdout: "hello"

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -3131,54 +3131,54 @@ impl RustEmitter {
             // sifr.io
             "read_file" => {
                 self.write("std::fs::read_to_string(");
-                self.emit_expr(&args[0]);
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap()");
             }
             "write_file" => {
                 self.write("std::fs::write(");
-                self.emit_expr(&args[0]);
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(", ");
-                self.emit_expr(&args[1]);
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(").unwrap()");
             }
             "file_exists" => {
-                self.write("std::path::Path::new(&");
-                self.emit_expr(&args[0]);
+                self.write("std::path::Path::new(");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").exists()");
             }
             "read_lines" => {
                 self.write("std::fs::read_to_string(");
-                self.emit_expr(&args[0]);
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap().lines().map(|s| s.to_string()).collect::<Vec<String>>()");
             }
             // sifr.json
             "json_loads" => {
-                self.write("serde_json::from_str::<serde_json::Value>(&");
-                self.emit_expr(&args[0]);
+                self.write("serde_json::from_str::<serde_json::Value>(");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap().to_string()");
             }
             "json_dumps" => {
-                // For now, json_dumps just returns the string as-is (it's already a string)
+                self.write("serde_json::to_string(&");
                 self.emit_expr(&args[0]);
-                self.write(".clone()");
+                self.write(").unwrap()");
             }
             // sifr.env
             "get_env" => {
                 self.write("std::env::var(");
-                self.emit_expr(&args[0]);
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").ok()");
             }
             "set_env" => {
                 self.write("std::env::set_var(");
-                self.emit_expr(&args[0]);
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(", ");
-                self.emit_expr(&args[1]);
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(")");
             }
             // sifr.os
             "run_command" => {
-                self.write("String::from_utf8(std::process::Command::new(\"sh\").args([\"-c\", &");
-                self.emit_expr(&args[0]);
+                self.write("String::from_utf8(std::process::Command::new(\"sh\").args([\"-c\", ");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write("]).output().unwrap().stdout).unwrap().trim().to_string()");
             }
             "get_args" => {
@@ -3236,13 +3236,13 @@ impl RustEmitter {
             }
             "set_from_list" => {
                 self.write("{ let mut s = ");
-                self.emit_expr(&args[0]);
-                self.write(".clone(); s.sort(); s.dedup(); s }");
+                self.emit_collection_expr(&args[0]);
+                self.write("; s.sort(); s.dedup(); s }");
             }
             "set_add" => {
                 self.write("{ let mut s = ");
-                self.emit_expr(&args[0]);
-                self.write(".clone(); let v = ");
+                self.emit_collection_expr(&args[0]);
+                self.write("; let v = ");
                 self.emit_expr(&args[1]);
                 self.write("; if !s.contains(&v) { s.push(v); } s }");
             }
@@ -3254,8 +3254,8 @@ impl RustEmitter {
             }
             "set_remove" => {
                 self.write("{ let mut s = ");
-                self.emit_expr(&args[0]);
-                self.write(".clone(); s.retain(|x| *x != ");
+                self.emit_collection_expr(&args[0]);
+                self.write("; s.retain(|x| *x != ");
                 self.emit_expr(&args[1]);
                 self.write("); s }");
             }
@@ -3265,16 +3265,17 @@ impl RustEmitter {
             }
             "set_union" => {
                 self.write("{ let mut s = ");
-                self.emit_expr(&args[0]);
-                self.write(".clone(); for v in ");
+                self.emit_collection_expr(&args[0]);
+                self.write("; for v in ");
                 self.emit_expr(&args[1]);
                 self.write(".iter() { if !s.contains(v) { s.push(*v); } } s.sort(); s }");
             }
             "set_intersection" => {
-                self.emit_expr(&args[0]);
-                self.write(".iter().filter(|x| ");
-                self.emit_expr(&args[1]);
-                self.write(".contains(x)).cloned().collect::<Vec<i64>>()");
+                self.write("{ let __a = ");
+                self.emit_collection_expr(&args[0]);
+                self.write("; let __b = ");
+                self.emit_collection_expr(&args[1]);
+                self.write("; __a.iter().filter(|x| __b.contains(x)).cloned().collect::<Vec<i64>>() }");
             }
             // sifr.collections — Counter
             "counter_from_list" => {
@@ -3285,15 +3286,15 @@ impl RustEmitter {
                 self.write("format!(\"{{{}}}\", pairs.join(\",\")) }");
             }
             "counter_get" => {
-                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(&");
-                self.emit_expr(&args[0]);
-                self.write(").unwrap_or_default(); *data.get(&");
-                self.emit_expr(&args[1]);
+                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").unwrap_or_default(); *data.get(");
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(").unwrap_or(&0) }");
             }
             "counter_most_common" => {
-                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(&");
-                self.emit_expr(&args[0]);
+                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap_or_default(); let mut pairs: Vec<(String, i64)> = data.into_iter().collect(); ");
                 self.write("pairs.sort_by(|a, b| b.1.cmp(&a.1)); pairs.truncate(");
                 self.emit_expr(&args[1]);
@@ -3308,16 +3309,16 @@ impl RustEmitter {
                 self.write(")");
             }
             "defaultdict_get" => {
-                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(&");
-                self.emit_expr(&args[0]);
+                self.write("{ let data: std::collections::HashMap<String, i64> = serde_json::from_str(");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap_or_default(); let def = data.get(\"__default__\").cloned().unwrap_or(0); ");
-                self.write("*data.get(&");
-                self.emit_expr(&args[1]);
+                self.write("*data.get(");
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(").unwrap_or(&def) }");
             }
             "defaultdict_set" => {
-                self.write("{ let mut data: std::collections::HashMap<String, serde_json::Value> = serde_json::from_str(&");
-                self.emit_expr(&args[0]);
+                self.write("{ let mut data: std::collections::HashMap<String, serde_json::Value> = serde_json::from_str(");
+                self.emit_expr_as_str_ref(&args[0]);
                 self.write(").unwrap_or_default(); data.insert(");
                 self.emit_expr(&args[1]);
                 self.write(".to_string(), serde_json::json!(");
@@ -3326,8 +3327,8 @@ impl RustEmitter {
             }
             // sifr.bytes
             "encode_utf8" => {
-                self.emit_expr(&args[0]);
-                self.write(".as_bytes().iter().map(|b| *b as i64).collect::<Vec<i64>>()");
+                self.emit_expr_as_bytes(&args[0]);
+                self.write(".iter().map(|b| *b as i64).collect::<Vec<i64>>()");
             }
             "decode_utf8" => {
                 self.write("String::from_utf8(");
@@ -3355,8 +3356,8 @@ impl RustEmitter {
             "time_format" => {
                 self.write("{ let secs = ");
                 self.emit_expr(&args[0]);
-                self.write(" as i64; let dt = chrono::DateTime::from_timestamp(secs, 0).unwrap(); dt.format(&");
-                self.emit_expr(&args[1]);
+                self.write(" as i64; let dt = chrono::DateTime::from_timestamp(secs, 0).unwrap(); dt.format(");
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(").to_string() }");
             }
             // sifr.random
@@ -3377,49 +3378,49 @@ impl RustEmitter {
             }
             // sifr.re
             "re_match" => {
-                self.write("regex::Regex::new(&");
-                self.emit_expr(&args[0]);
-                self.write(").unwrap().is_match(&");
-                self.emit_expr(&args[1]);
+                self.write("regex::Regex::new(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").unwrap().is_match(");
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(")");
             }
             "re_find" => {
-                self.write("regex::Regex::new(&");
-                self.emit_expr(&args[0]);
-                self.write(").unwrap().find(&");
-                self.emit_expr(&args[1]);
+                self.write("regex::Regex::new(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").unwrap().find(");
+                self.emit_expr_as_str_ref(&args[1]);
                 self.write(").map(|m| m.as_str().to_string())");
             }
             "re_replace" => {
-                self.write("regex::Regex::new(&");
-                self.emit_expr(&args[0]);
-                self.write(").unwrap().replace_all(&");
-                self.emit_expr(&args[2]);
+                self.write("regex::Regex::new(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").unwrap().replace_all(");
+                self.emit_expr_as_str_ref(&args[2]);
                 self.write(", ");
-                self.emit_expr(&args[1]);
-                self.write(".as_str()).to_string()");
+                self.emit_expr_as_str_ref(&args[1]);
+                self.write(").to_string()");
             }
             // sifr.hash
             "sha256" => {
                 self.write("{ use sha2::Digest; format!(\"{:x}\", sha2::Sha256::digest(");
-                self.emit_expr(&args[0]);
-                self.write(".as_bytes())) }");
+                self.emit_expr_as_bytes(&args[0]);
+                self.write(")) }");
             }
             "md5_hash" => {
                 self.write("format!(\"{:x}\", md5::compute(");
-                self.emit_expr(&args[0]);
-                self.write(".as_bytes()))");
+                self.emit_expr_as_bytes(&args[0]);
+                self.write("))");
             }
             // sifr.encoding
             "base64_encode" => {
                 self.write("{ use base64::Engine; base64::engine::general_purpose::STANDARD.encode(");
-                self.emit_expr(&args[0]);
-                self.write(".as_bytes()) }");
+                self.emit_expr_as_bytes(&args[0]);
+                self.write(") }");
             }
             "base64_decode" => {
                 self.write("{ use base64::Engine; String::from_utf8(base64::engine::general_purpose::STANDARD.decode(");
-                self.emit_expr(&args[0]);
-                self.write(".as_bytes()).unwrap()).unwrap() }");
+                self.emit_expr_as_bytes(&args[0]);
+                self.write(").unwrap()).unwrap() }");
             }
             _ => {
                 // Unknown stdlib function — emit as regular call
@@ -3506,6 +3507,46 @@ impl RustEmitter {
         } else {
             self.emit_expr(expr);
             self.write(".as_str()");
+        }
+    }
+
+    /// Emit an expression as a `&str` for stdlib call sites.
+    /// String literals are emitted as bare `"literal"` (no `.to_string()`).
+    /// Other expressions are emitted as `&expr` (borrow the String, deref-coerces to `&str`).
+    /// Use this for Rust APIs that accept `&str`, `AsRef<str>`, `AsRef<Path>`, `AsRef<OsStr>`, etc.
+    fn emit_expr_as_str_ref(&mut self, expr: &HirExpr) {
+        if let HirExpr::StringLiteral(val) = expr {
+            self.write(&format!("{:?}", val));
+        } else {
+            self.write("&");
+            self.emit_expr(expr);
+        }
+    }
+
+    /// Emit an expression as bytes for stdlib call sites (hash, encoding).
+    /// String literals are emitted as `"literal".as_bytes()` (no `.to_string()`).
+    /// Other expressions are emitted as `expr.as_bytes()` (String has `.as_bytes()`).
+    fn emit_expr_as_bytes(&mut self, expr: &HirExpr) {
+        if let HirExpr::StringLiteral(val) = expr {
+            self.write(&format!("{:?}.as_bytes()", val));
+        } else {
+            self.emit_expr(expr);
+            self.write(".as_bytes()");
+        }
+    }
+
+    /// Check if an expression is a list literal (HirExpr::ListLiteral).
+    fn is_list_literal(expr: &HirExpr) -> bool {
+        matches!(expr, HirExpr::ListLiteral { .. })
+    }
+
+    /// Emit a collection expression for set operations.
+    /// List literals are emitted directly (no `.clone()`).
+    /// Other expressions are emitted with `.clone()`.
+    fn emit_collection_expr(&mut self, expr: &HirExpr) {
+        self.emit_expr(expr);
+        if !Self::is_list_literal(expr) {
+            self.write(".clone()");
         }
     }
 

--- a/issues/milestone-codegen-quality-v3-epic.md
+++ b/issues/milestone-codegen-quality-v3-epic.md
@@ -1,0 +1,104 @@
+# milestone_codegen_quality_v3 — Phase 3 Codegen Polish
+
+## 1. Product Requirements
+
+### Objective
+
+Phase 3 milestones (core stdlib, test runner, extended collections, extended stdlib) introduced stdlib function codegen patterns that produce **correct but non-idiomatic** Rust output. This milestone cleans up 6 systematic quality issues to produce cleaner, more idiomatic Rust code with fewer unnecessary heap allocations.
+
+### Scope
+
+**In Scope:**
+
+1. Remove redundant `.to_string()` on string literal arguments to stdlib functions that accept `&str`
+2. Remove redundant `.clone()` on freshly-created `vec![...]` literals in set operations
+3. Fix `json_dumps` to use `serde_json::to_string` instead of `.clone()`
+4. Hoist second argument in `set_intersection` to avoid re-evaluation inside filter closure
+5. Fix `re_replace` to avoid `.to_string().as_str()` pattern
+6. Fix hash/encoding functions to avoid `.to_string().as_bytes()` pattern
+
+**Out of Scope:**
+
+| Feature | Reason |
+| --- | --- |
+| New language features | This is a polish-only milestone |
+| Bytes type system changes | Issue 4 from audit (i64 intermediate in bytes roundtrip) requires a proper `bytes` type — deferred |
+| Refactoring HIR or type system | Changes are codegen-only |
+| Performance optimizations beyond allocation removal | Focus is on code quality/idiom |
+
+### Acceptance Criteria
+
+| AC-ID | Criterion |
+| --- | --- |
+| AC-1 | **Given** `read_file("/tmp/test.txt")`, **When** Rust is emitted, **Then** output uses `std::fs::read_to_string("/tmp/test.txt")` without `.to_string()` |
+| AC-2 | **Given** `set_from_list([1, 2, 3])`, **When** Rust is emitted, **Then** output uses `vec![1_i64, 2_i64, 3_i64]` without `.clone()` |
+| AC-3 | **Given** `json_dumps(data)`, **When** Rust is emitted, **Then** output uses `serde_json::to_string(&data).unwrap()` |
+| AC-4 | **Given** `set_intersection(a, b)`, **When** Rust is emitted, **Then** second arg is hoisted to a `let` binding before the filter |
+| AC-5 | **Given** `re_replace("[0-9]+", "hello123", "N")`, **When** Rust is emitted, **Then** replacement string uses `"N"` directly, not `"N".to_string().as_str()` |
+| AC-6 | **Given** `sha256("sifr")`, **When** Rust is emitted, **Then** output uses `"sifr".as_bytes()` not `"sifr".to_string().as_bytes()` |
+| AC-7 | **Given** all existing E2E pass tests, **When** `cargo test` is run, **Then** all tests pass with no regressions |
+| AC-8 | **Given** all Phase 3 demos, **When** compiled and run, **Then** output is identical to before this milestone |
+
+---
+
+## 2. Solution Design
+
+### 2.1 Architecture
+
+All changes are confined to `crates/sifr_codegen/src/lib.rs`. No HIR, type system, or parser changes are needed. The core addition is a single helper method.
+
+```
+sifr_codegen/src/lib.rs
+    ├── emit_expr_as_str_ref()            → NEW helper (core fix)
+    ├── emit_stdlib_call() "read_file"    → Task 1 (use helper)
+    ├── emit_stdlib_call() "write_file"   → Task 1 (use helper)
+    ├── emit_stdlib_call() "env_get/set"  → Task 1 (use helper)
+    ├── emit_stdlib_call() "path_exists"  → Task 1 (use helper)
+    ├── emit_stdlib_call() "json_loads"   → Task 1 (use helper)
+    ├── emit_stdlib_call() "set_from_list"→ Task 2 (remove .clone())
+    ├── emit_stdlib_call() "set_add" etc  → Task 2 (remove .clone())
+    ├── emit_stdlib_call() "json_dumps"   → Task 3 (serde_json)
+    ├── emit_stdlib_call() "set_intersection" → Task 4 (hoist)
+    ├── emit_stdlib_call() "re_*"         → Task 5 (use helper)
+    └── emit_stdlib_call() hash/encoding  → Task 6 (use helper)
+```
+
+### 2.2 Detailed Changes
+
+**Core — `emit_expr_as_str_ref` helper:**
+- For `HirExpr::StringLiteral(val)`: emits `"val"` (bare string literal, no `.to_string()`)
+- For any other expression: emits `&{expr}` (borrow the String)
+
+**Task 1 — Remove redundant `.to_string()` on string literal args:**
+- Update all stdlib call sites in `emit_stdlib_call` that pass arguments to Rust APIs accepting `&str` / `AsRef<str>` to use `emit_expr_as_str_ref` instead of `emit_expr`.
+
+**Task 2 — Remove redundant `.clone()` on vec literals:**
+- In `set_from_list`, `set_add`, `set_union`, `set_remove`: when emitting the collection argument, detect if it's a list literal and skip `.clone()`.
+
+**Task 3 — Fix `json_dumps`:**
+- Replace current `.clone()` emission with `serde_json::to_string(&expr).unwrap()`.
+
+**Task 4 — Hoist second arg in `set_intersection`:**
+- Emit the second argument into a `let __b = ...` binding before the filter, then reference `__b` inside the closure.
+
+**Task 5 — Fix `re_replace`:**
+- Use `emit_expr_as_str_ref` for pattern, input, and replacement arguments.
+
+**Task 6 — Fix hash/encoding `.to_string().as_bytes()`:**
+- For string literals: emit `"literal".as_bytes()` directly.
+- For variables: emit `expr.as_bytes()` (String already has `.as_bytes()`).
+
+### 2.3 Testing Strategy
+
+| AC-ID | Test Layer | Happy-Path Check | Non-Happy / Edge Check |
+| --- | --- | --- | --- |
+| AC-1 | E2E | `read_file("/tmp/test.txt")` emits without `.to_string()` | Variable args still work with `&` |
+| AC-2 | E2E | `set_from_list([1,2,3])` emits without `.clone()` | Variable args still clone correctly |
+| AC-3 | E2E | `json_dumps(data)` emits `serde_json::to_string` | Nested objects serialize correctly |
+| AC-4 | E2E | `set_intersection(a, b)` hoists `b` | Single-element sets work |
+| AC-5 | E2E | `re_replace` uses bare string literals | Variable replacement strings work |
+| AC-6 | E2E | `sha256("sifr")` uses `"sifr".as_bytes()` | Variable args use `expr.as_bytes()` |
+| AC-7 | Full suite | All E2E tests pass | `cargo test` green |
+| AC-8 | Demos | All 4 Phase 3 demos produce identical output | No regressions |
+
+**Demo:** Existing Phase 3 demos serve as the verification demos for this milestone.


### PR DESCRIPTION
## Summary

- Add `emit_expr_as_str_ref` and `emit_expr_as_bytes` helper methods to `RustEmitter` for clean stdlib codegen
- Fix redundant `.to_string()` on string literal arguments across all stdlib modules (sifr.io, sifr.json, sifr.env, sifr.os, sifr.re, sifr.hash, sifr.encoding)
- Remove redundant `.clone()` on freshly-created `vec![...]` literals in set operations
- Fix `json_dumps` to use `serde_json::to_string` instead of `.clone()`
- Hoist second argument in `set_intersection` to avoid re-evaluation inside filter closure
- Fix `re_replace` to use bare string refs instead of `.to_string().as_str()`
- Fix hash/encoding functions to use `.as_bytes()` directly on string literals

## Test plan

- [x] All 106 E2E pass tests pass
- [x] All 13 E2E fail tests pass
- [x] All 4 Phase 3 demos produce correct output
- [x] Emitted Rust code verified to be visibly cleaner (no redundant allocations)
- [x] `cargo check` compiles with no warnings
- [x] `cargo test` (full suite including lib + E2E) passes

Closes #88

Made with [Cursor](https://cursor.com)