### PR TITLE
milestone_union_ops: Support union type operations

### DIFF
--- a/crates/sifr/tests/e2e/pass/union_ops_arithmetic.sifr
+++ b/crates/sifr/tests/e2e/pass/union_ops_arithmetic.sifr
@@ -1,0 +1,14 @@
+# Test: arithmetic on T|None
+# expect-stdout: 6
+# expect-stdout: 4
+
+def add_one(x: int | None) -> int:
+    return x + 1
+
+def sub_one(x: int | None) -> int:
+    return x - 1
+
+def main():
+    v: int | None = 5
+    print(add_one(v))
+    print(sub_one(v))

--- a/crates/sifr/tests/e2e/pass/union_ops_dict_get_default.sifr
+++ b/crates/sifr/tests/e2e/pass/union_ops_dict_get_default.sifr
@@ -1,0 +1,10 @@
+# Test: dict.get with default value
+# expect-stdout: 1
+# expect-stdout: 0
+
+def main():
+    d: dict[str, int] = {"a": 1, "b": 2}
+    v1: int = d.get("a", 0)
+    print(v1)
+    v2: int = d.get("c", 0)
+    print(v2)

--- a/crates/sifr/tests/e2e/pass/union_ops_len.sifr
+++ b/crates/sifr/tests/e2e/pass/union_ops_len.sifr
@@ -1,0 +1,9 @@
+# Test: len() on union/optional types
+# expect-stdout: 3
+
+def get_len(x: list[int] | None) -> int:
+    return len(x)
+
+def main():
+    v: list[int] | None = [1, 2, 3]
+    print(get_len(v))

--- a/crates/sifr/tests/e2e/pass/union_ops_list_concat.sifr
+++ b/crates/sifr/tests/e2e/pass/union_ops_list_concat.sifr
@@ -1,0 +1,14 @@
+# Test: list + list concatenation
+# expect-stdout: 4
+# expect-stdout: 1
+# expect-stdout: 2
+# expect-stdout: 3
+# expect-stdout: 4
+
+def main():
+    a: list[int] = [1, 2]
+    b: list[int] = [3, 4]
+    c: list[int] = a + b
+    print(len(c))
+    for x in c:
+        print(x)

--- a/crates/sifr/tests/e2e/pass/union_ops_list_remove.sifr
+++ b/crates/sifr/tests/e2e/pass/union_ops_list_remove.sifr
@@ -1,0 +1,12 @@
+# Test: list.remove
+# expect-stdout: 3
+# expect-stdout: 1
+# expect-stdout: 3
+# expect-stdout: 2
+
+def main():
+    items: list[int] = [1, 2, 3, 2]
+    items.remove(2)
+    print(len(items))
+    for x in items:
+        print(x)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2598,6 +2598,27 @@ impl RustEmitter {
                 self.emit_expr(object);
                 self.write(".pop()");
             }
+            (Type::List(_), "remove") => {
+                // list.remove(val) -> { let pos = list.iter().position(|x| *x == val).unwrap(); list.remove(pos); }
+                self.write("{ let __pos = ");
+                self.emit_expr(object);
+                self.write(".iter().position(|__x| *__x == ");
+                if !args.is_empty() {
+                    self.emit_expr(&args[0]);
+                }
+                self.write(").unwrap(); ");
+                self.emit_expr(object);
+                self.write(".remove(__pos); }");
+            }
+            (Type::List(_), "index") => {
+                // list.index(val) -> list.iter().position(|x| *x == val).unwrap() as i64
+                self.emit_expr(object);
+                self.write(".iter().position(|__x| *__x == ");
+                if !args.is_empty() {
+                    self.emit_expr(&args[0]);
+                }
+                self.write(").unwrap() as i64");
+            }
             // Dict methods
             (Type::Dict(_, _), "keys") => {
                 self.emit_expr(object);
@@ -2636,13 +2657,23 @@ impl RustEmitter {
                 self.write(")");
             }
             (Type::Dict(_, _), "get") => {
-                // Returns Option<V> = V | None
-                self.emit_expr(object);
-                self.write(".get(");
-                if !args.is_empty() {
+                if args.len() == 2 {
+                    // dict.get(key, default) -> d.get(&key).cloned().unwrap_or(default)
+                    self.emit_expr(object);
+                    self.write(".get(");
                     self.emit_key_ref_expr(&args[0]);
+                    self.write(").cloned().unwrap_or(");
+                    self.emit_expr(&args[1]);
+                    self.write(")");
+                } else {
+                    // dict.get(key) -> d.get(&key).cloned() (returns Option<V>)
+                    self.emit_expr(object);
+                    self.write(".get(");
+                    if !args.is_empty() {
+                        self.emit_key_ref_expr(&args[0]);
+                    }
+                    self.write(").cloned()");
                 }
-                self.write(").cloned()");
             }
             (Type::Dict(_, _), "pop") => {
                 // Returns Option<V> = V | None
@@ -2782,6 +2813,11 @@ impl RustEmitter {
                 self.emit_expr(object);
                 self.write(".chars().count() as i64");
             }
+            // len() on Option types (T|None) - unwrap first
+            (ty, "len") if is_option_type(ty) => {
+                self.emit_expr(object);
+                self.write(".as_ref().unwrap().len() as i64");
+            }
             // Generic len() for all types
             (_, "len") => {
                 self.emit_expr(object);
@@ -2881,6 +2917,13 @@ impl RustEmitter {
                         }
                         self.write(")");
                     }
+                } else if op == "+" && matches!(ty, Type::List(_)) {
+                    // List concatenation: a + b -> { let mut tmp = a.clone(); tmp.extend(b.iter().cloned()); tmp }
+                    self.write("{ let mut __tmp = ");
+                    self.emit_expr(left);
+                    self.write(".clone(); __tmp.extend(");
+                    self.emit_expr(right);
+                    self.write(".iter().cloned()); __tmp }");
                 } else if op == "//" {
                     // Floor division
                     self.emit_expr(left);
@@ -2933,6 +2976,21 @@ impl RustEmitter {
                     self.write(&format!(" {} ", op));
                     self.write("&");
                     self.emit_expr(right);
+                } else if is_option_type(left.ty()) || is_option_type(right.ty()) {
+                    // Union/optional arithmetic: unwrap Option with .unwrap()
+                    if is_option_type(left.ty()) {
+                        self.emit_expr(left);
+                        self.write(".unwrap()");
+                    } else {
+                        self.emit_expr(left);
+                    }
+                    self.write(&format!(" {} ", op));
+                    if is_option_type(right.ty()) {
+                        self.emit_expr(right);
+                        self.write(".unwrap()");
+                    } else {
+                        self.emit_expr(right);
+                    }
                 } else {
                     // Handle mixed int/float arithmetic: cast int side to f64
                     let left_is_int = left.ty() == &Type::Int;

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -3783,6 +3783,20 @@ fn resolve_method_type(object_ty: &Type, method: &str, args: &[HirExpr], ctx: &m
                 // pop() returns Option[T] = T | None
                 Some(Type::Union(vec![*elem_ty.clone(), Type::None]))
             }
+            "remove" => {
+                if args.len() != 1 {
+                    ctx.error(format!("list.remove() takes exactly 1 argument, got {}", args.len()));
+                    return None;
+                }
+                Some(Type::None)
+            }
+            "index" => {
+                if args.len() != 1 {
+                    ctx.error(format!("list.index() takes exactly 1 argument, got {}", args.len()));
+                    return None;
+                }
+                Some(Type::Int)
+            }
             _ => {
                 ctx.error(format!("list has no method '{}'", method));
                 None
@@ -3846,12 +3860,17 @@ fn resolve_method_type(object_ty: &Type, method: &str, args: &[HirExpr], ctx: &m
                 Some(Type::Bool)
             }
             "get" => {
-                if args.len() != 1 {
-                    ctx.error(format!("dict.get() takes exactly 1 argument, got {}", args.len()));
+                if args.is_empty() || args.len() > 2 {
+                    ctx.error(format!("dict.get() takes 1 or 2 arguments, got {}", args.len()));
                     return None;
                 }
-                // get() returns Option[V] = V | None
-                Some(Type::Union(vec![*val_ty.clone(), Type::None]))
+                if args.len() == 2 {
+                    // dict.get(key, default) -> V (returns default if key not found)
+                    Some(*val_ty.clone())
+                } else {
+                    // dict.get(key) -> V | None
+                    Some(Type::Union(vec![*val_ty.clone(), Type::None]))
+                }
             }
             "pop" => {
                 if args.len() != 1 {
@@ -4072,9 +4091,20 @@ fn lower_len_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
     let arg = lower_expr(&call.arguments.args[0], ctx)?;
     let arg_ty = arg.ty().clone();
 
-    // len() works on str, list, dict, tuple
-    match &arg_ty {
-        Type::Str | Type::List(_) | Type::Dict(_, _) | Type::Tuple(_) => {
+    // len() works on str, list, dict, tuple, set
+    // Also works on T|None where T is a valid len() argument (auto-unwrap)
+    let effective_ty = if let Type::Union(members) = &arg_ty {
+        let non_none: Vec<&Type> = members.iter().filter(|m| !matches!(m, Type::None)).collect();
+        if non_none.len() == 1 {
+            non_none[0].clone()
+        } else {
+            arg_ty.clone()
+        }
+    } else {
+        arg_ty.clone()
+    };
+    match &effective_ty {
+        Type::Str | Type::List(_) | Type::Dict(_, _) | Type::Tuple(_) | Type::Set(_) => {
             Some(HirExpr::MethodCall {
                 object: Box::new(arg),
                 method: "len".to_string(),

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -21,6 +21,16 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             if left == &Type::Str && right == &Type::Str {
                 return Ok(Type::Str);
             }
+            // List concatenation: list[T] + list[T] -> list[T]
+            if let (Type::List(l_elem), Type::List(r_elem)) = (left, right) {
+                if l_elem == r_elem {
+                    return Ok(Type::List(l_elem.clone()));
+                }
+            }
+            // Union type unwrapping: T|None + T -> T (auto-unwrap)
+            if let Some(result) = try_unwrap_union_binary(left, op, right) {
+                return Ok(result);
+            }
             Err(TypeError {
                 message: format!(
                     "unsupported operand type(s) for +: '{}' and '{}'",
@@ -55,6 +65,10 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                     }
                 }
             }
+            // Union type unwrapping
+            if let Some(result) = try_unwrap_union_binary(left, op, right) {
+                return Ok(result);
+            }
             Err(TypeError {
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
@@ -71,6 +85,9 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             // Division always returns float in Sifr (like Python 3)
             if left.is_numeric() && right.is_numeric() {
                 return Ok(Type::Float);
+            }
+            if let Some(result) = try_unwrap_union_binary(left, op, right) {
+                return Ok(result);
             }
             Err(TypeError {
                 message: format!(
@@ -92,6 +109,9 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             if left.is_numeric() && right.is_numeric() {
                 return Ok(Type::Float);
             }
+            if let Some(result) = try_unwrap_union_binary(left, op, right) {
+                return Ok(result);
+            }
             Err(TypeError {
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
@@ -111,6 +131,9 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             }
             if left.is_numeric() && right.is_numeric() {
                 return Ok(Type::Float);
+            }
+            if let Some(result) = try_unwrap_union_binary(left, op, right) {
+                return Ok(result);
             }
             Err(TypeError {
                 message: format!(
@@ -355,6 +378,28 @@ pub fn type_check_bool_op(left: &Type, op: &str, right: &Type) -> Result<Type, T
                 ty: left.clone(),
             },
         }),
+    }
+}
+
+/// Try to unwrap union types (T|None) for binary operations.
+/// If either side is a union containing None, unwrap to the non-None type and retry.
+fn try_unwrap_union_binary(left: &Type, op: &str, right: &Type) -> Option<Type> {
+    let left_unwrapped = if union_contains_none(left) {
+        Some(remove_none_from_union(left))
+    } else {
+        None
+    };
+    let right_unwrapped = if union_contains_none(right) {
+        Some(remove_none_from_union(right))
+    } else {
+        None
+    };
+    let l = left_unwrapped.as_ref().unwrap_or(left);
+    let r = right_unwrapped.as_ref().unwrap_or(right);
+    if left_unwrapped.is_some() || right_unwrapped.is_some() {
+        type_check_binary_op(l, op, r).ok()
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

- Allow arithmetic (+, -, *, /, //, %, **) on `T|None` types by auto-unwrapping the Option in both type checking and codegen
- Support `len()` on union/optional types (`list[T]|None`, etc.)
- Add `list + list` concatenation via `extend()` in codegen
- Support `dict.get(key, default)` 2-arg form returning `V` instead of `V|None`
- Add `list.remove(val)` and `list.index(val)` methods
- Add 5 E2E tests covering all union operation features

## Test plan

- [x] All 152 E2E tests pass (147 existing + 5 new)
- [x] Demo showcasing all union operation features works correctly
- [x] No regressions in existing tests


Made with [Cursor](https://cursor.com)