### PR TITLE
milestone_subscript_mutation: Support Subscript and Attribute Assignment

### DIFF
--- a/crates/sifr/tests/e2e/pass/subscript_dict_assign.sifr
+++ b/crates/sifr/tests/e2e/pass/subscript_dict_assign.sifr
@@ -1,0 +1,9 @@
+# expect-stdout: 2
+# Tests dict subscript assignment: dict[key] = val
+
+def main():
+    d: dict[str, int] = {"a": 1}
+    d["b"] = 2
+    val: int | None = d["b"]
+    if val is not None:
+        print(val)

--- a/crates/sifr/tests/e2e/pass/subscript_list_assign.sifr
+++ b/crates/sifr/tests/e2e/pass/subscript_list_assign.sifr
@@ -1,0 +1,7 @@
+# expect-stdout: [10, 2, 3]
+# Tests list subscript assignment: list[i] = val
+
+def main():
+    nums: list[int] = [1, 2, 3]
+    nums[0] = 10
+    print(nums)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1873,6 +1873,47 @@ impl RustEmitter {
                 self.emit_expr(value);
                 self.write(";\n");
             }
+            HirStmt::SubscriptAssign { object, index, value, object_ty } => {
+                self.write_indent();
+                match object_ty {
+                    Type::List(_) => {
+                        // list[i] = val -> list[i as usize] = val
+                        self.write(object);
+                        self.write("[");
+                        self.emit_expr(index);
+                        self.write(" as usize] = ");
+                        self.emit_expr(value);
+                        self.write(";\n");
+                    }
+                    Type::Dict(_, _) => {
+                        // dict[key] = val -> dict.insert(key, val)
+                        self.write(object);
+                        self.write(".insert(");
+                        self.emit_expr(index);
+                        self.write(", ");
+                        self.emit_expr(value);
+                        self.write(");\n");
+                    }
+                    _ => {
+                        // Fallback: direct subscript
+                        self.write(object);
+                        self.write("[");
+                        self.emit_expr(index);
+                        self.write("] = ");
+                        self.emit_expr(value);
+                        self.write(";\n");
+                    }
+                }
+            }
+            HirStmt::AttributeAugAssign { object, field, op, value } => {
+                self.write_indent();
+                self.write(object);
+                self.write(".");
+                self.write(field);
+                self.write(&format!(" {} ", op));
+                self.emit_expr(value);
+                self.write(";\n");
+            }
             HirStmt::Delete { object, index } => {
                 let obj_ty = object.ty();
                 self.write_indent();
@@ -3936,6 +3977,13 @@ fn stmts_reference_var(stmts: &[HirStmt], var_name: &str) -> bool {
             HirStmt::FieldAssign { value, .. } => {
                 if expr_references_var(value, var_name) { return true; }
             }
+            HirStmt::SubscriptAssign { index, value, .. } => {
+                if expr_references_var(index, var_name) { return true; }
+                if expr_references_var(value, var_name) { return true; }
+            }
+            HirStmt::AttributeAugAssign { value, .. } => {
+                if expr_references_var(value, var_name) { return true; }
+            }
             HirStmt::If { condition, then_body, elif_clauses, else_body } => {
                 if expr_references_var(condition, var_name) { return true; }
                 if stmts_reference_var(then_body, var_name) { return true; }
@@ -4115,6 +4163,12 @@ fn collect_mutated_vars_inner(stmts: &[HirStmt], mutated: &mut HashSet<String>) 
                 for handler in handlers {
                     collect_mutated_vars_inner(&handler.body, mutated);
                 }
+            }
+            HirStmt::SubscriptAssign { object, .. } => {
+                mutated.insert(object.clone());
+            }
+            HirStmt::AttributeAugAssign { object, .. } => {
+                mutated.insert(object.clone());
             }
             HirStmt::Delete { object, .. } => {
                 if let HirExpr::Name { name, .. } = object {

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -161,6 +161,20 @@ pub enum HirStmt {
         field: String,
         value: HirExpr,
     },
+    /// Subscript assignment: list[i] = val or dict[key] = val
+    SubscriptAssign {
+        object: String,
+        index: HirExpr,
+        value: HirExpr,
+        object_ty: Type,
+    },
+    /// Augmented assignment on attribute: self.field += val
+    AttributeAugAssign {
+        object: String,
+        field: String,
+        op: String,
+        value: HirExpr,
+    },
     /// Delete statement: del d[key] or del a[i]
     Delete {
         object: HirExpr,

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -1413,6 +1413,28 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
         });
     }
 
+    // Handle subscript assignment: list[i] = val or dict[key] = val
+    if let Expr::Subscript(sub) = &assign.targets[0] {
+        let obj_name = match sub.value.as_ref() {
+            Expr::Name(n) => n.id.to_string(),
+            _ => {
+                ctx.error("subscript assignment target must be a simple name".to_string());
+                return None;
+            }
+        };
+        let obj_ty = ctx.scope.lookup(&obj_name)
+            .map(|info| info.effective_type().clone())
+            .unwrap_or(Type::Unknown);
+        let index = lower_expr(&sub.slice, ctx)?;
+        let value = lower_expr(&assign.value, ctx)?;
+        return Some(HirStmt::SubscriptAssign {
+            object: obj_name,
+            index,
+            value,
+            object_ty: obj_ty,
+        });
+    }
+
     let name = match &assign.targets[0] {
         Expr::Name(n) => n.id.to_string(),
         _ => {
@@ -1463,6 +1485,37 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
 }
 
 fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
+    // Handle augmented assignment on attributes: self.field += val
+    if let Expr::Attribute(attr) = aug.target.as_ref() {
+        let obj_name = match attr.value.as_ref() {
+            Expr::Name(n) => n.id.to_string(),
+            _ => {
+                ctx.error("augmented attribute assignment target must be a simple name".to_string());
+                return None;
+            }
+        };
+        let field_name = attr.attr.to_string();
+        let value = lower_expr(&aug.value, ctx)?;
+        let op_str = match aug.op {
+            Operator::Add => "+=",
+            Operator::Sub => "-=",
+            Operator::Mult => "*=",
+            Operator::Div => "/=",
+            Operator::Mod => "%=",
+            Operator::Pow => "**=",
+            _ => {
+                ctx.error("unsupported augmented assignment operator".to_string());
+                return None;
+            }
+        };
+        return Some(HirStmt::AttributeAugAssign {
+            object: obj_name,
+            field: field_name,
+            op: op_str.to_string(),
+            value,
+        });
+    }
+
     let name = match aug.target.as_ref() {
         Expr::Name(n) => n.id.to_string(),
         _ => {


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/96

#### **Changes**

* Add `HirStmt::SubscriptAssign` and `HirStmt::AttributeAugAssign` HIR nodes
* Recognize `Expr::Subscript` as valid assignment target (was: "assignment target must be a simple name")
* Recognize `Expr::Attribute` in augmented assignment
* Emit `vec[i as usize] = val` for lists, `map.insert(key, val)` for dicts
* Track subscript/attribute mutations in `collect_mutated_vars` for proper `let mut`
* 2 new e2e pass tests

#### **Why**
This was the #1 blocker for LeetCode problems. 3 problems were completely unfixable without subscript assignment, and many more required workarounds.

Made with [Cursor](https://cursor.com)