### PR TITLE
milestone_syntax_expansion: Add Missing Syntax Support

### DIFF
--- a/crates/sifr/tests/e2e/pass/syntax_bitwise_augassign.sifr
+++ b/crates/sifr/tests/e2e/pass/syntax_bitwise_augassign.sifr
@@ -1,0 +1,19 @@
+# expect-stdout: 1
+# expect-stdout: 7
+# expect-stdout: 4
+# expect-stdout: 8
+# expect-stdout: 2
+# Tests bitwise augmented assignment operators
+
+def main():
+    x: int = 5
+    x &= 3
+    print(x)
+    x |= 6
+    print(x)
+    x ^= 3
+    print(x)
+    x <<= 1
+    print(x)
+    x >>= 2
+    print(x)

--- a/crates/sifr/tests/e2e/pass/syntax_bitwise_invert.sifr
+++ b/crates/sifr/tests/e2e/pass/syntax_bitwise_invert.sifr
@@ -1,0 +1,8 @@
+# expect-stdout: -6
+# expect-stdout: -1
+# Tests bitwise invert (~) operator
+
+def main():
+    x: int = 5
+    print(~x)
+    print(~0)

--- a/crates/sifr/tests/e2e/pass/syntax_bitwise_ops.sifr
+++ b/crates/sifr/tests/e2e/pass/syntax_bitwise_ops.sifr
@@ -1,0 +1,15 @@
+# expect-stdout: 1
+# expect-stdout: 7
+# expect-stdout: 6
+# expect-stdout: 10
+# expect-stdout: 2
+# Tests bitwise operators: &, |, ^, <<, >>
+
+def main():
+    a: int = 5
+    b: int = 3
+    print(a & b)
+    print(a | b)
+    print(a ^ b)
+    print(a << 1)
+    print(a >> 1)

--- a/crates/sifr/tests/e2e/pass/syntax_chained_assign.sifr
+++ b/crates/sifr/tests/e2e/pass/syntax_chained_assign.sifr
@@ -1,0 +1,13 @@
+# expect-stdout: 42
+# expect-stdout: 42
+# expect-stdout: 42
+# Tests chained assignment: x = y = z = 42
+
+def main():
+    x: int = 0
+    y: int = 0
+    z: int = 0
+    x = y = z = 42
+    print(x)
+    print(y)
+    print(z)

--- a/crates/sifr/tests/e2e/pass/syntax_unary_plus.sifr
+++ b/crates/sifr/tests/e2e/pass/syntax_unary_plus.sifr
@@ -1,0 +1,9 @@
+# expect-stdout: 5
+# expect-stdout: -3
+# Tests unary + operator
+
+def main():
+    x: int = 5
+    print(+x)
+    y: int = -3
+    print(+y)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2611,12 +2611,17 @@ impl RustEmitter {
                 }
             }
             HirExpr::UnaryOp { op, operand, .. } => {
-                if op == "not" {
+                if op == "not" || op == "~" {
+                    // Both `not` (logical) and `~` (bitwise invert) map to `!` in Rust
                     self.write("!");
+                    self.emit_expr(operand);
+                } else if op == "+" {
+                    // Unary + is a no-op in Python/Rust, just emit the operand
+                    self.emit_expr(operand);
                 } else {
                     self.write(op);
+                    self.emit_expr(operand);
                 }
-                self.emit_expr(operand);
             }
             HirExpr::Compare { left, ops, comparators, .. } => {
                 // For single comparison

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -1154,6 +1154,14 @@ fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Option<HirFunct
 fn lower_stmts(stmts: &[Stmt], func_type: &FunctionType, ctx: &mut LowerCtx) -> Vec<HirStmt> {
     let mut result = Vec::new();
     for stmt in stmts {
+        // Handle chained assignment (x = y = z = 0) by expanding into multiple statements
+        if let Stmt::Assign(assign) = stmt {
+            if assign.targets.len() > 1 {
+                let expanded = lower_chained_assign(assign, ctx);
+                result.extend(expanded);
+                continue;
+            }
+        }
         if let Some(hir_stmt) = lower_stmt(stmt, func_type, ctx) {
             result.push(hir_stmt);
         }
@@ -1379,6 +1387,76 @@ fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Option<HirStmt> 
     })
 }
 
+/// Handle chained assignment: x = y = z = 0
+/// Expands into: z = 0; y = z; x = y (right-to-left, last target gets the value first)
+fn lower_chained_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Vec<HirStmt> {
+    let mut result = Vec::new();
+
+    // Lower the value expression once
+    let value = match lower_expr(&assign.value, ctx) {
+        Some(v) => v,
+        None => return result,
+    };
+    let val_ty = value.ty().clone();
+
+    // Process targets in reverse order (rightmost gets the value first)
+    let targets: Vec<_> = assign.targets.iter().collect();
+    for (i, target) in targets.iter().rev().enumerate() {
+        if let Expr::Name(n) = target {
+            let name = n.id.to_string();
+            if i == 0 {
+                // First (rightmost) target gets the actual value
+                let existing = ctx.scope.lookup(&name);
+                if existing.is_some() {
+                    // Reassignment
+                    result.push(HirStmt::Assign {
+                        name: name.clone(),
+                        value: value.clone(),
+                    });
+                } else {
+                    // New variable
+                    ctx.scope.define(name.clone(), val_ty.clone());
+                    result.push(HirStmt::Let {
+                        name: name.clone(),
+                        ty: val_ty.clone(),
+                        value: value.clone(),
+                        is_mutable: true,
+                    });
+                }
+            } else {
+                // Subsequent targets get a reference to the previous target
+                let prev_target = match targets.get(targets.len() - i) {
+                    Some(Expr::Name(prev_n)) => prev_n.id.to_string(),
+                    _ => continue,
+                };
+                let name_expr = HirExpr::Name {
+                    name: prev_target,
+                    ty: val_ty.clone(),
+                };
+                let existing = ctx.scope.lookup(&name);
+                if existing.is_some() {
+                    result.push(HirStmt::Assign {
+                        name: name.clone(),
+                        value: name_expr,
+                    });
+                } else {
+                    ctx.scope.define(name.clone(), val_ty.clone());
+                    result.push(HirStmt::Let {
+                        name: name.clone(),
+                        ty: val_ty.clone(),
+                        value: name_expr,
+                        is_mutable: true,
+                    });
+                }
+            }
+        } else {
+            ctx.error("chained assignment targets must be simple names".to_string());
+        }
+    }
+
+    result
+}
+
 fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
     if assign.targets.len() != 1 {
         ctx.error("multiple assignment targets not supported yet".to_string());
@@ -1503,8 +1581,14 @@ fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Option<HirStmt> 
             Operator::Div => "/=",
             Operator::Mod => "%=",
             Operator::Pow => "**=",
-            _ => {
-                ctx.error("unsupported augmented assignment operator".to_string());
+            Operator::BitAnd => "&=",
+            Operator::BitOr => "|=",
+            Operator::BitXor => "^=",
+            Operator::LShift => "<<=",
+            Operator::RShift => ">>=",
+            Operator::FloorDiv => "//=",
+            Operator::MatMult => {
+                ctx.error("matrix multiplication operator (@) is not supported".to_string());
                 return None;
             }
         };
@@ -1534,8 +1618,13 @@ fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Option<HirStmt> 
         Operator::FloorDiv => "//=",
         Operator::Mod => "%=",
         Operator::Pow => "**=",
-        _ => {
-            ctx.error("unsupported augmented assignment operator".to_string());
+        Operator::BitAnd => "&=",
+        Operator::BitOr => "|=",
+        Operator::BitXor => "^=",
+        Operator::LShift => "<<=",
+        Operator::RShift => ">>=",
+        Operator::MatMult => {
+            ctx.error("matrix multiplication operator (@) is not supported".to_string());
             return None;
         }
     };
@@ -2033,8 +2122,13 @@ fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirExpr> {
         Operator::FloorDiv => "//",
         Operator::Mod => "%",
         Operator::Pow => "**",
-        _ => {
-            ctx.error(format!("unsupported binary operator"));
+        Operator::BitAnd => "&",
+        Operator::BitOr => "|",
+        Operator::BitXor => "^",
+        Operator::LShift => "<<",
+        Operator::RShift => ">>",
+        Operator::MatMult => {
+            ctx.error("matrix multiplication operator (@) is not supported".to_string());
             return None;
         }
     };
@@ -2074,10 +2168,7 @@ fn lower_unaryop(unary: &ExprUnaryOp, ctx: &mut LowerCtx) -> Option<HirExpr> {
         UnaryOp::USub => "-",
         UnaryOp::UAdd => "+",
         UnaryOp::Not => "not",
-        _ => {
-            ctx.error("unsupported unary operator".to_string());
-            return None;
-        }
+        UnaryOp::Invert => "~",
     };
 
     match type_check_unary_op(op_str, operand.ty()) {
@@ -4117,8 +4208,10 @@ mod tests {
 
     #[test]
     fn test_use_after_move() {
+        // print() borrows, so print(s); print(s) should NOT error.
+        // Use a user-defined consuming function to test move semantics.
         let result = lower_source(
-            "def main():\n    s: str = \"hello\"\n    print(s)\n    print(s)\n"
+            "def consume(s: str) -> str:\n    return s\ndef main():\n    s: str = \"hello\"\n    x: str = consume(s)\n    print(s)\n"
         );
         assert!(result.is_err());
         let errors = result.unwrap_err();

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -123,6 +123,44 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 },
             })
         }
+        "&" | "|" | "^" => {
+            // Bitwise operators: int & int -> int, int | int -> int, int ^ int -> int
+            // Also bool & bool -> bool, bool | bool -> bool, bool ^ bool -> bool
+            if left == &Type::Int && right == &Type::Int {
+                return Ok(Type::Int);
+            }
+            if left == &Type::Bool && right == &Type::Bool {
+                return Ok(Type::Bool);
+            }
+            Err(TypeError {
+                message: format!(
+                    "unsupported operand type(s) for {op}: '{}' and '{}'",
+                    left.display_name(),
+                    right.display_name()
+                ),
+                kind: crate::TypeErrorKind::InvalidOperator {
+                    op: op.to_string(),
+                    ty: left.clone(),
+                },
+            })
+        }
+        "<<" | ">>" => {
+            // Shift operators: int << int -> int, int >> int -> int
+            if left == &Type::Int && right == &Type::Int {
+                return Ok(Type::Int);
+            }
+            Err(TypeError {
+                message: format!(
+                    "unsupported operand type(s) for {op}: '{}' and '{}'",
+                    left.display_name(),
+                    right.display_name()
+                ),
+                kind: crate::TypeErrorKind::InvalidOperator {
+                    op: op.to_string(),
+                    ty: left.clone(),
+                },
+            })
+        }
         _ => Err(TypeError {
             message: format!("unknown binary operator: {op}"),
             kind: crate::TypeErrorKind::InvalidOperator {
@@ -208,6 +246,22 @@ pub fn type_check_unary_op(op: &str, operand: &Type) -> Result<Type, TypeError> 
             Err(TypeError {
                 message: format!(
                     "bad operand type for unary not: '{}'",
+                    operand.display_name()
+                ),
+                kind: crate::TypeErrorKind::InvalidOperator {
+                    op: op.to_string(),
+                    ty: operand.clone(),
+                },
+            })
+        }
+        "~" => {
+            // Bitwise invert: ~int -> int, ~bool -> int
+            if operand == &Type::Int || operand == &Type::Bool {
+                return Ok(Type::Int);
+            }
+            Err(TypeError {
+                message: format!(
+                    "bad operand type for unary ~: '{}'",
                     operand.display_name()
                 ),
                 kind: crate::TypeErrorKind::InvalidOperator {


### PR DESCRIPTION
#### **Issue**
https://github.com/yaseralnajjar/sifr/issues/102

#### **Changes**

* Add bitwise binary operators (`&`, `|`, `^`, `<<`, `>>`) with full type checking (int & int -> int, bool & bool -> bool)
* Add bitwise invert (`~`) unary operator, mapping to Rust's `!` operator for integers
* Fix unary `+` codegen to emit operand directly (no-op, since Rust doesn't support unary `+`)
* Add bitwise augmented assignment operators (`&=`, `|=`, `^=`, `<<=`, `>>=`) for both variable and attribute targets
* Implement chained assignment (`x = y = z = 0`) by expanding into sequential assignments in `lower_stmts`
* Handle `MatMult` (`@`) operator with explicit unsupported error instead of catch-all
* Fix stale `test_use_after_move` unit test to match Milestone 3's borrow semantics for `print()`
* Add 5 new e2e pass tests covering all new syntax features
* Demo in `tmp/milestone_syntax_expansion_demo/demo.sifr` showcasing all features

#### **Why**
These operators are essential for LeetCode problems involving bit manipulation (e.g., single number XOR, power of two checks, bit counting) and general systems programming. Chained assignment is a common Python pattern that was previously unsupported.

Made with [Cursor](https://cursor.com)