### PR TITLE
feat: milestone_compiler_hardening — Drop-based context manager cleanup

### DIFF
--- a/.cursor/plans/main/phases/07_stdlib_parity.md
+++ b/.cursor/plans/main/phases/07_stdlib_parity.md
@@ -12,7 +12,7 @@ This phase closes the remaining gaps between Sifr's stdlib and CPython's stdlib.
 
 ## milestone_compiler_hardening: Import Errors, Context Managers, and Callable Fix
 
-status: pending
+status: done
 
 **Goal:** Fix three compiler correctness gaps: (1) importing from a nonexistent module silently fails instead of producing a clear error, (2) the `with` statement is incomplete — it's syntactic sugar for scoped blocks but doesn't implement the Python context manager protocol (`__enter__`/`__exit__`), and (3) `Callable` types emit `impl Fn(...)` which is invalid in Rust struct fields — needs `Box<dyn Fn(...)>`.
 

--- a/crates/sifr/tests/e2e/pass/with_break.sifr
+++ b/crates/sifr/tests/e2e/pass/with_break.sifr
@@ -1,0 +1,30 @@
+# Tests: with statement calls __exit__ on break (Drop semantics)
+class Resource:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __enter__(self) -> Resource:
+        print("enter")
+        return self
+
+    def __exit__(self) -> None:
+        print("exit")
+
+def main():
+    i: int = 0
+    while i < 3:
+        with Resource("r") as r:
+            if i == 1:
+                break
+            print("body")
+        i = i + 1
+    print("done")
+
+# expect-stdout: enter
+# expect-stdout: body
+# expect-stdout: exit
+# expect-stdout: enter
+# expect-stdout: exit
+# expect-stdout: done

--- a/crates/sifr/tests/e2e/pass/with_early_return.sifr
+++ b/crates/sifr/tests/e2e/pass/with_early_return.sifr
@@ -1,0 +1,28 @@
+# Tests: with statement calls __exit__ on early return (Drop semantics)
+class Resource:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __enter__(self) -> Resource:
+        print("enter: " + self.name)
+        return self
+
+    def __exit__(self) -> None:
+        print("exit: " + self.name)
+
+def test_return() -> int:
+    with Resource("res") as r:
+        print("using: " + r.name)
+        return 42
+    return 0
+
+def main():
+    val: int = test_return()
+    print(val)
+
+# expect-stdout: enter: res
+# expect-stdout: using: res
+# expect-stdout: exit: res
+# expect-stdout: 42

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2717,11 +2717,20 @@ impl RustEmitter {
                 self.write_indent();
                 self.write("{\n");
                 self.indent += 1;
-                // Emit each context manager item
-                let mut ctx_vars = Vec::new();
+                // Emit each context manager item with Drop-based cleanup
+                // This ensures __exit__() is called on ALL exit paths:
+                // normal completion, early return, break, continue
                 for (i, (var, value, has_cm)) in items.iter().enumerate() {
                     let ctx_name = format!("__ctx_{}", i);
+                    let guard_type = format!("__WithGuard{}", i);
+                    let guard_var = format!("__guard_{}", i);
                     if *has_cm {
+                        // Extract the class type name for the guard struct
+                        let class_name = if let Type::Class { name, .. } = value.ty() {
+                            name.clone()
+                        } else {
+                            "Unknown".to_string()
+                        };
                         // Create context manager variable
                         self.write_indent();
                         self.write("let mut ");
@@ -2741,7 +2750,20 @@ impl RustEmitter {
                         self.write(" = ");
                         self.write(&ctx_name);
                         self.write(".__enter__();\n");
-                        ctx_vars.push(ctx_name);
+                        // Emit Drop guard struct that calls __exit__() on scope exit
+                        self.write_indent();
+                        self.write(&format!("struct {} {{ ctx: {} }}\n", guard_type, class_name));
+                        self.write_indent();
+                        self.write(&format!("impl Drop for {} {{\n", guard_type));
+                        self.indent += 1;
+                        self.write_indent();
+                        self.write("fn drop(&mut self) { self.ctx.__exit__(); }\n");
+                        self.indent -= 1;
+                        self.write_indent();
+                        self.write("}\n");
+                        // Create guard instance, moving ctx into it
+                        self.write_indent();
+                        self.write(&format!("let {} = {} {{ ctx: {} }};\n", guard_var, guard_type, ctx_name));
                     } else {
                         // Fallback: no context manager protocol, just bind directly
                         self.write_indent();
@@ -2761,12 +2783,7 @@ impl RustEmitter {
                 for s in body {
                     self.emit_stmt(s);
                 }
-                // Call __exit__() on all context managers in reverse order
-                for ctx_name in ctx_vars.iter().rev() {
-                    self.write_indent();
-                    self.write(ctx_name);
-                    self.write(".__exit__();\n");
-                }
+                // No explicit __exit__() calls needed — Drop guards handle cleanup
                 self.indent -= 1;
                 self.write_indent();
                 self.write("}\n");

--- a/demos/milestone_compiler_hardening_demo.sifr
+++ b/demos/milestone_compiler_hardening_demo.sifr
@@ -1,87 +1,112 @@
-# milestone_compiler_hardening demo
-# Demonstrates three compiler correctness fixes:
-# 1. Import error reporting for nonexistent modules
-# 2. Full with statement protocol (__enter__/__exit__)
-# 3. Callable-as-struct-field compilation
+# Demo: milestone_compiler_hardening — Import Errors, Context Managers, Callable Fix
+# This demo showcases the three compiler correctness improvements.
 
 from typing import Callable
 
-# ============================================================
-# Part 1: with statement — full ContextManager protocol
-# ============================================================
+# ===== 1. Context Manager with Drop-based cleanup =====
+# __exit__() is now called on ALL exit paths: normal, return, break, continue
 
-# A resource class implementing __enter__ and __exit__
-class DatabaseConnection:
-    host: str
-    connected: bool
+class FileResource:
+    path: str
 
-    def __init__(self, host: str, connected: bool):
-        self.host = host
-        self.connected = connected
+    def __init__(self, path: str):
+        self.path = path
 
-    def __enter__(self) -> DatabaseConnection:
-        print("Connecting to " + self.host + "...")
+    def __enter__(self) -> FileResource:
+        print("Opening: " + self.path)
         return self
 
     def __exit__(self) -> None:
-        print("Disconnecting from " + self.host)
+        print("Closing: " + self.path)
 
-    def query(self, sql: str) -> str:
-        return "Result from " + self.host + ": " + sql
-
-# expect-stdout: Connecting to localhost...
-# expect-stdout: Query: Result from localhost: SELECT 1
-# expect-stdout: Disconnecting from localhost
-
-# A second context manager for demonstrating multiple context managers
-class Logger:
+class DBConnection:
     name: str
 
     def __init__(self, name: str):
         self.name = name
 
-    def __enter__(self) -> Logger:
-        print("[" + self.name + "] Session started")
+    def __enter__(self) -> DBConnection:
+        print("Connecting: " + self.name)
         return self
 
     def __exit__(self) -> None:
-        print("[" + self.name + "] Session ended")
+        print("Disconnecting: " + self.name)
 
-    def log(self, msg: str) -> None:
-        print("[" + self.name + "] " + msg)
+# ===== 2. Callable-as-struct-field =====
+# Callable fields emit Box<dyn Fn(...)> for struct fields
 
-# expect-stdout: [audit] Session started
-# expect-stdout: [audit] Processing data
-# expect-stdout: [audit] Session ended
+class Config:
+    value: int
+    callback: Callable[[int], int]
 
-# ============================================================
-# Part 2: Callable-as-struct-field
-# ============================================================
+    def __init__(self, value: int, callback: Callable[[int], int]):
+        self.value = value
+        self.callback = callback
 
-# A class that stores a callback function as a field
-class EventHandler:
-    name: str
-    handler: Callable[[str], str]
+def double(x: int) -> int:
+    return x * 2
 
-    def __init__(self, name: str, handler: Callable[[str], str]):
-        self.name = name
-        self.handler = handler
+# ===== Demo functions =====
 
-# expect-stdout: Handler: onClick
-
-def on_click(event: str) -> str:
-    return "Handled: " + event
+def demo_early_return() -> int:
+    with FileResource("data.csv") as f:
+        print("Reading: " + f.path)
+        return 42
 
 def main():
-    # Part 1: Single context manager with __enter__/__exit__
-    with DatabaseConnection("localhost", true) as db:
-        result: str = db.query("SELECT 1")
-        print("Query: " + result)
+    print("=== Context Manager: Normal Exit ===")
+    with FileResource("config.json") as f:
+        print("Using: " + f.path)
 
-    # Part 1b: Single context manager
-    with Logger("audit") as log:
-        log.log("Processing data")
+    print("")
+    print("=== Context Manager: Early Return ===")
+    result: int = demo_early_return()
+    print(result)
 
-    # Part 2: Callable-as-struct-field compiles correctly
-    eh: EventHandler = EventHandler("onClick", on_click)
-    print("Handler: " + eh.name)
+    print("")
+    print("=== Context Manager: Break in Loop ===")
+    i: int = 0
+    while i < 3:
+        with DBConnection("db") as conn:
+            if i == 1:
+                break
+            print("Query on: " + conn.name)
+        i = i + 1
+
+    print("")
+    print("=== Multiple Context Managers ===")
+    with FileResource("input.txt") as fin, DBConnection("postgres") as db:
+        print("Processing with: " + fin.path + " and " + db.name)
+
+    print("")
+    print("=== Callable Struct Field ===")
+    c: Config = Config(21, double)
+    print(c.value)
+
+    print("")
+    print("=== Compiler Hardening Demo Complete ===")
+
+# expect-stdout: === Context Manager: Normal Exit ===
+# expect-stdout: Opening: config.json
+# expect-stdout: Using: config.json
+# expect-stdout: Closing: config.json
+# expect-stdout: === Context Manager: Early Return ===
+# expect-stdout: Opening: data.csv
+# expect-stdout: Reading: data.csv
+# expect-stdout: Closing: data.csv
+# expect-stdout: 42
+# expect-stdout: === Context Manager: Break in Loop ===
+# expect-stdout: Connecting: db
+# expect-stdout: Query on: db
+# expect-stdout: Disconnecting: db
+# expect-stdout: Connecting: db
+# expect-stdout: Disconnecting: db
+# expect-stdout: === Multiple Context Managers ===
+# expect-stdout: Opening: input.txt
+# expect-stdout: Connecting: postgres
+# expect-stdout: Processing with: input.txt and postgres
+# expect-stdout: Disconnecting: postgres
+# expect-stdout: Closing: input.txt
+# expect-stdout: === Callable Struct Field ===
+# expect-stdout: 21
+# expect-stdout: === Compiler Hardening Demo Complete ===


### PR DESCRIPTION
## Summary
- Implement Drop-based cleanup for `with` statement context managers, ensuring `__exit__()` is called on ALL exit paths (normal completion, early return, break, continue)
- Each context manager gets a `__WithGuardN` struct with `Drop` impl that owns the context manager and calls `__exit__()` on scope exit
- Import error reporting and Callable-as-struct-field were already implemented in prior milestones

## Changes
- **Codegen** (`sifr_codegen/src/lib.rs`): Replace explicit `__exit__()` calls at block end with Drop guard structs. For each context manager, emit a `struct __WithGuardN` with `Drop` impl that calls `__exit__()`, ensuring cleanup on all exit paths.
- **New E2E tests**: `with_early_return.sifr`, `with_break.sifr`
- **Demo**: `milestone_compiler_hardening_demo.sifr` showcasing normal exit, early return, break, multiple context managers, and Callable struct fields

## Test plan
- [x] All E2E pass tests pass (246 total, including 2 new with_* tests)
- [x] All E2E fail tests pass (no regressions)
- [x] Demo runs correctly showing __exit__ on all exit paths
- [x] Existing with_enter_exit, with_multiple, with_basic tests still pass


Made with [Cursor](https://cursor.com)