### PR TITLE
milestone_comprehension_v2: Range comprehension, dict/set comprehension, and tuple unpacking

### DIFF
--- a/crates/sifr/tests/e2e/pass/comp_dict.sifr
+++ b/crates/sifr/tests/e2e/pass/comp_dict.sifr
@@ -1,0 +1,6 @@
+# Test: dict comprehension
+# expect-stdout: 3
+
+def main():
+    d: dict[int, int] = {x: x * x for x in range(3)}
+    print(len(d))

--- a/crates/sifr/tests/e2e/pass/comp_range.sifr
+++ b/crates/sifr/tests/e2e/pass/comp_range.sifr
@@ -1,0 +1,13 @@
+# Test: comprehension over range
+# expect-stdout: 5
+# expect-stdout: 0
+# expect-stdout: 1
+# expect-stdout: 4
+# expect-stdout: 9
+# expect-stdout: 16
+
+def main():
+    squares: list[int] = [x * x for x in range(5)]
+    print(len(squares))
+    for s in squares:
+        print(s)

--- a/crates/sifr/tests/e2e/pass/comp_set.sifr
+++ b/crates/sifr/tests/e2e/pass/comp_set.sifr
@@ -1,0 +1,6 @@
+# Test: set comprehension
+# expect-stdout: 5
+
+def main():
+    s: set[int] = {x * x for x in range(5)}
+    print(len(s))

--- a/crates/sifr/tests/e2e/pass/for_tuple_unpack.sifr
+++ b/crates/sifr/tests/e2e/pass/for_tuple_unpack.sifr
@@ -1,0 +1,8 @@
+# Test: tuple unpacking in for loop
+# expect-stdout: 1
+# expect-stdout: 2
+
+def main():
+    pairs: list[tuple[int, str]] = [(1, "a"), (2, "b")]
+    for i, s in pairs:
+        print(i)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1793,7 +1793,18 @@ impl RustEmitter {
                 self.in_loop_with_else = has_else;
                 self.write_indent();
                 self.write("for ");
-                self.write(target);
+                // Handle tuple unpacking: "i,v" -> "(i, v)"
+                if target.contains(',') {
+                    let names: Vec<&str> = target.split(',').collect();
+                    self.write("(");
+                    for (i, name) in names.iter().enumerate() {
+                        if i > 0 { self.write(", "); }
+                        self.write(name);
+                    }
+                    self.write(")");
+                } else {
+                    self.write(target);
+                }
                 self.write(" in ");
                 // For lists, iterate with .iter() to borrow and clone elements
                 // But not for generator expressions which are already iterators
@@ -3821,30 +3832,39 @@ impl RustEmitter {
             }
             HirExpr::ListComp { expr, var, iter, filter, ty } => {
                 // [expr for var in iter] -> iter.clone().into_iter().map(|var| expr).collect()
-                // [expr for var in iter if cond] -> iter.clone().into_iter().filter(|var| cond).map(|var| expr).collect()
-                self.emit_expr(iter);
-                self.write(".clone().into_iter()");
+                let is_range = matches!(iter.ty(), Type::Range);
+                let var_pattern = if var.contains(',') {
+                    let names: Vec<&str> = var.split(',').collect();
+                    format!("({})", names.join(", "))
+                } else {
+                    var.clone()
+                };
+                if is_range {
+                    self.write("(");
+                    self.emit_expr(iter);
+                    self.write(")");
+                } else {
+                    self.emit_expr(iter);
+                    self.write(".clone().into_iter()");
+                }
                 if let Some(ref cond) = filter {
-                    // .filter() passes &T; check if element is Copy to use |&var| destructuring
                     let elem_is_copy = if let Type::List(ref elem) = iter.ty() {
                         !needs_clone_for_type(elem)
                     } else {
-                        false
+                        is_range
                     };
-                    if elem_is_copy {
-                        // Copy types: use |&var| pattern to bind as owned value
+                    if elem_is_copy && !var.contains(',') {
                         self.write(".filter(|&");
                     } else {
-                        // Non-Copy types: use |var| and access via reference
                         self.write(".filter(|");
                     }
-                    self.write(var);
+                    self.write(&var_pattern);
                     self.write("| ");
                     self.emit_expr(cond);
                     self.write(")");
                 }
                 self.write(".map(|");
-                self.write(var);
+                self.write(&var_pattern);
                 self.write("| ");
                 self.emit_expr(expr);
                 self.write(")");
@@ -3853,6 +3873,78 @@ impl RustEmitter {
                     self.write(&format!(".collect::<Vec<{}>>()", elem.rust_type()));
                 } else {
                     self.write(".collect::<Vec<_>>()");
+                }
+            }
+            HirExpr::SetComp { expr, var, iter, filter, ty } => {
+                let is_range = matches!(iter.ty(), Type::Range);
+                let var_pattern = if var.contains(',') {
+                    let names: Vec<&str> = var.split(',').collect();
+                    format!("({})", names.join(", "))
+                } else {
+                    var.clone()
+                };
+                self.needs_hashset = true;
+                if is_range {
+                    self.write("(");
+                    self.emit_expr(iter);
+                    self.write(")");
+                } else {
+                    self.emit_expr(iter);
+                    self.write(".clone().into_iter()");
+                }
+                if let Some(ref cond) = filter {
+                    self.write(".filter(|");
+                    self.write(&var_pattern);
+                    self.write("| ");
+                    self.emit_expr(cond);
+                    self.write(")");
+                }
+                self.write(".map(|");
+                self.write(&var_pattern);
+                self.write("| ");
+                self.emit_expr(expr);
+                self.write(")");
+                if let Type::Set(ref elem) = ty {
+                    self.write(&format!(".collect::<HashSet<{}>>()", elem.rust_type()));
+                } else {
+                    self.write(".collect::<HashSet<_>>()");
+                }
+            }
+            HirExpr::DictComp { key_expr, val_expr, var, iter, filter, ty } => {
+                let is_range = matches!(iter.ty(), Type::Range);
+                let var_pattern = if var.contains(',') {
+                    let names: Vec<&str> = var.split(',').collect();
+                    format!("({})", names.join(", "))
+                } else {
+                    var.clone()
+                };
+                self.needs_hashmap = true;
+                if is_range {
+                    self.write("(");
+                    self.emit_expr(iter);
+                    self.write(")");
+                } else {
+                    self.emit_expr(iter);
+                    self.write(".clone().into_iter()");
+                }
+                if let Some(ref cond) = filter {
+                    self.write(".filter(|");
+                    self.write(&var_pattern);
+                    self.write("| ");
+                    self.emit_expr(cond);
+                    self.write(")");
+                }
+                self.write(".map(|");
+                self.write(&var_pattern);
+                self.write("| (");
+                self.emit_expr(key_expr);
+                self.write(", ");
+                self.emit_expr(val_expr);
+                self.write("))");
+                if let Type::Dict(ref k, ref v) = ty {
+                    self.write(&format!(".collect::<HashMap<{}, {}>>()", k.rust_type(), v.rust_type()));
+                } else {
+                    self.write(".collect::<HashMap<_, _>>()");
                 }
             }
             HirExpr::GeneratorExpr { expr, var, iter, filter, .. } => {

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -407,6 +407,23 @@ pub enum HirExpr {
         filter: Option<Box<HirExpr>>,
         ty: Type,
     },
+    /// Dict comprehension: {key: val for var in iter}
+    DictComp {
+        key_expr: Box<HirExpr>,
+        val_expr: Box<HirExpr>,
+        var: String,
+        iter: Box<HirExpr>,
+        filter: Option<Box<HirExpr>>,
+        ty: Type,
+    },
+    /// Set comprehension: {expr for var in iter}
+    SetComp {
+        expr: Box<HirExpr>,
+        var: String,
+        iter: Box<HirExpr>,
+        filter: Option<Box<HirExpr>>,
+        ty: Type,
+    },
     /// Generator expression: (expr for var in iter) -> lazy iterator
     GeneratorExpr {
         expr: Box<HirExpr>,
@@ -452,6 +469,8 @@ impl HirExpr {
             | Self::SuperCall { ty, .. }
             | Self::Lambda { ty, .. }
             | Self::ListComp { ty, .. }
+            | Self::DictComp { ty, .. }
+            | Self::SetComp { ty, .. }
             | Self::GeneratorExpr { ty, .. } => ty,
         }
     }

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -2266,18 +2266,49 @@ fn lower_for(for_stmt: &StmtFor, func_type: &FunctionType, ctx: &mut LowerCtx) -
         Type::Any
     });
 
-    // Extract the target variable name
+    // Extract the target variable name(s)
     let target_name = match for_stmt.target.as_ref() {
         Expr::Name(n) => n.id.to_string(),
+        Expr::Tuple(tup) => {
+            // Tuple unpacking: for i, v in enumerate(lst)
+            let names: Vec<String> = tup.elts.iter().filter_map(|e| {
+                if let Expr::Name(n) = e {
+                    Some(n.id.to_string())
+                } else {
+                    None
+                }
+            }).collect();
+            if names.len() != tup.elts.len() {
+                ctx.error("for loop tuple target must contain only simple names".to_string());
+                return None;
+            }
+            names.join(",")
+        }
         _ => {
-            ctx.error("for loop target must be a simple name".to_string());
+            ctx.error("for loop target must be a simple name or tuple".to_string());
             return None;
         }
     };
 
-    // Create a new scope for the loop body, define the loop variable
+    // Create a new scope for the loop body, define the loop variable(s)
     ctx.scope.push();
-    ctx.scope.define(target_name.clone(), elem_ty.clone());
+    if target_name.contains(',') {
+        // Tuple unpacking: define each variable with its type from the tuple
+        let names: Vec<&str> = target_name.split(',').collect();
+        if let Type::Tuple(elem_types) = &elem_ty {
+            for (i, name) in names.iter().enumerate() {
+                let ty = elem_types.get(i).cloned().unwrap_or(Type::Any);
+                ctx.scope.define(name.to_string(), ty);
+            }
+        } else {
+            // Fallback: define all as Any
+            for name in &names {
+                ctx.scope.define(name.to_string(), Type::Any);
+            }
+        }
+    } else {
+        ctx.scope.define(target_name.clone(), elem_ty.clone());
+    }
     ctx.loop_depth += 1;
     let body = lower_stmts(&for_stmt.body, func_type, ctx);
     ctx.loop_depth -= 1;
@@ -2327,6 +2358,8 @@ fn lower_expr(expr: &Expr, ctx: &mut LowerCtx) -> Option<HirExpr> {
         Expr::Named(named) => lower_named_expr(named, ctx),
         Expr::Lambda(lambda) => lower_lambda(lambda, ctx),
         Expr::ListComp(comp) => lower_list_comp(comp, ctx),
+        Expr::SetComp(comp) => lower_set_comp(comp, ctx),
+        Expr::DictComp(comp) => lower_dict_comp(comp, ctx),
         Expr::Generator(gen) => lower_generator_expr(gen, ctx),
         _ => {
             ctx.error("unsupported expression type".to_string());
@@ -4422,11 +4455,25 @@ fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
 
     let gen = &comp.generators[0];
 
-    // Get the variable name
+    // Get the variable name(s)
     let var_name = match &gen.target {
         Expr::Name(n) => n.id.to_string(),
+        Expr::Tuple(tup) => {
+            let names: Vec<String> = tup.elts.iter().filter_map(|e| {
+                if let Expr::Name(n) = e {
+                    Some(n.id.to_string())
+                } else {
+                    None
+                }
+            }).collect();
+            if names.len() != tup.elts.len() {
+                ctx.error("comprehension tuple target must contain only simple names".to_string());
+                return None;
+            }
+            names.join(",")
+        }
         _ => {
-            ctx.error("comprehension target must be a simple name".to_string());
+            ctx.error("comprehension target must be a simple name or tuple".to_string());
             return None;
         }
     };
@@ -4438,16 +4485,34 @@ fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
     // Determine element type from the iterable
     let elem_ty = match &iter_ty {
         Type::List(elem) => *elem.clone(),
-        Type::Str => Type::Str, // iterating over str yields str (chars)
+        Type::Set(elem) => *elem.clone(),
+        Type::Str => Type::Str,
+        Type::Range => Type::Int,
+        Type::Dict(key, _) => *key.clone(),
+        Type::Tuple(elems) if !elems.is_empty() => elems[0].clone(),
         _ => {
             ctx.error(format!("cannot iterate over type '{}'", iter_ty.display_name()));
             return None;
         }
     };
 
-    // Push scope and define the loop variable
+    // Push scope and define the loop variable(s)
     ctx.scope.push();
-    ctx.scope.define(var_name.clone(), elem_ty.clone());
+    if var_name.contains(',') {
+        let names: Vec<&str> = var_name.split(',').collect();
+        if let Type::Tuple(elem_types) = &elem_ty {
+            for (i, name) in names.iter().enumerate() {
+                let ty = elem_types.get(i).cloned().unwrap_or(Type::Any);
+                ctx.scope.define(name.to_string(), ty);
+            }
+        } else {
+            for name in &names {
+                ctx.scope.define(name.to_string(), Type::Any);
+            }
+        }
+    } else {
+        ctx.scope.define(var_name.clone(), elem_ty.clone());
+    }
 
     // Lower the expression
     let expr = lower_expr(&comp.elt, ctx)?;
@@ -4482,6 +4547,118 @@ fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
 
     Some(HirExpr::ListComp {
         expr: Box::new(expr),
+        var: var_name,
+        iter: Box::new(iter_expr),
+        filter,
+        ty: result_ty,
+    })
+}
+
+fn lower_set_comp(comp: &ExprSetComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if comp.generators.len() != 1 {
+        ctx.error("only single-generator set comprehensions are supported".to_string());
+        return None;
+    }
+    let gen = &comp.generators[0];
+    let var_name = match &gen.target {
+        Expr::Name(n) => n.id.to_string(),
+        _ => {
+            ctx.error("set comprehension target must be a simple name".to_string());
+            return None;
+        }
+    };
+    let iter_expr = lower_expr(&gen.iter, ctx)?;
+    let iter_ty = iter_expr.ty().clone();
+    let elem_ty = match &iter_ty {
+        Type::List(elem) => *elem.clone(),
+        Type::Set(elem) => *elem.clone(),
+        Type::Range => Type::Int,
+        _ => {
+            ctx.error(format!("cannot iterate over type '{}'", iter_ty.display_name()));
+            return None;
+        }
+    };
+    ctx.scope.push();
+    ctx.scope.define(var_name.clone(), elem_ty);
+    let expr = lower_expr(&comp.elt, ctx)?;
+    let expr_ty = expr.ty().clone();
+    let filter = if !gen.ifs.is_empty() {
+        Some(Box::new(lower_expr(&gen.ifs[0], ctx)?))
+    } else {
+        None
+    };
+    ctx.scope.pop();
+    let result_ty = Type::Set(Box::new(expr_ty));
+    Some(HirExpr::SetComp {
+        expr: Box::new(expr),
+        var: var_name,
+        iter: Box::new(iter_expr),
+        filter,
+        ty: result_ty,
+    })
+}
+
+fn lower_dict_comp(comp: &ExprDictComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if comp.generators.len() != 1 {
+        ctx.error("only single-generator dict comprehensions are supported".to_string());
+        return None;
+    }
+    let gen = &comp.generators[0];
+    let var_name = match &gen.target {
+        Expr::Name(n) => n.id.to_string(),
+        Expr::Tuple(tup) => {
+            let names: Vec<String> = tup.elts.iter().filter_map(|e| {
+                if let Expr::Name(n) = e { Some(n.id.to_string()) } else { None }
+            }).collect();
+            names.join(",")
+        }
+        _ => {
+            ctx.error("dict comprehension target must be a simple name or tuple".to_string());
+            return None;
+        }
+    };
+    let iter_expr = lower_expr(&gen.iter, ctx)?;
+    let iter_ty = iter_expr.ty().clone();
+    let elem_ty = match &iter_ty {
+        Type::List(elem) => *elem.clone(),
+        Type::Set(elem) => *elem.clone(),
+        Type::Range => Type::Int,
+        Type::Dict(key, _) => *key.clone(),
+        _ => {
+            ctx.error(format!("cannot iterate over type '{}'", iter_ty.display_name()));
+            return None;
+        }
+    };
+    ctx.scope.push();
+    if var_name.contains(',') {
+        let names: Vec<&str> = var_name.split(',').collect();
+        if let Type::Tuple(elem_types) = &elem_ty {
+            for (i, name) in names.iter().enumerate() {
+                let ty = elem_types.get(i).cloned().unwrap_or(Type::Any);
+                ctx.scope.define(name.to_string(), ty);
+            }
+        } else {
+            for name in &names {
+                ctx.scope.define(name.to_string(), Type::Any);
+            }
+        }
+    } else {
+        ctx.scope.define(var_name.clone(), elem_ty);
+    }
+    let key_expr = lower_expr(&comp.key, ctx)?;
+    let val_expr = lower_expr(&comp.value, ctx)?;
+    let key_ty = key_expr.ty().clone();
+    let val_ty = val_expr.ty().clone();
+    let filter = if !gen.ifs.is_empty() {
+        Some(Box::new(lower_expr(&gen.ifs[0], ctx)?))
+    } else {
+        None
+    };
+    ctx.scope.pop();
+    let result_ty = Type::Dict(Box::new(key_ty), Box::new(val_ty));
+    Some(HirExpr::DictComp {
+        key_expr: Box::new(key_expr),
+        val_expr: Box::new(val_expr),
         var: var_name,
         iter: Box::new(iter_expr),
         filter,


### PR DESCRIPTION
## Summary

- Support `range()` in list/dict/set comprehensions
- Add dict comprehension: `{k: v for k, v in items}`
- Add set comprehension: `{x*x for x in range(10)}`
- Support tuple unpacking in for loops: `for i, v in enumerate(lst)`
- Support tuple unpacking in comprehensions: `[v for i, v in enumerate(lst)]`
- Add 4 E2E tests covering all comprehension v2 features

## Test plan

- [x] All 159 E2E tests pass (155 existing + 4 new)
- [x] Demo showcasing all comprehension features works correctly
- [x] No regressions in existing tests


Made with [Cursor](https://cursor.com)