### PR TITLE
M18: Phase Bug Fixes and Polish

### DIFF
--- a/crates/sifr/tests/e2e/pass/cls_constructor.sifr
+++ b/crates/sifr/tests/e2e/pass/cls_constructor.sifr
@@ -1,0 +1,19 @@
+# Test: @classmethod cls() constructor call
+# expect-stdout: 100
+# expect-stdout: 100
+
+class Temperature:
+    celsius: float
+
+    def __init__(self, celsius: float):
+        self.celsius = celsius
+
+    @classmethod
+    def from_fahrenheit(cls, f: float) -> Temperature:
+        return cls((f - 32.0) * 5.0 / 9.0)
+
+def main():
+    t: Temperature = Temperature(100.0)
+    print(t.celsius)
+    t2: Temperature = Temperature.from_fahrenheit(212.0)
+    print(t2.celsius)

--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -1,0 +1,13 @@
+# Test: module-level constants accessible from functions
+# expect-stdout: 78.53975
+# expect-stdout: 3
+
+PI: float = 3.14159
+MAX_RETRIES: int = 3
+
+def circle_area(r: float) -> float:
+    return PI * r * r
+
+def main():
+    print(circle_area(5.0))
+    print(MAX_RETRIES)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -243,6 +243,10 @@ struct RustEmitter {
     /// Map from nested function name -> list of captured variable (name, type) pairs
     /// Used to pass extra args at call sites for recursive+capturing nested functions
     nested_fn_captures: HashMap<String, Vec<(String, Type)>>,
+    /// Map from module-level constant name -> (type, rust_name)
+    /// For primitives: rust_name is the UPPERCASE const name
+    /// For strings/complex: rust_name is __const_name() function call
+    module_constants: HashMap<String, (Type, String)>,
 }
 
 impl RustEmitter {
@@ -269,6 +273,7 @@ impl RustEmitter {
             recursive_fields: HashSet::new(),
             class_field_order: HashMap::new(),
             nested_fn_captures: HashMap::new(),
+            module_constants: HashMap::new(),
         }
     }
 
@@ -446,6 +451,38 @@ impl RustEmitter {
                     );
                 }
             }
+        }
+
+        // Emit module-level constants and register them for name resolution
+        for (name, ty, value) in &module.constants {
+            self.write_indent();
+            // Use const for primitives, static for strings
+            match ty {
+                Type::Int | Type::Float | Type::Bool => {
+                    let rust_name = name.to_uppercase();
+                    self.write(&format!("const {}: {} = ", rust_name, ty.rust_type()));
+                    self.emit_expr(value);
+                    self.write(";\n");
+                    self.module_constants.insert(name.clone(), (ty.clone(), rust_name));
+                }
+                Type::Str => {
+                    let rust_name = format!("__const_{}", name);
+                    self.write(&format!("fn {}() -> String {{ ", rust_name));
+                    self.emit_expr(value);
+                    self.write(".to_string() }\n");
+                    self.module_constants.insert(name.clone(), (ty.clone(), format!("{}()", rust_name)));
+                }
+                _ => {
+                    let rust_name = format!("__const_{}", name);
+                    self.write(&format!("fn {}() -> {} {{ ", rust_name, ty.rust_type()));
+                    self.emit_expr(value);
+                    self.write(" }\n");
+                    self.module_constants.insert(name.clone(), (ty.clone(), format!("{}()", rust_name)));
+                }
+            }
+        }
+        if !module.constants.is_empty() {
+            self.output.push('\n');
         }
 
         // Emit class definitions first (structs + impls)
@@ -2958,6 +2995,9 @@ impl RustEmitter {
                 // Check for stdlib constants
                 if self.stdlib_functions.contains(name.as_str()) || self.is_stdlib_constant(name) {
                     self.emit_stdlib_constant(name);
+                } else if let Some((_ty, rust_name)) = self.module_constants.get(name).cloned() {
+                    // Module-level constant
+                    self.write(&rust_name);
                 } else {
                     self.write(name);
                 }
@@ -5273,6 +5313,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5305,6 +5346,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5343,6 +5385,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5376,6 +5419,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5418,6 +5462,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5446,6 +5491,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5477,6 +5523,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5525,6 +5572,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5562,6 +5610,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5606,6 +5655,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);
@@ -5633,6 +5683,7 @@ mod tests {
             }],
             classes: vec![],
             imports: vec![],
+            constants: vec![],
         };
 
         let rust_code = generate_rust(&module);

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -301,7 +301,7 @@ pub fn build_project(main_file: &Path, output_dir: &Path) -> Result<PathBuf, Vec
 
     // Write Cargo.toml
     let (cargo_toml, _) = generate_project(
-        &HirModule { functions: vec![], classes: vec![], imports: vec![] },
+        &HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![] },
         "sifr_output",
     );
     std::fs::write(project_path.join("Cargo.toml"), cargo_toml).map_err(|e| {
@@ -400,7 +400,7 @@ pub fn build(source: &str, output_dir: &Path) -> Result<PathBuf, Vec<CompileErro
 
     // Write Cargo.toml with stdlib dependencies
     let (cargo_toml, _) = generate_project_with_deps(
-        &sifr_hir::HirModule { functions: vec![], classes: vec![], imports: vec![] },
+        &sifr_hir::HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![] },
         "sifr_output",
         &used_stdlib_modules,
     );

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -8,6 +8,8 @@ pub struct HirModule {
     pub functions: Vec<HirFunction>,
     pub classes: Vec<HirClass>,
     pub imports: Vec<HirImport>,
+    /// Module-level constants (name, type, value)
+    pub constants: Vec<(String, Type, HirExpr)>,
 }
 
 /// An import statement.

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -405,6 +405,40 @@ pub fn lower_module_with_externals(stmts: &[Stmt], externals: &ExternalDefs) -> 
         }
     }
 
+    // Collect module-level constants (annotated assignments at top level)
+    let mut constants = Vec::new();
+    for stmt in stmts {
+        if let Stmt::AnnAssign(ann) = stmt {
+            if let Expr::Name(name) = ann.target.as_ref() {
+                let var_name = name.id.to_string();
+                let ty = resolve_annotation_expr(&ann.annotation, &mut ctx);
+                if let Some(ref value_expr) = ann.value {
+                    if let Some(hir_value) = lower_expr_simple(value_expr) {
+                        ctx.scope.define(var_name.clone(), ty.clone());
+                        constants.push((var_name, ty, hir_value));
+                    }
+                }
+            }
+        }
+        // Also handle bare assignments: PI = 3.14 (without annotation)
+        if let Stmt::Assign(assign) = stmt {
+            if assign.targets.len() == 1 {
+                if let Expr::Name(name) = &assign.targets[0] {
+                    let var_name = name.id.to_string();
+                    // Skip TypeVar declarations (already handled)
+                    if ctx.type_vars.contains(&var_name) {
+                        continue;
+                    }
+                    if let Some(hir_value) = lower_expr_simple(&assign.value) {
+                        let ty = hir_value.ty().clone();
+                        ctx.scope.define(var_name.clone(), ty.clone());
+                        constants.push((var_name, ty, hir_value));
+                    }
+                }
+            }
+        }
+    }
+
     // Second pass: lower function bodies and class method bodies
     let mut functions = Vec::new();
     let mut classes = Vec::new();
@@ -426,7 +460,7 @@ pub fn lower_module_with_externals(stmts: &[Stmt], externals: &ExternalDefs) -> 
 
     if ctx.errors.is_empty() {
         Ok(LoweringResult {
-            module: HirModule { functions, classes, imports },
+            module: HirModule { functions, classes, imports, constants },
             reveal_types: ctx.reveal_types,
         })
     } else {
@@ -2841,6 +2875,26 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
             return None;
         }
     };
+
+    // Handle `cls(...)` in @classmethod as constructor call for the current class
+    if func_name == "cls" {
+        if let Some(ref class_name) = ctx.current_class {
+            let class_name = class_name.clone();
+            if let Some(class_ty) = ctx.class_types.get(&class_name).cloned() {
+                // Lower arguments
+                let mut args = Vec::new();
+                for arg in &call.arguments.args {
+                    let expr = lower_expr(arg, ctx)?;
+                    args.push(expr);
+                }
+                return Some(HirExpr::ConstructorCall {
+                    class_name,
+                    args,
+                    ty: class_ty,
+                });
+            }
+        }
+    }
 
     // Special handling for range() built-in
     if func_name == "range" {


### PR DESCRIPTION
## Summary
- Adds module-level constants support (top-level `PI: float = 3.14` accessible from functions)
- Fixes `@classmethod` `cls(...)` constructor calls
- Adds `HirModule.constants` field for tracking module-level constants
- Emits Rust `const` for primitive constants and helper functions for string constants
- Audit python_basics improved from 38/45 to 41/45 passing
- E2E tests: `module_constants`, `cls_constructor`
- All existing E2E tests pass (no regressions)

## Test plan
- [x] Module-level constants (PI, MAX_RETRIES, APP_NAME) accessible from functions
- [x] @classmethod cls() constructor calls work correctly
- [x] All existing E2E tests pass
- [x] Audit python_basics: 41/45 passing (up from 38/45)


Made with [Cursor](https://cursor.com)