### PR TITLE
milestone_ownership_v2: Fix Overly Aggressive Move Semantics

### DIFF
--- a/crates/sifr/tests/e2e/fail/use_after_move.sifr
+++ b/crates/sifr/tests/e2e/fail/use_after_move.sifr
@@ -1,5 +1,8 @@
 # expect-error: moved value
+def consume(s: str) -> str:
+    return s
+
 def main():
     s: str = "hello"
-    print(s)
+    x: str = consume(s)
     print(s)

--- a/crates/sifr/tests/e2e/pass/ownership_print_reuse.sifr
+++ b/crates/sifr/tests/e2e/pass/ownership_print_reuse.sifr
@@ -1,0 +1,11 @@
+# expect-stdout: hello
+# expect-stdout: hello
+# expect-stdout: 5
+# Tests that print() doesn't consume values - they can be reused
+
+def main():
+    s: str = "hello"
+    print(s)
+    print(s)
+    nums: list[int] = [1, 2, 3, 4, 5]
+    print(len(nums))

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -2781,10 +2781,18 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
     }
 
     // Track ownership: move arguments of move types
-    for arg in &args {
-        if let HirExpr::Name { name, ty } = arg {
-            if ty.ownership() == sifr_type_system::OwnershipKind::Move {
-                ctx.scope.mark_moved(name);
+    // Skip for built-in functions that borrow their arguments (print, len, bool, etc.)
+    let borrows_args = matches!(func_name.as_str(),
+        "print" | "len" | "bool" | "str" | "int" | "float" | "isinstance" |
+        "type" | "id" | "hash" | "repr" | "sorted" | "reversed" | "enumerate" |
+        "zip" | "any" | "all" | "sum" | "min" | "max" | "abs" | "round"
+    );
+    if !borrows_args {
+        for arg in &args {
+            if let HirExpr::Name { name, ty } = arg {
+                if ty.ownership() == sifr_type_system::OwnershipKind::Move {
+                    ctx.scope.mark_moved(name);
+                }
             }
         }
     }


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/94

#### **Changes**

* Built-in functions (print, len, bool, str, sorted, enumerate, zip, etc.) now borrow arguments instead of consuming them
* Variables can be reused after being passed to print() and other builtins
* Updated use_after_move fail test to use a user-defined consuming function
* Add ownership_print_reuse pass test and demo

#### **Why**
print() consuming values was the most common ownership complaint. In Python, print() never consumes. This fix makes the ownership model more Pythonic while still enforcing moves for user-defined functions.

Made with [Cursor](https://cursor.com)