### PR TITLE
feat: implement milestone_error_safety_stdlib_types

### DIFF
--- a/crates/sifr/tests/e2e/pass/error_mixed_builtin_stdlib.sifr
+++ b/crates/sifr/tests/e2e/pass/error_mixed_builtin_stdlib.sifr
@@ -1,0 +1,29 @@
+# expect-stdout: caught ValueError: bad age
+# expect-stdout: caught StatisticsError: no data
+# expect-stdout: mixed error types work
+
+from sifr.statistics import StatisticsError
+
+def validate_age(age: int) -> Result[int, ValueError]:
+    if age < 0:
+        raise ValueError("bad age")
+    return age
+
+def check_data(data: list[float]) -> Result[float, StatisticsError]:
+    if len(data) == 0:
+        raise StatisticsError("no data")
+    return 1.0
+
+def main():
+    try:
+        val: int = validate_age(-1)
+    except ValueError as e:
+        print(f"caught ValueError: {e.message}")
+
+    empty: list[float] = []
+    try:
+        avg: float = check_data(empty)
+    except StatisticsError as e:
+        print(f"caught StatisticsError: {e.message}")
+
+    print("mixed error types work")

--- a/crates/sifr/tests/e2e/pass/error_stdlib_graphlib.sifr
+++ b/crates/sifr/tests/e2e/pass/error_stdlib_graphlib.sifr
@@ -1,0 +1,17 @@
+# expect-stdout: caught CycleError: cycle detected
+# expect-stdout: stdlib error types work
+
+from sifr.graphlib import CycleError
+
+def check_graph(has_cycle: bool) -> Result[int, CycleError]:
+    if has_cycle:
+        raise CycleError("cycle detected")
+    return 0
+
+def main():
+    try:
+        result: int = check_graph(True)
+    except CycleError as e:
+        print(f"caught CycleError: {e.message}")
+
+    print("stdlib error types work")

--- a/crates/sifr/tests/e2e/pass/error_stdlib_statistics.sifr
+++ b/crates/sifr/tests/e2e/pass/error_stdlib_statistics.sifr
@@ -1,0 +1,21 @@
+# expect-stdout: caught StatisticsError: empty dataset
+# expect-stdout: stdlib error types work
+
+from sifr.statistics import StatisticsError
+
+def compute_stats(data: list[float]) -> Result[float, StatisticsError]:
+    if len(data) == 0:
+        raise StatisticsError("empty dataset")
+    total: float = 0.0
+    for val in data:
+        total = total + val
+    return total / float(len(data))
+
+def main():
+    empty: list[float] = []
+    try:
+        avg: float = compute_stats(empty)
+    except StatisticsError as e:
+        print(f"caught StatisticsError: {e.message}")
+
+    print("stdlib error types work")

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -198,6 +198,10 @@ fn compile_stdlib() -> Result<StdlibCompiled, Vec<CompileError>> {
                     methods,
                 };
                 class_exports.insert(class.name.clone(), class_ty);
+                // Track error types for cross-module import resolution
+                if class.is_error_type {
+                    stdlib_defs.error_types.insert(class.name.clone());
+                }
             }
         }
 

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -204,6 +204,8 @@ pub struct ExternalDefs {
     pub classes: std::collections::HashMap<String, std::collections::HashMap<String, Type>>,
     /// Map of module_name -> (constant_name -> Type)
     pub constants: std::collections::HashMap<String, std::collections::HashMap<String, Type>>,
+    /// Set of class names that are error types (class Foo(Error)) across all modules
+    pub error_types: std::collections::HashSet<String>,
 }
 
 /// Lower a parsed module AST into a typed HIR module.
@@ -279,6 +281,12 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
             collect_class_type(class_def, &mut ctx);
         }
     }
+
+    // Early import pass: resolve imported types so they're available for function signatures.
+    // This must happen before function signature extraction so that imported error classes
+    // (e.g., StatisticsError from sifr.statistics) can be used in Result[T, E] annotations.
+    resolve_imports_early(stmts, externals, &mut ctx);
+
     for stmt in stmts {
         match stmt {
             Stmt::TypeAlias(type_alias) => {
@@ -446,6 +454,10 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                                 if let Some(module_classes) = externals.classes.get(&stdlib_module_key) {
                                     if let Some(class_ty) = module_classes.get(name) {
                                         ctx.class_types.insert(local.clone(), class_ty.clone());
+                                        // Register as error type if flagged in external defs
+                                        if externals.error_types.contains(name) {
+                                            ctx.error_types.insert(local.clone());
+                                        }
                                         // Register constructor: prefer `new` method params if available
                                         if let Type::Class { fields, methods, .. } = class_ty {
                                             let ft = if let Some((_, new_ft)) = methods.iter().find(|(n, _)| n == "new") {
@@ -519,6 +531,10 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                         if let Some(module_classes) = externals.classes.get(&module_name) {
                             if let Some(class_ty) = module_classes.get(name) {
                                 ctx.class_types.insert(local.clone(), class_ty.clone());
+                                // Register as error type if flagged in external defs
+                                if externals.error_types.contains(name) {
+                                    ctx.error_types.insert(local.clone());
+                                }
                                 // Register the constructor: prefer `new` method params if available,
                                 // otherwise fall back to field-based constructor
                                 if let Type::Class { fields, methods, .. } = class_ty {
@@ -613,6 +629,83 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
         })
     } else {
         Err(ctx.errors)
+    }
+}
+
+/// Early import resolution: register imported types/functions/constants in the context
+/// so they're available during function signature extraction and type annotation resolution.
+/// This is a subset of the full import processing — it doesn't produce HirImport nodes.
+fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ctx: &mut LowerCtx) {
+    for stmt in stmts {
+        if let Stmt::ImportFrom(import_from) = stmt {
+            if let Some(ref module) = import_from.module {
+                let module_name = module.to_string();
+                let names: Vec<String> = import_from.names.iter()
+                    .map(|alias| alias.name.to_string())
+                    .collect();
+                let aliases: Vec<(String, String)> = import_from.names.iter()
+                    .filter_map(|alias| {
+                        alias.asname.as_ref().map(|asname| {
+                            (alias.name.to_string(), asname.to_string())
+                        })
+                    })
+                    .collect();
+                let local_name_for = |original: &str| -> String {
+                    aliases.iter()
+                        .find(|(orig, _)| orig == original)
+                        .map(|(_, alias)| alias.clone())
+                        .unwrap_or_else(|| original.to_string())
+                };
+
+                // Only resolve from externals (stdlib and local modules)
+                let module_key = module_name.clone();
+                if let Some(module_classes) = externals.classes.get(&module_key) {
+                    for name in &names {
+                        let local = local_name_for(name);
+                        if let Some(class_ty) = module_classes.get(name) {
+                            if !ctx.class_types.contains_key(&local) {
+                                ctx.class_types.insert(local.clone(), class_ty.clone());
+                                // Register as error type if flagged
+                                if externals.error_types.contains(name) {
+                                    ctx.error_types.insert(local.clone());
+                                }
+                                // Register constructor
+                                if let Type::Class { fields, methods, .. } = class_ty {
+                                    let ft = if let Some((_, new_ft)) = methods.iter().find(|(n, _)| n == "new") {
+                                        let params: Vec<(String, Type)> = new_ft.params.iter()
+                                            .map(|(n, t, _)| (n.clone(), t.clone()))
+                                            .collect();
+                                        FunctionType::new(params, class_ty.clone())
+                                    } else {
+                                        let params: Vec<(String, Type)> = fields.clone();
+                                        FunctionType::new(params, class_ty.clone())
+                                    };
+                                    ctx.functions.insert(local, ft);
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some(module_fns) = externals.functions.get(&module_key) {
+                    for name in &names {
+                        let local = local_name_for(name);
+                        if let Some(ft) = module_fns.get(name) {
+                            if !ctx.functions.contains_key(&local) {
+                                ctx.functions.insert(local, ft.clone());
+                            }
+                        }
+                    }
+                }
+                if let Some(module_consts) = externals.constants.get(&module_key) {
+                    for name in &names {
+                        let local = local_name_for(name);
+                        if let Some(const_ty) = module_consts.get(name) {
+                            ctx.scope.define(local, const_ty.clone());
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/demos/milestone_error_safety_stdlib_types_demo.sifr
+++ b/demos/milestone_error_safety_stdlib_types_demo.sifr
@@ -1,0 +1,64 @@
+# Demo: milestone_error_safety_stdlib_types
+# Module-specific error types defined in stdlib .sifr files,
+# imported by user code, and caught with exhaustiveness checking.
+
+from sifr.statistics import StatisticsError
+from sifr.graphlib import CycleError
+
+# --- StatisticsError from sifr.statistics ---
+
+def compute_mean(data: list[float]) -> Result[float, StatisticsError]:
+    if len(data) == 0:
+        raise StatisticsError("cannot compute mean of empty dataset")
+    total: float = 0.0
+    for val in data:
+        total = total + val
+    return total / len(data)
+
+# --- CycleError from sifr.graphlib ---
+
+def topo_sort(has_cycle: bool) -> Result[int, CycleError]:
+    if has_cycle:
+        raise CycleError("graph contains a cycle")
+    return 42
+
+# --- Using module-specific error types ---
+
+def main():
+    # 1. StatisticsError: success case
+    try:
+        mean: float = compute_mean([1.0, 2.0, 3.0])
+        print(f"mean = {mean}")
+    except StatisticsError as e:
+        print(f"stats error: {e.message}")
+
+    # 2. StatisticsError: failure case
+    empty: list[float] = []
+    try:
+        mean2: float = compute_mean(empty)
+    except StatisticsError as e:
+        print(f"caught StatisticsError: {e.message}")
+
+    # 3. CycleError: success case
+    try:
+        order: int = topo_sort(False)
+        print(f"topo sort result = {order}")
+    except CycleError as e:
+        print(f"cycle error: {e.message}")
+
+    # 4. CycleError: failure case
+    try:
+        order2: int = topo_sort(True)
+    except CycleError as e:
+        print(f"caught CycleError: {e.message}")
+
+    # 5. Mixed: built-in + module-specific error types with exhaustiveness
+    try:
+        val: int = int("not_a_number")
+        mean3: float = compute_mean(empty)
+    except ParseError as e:
+        print(f"caught ParseError: {e.message}")
+    except StatisticsError as e:
+        print(f"caught StatisticsError: {e.message}")
+
+    print("all module-specific error types work correctly")

--- a/lib/sifr/graphlib.sifr
+++ b/lib/sifr/graphlib.sifr
@@ -1,5 +1,8 @@
 # sifr.graphlib — Graph algorithms (pure Sifr)
 
+class CycleError(Error):
+    message: str
+
 def topological_sort(num_nodes: int, from_nodes: list[int], to_nodes: list[int]) -> list[int]:
     result: list[int] = []
     visited: list[int] = []

--- a/lib/sifr/statistics.sifr
+++ b/lib/sifr/statistics.sifr
@@ -1,6 +1,9 @@
 # sifr.statistics — Basic statistical functions (pure Sifr)
 from sifr.math import sqrt, log, exp
 
+class StatisticsError(Error):
+    message: str
+
 def mean(data: list[float]) -> float:
     total: float = 0.0
     count: int = len(data)


### PR DESCRIPTION
## Summary

- Define module-specific error types (`StatisticsError` in `sifr.statistics`, `CycleError` in `sifr.graphlib`) as classes extending `Error` in stdlib `.sifr` files
- Add early import resolution pass in the lowering phase so that imported types are available when function signatures and `Result[T, E]` annotations are resolved — fixes `unknown type` errors for stdlib error classes used in return type annotations
- Track `error_types` in `ExternalDefs` for cross-module error type registration, enabling exhaustiveness checking on imported error classes
- Add E2E tests for importing and catching `StatisticsError`, `CycleError`, and mixed built-in + module-specific error types
- Add milestone demo (`demos/milestone_error_safety_stdlib_types_demo.sifr`) showcasing all features

## Test plan

- [x] `cargo build` succeeds with no errors
- [x] `cargo test --test e2e` — all pass and fail tests pass (2/2)
- [x] `cargo run -- run demos/milestone_error_safety_stdlib_types_demo.sifr` produces expected output
- [x] Individual E2E tests verified: `error_stdlib_statistics`, `error_stdlib_graphlib`, `error_mixed_builtin_stdlib`
- [x] No regressions in existing error safety tests from Milestone 1


Made with [Cursor](https://cursor.com)