### PR TITLE
milestone_subscript_v2: Nested subscript assign, augmented subscript assign, and &mut self

### DIFF
--- a/crates/sifr/tests/e2e/pass/class_mut_self.sifr
+++ b/crates/sifr/tests/e2e/pass/class_mut_self.sifr
@@ -1,0 +1,13 @@
+# Test: &mut self for methods that mutate fields
+# expect-stdout: 2
+
+class Counter:
+    count: int
+    def increment(self) -> None:
+        self.count += 1
+
+def main():
+    c: Counter = Counter(0)
+    c.increment()
+    c.increment()
+    print(c.count)

--- a/crates/sifr/tests/e2e/pass/subscript_aug_assign.sifr
+++ b/crates/sifr/tests/e2e/pass/subscript_aug_assign.sifr
@@ -1,0 +1,10 @@
+# Test: augmented subscript assignment
+# expect-stdout: 5
+# expect-stdout: 7
+
+def main():
+    counts: list[int] = [0, 0, 0]
+    counts[1] += 5
+    print(counts[1])
+    counts[1] += 2
+    print(counts[1])

--- a/crates/sifr/tests/e2e/pass/subscript_nested_assign.sifr
+++ b/crates/sifr/tests/e2e/pass/subscript_nested_assign.sifr
@@ -1,0 +1,7 @@
+# Test: nested subscript assignment
+# expect-stdout: 99
+
+def main():
+    matrix: list[list[int]] = [[1, 2], [3, 4]]
+    matrix[0][1] = 99
+    print(matrix[0][1])

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1998,6 +1998,49 @@ impl RustEmitter {
                     }
                 }
             }
+            HirStmt::NestedSubscriptAssign { object, outer_index, inner_index, value, object_ty: _ } => {
+                self.write_indent();
+                // matrix[i][j] = val -> matrix[i as usize][j as usize] = val
+                self.write(object);
+                self.write("[");
+                self.emit_expr(outer_index);
+                self.write(" as usize][");
+                self.emit_expr(inner_index);
+                self.write(" as usize] = ");
+                self.emit_expr(value);
+                self.write(";\n");
+            }
+            HirStmt::SubscriptAugAssign { object, index, op, value, object_ty: _ } => {
+                self.write_indent();
+                // list[i] += val -> list[i as usize] += val
+                self.write(object);
+                self.write("[");
+                self.emit_expr(index);
+                self.write(" as usize] ");
+                // Convert **= to .pow() pattern
+                if op == "**=" {
+                    self.write("= ");
+                    self.write(object);
+                    self.write("[");
+                    self.emit_expr(index);
+                    self.write(" as usize].pow(");
+                    self.emit_expr(value);
+                    self.write(" as u32);\n");
+                } else if op == "//=" {
+                    self.write("= ");
+                    self.write(object);
+                    self.write("[");
+                    self.emit_expr(index);
+                    self.write(" as usize] / ");
+                    self.emit_expr(value);
+                    self.write(";\n");
+                } else {
+                    self.write(op);
+                    self.write(" ");
+                    self.emit_expr(value);
+                    self.write(";\n");
+                }
+            }
             HirStmt::AttributeAugAssign { object, field, op, value } => {
                 self.write_indent();
                 self.write(object);
@@ -3569,6 +3612,14 @@ impl RustEmitter {
                         self.emit_expr(index);
                         self.write("; let _idx = if _i < 0 { (_s.chars().count() as i64 + _i) as usize } else { _i as usize }; _s.chars().nth(_idx).map(|c| c.to_string()) }");
                     }
+                    // Union/Optional type indexing: unwrap the Option first
+                    ty if is_option_type(ty) => {
+                        self.write("{ let __opt = ");
+                        self.emit_expr(object);
+                        self.write("; let _v = __opt.as_ref().unwrap(); let _i = ");
+                        self.emit_expr(index);
+                        self.write("; let _idx = if _i < 0 { (_v.len() as i64 + _i) as usize } else { _i as usize }; _v.get(_idx).cloned() }");
+                    }
                     _ => {
                         // Safe list indexing: returns Option<T>
                         // Handle negative indices
@@ -4488,9 +4539,22 @@ fn collect_string_concat_parts<'a>(expr: &'a HirExpr, parts: &mut Vec<&'a HirExp
     parts.push(expr);
 }
 
-/// Check if a method body contains any field assignments (self.field = ...).
+/// Check if a method body contains any field assignments or attribute augmented assignments (self.field = ... or self.field += ...).
 fn body_contains_field_assign_codegen(stmts: &[HirStmt]) -> bool {
-    stmts.iter().any(|s| matches!(s, HirStmt::FieldAssign { .. }))
+    stmts.iter().any(|s| {
+        match s {
+            HirStmt::FieldAssign { .. } | HirStmt::AttributeAugAssign { .. } => true,
+            HirStmt::If { then_body, elif_clauses, else_body, .. } => {
+                body_contains_field_assign_codegen(then_body)
+                    || elif_clauses.iter().any(|(_, body)| body_contains_field_assign_codegen(body))
+                    || else_body.as_ref().map_or(false, |b| body_contains_field_assign_codegen(b))
+            }
+            HirStmt::While { body, .. } | HirStmt::For { body, .. } => {
+                body_contains_field_assign_codegen(body)
+            }
+            _ => false,
+        }
+    })
 }
 
 /// Check if a type references a specific class name (directly or via union/option).
@@ -4745,6 +4809,12 @@ fn collect_mutated_vars_inner(stmts: &[HirStmt], mutated: &mut HashSet<String>) 
             HirStmt::SubscriptAssign { object, .. } => {
                 mutated.insert(object.clone());
             }
+            HirStmt::NestedSubscriptAssign { object, .. } => {
+                mutated.insert(object.clone());
+            }
+            HirStmt::SubscriptAugAssign { object, .. } => {
+                mutated.insert(object.clone());
+            }
             HirStmt::AttributeAugAssign { object, .. } => {
                 mutated.insert(object.clone());
             }
@@ -4769,6 +4839,12 @@ fn collect_mutated_vars_in_expr(expr: &HirExpr, mutated: &mut HashSet<String>) {
     match expr {
         HirExpr::MethodCall { object, method, args, .. } => {
             if MUTATING_METHODS.contains(&method.as_str()) {
+                if let HirExpr::Name { name, .. } = object.as_ref() {
+                    mutated.insert(name.clone());
+                }
+            }
+            // Class method calls may mutate the object (conservative)
+            if matches!(object.ty(), Type::Class { .. }) {
                 if let HirExpr::Name { name, .. } = object.as_ref() {
                     mutated.insert(name.clone());
                 }

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -170,6 +170,22 @@ pub enum HirStmt {
         value: HirExpr,
         object_ty: Type,
     },
+    /// Nested subscript assignment: matrix[i][j] = val
+    NestedSubscriptAssign {
+        object: String,
+        outer_index: HirExpr,
+        inner_index: HirExpr,
+        value: HirExpr,
+        object_ty: Type,
+    },
+    /// Subscript augmented assignment: list[i] += val
+    SubscriptAugAssign {
+        object: String,
+        index: HirExpr,
+        op: String,
+        value: HirExpr,
+        object_ty: Type,
+    },
     /// Augmented assignment on attribute: self.field += val
     AttributeAugAssign {
         object: String,

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -1662,6 +1662,29 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
 
     // Handle subscript assignment: list[i] = val or dict[key] = val
     if let Expr::Subscript(sub) = &assign.targets[0] {
+        // Handle nested subscript: matrix[i][j] = val
+        if let Expr::Subscript(inner_sub) = sub.value.as_ref() {
+            let obj_name = match inner_sub.value.as_ref() {
+                Expr::Name(n) => n.id.to_string(),
+                _ => {
+                    ctx.error("nested subscript assignment target must be a simple name".to_string());
+                    return None;
+                }
+            };
+            let obj_ty = ctx.scope.lookup(&obj_name)
+                .map(|info| info.effective_type().clone())
+                .unwrap_or(Type::Unknown);
+            let outer_index = lower_expr(&inner_sub.slice, ctx)?;
+            let inner_index = lower_expr(&sub.slice, ctx)?;
+            let value = lower_expr(&assign.value, ctx)?;
+            return Some(HirStmt::NestedSubscriptAssign {
+                object: obj_name,
+                outer_index,
+                inner_index,
+                value,
+                object_ty: obj_ty,
+            });
+        }
         let obj_name = match sub.value.as_ref() {
             Expr::Name(n) => n.id.to_string(),
             _ => {
@@ -1766,6 +1789,47 @@ fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Option<HirStmt> 
             field: field_name,
             op: op_str.to_string(),
             value,
+        });
+    }
+
+    // Handle augmented assignment on subscript: list[i] += val
+    if let Expr::Subscript(sub) = aug.target.as_ref() {
+        let obj_name = match sub.value.as_ref() {
+            Expr::Name(n) => n.id.to_string(),
+            _ => {
+                ctx.error("augmented subscript assignment target must be a simple name".to_string());
+                return None;
+            }
+        };
+        let obj_ty = ctx.scope.lookup(&obj_name)
+            .map(|info| info.effective_type().clone())
+            .unwrap_or(Type::Unknown);
+        let index = lower_expr(&sub.slice, ctx)?;
+        let value = lower_expr(&aug.value, ctx)?;
+        let op_str = match aug.op {
+            Operator::Add => "+=",
+            Operator::Sub => "-=",
+            Operator::Mult => "*=",
+            Operator::Div => "/=",
+            Operator::Mod => "%=",
+            Operator::Pow => "**=",
+            Operator::BitAnd => "&=",
+            Operator::BitOr => "|=",
+            Operator::BitXor => "^=",
+            Operator::LShift => "<<=",
+            Operator::RShift => ">>=",
+            Operator::FloorDiv => "//=",
+            Operator::MatMult => {
+                ctx.error("matrix multiplication operator (@) is not supported".to_string());
+                return None;
+            }
+        };
+        return Some(HirStmt::SubscriptAugAssign {
+            object: obj_name,
+            index,
+            op: op_str.to_string(),
+            value,
+            object_ty: obj_ty,
         });
     }
 

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -365,6 +365,15 @@ impl Type {
                     None
                 }
             }
+            // Union type: if T|None where T is indexable, unwrap and delegate
+            Self::Union(members) => {
+                let non_none: Vec<&Type> = members.iter().filter(|m| !matches!(m, Type::None)).collect();
+                if non_none.len() == 1 {
+                    non_none[0].index_result_type(index_ty)
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Add `NestedSubscriptAssign` HIR node for `matrix[i][j] = val` patterns
- Add `SubscriptAugAssign` HIR node for `list[i] += val` patterns
- Fix `&mut self` detection to include `AttributeAugAssign` (`self.field += val`) and recurse into control flow bodies
- Mark class instances as mutable when any method is called on them (conservative but correct)
- Support indexing on `T|None` types by auto-unwrapping the Option in codegen
- Add 3 E2E tests for nested subscript, augmented subscript, and `&mut self`

## Test plan

- [x] All 155 E2E tests pass (152 existing + 3 new)
- [x] Demo showcasing all subscript v2 features works correctly
- [x] No regressions in existing tests


Made with [Cursor](https://cursor.com)