### PR TITLE
milestone_builtins_v2: Expand Built-in Functions

### DIFF
--- a/crates/sifr/tests/e2e/pass/builtins_max_min_2arg.sifr
+++ b/crates/sifr/tests/e2e/pass/builtins_max_min_2arg.sifr
@@ -1,0 +1,9 @@
+# expect-stdout: 10
+# expect-stdout: 3
+# Tests max(a, b) and min(a, b) with 2 arguments
+
+def main():
+    a: int = 10
+    b: int = 3
+    print(max(a, b))
+    print(min(a, b))

--- a/crates/sifr/tests/e2e/pass/builtins_pow.sifr
+++ b/crates/sifr/tests/e2e/pass/builtins_pow.sifr
@@ -1,0 +1,7 @@
+# expect-stdout: 8
+# expect-stdout: 27
+# Tests pow(base, exp) builtin
+
+def main():
+    print(pow(2, 3))
+    print(pow(3, 3))

--- a/crates/sifr/tests/e2e/pass/builtins_range_3arg.sifr
+++ b/crates/sifr/tests/e2e/pass/builtins_range_3arg.sifr
@@ -1,0 +1,10 @@
+# expect-stdout: 0
+# expect-stdout: 2
+# expect-stdout: 4
+# expect-stdout: 6
+# expect-stdout: 8
+# Tests range(start, stop, step) with 3 arguments
+
+def main():
+    for i in range(0, 10, 2):
+        print(i)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2726,6 +2726,22 @@ impl RustEmitter {
                     } else {
                         self.write("String::new()");
                     }
+                } else if func == "pow" {
+                    // pow(base, exp)
+                    if args.len() == 2 {
+                        if args[0].ty() == &Type::Int && args[1].ty() == &Type::Int {
+                            self.emit_expr(&args[0]);
+                            self.write(".pow(");
+                            self.emit_expr(&args[1]);
+                            self.write(" as u32)");
+                        } else {
+                            self.write("(");
+                            self.emit_expr(&args[0]);
+                            self.write(" as f64).powf(");
+                            self.emit_expr(&args[1]);
+                            self.write(" as f64)");
+                        }
+                    }
                 } else if func == "abs" {
                     if !args.is_empty() {
                         self.write("(");
@@ -2834,8 +2850,21 @@ impl RustEmitter {
                         }
                     }
                 } else if func == "min" {
-                    // min(list) -> *list.iter().min().unwrap()
-                    if matches!(args[0].ty(), Type::List(ref e) if matches!(e.as_ref(), Type::Float)) {
+                    if args.len() == 2 {
+                        // min(a, b) -> std::cmp::min(a, b) or a.min(b) for floats
+                        if matches!(args[0].ty(), Type::Float) {
+                            self.emit_expr(&args[0]);
+                            self.write(".min(");
+                            self.emit_expr(&args[1]);
+                            self.write(")");
+                        } else {
+                            self.write("std::cmp::min(");
+                            self.emit_expr(&args[0]);
+                            self.write(", ");
+                            self.emit_expr(&args[1]);
+                            self.write(")");
+                        }
+                    } else if matches!(args[0].ty(), Type::List(ref e) if matches!(e.as_ref(), Type::Float)) {
                         self.emit_expr(&args[0]);
                         self.write(".iter().cloned().reduce(f64::min).unwrap()");
                     } else {
@@ -2845,8 +2874,21 @@ impl RustEmitter {
                         self.write(".iter().min().unwrap()");
                     }
                 } else if func == "max" {
-                    // max(list) -> *list.iter().max().unwrap()
-                    if matches!(args[0].ty(), Type::List(ref e) if matches!(e.as_ref(), Type::Float)) {
+                    if args.len() == 2 {
+                        // max(a, b) -> std::cmp::max(a, b) or a.max(b) for floats
+                        if matches!(args[0].ty(), Type::Float) {
+                            self.emit_expr(&args[0]);
+                            self.write(".max(");
+                            self.emit_expr(&args[1]);
+                            self.write(")");
+                        } else {
+                            self.write("std::cmp::max(");
+                            self.emit_expr(&args[0]);
+                            self.write(", ");
+                            self.emit_expr(&args[1]);
+                            self.write(")");
+                        }
+                    } else if matches!(args[0].ty(), Type::List(ref e) if matches!(e.as_ref(), Type::Float)) {
                         self.emit_expr(&args[0]);
                         self.write(".iter().cloned().reduce(f64::max).unwrap()");
                     } else {
@@ -2970,10 +3012,20 @@ impl RustEmitter {
                 self.emit_expr(else_expr);
                 self.write(" }");
             }
-            HirExpr::RangeLiteral { start, end, .. } => {
-                self.emit_expr(start);
-                self.write("..");
-                self.emit_expr(end);
+            HirExpr::RangeLiteral { start, end, step, .. } => {
+                if let Some(step) = step {
+                    self.write("(");
+                    self.emit_expr(start);
+                    self.write("..");
+                    self.emit_expr(end);
+                    self.write(").step_by(");
+                    self.emit_expr(step);
+                    self.write(" as usize)");
+                } else {
+                    self.emit_expr(start);
+                    self.write("..");
+                    self.emit_expr(end);
+                }
             }
             HirExpr::ListLiteral { elements, .. } => {
                 self.write("vec![");

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -275,6 +275,7 @@ pub enum HirExpr {
     RangeLiteral {
         start: Box<HirExpr>,
         end: Box<HirExpr>,
+        step: Option<Box<HirExpr>>,
         ty: Type,
     },
     /// List literal: [1, 2, 3]

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -2284,6 +2284,26 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         }
     }
 
+    // pow(base, exp) -> base ** exp
+    if func_name == "pow" {
+        if call.arguments.args.len() != 2 {
+            ctx.error("pow() takes exactly 2 arguments".to_string());
+            return None;
+        }
+        let base = lower_expr(&call.arguments.args[0], ctx)?;
+        let exp = lower_expr(&call.arguments.args[1], ctx)?;
+        let result_ty = if base.ty() == &Type::Int && exp.ty() == &Type::Int {
+            Type::Int
+        } else {
+            Type::Float
+        };
+        return Some(HirExpr::Call {
+            func: "pow".to_string(),
+            args: vec![base, exp],
+            ty: result_ty,
+        });
+    }
+
     // Special handling for abs() built-in
     if func_name == "abs" {
         if call.arguments.args.len() != 1 {
@@ -2426,46 +2446,68 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
 
     // --- Built-in generic functions ---
 
-    // min(iterable) -> element type
+    // min(iterable) or min(a, b) -> element type
     if func_name == "min" {
-        if call.arguments.args.len() != 1 {
-            ctx.error("min() takes exactly 1 argument".to_string());
+        if call.arguments.args.len() == 2 {
+            // min(a, b) -> std::cmp::min(a, b)
+            let a = lower_expr(&call.arguments.args[0], ctx)?;
+            let b = lower_expr(&call.arguments.args[1], ctx)?;
+            let result_ty = a.ty().clone();
+            return Some(HirExpr::Call {
+                func: "min".to_string(),
+                args: vec![a, b],
+                ty: result_ty,
+            });
+        } else if call.arguments.args.len() == 1 {
+            let arg = lower_expr(&call.arguments.args[0], ctx)?;
+            let elem_ty = match arg.ty() {
+                Type::List(elem) => *elem.clone(),
+                _ => {
+                    ctx.error(format!("min() argument must be a list, got '{}'", arg.ty().display_name()));
+                    return None;
+                }
+            };
+            return Some(HirExpr::Call {
+                func: "min".to_string(),
+                args: vec![arg],
+                ty: elem_ty,
+            });
+        } else {
+            ctx.error("min() takes 1 or 2 arguments".to_string());
             return None;
         }
-        let arg = lower_expr(&call.arguments.args[0], ctx)?;
-        let elem_ty = match arg.ty() {
-            Type::List(elem) => *elem.clone(),
-            _ => {
-                ctx.error(format!("min() argument must be a list, got '{}'", arg.ty().display_name()));
-                return None;
-            }
-        };
-        return Some(HirExpr::Call {
-            func: "min".to_string(),
-            args: vec![arg],
-            ty: elem_ty,
-        });
     }
 
-    // max(iterable) -> element type
+    // max(iterable) or max(a, b) -> element type
     if func_name == "max" {
-        if call.arguments.args.len() != 1 {
-            ctx.error("max() takes exactly 1 argument".to_string());
+        if call.arguments.args.len() == 2 {
+            // max(a, b) -> std::cmp::max(a, b)
+            let a = lower_expr(&call.arguments.args[0], ctx)?;
+            let b = lower_expr(&call.arguments.args[1], ctx)?;
+            let result_ty = a.ty().clone();
+            return Some(HirExpr::Call {
+                func: "max".to_string(),
+                args: vec![a, b],
+                ty: result_ty,
+            });
+        } else if call.arguments.args.len() == 1 {
+            let arg = lower_expr(&call.arguments.args[0], ctx)?;
+            let elem_ty = match arg.ty() {
+                Type::List(elem) => *elem.clone(),
+                _ => {
+                    ctx.error(format!("max() argument must be a list, got '{}'", arg.ty().display_name()));
+                    return None;
+                }
+            };
+            return Some(HirExpr::Call {
+                func: "max".to_string(),
+                args: vec![arg],
+                ty: elem_ty,
+            });
+        } else {
+            ctx.error("max() takes 1 or 2 arguments".to_string());
             return None;
         }
-        let arg = lower_expr(&call.arguments.args[0], ctx)?;
-        let elem_ty = match arg.ty() {
-            Type::List(elem) => *elem.clone(),
-            _ => {
-                ctx.error(format!("max() argument must be a list, got '{}'", arg.ty().display_name()));
-                return None;
-            }
-        };
-        return Some(HirExpr::Call {
-            func: "max".to_string(),
-            args: vec![arg],
-            ty: elem_ty,
-        });
     }
 
     // sum(iterable) -> element type (int or float)
@@ -2838,7 +2880,7 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
     let borrows_args = matches!(func_name.as_str(),
         "print" | "len" | "bool" | "str" | "int" | "float" | "isinstance" |
         "type" | "id" | "hash" | "repr" | "sorted" | "reversed" | "enumerate" |
-        "zip" | "any" | "all" | "sum" | "min" | "max" | "abs" | "round"
+        "zip" | "any" | "all" | "sum" | "min" | "max" | "abs" | "round" | "pow"
     );
     if !borrows_args {
         for arg in &args {
@@ -3691,6 +3733,7 @@ fn lower_range_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
             Some(HirExpr::RangeLiteral {
                 start: Box::new(HirExpr::IntLiteral(0)),
                 end: Box::new(end),
+                step: None,
                 ty: Type::Range,
             })
         }
@@ -3715,12 +3758,25 @@ fn lower_range_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
             Some(HirExpr::RangeLiteral {
                 start: Box::new(start),
                 end: Box::new(end),
+                step: None,
+                ty: Type::Range,
+            })
+        }
+        3 => {
+            // range(start, end, step) -> (start..end).step_by(step)
+            let start = lower_expr(args[0], ctx)?;
+            let end = lower_expr(args[1], ctx)?;
+            let step = lower_expr(args[2], ctx)?;
+            Some(HirExpr::RangeLiteral {
+                start: Box::new(start),
+                end: Box::new(end),
+                step: Some(Box::new(step)),
                 ty: Type::Range,
             })
         }
         _ => {
             ctx.error(format!(
-                "range() takes 1 or 2 arguments, got {}",
+                "range() takes 1, 2, or 3 arguments, got {}",
                 args.len()
             ));
             None


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/100

#### **Changes**

* `max(a, b)` and `min(a, b)`: 2-arg overloads using `std::cmp::max/min`
* `range(start, stop, step)`: 3-arg support with `.step_by()`
* `pow(base, exp)`: new standalone builtin
* Add `step` field to `HirExpr::RangeLiteral`
* 3 new e2e pass tests

#### **Why**
These are the most commonly used Python builtins that were missing. max/min 2-arg was needed for 20+ LeetCode problems.

Made with [Cursor](https://cursor.com)