### PR TITLE
feat: milestone_test_infra — test assertion intrinsics and statistics bug fix

### DIFF
--- a/crates/sifr/tests/e2e/pass/stdlib_statistics_variance_fix.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_statistics_variance_fix.sifr
@@ -1,0 +1,22 @@
+# Tests: variance bug fix — sample variance (N-1) vs population variance (N)
+from sifr.statistics import variance, pvariance, stdev, pstdev
+from sifr.test import assert_almost_eq
+
+def main():
+    data: list[float] = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+
+    # Sample variance (N-1): should be ~4.571
+    v: float = variance(data)
+    assert_almost_eq(v, 4.571428571428571, 0.0001)
+
+    # Population variance (N): should be 4.0
+    pv: float = pvariance(data)
+    assert_almost_eq(pv, 4.0, 0.0001)
+
+    # Sample stdev
+    sd: float = stdev(data)
+    assert_almost_eq(sd, 2.138089935299395, 0.0001)
+
+    # Population stdev
+    psd: float = pstdev(data)
+    assert_almost_eq(psd, 2.0, 0.0001)

--- a/crates/sifr/tests/e2e/pass/stdlib_test_almost_eq.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_test_almost_eq.sifr
@@ -1,0 +1,8 @@
+# Tests: assert_almost_eq with known float values
+from sifr.test import assert_almost_eq
+
+def main():
+    assert_almost_eq(3.14159, 3.14159, 0.001)
+    assert_almost_eq(1.0, 1.0000001, 0.001)
+    assert_almost_eq(0.1 + 0.2, 0.3, 0.0001)
+    assert_almost_eq(100.0, 100.0, 0.0001)

--- a/crates/sifr/tests/e2e/pass/stdlib_test_gt_lt.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_test_gt_lt.sifr
@@ -1,0 +1,10 @@
+# Tests: assert_gt and assert_lt
+from sifr.test import assert_gt, assert_lt
+
+def main():
+    assert_gt(10, 5)
+    assert_gt(1, 0)
+    assert_gt(100, 99)
+    assert_lt(5, 10)
+    assert_lt(0, 1)
+    assert_lt(-1, 0)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -3700,8 +3700,9 @@ impl RustEmitter {
                     if !args.is_empty() {
                         match args[0].ty() {
                             Type::Float => {
+                                self.write("(");
                                 self.emit_expr(&args[0]);
-                                self.write(" as i64");
+                                self.write(") as i64");
                             }
                             Type::Str => {
                                 // int(str) -> Result<i64, String>
@@ -3722,8 +3723,9 @@ impl RustEmitter {
                     if !args.is_empty() {
                         match args[0].ty() {
                             Type::Int => {
+                                self.write("(");
                                 self.emit_expr(&args[0]);
-                                self.write(" as f64");
+                                self.write(") as f64");
                             }
                             Type::Str => {
                                 // float(str) -> Result<f64, String>
@@ -4855,6 +4857,43 @@ impl RustEmitter {
                 self.write("assert!(!(");
                 self.emit_expr(&args[0]);
                 self.write("))");
+            }
+            "assert_almost_eq" => {
+                self.write("assert!((");
+                self.emit_expr(&args[0]);
+                self.write(" - ");
+                self.emit_expr(&args[1]);
+                self.write(").abs() < ");
+                self.emit_expr(&args[2]);
+                self.write(", \"assert_almost_eq failed: {} != {} (tolerance {})\", ");
+                self.emit_expr(&args[0]);
+                self.write(", ");
+                self.emit_expr(&args[1]);
+                self.write(", ");
+                self.emit_expr(&args[2]);
+                self.write(")");
+            }
+            "assert_gt" => {
+                self.write("assert!(");
+                self.emit_expr(&args[0]);
+                self.write(" > ");
+                self.emit_expr(&args[1]);
+                self.write(", \"assert_gt failed: {} is not > {}\", ");
+                self.emit_expr(&args[0]);
+                self.write(", ");
+                self.emit_expr(&args[1]);
+                self.write(")");
+            }
+            "assert_lt" => {
+                self.write("assert!(");
+                self.emit_expr(&args[0]);
+                self.write(" < ");
+                self.emit_expr(&args[1]);
+                self.write(", \"assert_lt failed: {} is not < {}\", ");
+                self.emit_expr(&args[0]);
+                self.write(", ");
+                self.emit_expr(&args[1]);
+                self.write(")");
             }
             // sifr.collections — Set operations
             "new_set" => {

--- a/crates/sifr_hir/src/stdlib.rs
+++ b/crates/sifr_hir/src/stdlib.rs
@@ -217,6 +217,25 @@ fn intrinsic_test() -> IntrinsicModule {
     // assert_false(value: bool) -> None
     functions.insert("assert_false".to_string(), FunctionType::all_borrow(vec![("value".to_string(), Type::Bool)], Type::None));
 
+    // assert_almost_eq(actual: float, expected: float, tolerance: float) -> None
+    functions.insert("assert_almost_eq".to_string(), FunctionType::all_borrow(vec![
+        ("actual".to_string(), Type::Float),
+        ("expected".to_string(), Type::Float),
+        ("tolerance".to_string(), Type::Float),
+    ], Type::None));
+
+    // assert_gt(a: int, b: int) -> None
+    functions.insert("assert_gt".to_string(), FunctionType::all_borrow(vec![
+        ("a".to_string(), Type::Int),
+        ("b".to_string(), Type::Int),
+    ], Type::None));
+
+    // assert_lt(a: int, b: int) -> None
+    functions.insert("assert_lt".to_string(), FunctionType::all_borrow(vec![
+        ("a".to_string(), Type::Int),
+        ("b".to_string(), Type::Int),
+    ], Type::None));
+
     IntrinsicModule {
         functions,
         constants: HashMap::new(),

--- a/demos/milestone_test_infra_demo.sifr
+++ b/demos/milestone_test_infra_demo.sifr
@@ -1,0 +1,50 @@
+# milestone_test_infra demo
+# Demonstrates new test assertion intrinsics and corrected statistics functions
+
+# expect-stdout: mean = 5
+# expect-stdout: sample variance = 4.571428571428571
+# expect-stdout: population variance = 4
+# expect-stdout: sample stdev = 2.138089935299395
+# expect-stdout: population stdev = 2
+# expect-stdout: All assertions passed!
+
+from sifr.statistics import mean, variance, pvariance, stdev, pstdev
+from sifr.test import assert_almost_eq, assert_gt, assert_lt
+
+def main():
+    # ============================================================
+    # Part 1: Corrected statistics functions
+    # ============================================================
+    data: list[float] = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+
+    m: float = mean(data)
+    print("mean = " + str(m))
+
+    sv: float = variance(data)
+    print("sample variance = " + str(sv))
+
+    pv: float = pvariance(data)
+    print("population variance = " + str(pv))
+
+    sd: float = stdev(data)
+    print("sample stdev = " + str(sd))
+
+    pd: float = pstdev(data)
+    print("population stdev = " + str(pd))
+
+    # ============================================================
+    # Part 2: New test assertion intrinsics
+    # ============================================================
+
+    # assert_almost_eq: compare floats with tolerance
+    assert_almost_eq(m, 5.0, 0.001)
+    assert_almost_eq(sv, 4.571, 0.01)
+    assert_almost_eq(pv, 4.0, 0.001)
+
+    # assert_gt / assert_lt: range-based assertions
+    assert_gt(10, 5)
+    assert_lt(3, 7)
+    assert_gt(100, 0)
+    assert_lt(0, 1)
+
+    print("All assertions passed!")

--- a/lib/sifr/statistics.sifr
+++ b/lib/sifr/statistics.sifr
@@ -31,10 +31,21 @@ def variance(data: list[float]) -> float:
     for val in data:
         diff: float = val - avg
         total = total + diff * diff
+    return total / float(len(data) - 1)
+
+def pvariance(data: list[float]) -> float:
+    avg: float = mean(data)
+    total: float = 0.0
+    for val in data:
+        diff: float = val - avg
+        total = total + diff * diff
     return total / float(len(data))
 
 def stdev(data: list[float]) -> float:
     return sqrt(variance(data))
+
+def pstdev(data: list[float]) -> float:
+    return sqrt(pvariance(data))
 
 def mode(data: list[int]) -> int:
     if len(data) == 0:

--- a/lib/sifr/test.sifr
+++ b/lib/sifr/test.sifr
@@ -1,2 +1,2 @@
 # sifr.test — Test assertion functions
-from _sifr.test import assert_eq, assert_ne, assert_true, assert_false
+from _sifr.test import assert_eq, assert_ne, assert_true, assert_false, assert_almost_eq, assert_gt, assert_lt


### PR DESCRIPTION
## Summary
- Add `assert_almost_eq`, `assert_gt`, `assert_lt` intrinsics to `sifr.test` module, enabling float comparison and range-based testing needed for CPython test parity
- Fix `statistics.variance` to use sample variance (N-1) matching CPython; add `pvariance` (population variance) and `pstdev` (population standard deviation)
- Fix operator precedence bug in `float()`/`int()` cast codegen by wrapping inner expressions in parentheses

## Test plan
- [x] New E2E pass tests: `stdlib_test_almost_eq`, `stdlib_test_gt_lt`, `stdlib_statistics_variance_fix`
- [x] Existing E2E tests pass with zero regressions (`cargo test --package sifr --test e2e`)
- [x] Demo: `cargo run -- run demos/milestone_test_infra_demo.sifr` runs successfully
- [x] `variance([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])` returns sample variance (4.571...)
- [x] `pvariance(...)` returns population variance (4.0)
- [x] `assert_almost_eq(3.14159, 3.14159, 0.001)` passes


Made with [Cursor](https://cursor.com)