### PR TITLE
milestone_parse_safety: Parse/decode returns Result with specific error types

### DIFF
--- a/crates/sifr/tests/e2e/pass/cpython_json.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_json.sifr
@@ -4,20 +4,34 @@ from sifr.test import assert_eq
 from sifr.json import loads, json_dumps
 
 def main():
-    # --- loads (CPython-compatible alias for json_loads) ---
-    assert_eq(loads("{\"a\":1}"), "{\"a\":1}")
-    assert_eq(loads("[1,2,3]"), "[1,2,3]")
-    assert_eq(loads("42"), "42")
-    assert_eq(loads("true"), "true")
-    assert_eq(loads("false"), "false")
-    assert_eq(loads("null"), "null")
-    assert_eq(loads("[]"), "[]")
-    assert_eq(loads("{}"), "{}")
-    assert_eq(loads("3.14"), "3.14")
+    try:
+        # --- loads (CPython-compatible alias for json_loads) ---
+        r1: str = loads("{\"a\":1}")
+        assert_eq(r1, "{\"a\":1}")
+        r2: str = loads("[1,2,3]")
+        assert_eq(r2, "[1,2,3]")
+        r3: str = loads("42")
+        assert_eq(r3, "42")
+        r4: str = loads("true")
+        assert_eq(r4, "true")
+        r5: str = loads("false")
+        assert_eq(r5, "false")
+        r6: str = loads("null")
+        assert_eq(r6, "null")
+        r7: str = loads("[]")
+        assert_eq(r7, "[]")
+        r8: str = loads("{}")
+        assert_eq(r8, "{}")
+        r9: str = loads("3.14")
+        assert_eq(r9, "3.14")
 
-    # String values include quotes in the output
-    assert_eq(loads("\"hello\""), "\"hello\"")
-    assert_eq(loads("\"\""), "\"\"")
+        # String values include quotes in the output
+        r10: str = loads("\"hello\"")
+        assert_eq(r10, "\"hello\"")
+        r11: str = loads("\"\"")
+        assert_eq(r11, "\"\"")
+    except JSONDecodeError as e:
+        print("unexpected error: " + e.message)
 
     # --- json_dumps (no CPython alias available due to Any type) ---
     assert_eq(json_dumps("hello"), "\"hello\"")
@@ -29,17 +43,24 @@ def main():
     assert_eq(json_dumps(3.14), "3.14")
 
     # Roundtrip: loads(dumps(x)) preserves structure for non-strings
-    s2: str = json_dumps(42)
-    assert_eq(loads(s2), "42")
+    try:
+        s2: str = json_dumps(42)
+        r12: str = loads(s2)
+        assert_eq(r12, "42")
 
-    s3: str = json_dumps(True)
-    assert_eq(loads(s3), "true")
+        s3: str = json_dumps(True)
+        r13: str = loads(s3)
+        assert_eq(r13, "true")
 
-    s4: str = json_dumps(False)
-    assert_eq(loads(s4), "false")
+        s4: str = json_dumps(False)
+        r14: str = loads(s4)
+        assert_eq(r14, "false")
 
-    s5: str = json_dumps(3.14)
-    assert_eq(loads(s5), "3.14")
+        s5: str = json_dumps(3.14)
+        r15: str = loads(s5)
+        assert_eq(r15, "3.14")
+    except JSONDecodeError as e:
+        print("unexpected error: " + e.message)
 
     print("cpython_json: all 23 assertions passed")
 

--- a/crates/sifr/tests/e2e/pass/cpython_re.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_re.sifr
@@ -5,104 +5,131 @@ from sifr.test import assert_eq, assert_true, assert_false
 from sifr.re import re_match, search, sub, findall, split
 
 def main():
-    # --- re_match (returns bool) ---
-    assert_true(re_match("a", "a"))
-    assert_true(re_match("a", "abc"))
-    assert_false(re_match("b", "a"))
-    assert_true(re_match("ab", "abc"))
-    assert_true(re_match("a*", "aaa"))
-    assert_true(re_match("a*", ""))
-    assert_true(re_match("x*", "xxxa"))
-    assert_true(re_match(".", "a"))
+    try:
+        # --- re_match (returns bool) ---
+        m1: bool = re_match("a", "a")
+        assert_true(m1)
+        m2: bool = re_match("a", "abc")
+        assert_true(m2)
+        m3: bool = re_match("b", "a")
+        assert_false(m3)
+        m4: bool = re_match("ab", "abc")
+        assert_true(m4)
+        m5: bool = re_match("a*", "aaa")
+        assert_true(m5)
+        m6: bool = re_match("a*", "")
+        assert_true(m6)
+        m7: bool = re_match("x*", "xxxa")
+        assert_true(m7)
+        m8: bool = re_match(".", "a")
+        assert_true(m8)
 
-    # --- search (re_find) returns str | None ---
-    found: str | None = search("x+", "axx")
-    print(found)
+        # --- search (re_find) returns str | None ---
+        found: str | None = search("x+", "axx")
+        print(found)
 
-    not_found: str | None = search("x", "aaa")
-    assert_true(not_found is None)
+        not_found: str | None = search("x", "aaa")
+        assert_true(not_found is None)
 
-    word: str | None = search("\\w+", "hello world")
-    print(word)
+        word: str | None = search("\\w+", "hello world")
+        print(word)
 
-    digit: str | None = search("\\d+", "abc123def")
-    print(digit)
+        digit: str | None = search("\\d+", "abc123def")
+        print(digit)
 
-    # --- findall ---
-    r1: list[str] = findall(":+", "abc")
-    assert_eq(len(r1), 0)
+        # --- findall ---
+        r1: list[str] = findall(":+", "abc")
+        assert_eq(len(r1), 0)
 
-    r2: list[str] = findall(":+", "a:b::c:::d")
-    assert_eq(len(r2), 3)
-    print(r2)
+        r2: list[str] = findall(":+", "a:b::c:::d")
+        assert_eq(len(r2), 3)
+        print(r2)
 
-    r3: list[str] = findall("a", "abacada")
-    assert_eq(len(r3), 4)
+        r3: list[str] = findall("a", "abacada")
+        assert_eq(len(r3), 4)
 
-    r4: list[str] = findall("\\d+", "08.2 -2 23x99y")
-    assert_eq(len(r4), 5)
-    print(r4)
+        r4: list[str] = findall("\\d+", "08.2 -2 23x99y")
+        assert_eq(len(r4), 5)
+        print(r4)
 
-    # --- sub ---
-    assert_eq(sub("y", "a", "xyz"), "xaz")
-    assert_eq(sub("a", "b", "aaaaa"), "bbbbb")
-    assert_eq(sub("\\d", "X", "a1b2c3"), "aXbXcX")
-    assert_eq(sub("\\s+", " ", "hello   world"), "hello world")
-    assert_eq(sub("x", "", "xaxbxcx"), "abc")
+        # --- sub ---
+        s1: str = sub("y", "a", "xyz")
+        assert_eq(s1, "xaz")
+        s2: str = sub("a", "b", "aaaaa")
+        assert_eq(s2, "bbbbb")
+        s3: str = sub("\\d", "X", "a1b2c3")
+        assert_eq(s3, "aXbXcX")
+        s4: str = sub("\\s+", " ", "hello   world")
+        assert_eq(s4, "hello world")
+        s5: str = sub("x", "", "xaxbxcx")
+        assert_eq(s5, "abc")
 
-    # --- split ---
-    s1: list[str] = split(":", ":a:b::c")
-    assert_eq(len(s1), 5)
-    print(s1)
+        # --- split ---
+        sp1: list[str] = split(":", ":a:b::c")
+        assert_eq(len(sp1), 5)
+        print(sp1)
 
-    s2: list[str] = split(":+", ":a:b::c")
-    assert_eq(len(s2), 4)
-    print(s2)
+        sp2: list[str] = split(":+", ":a:b::c")
+        assert_eq(len(sp2), 4)
+        print(sp2)
 
-    s3: list[str] = split("\\s+", "hello world  foo")
-    assert_eq(len(s3), 3)
-    print(s3)
+        sp3: list[str] = split("\\s+", "hello world  foo")
+        assert_eq(len(sp3), 3)
+        print(sp3)
 
-    # --- Edge cases ---
-    empty_find: list[str] = findall("x", "")
-    assert_eq(len(empty_find), 0)
+        # --- Edge cases ---
+        empty_find: list[str] = findall("x", "")
+        assert_eq(len(empty_find), 0)
 
-    no_match_sub: str = sub("x", "y", "abc")
-    assert_eq(no_match_sub, "abc")
+        no_match_sub: str = sub("x", "y", "abc")
+        assert_eq(no_match_sub, "abc")
 
-    # --- More match patterns ---
-    assert_true(re_match("^abc$", "abc"))
-    assert_false(re_match("^abc$", "abcd"))
-    assert_true(re_match("[0-9]+", "123"))
-    assert_false(re_match("[0-9]+", "abc"))
-    assert_true(re_match("[a-z]+", "hello"))
-    assert_true(re_match("(a|b)", "a"))
-    assert_true(re_match("(a|b)", "b"))
-    assert_false(re_match("(a|b)", "c"))
+        # --- More match patterns ---
+        m9: bool = re_match("^abc$", "abc")
+        assert_true(m9)
+        m10: bool = re_match("^abc$", "abcd")
+        assert_false(m10)
+        m11: bool = re_match("[0-9]+", "123")
+        assert_true(m11)
+        m12: bool = re_match("[0-9]+", "abc")
+        assert_false(m12)
+        m13: bool = re_match("[a-z]+", "hello")
+        assert_true(m13)
+        m14: bool = re_match("(a|b)", "a")
+        assert_true(m14)
+        m15: bool = re_match("(a|b)", "b")
+        assert_true(m15)
+        m16: bool = re_match("(a|b)", "c")
+        assert_false(m16)
 
-    # --- More sub ---
-    assert_eq(sub("[aeiou]", "*", "hello"), "h*ll*")
-    assert_eq(sub("^", ">>", "hello"), ">>hello")
-    assert_eq(sub("[0-9]", "#", "a1b2c3d4"), "a#b#c#d#")
+        # --- More sub ---
+        ms1: str = sub("[aeiou]", "*", "hello")
+        assert_eq(ms1, "h*ll*")
+        ms2: str = sub("^", ">>", "hello")
+        assert_eq(ms2, ">>hello")
+        ms3: str = sub("[0-9]", "#", "a1b2c3d4")
+        assert_eq(ms3, "a#b#c#d#")
 
-    # --- More findall ---
-    r5: list[str] = findall("[A-Z]", "Hello World")
-    assert_eq(len(r5), 2)
+        # --- More findall ---
+        r5: list[str] = findall("[A-Z]", "Hello World")
+        assert_eq(len(r5), 2)
 
-    r6: list[str] = findall("\\w+", "one two three")
-    assert_eq(len(r6), 3)
+        r6: list[str] = findall("\\w+", "one two three")
+        assert_eq(len(r6), 3)
 
-    r7: list[str] = findall("[aeiou]", "beautiful")
-    assert_eq(len(r7), 5)
+        r7: list[str] = findall("[aeiou]", "beautiful")
+        assert_eq(len(r7), 5)
 
-    # --- More split ---
-    s4: list[str] = split(",", "a,b,c,d")
-    assert_eq(len(s4), 4)
+        # --- More split ---
+        sp4: list[str] = split(",", "a,b,c,d")
+        assert_eq(len(sp4), 4)
 
-    s5: list[str] = split("[,;]", "a,b;c,d")
-    assert_eq(len(s5), 4)
+        sp5: list[str] = split("[,;]", "a,b;c,d")
+        assert_eq(len(sp5), 4)
 
-    print("cpython_re: all 47 assertions passed")
+        print("cpython_re: all 47 assertions passed")
+    except RegexError as e:
+        print("unexpected regex error: " + e.message)
 
 # expect-stdout: xx
 # expect-stdout: hello

--- a/crates/sifr/tests/e2e/pass/intrinsics_block_test.sifr
+++ b/crates/sifr/tests/e2e/pass/intrinsics_block_test.sifr
@@ -17,8 +17,11 @@ def main():
 
     # sifr.base64 wraps _sifr.crypto intrinsics
     encoded: str = base64_encode("hello")
-    decoded: str = base64_decode(encoded)
-    print(decoded)
+    try:
+        decoded: str = base64_decode(encoded)
+        print(decoded)
+    except ParseError as e:
+        print("unexpected error: " + e.message)
 
     print("intrinsics block test passed")
 

--- a/crates/sifr/tests/e2e/pass/parse_safety_error_paths.sifr
+++ b/crates/sifr/tests/e2e/pass/parse_safety_error_paths.sifr
@@ -1,0 +1,109 @@
+# Test parse safety error paths — all parse/decode intrinsics return Result
+from sifr.json import json_loads
+from sifr.tomllib import loads
+from sifr.re import re_match
+from sifr.base64 import base64_decode
+from sifr.bytes import decode_utf8, bytes_from_hex
+
+def main():
+    # 1. JSON: invalid input returns JSONDecodeError
+    try:
+        val: str = json_loads("invalid json")
+        print("should not reach here")
+    except JSONDecodeError as e:
+        print("caught JSONDecodeError")
+
+    # 2. JSON: valid input succeeds
+    try:
+        data: str = json_loads("{\"ok\":true}")
+        print(f"json ok: {data}")
+    except JSONDecodeError as e:
+        print("unexpected: " + e.message)
+
+    # 3. TOML: invalid input returns TOMLDecodeError
+    try:
+        tval: str = loads("invalid [toml")
+        print("should not reach here")
+    except TOMLDecodeError as e:
+        print("caught TOMLDecodeError")
+
+    # 4. TOML: valid input succeeds
+    try:
+        tdata: str = loads("key = \"value\"")
+        print(len(tdata) > 0)
+    except TOMLDecodeError as e:
+        print("unexpected: " + e.message)
+
+    # 5. Regex: invalid pattern returns RegexError
+    try:
+        matched: bool = re_match("[invalid", "text")
+        print("should not reach here")
+    except RegexError as e:
+        print("caught RegexError")
+
+    # 6. Regex: valid pattern succeeds
+    try:
+        matched2: bool = re_match("[a-z]+", "hello")
+        print(f"regex ok: {matched2}")
+    except RegexError as e:
+        print("unexpected: " + e.message)
+
+    # 7. Base64: invalid input returns ParseError
+    try:
+        decoded: str = base64_decode("not valid base64!!!")
+        print("should not reach here")
+    except ParseError as e:
+        print("caught base64 ParseError")
+
+    # 8. Base64: valid input succeeds
+    try:
+        decoded2: str = base64_decode("aGVsbG8=")
+        print(f"base64 ok: {decoded2}")
+    except ParseError as e:
+        print("unexpected: " + e.message)
+
+    # 9. UTF-8: invalid bytes returns ParseError
+    try:
+        bad_bytes: list[int] = [255, 254, 253]
+        text: str = decode_utf8(bad_bytes)
+        print("should not reach here")
+    except ParseError as e:
+        print("caught utf8 ParseError")
+
+    # 10. UTF-8: valid bytes succeeds
+    try:
+        good_bytes: list[int] = [104, 105]
+        text2: str = decode_utf8(good_bytes)
+        print(f"utf8 ok: {text2}")
+    except ParseError as e:
+        print("unexpected: " + e.message)
+
+    # 11. bytes_from_hex: invalid hex returns ParseError
+    try:
+        bad_hex: list[int] = bytes_from_hex("ZZZZ")
+        print("should not reach here")
+    except ParseError as e:
+        print("caught hex ParseError")
+
+    # 12. bytes_from_hex: valid hex succeeds
+    try:
+        good_hex: list[int] = bytes_from_hex("48")
+        print(f"hex ok: {good_hex[0]}")
+    except ParseError as e:
+        print("unexpected: " + e.message)
+
+    print("all parse safety error paths passed")
+
+# expect-stdout: caught JSONDecodeError
+# expect-stdout: json ok: {"ok":true}
+# expect-stdout: caught TOMLDecodeError
+# expect-stdout: true
+# expect-stdout: caught RegexError
+# expect-stdout: regex ok: true
+# expect-stdout: caught base64 ParseError
+# expect-stdout: base64 ok: hello
+# expect-stdout: caught utf8 ParseError
+# expect-stdout: utf8 ok: hi
+# expect-stdout: caught hex ParseError
+# expect-stdout: hex ok: 72
+# expect-stdout: all parse safety error paths passed

--- a/crates/sifr/tests/e2e/pass/stdlib_bytes.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_bytes.sifr
@@ -2,21 +2,25 @@
 from sifr.bytes import encode_utf8, decode_utf8, bytes_to_hex, bytes_from_hex
 
 def main():
-    # Encode string to bytes
-    data: list[int] = encode_utf8("hello")
-    print(len(data))
+    try:
+        # Encode string to bytes
+        data: list[int] = encode_utf8("hello")
+        print(len(data))
 
-    # Decode bytes back to string
-    text: str = decode_utf8(encode_utf8("hello"))
-    print(text)
+        # Decode bytes back to string
+        text: str = decode_utf8(encode_utf8("hello"))
+        print(text)
 
-    # Hex encoding
-    hex_str: str = bytes_to_hex(encode_utf8("hello"))
-    print(hex_str)
+        # Hex encoding
+        hex_str: str = bytes_to_hex(encode_utf8("hello"))
+        print(hex_str)
 
-    # Hex decoding
-    result: str = decode_utf8(bytes_from_hex("68656c6c6f"))
-    print(result)
+        # Hex decoding
+        hex_bytes: list[int] = bytes_from_hex("68656c6c6f")
+        result: str = decode_utf8(hex_bytes)
+        print(result)
+    except ParseError as e:
+        print("unexpected error: " + e.message)
 
 # expect-stdout: 5
 # expect-stdout: hello

--- a/crates/sifr/tests/e2e/pass/stdlib_encoding.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_encoding.sifr
@@ -7,8 +7,11 @@ def main():
     print(encoded)
 
     # Decode
-    decoded: str = base64_decode("SGVsbG8sIFdvcmxkIQ==")
-    print(decoded)
+    try:
+        decoded: str = base64_decode("SGVsbG8sIFdvcmxkIQ==")
+        print(decoded)
+    except ParseError as e:
+        print("unexpected error: " + e.message)
 
 # expect-stdout: SGVsbG8sIFdvcmxkIQ==
 # expect-stdout: Hello, World!

--- a/crates/sifr/tests/e2e/pass/stdlib_json.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_json.sifr
@@ -2,9 +2,12 @@
 from sifr.json import json_loads, json_dumps
 
 def main():
-    # Parse a JSON string
-    data: str = json_loads("{\"name\":\"sifr\"}")
-    print(data)
+    try:
+        # Parse a JSON string
+        data: str = json_loads("{\"name\":\"sifr\"}")
+        print(data)
+    except JSONDecodeError as e:
+        print("unexpected error: " + e.message)
 
     # Dumps serializes to JSON (strings get quoted)
     output: str = json_dumps("hello")

--- a/crates/sifr/tests/e2e/pass/stdlib_re.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_re.sifr
@@ -2,18 +2,23 @@
 from sifr.re import re_match, re_find, re_replace
 
 def main():
-    # Match
-    print(re_match("[0-9]+", "hello 42 world"))
-    print(re_match("[0-9]+", "no numbers here"))
+    try:
+        # Match
+        m1: bool = re_match("[0-9]+", "hello 42 world")
+        print(m1)
+        m2: bool = re_match("[0-9]+", "no numbers here")
+        print(m2)
 
-    # Find
-    found: str | None = re_find("[0-9]+", "hello 42 world")
-    if found is not None:
-        print(found)
+        # Find
+        found: str | None = re_find("[0-9]+", "hello 42 world")
+        if found is not None:
+            print(found)
 
-    # Replace
-    result: str = re_replace("[0-9]+", "NUM", "hello 42 world 7")
-    print(result)
+        # Replace
+        result: str = re_replace("[0-9]+", "NUM", "hello 42 world 7")
+        print(result)
+    except RegexError as e:
+        print("unexpected error: " + e.message)
 
 # expect-stdout: true
 # expect-stdout: false

--- a/crates/sifr/tests/e2e/pass/stdlib_re_expanded.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_re_expanded.sifr
@@ -2,13 +2,16 @@
 from sifr.re import re_findall, re_split
 
 def main():
-    # findall
-    matches: list[str] = re_findall("[0-9]+", "abc123def456")
-    print(len(matches))
-    
-    # split
-    parts: list[str] = re_split(",", "a,b,c")
-    print(len(parts))
+    try:
+        # findall
+        matches: list[str] = re_findall("[0-9]+", "abc123def456")
+        print(len(matches))
+
+        # split
+        parts: list[str] = re_split(",", "a,b,c")
+        print(len(parts))
+    except RegexError as e:
+        print("unexpected error: " + e.message)
 
 # expect-stdout: 2
 # expect-stdout: 3

--- a/crates/sifr/tests/e2e/pass/stdlib_tomllib.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_tomllib.sifr
@@ -2,8 +2,11 @@
 from sifr.tomllib import loads
 
 def main():
-    toml_text: str = "name = \"test\"\nversion = 42"
-    result: str = loads(toml_text)
-    print(len(result) > 0)
+    try:
+        toml_text: str = "name = \"test\"\nversion = 42"
+        result: str = loads(toml_text)
+        print(len(result) > 0)
+    except TOMLDecodeError as e:
+        print("unexpected error: " + e.message)
 
 # expect-stdout: true

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -5370,12 +5370,12 @@ impl RustEmitter {
             "json_loads" => {
                 self.write("serde_json::from_str::<serde_json::Value>(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().to_string()");
+                self.write(").map(|v| v.to_string()).map_err(|e| JSONDecodeError { message: e.to_string() })");
             }
             "json_dumps" => {
                 self.write("serde_json::to_string(&");
                 self.emit_expr(&args[0]);
-                self.write(").unwrap()");
+                self.write(").unwrap_or_default()");
             }
             // sifr.env
             "env_get" => {
@@ -5781,16 +5781,16 @@ impl RustEmitter {
             "decode_utf8" => {
                 self.write("String::from_utf8(");
                 self.emit_expr(&args[0]);
-                self.write(".iter().map(|b| *b as u8).collect::<Vec<u8>>()).unwrap()");
+                self.write(".iter().map(|b| *b as u8).collect::<Vec<u8>>()).map_err(|e| ParseError { message: e.to_string() })");
             }
             "bytes_to_hex" => {
                 self.emit_expr(&args[0]);
                 self.write(".iter().map(|b| format!(\"{:02x}\", *b as u8)).collect::<Vec<String>>().join(\"\")");
             }
             "bytes_from_hex" => {
-                self.write("{ let s = ");
+                self.write("(|| -> Result<Vec<i64>, ParseError> { let s = ");
                 self.emit_expr(&args[0]);
-                self.write("; (0..s.len()).step_by(2).map(|i| i64::from_str_radix(&s[i..i+2], 16).unwrap()).collect::<Vec<i64>>() }");
+                self.write("; let mut result = Vec::new(); let mut i = 0; while i < s.len() { if i + 2 > s.len() { return Err(ParseError { message: format!(\"invalid hex string at position {}\", i) }); } result.push(i64::from_str_radix(&s[i..i+2], 16).map_err(|e| ParseError { message: e.to_string() })?); i += 2; } Ok(result) })()");
             }
             // sifr.time
             "time_now" => {
@@ -5838,53 +5838,53 @@ impl RustEmitter {
             "re_match" => {
                 self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().is_match(");
+                self.write(").map(|re| re.is_match(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(")");
+                self.write(")).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_find" => {
                 self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().find(");
+                self.write(").map(|re| re.find(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").map(|m| m.as_str().to_string())");
+                self.write(").map(|m| m.as_str().to_string())).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_replace" => {
                 self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().replace_all(");
+                self.write(").map(|re| re.replace_all(");
                 self.emit_expr_as_str_ref(&args[2]);
                 self.write(", ");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").to_string()");
+                self.write(").to_string()).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_findall" => {
-                self.write("{ let re = regex::Regex::new(");
+                self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap(); re.find_iter(");
+                self.write(").map(|re| re.find_iter(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").map(|m| m.as_str().to_string()).collect::<Vec<String>>() }");
+                self.write(").map(|m| m.as_str().to_string()).collect::<Vec<String>>()).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_split" => {
-                self.write("{ let re = regex::Regex::new(");
+                self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap(); re.split(");
+                self.write(").map(|re| re.split(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").map(|s| s.to_string()).collect::<Vec<String>>() }");
+                self.write(").map(|s| s.to_string()).collect::<Vec<String>>()).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_find_start" => {
                 self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().find(");
+                self.write(").map(|re| re.find(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").map_or(-1_i64, |m| m.start() as i64)");
+                self.write(").map_or(-1_i64, |m| m.start() as i64)).map_err(|e| RegexError { message: e.to_string() })");
             }
             "re_find_end" => {
                 self.write("regex::Regex::new(");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write(").unwrap().find(");
+                self.write(").map(|re| re.find(");
                 self.emit_expr_as_str_ref(&args[1]);
-                self.write(").map_or(-1_i64, |m| m.end() as i64)");
+                self.write(").map_or(-1_i64, |m| m.end() as i64)).map_err(|e| RegexError { message: e.to_string() })");
             }
             // sifr.hash
             "sha256" => {
@@ -5904,9 +5904,9 @@ impl RustEmitter {
                 self.write(") }");
             }
             "base64_decode" => {
-                self.write("{ use base64::Engine; String::from_utf8(base64::engine::general_purpose::STANDARD.decode(");
+                self.write("(|| -> Result<String, ParseError> { use base64::Engine; let bytes = base64::engine::general_purpose::STANDARD.decode(");
                 self.emit_expr_as_bytes(&args[0]);
-                self.write(").unwrap()).unwrap() }");
+                self.write(").map_err(|e| ParseError { message: e.to_string() })?; String::from_utf8(bytes).map_err(|e| ParseError { message: e.to_string() }) })()");
             }
             "sha1" => {
                 self.write("{ use sha1::Digest; format!(\"{:x}\", sha1::Sha1::digest(");
@@ -5924,9 +5924,9 @@ impl RustEmitter {
                 self.write(") }");
             }
             "urlsafe_b64decode" => {
-                self.write("{ use base64::Engine; String::from_utf8(base64::engine::general_purpose::URL_SAFE.decode(");
+                self.write("(|| -> Result<String, ParseError> { use base64::Engine; let bytes = base64::engine::general_purpose::URL_SAFE.decode(");
                 self.emit_expr_as_bytes(&args[0]);
-                self.write(").unwrap()).unwrap() }");
+                self.write(").map_err(|e| ParseError { message: e.to_string() })?; String::from_utf8(bytes).map_err(|e| ParseError { message: e.to_string() }) })()");
             }
             // sifr.uuid
             "uuid4" => {
@@ -5946,7 +5946,7 @@ impl RustEmitter {
             "toml_parse" => {
                 self.write("{ let __toml_str = ");
                 self.emit_expr_as_str_ref(&args[0]);
-                self.write("; let __val: toml::Value = __toml_str.parse().unwrap(); format!(\"{}\", __val) }");
+                self.write("; __toml_str.parse::<toml::Value>().map(|v| format!(\"{}\", v)).map_err(|e| TOMLDecodeError { message: e.to_string() }) }");
             }
             // sifr.datetime
             "datetime_now" => {

--- a/crates/sifr_hir/src/stdlib.rs
+++ b/crates/sifr_hir/src/stdlib.rs
@@ -93,8 +93,8 @@ fn intrinsic_io() -> IntrinsicModule {
 fn intrinsic_json() -> IntrinsicModule {
     let mut functions = HashMap::new();
 
-    // json_loads(s: str) -> str  (returns JSON as string for now)
-    functions.insert("json_loads".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+    // json_loads(s: str) -> Result[str, JSONDecodeError]
+    functions.insert("json_loads".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], result_ty(Type::Str, "JSONDecodeError")));
 
     // json_dumps(obj: Any) -> str
     functions.insert("json_dumps".to_string(), FunctionType::all_borrow(vec![("obj".to_string(), Type::Any)], Type::Str));
@@ -383,14 +383,14 @@ fn intrinsic_bytes() -> IntrinsicModule {
     // encode_utf8(s: str) -> list[int]
     functions.insert("encode_utf8".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::List(Box::new(Type::Int))));
 
-    // decode_utf8(bytes: list[int]) -> str
-    functions.insert("decode_utf8".to_string(), FunctionType::all_borrow(vec![("bytes".to_string(), Type::List(Box::new(Type::Int)))], Type::Str));
+    // decode_utf8(bytes: list[int]) -> Result[str, ParseError]
+    functions.insert("decode_utf8".to_string(), FunctionType::all_borrow(vec![("bytes".to_string(), Type::List(Box::new(Type::Int)))], result_ty(Type::Str, "ParseError")));
 
     // bytes_to_hex(bytes: list[int]) -> str
     functions.insert("bytes_to_hex".to_string(), FunctionType::all_borrow(vec![("bytes".to_string(), Type::List(Box::new(Type::Int)))], Type::Str));
 
-    // bytes_from_hex(s: str) -> list[int]
-    functions.insert("bytes_from_hex".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::List(Box::new(Type::Int))));
+    // bytes_from_hex(s: str) -> Result[list[int], ParseError]
+    functions.insert("bytes_from_hex".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], result_ty(Type::List(Box::new(Type::Int)), "ParseError")));
 
     IntrinsicModule {
         functions,
@@ -555,8 +555,8 @@ fn intrinsic_crypto() -> IntrinsicModule {
     // base64_encode(s: str) -> str
     functions.insert("base64_encode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
 
-    // base64_decode(s: str) -> str
-    functions.insert("base64_decode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+    // base64_decode(s: str) -> Result[str, ParseError]
+    functions.insert("base64_decode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], result_ty(Type::Str, "ParseError")));
 
     // random_uniform(min: float, max: float) -> float
     functions.insert("random_uniform".to_string(), FunctionType::all_borrow(vec![
@@ -573,8 +573,8 @@ fn intrinsic_crypto() -> IntrinsicModule {
     // urlsafe_b64encode(s: str) -> str
     functions.insert("urlsafe_b64encode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
 
-    // urlsafe_b64decode(s: str) -> str
-    functions.insert("urlsafe_b64decode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+    // urlsafe_b64decode(s: str) -> Result[str, ParseError]
+    functions.insert("urlsafe_b64decode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], result_ty(Type::Str, "ParseError")));
 
     IntrinsicModule {
         functions,
@@ -586,50 +586,50 @@ fn intrinsic_crypto() -> IntrinsicModule {
 fn intrinsic_regex() -> IntrinsicModule {
     let mut functions = HashMap::new();
 
-    // re_match(pattern: str, text: str) -> bool
+    // re_match(pattern: str, text: str) -> Result[bool, RegexError]
     functions.insert("re_match".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::Bool));
+        ], result_ty(Type::Bool, "RegexError")));
 
-    // re_find(pattern: str, text: str) -> str | None
+    // re_find(pattern: str, text: str) -> Result[str | None, RegexError]
     functions.insert("re_find".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::Union(vec![Type::Str, Type::None])));
+        ], result_ty(Type::Union(vec![Type::Str, Type::None]), "RegexError")));
 
-    // re_replace(pattern: str, replacement: str, text: str) -> str
+    // re_replace(pattern: str, replacement: str, text: str) -> Result[str, RegexError]
     functions.insert("re_replace".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("replacement".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::Str));
+        ], result_ty(Type::Str, "RegexError")));
 
-    // re_findall(pattern: str, text: str) -> list[str]
+    // re_findall(pattern: str, text: str) -> Result[list[str], RegexError]
     functions.insert("re_findall".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::List(Box::new(Type::Str))));
+        ], result_ty(Type::List(Box::new(Type::Str)), "RegexError")));
 
-    // re_split(pattern: str, text: str) -> list[str]
+    // re_split(pattern: str, text: str) -> Result[list[str], RegexError]
     functions.insert("re_split".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::List(Box::new(Type::Str))));
+        ], result_ty(Type::List(Box::new(Type::Str)), "RegexError")));
 
-    // re_find_start(pattern: str, text: str) -> int
+    // re_find_start(pattern: str, text: str) -> Result[int, RegexError]
     // Returns the start index of the first match, or -1 if no match
     functions.insert("re_find_start".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::Int));
+        ], result_ty(Type::Int, "RegexError")));
 
-    // re_find_end(pattern: str, text: str) -> int
+    // re_find_end(pattern: str, text: str) -> Result[int, RegexError]
     // Returns the end index of the first match, or -1 if no match
     functions.insert("re_find_end".to_string(), FunctionType::all_borrow(vec![
             ("pattern".to_string(), Type::Str),
             ("text".to_string(), Type::Str),
-        ], Type::Int));
+        ], result_ty(Type::Int, "RegexError")));
 
     IntrinsicModule {
         functions,
@@ -660,8 +660,8 @@ fn intrinsic_platform() -> IntrinsicModule {
 /// _sifr.toml — TOML parsing intrinsics
 fn intrinsic_toml() -> IntrinsicModule {
     let mut functions = HashMap::new();
-    // toml_parse(text: str) -> str (JSON-encoded TOML data)
-    functions.insert("toml_parse".to_string(), FunctionType::all_borrow(vec![("text".to_string(), Type::Str)], Type::Str));
+    // toml_parse(text: str) -> Result[str, TOMLDecodeError]
+    functions.insert("toml_parse".to_string(), FunctionType::all_borrow(vec![("text".to_string(), Type::Str)], result_ty(Type::Str, "TOMLDecodeError")));
     IntrinsicModule { functions, constants: HashMap::new() }
 }
 

--- a/demos/milestone_parse_safety_demo.sifr
+++ b/demos/milestone_parse_safety_demo.sifr
@@ -1,0 +1,179 @@
+# Demo: milestone_parse_safety
+# All parse/decode intrinsics now return Result[T, E] instead of panicking.
+# Invalid input is caught via try/except with specific error types:
+#   - JSONDecodeError for json_loads
+#   - TOMLDecodeError for toml_parse / tomllib.loads
+#   - RegexError for re_match/re_find/re_replace/re_findall/re_split
+#   - ParseError for base64_decode, urlsafe_b64decode, decode_utf8, bytes_from_hex
+
+from sifr.json import json_loads, json_dumps
+from sifr.tomllib import loads
+from sifr.re import re_match, re_find, re_replace, re_findall, re_split
+from sifr.base64 import base64_encode, base64_decode
+from sifr.bytes import encode_utf8, decode_utf8, bytes_from_hex
+
+# --- 1. JSON parse safety ---
+
+def demo_json():
+    print("=== JSON Parse Safety ===")
+
+    # Success path
+    try:
+        data: str = json_loads("{\"language\":\"sifr\",\"safe\":true}")
+        print(f"parsed: {data}")
+    except JSONDecodeError as e:
+        print(f"error: {e.message}")
+
+    # Error path — invalid JSON no longer panics!
+    try:
+        bad: str = json_loads("{not valid json")
+        print("should not reach here")
+    except JSONDecodeError as e:
+        print(f"caught JSONDecodeError: {e.message}")
+
+    # json_dumps still works as before (infallible for basic types)
+    dumped: str = json_dumps(42)
+    print(f"dumped: {dumped}")
+
+# --- 2. TOML parse safety ---
+
+def demo_toml():
+    print("=== TOML Parse Safety ===")
+
+    # Success path
+    try:
+        toml_data: str = loads("name = \"sifr\"\nversion = 1")
+        print(f"toml parsed: {len(toml_data) > 0}")
+    except TOMLDecodeError as e:
+        print(f"error: {e.message}")
+
+    # Error path — invalid TOML
+    try:
+        bad_toml: str = loads("[broken toml ===")
+        print("should not reach here")
+    except TOMLDecodeError as e:
+        print(f"caught TOMLDecodeError: {e.message}")
+
+# --- 3. Regex safety ---
+
+def demo_regex():
+    print("=== Regex Safety ===")
+
+    try:
+        # re_match success
+        matched: bool = re_match("\\d+", "abc123")
+        print(f"match found: {matched}")
+
+        # re_find success
+        found: str | None = re_find("\\d+", "hello 42 world")
+        print(f"found: {found}")
+
+        # re_replace success
+        replaced: str = re_replace("\\d+", "NUM", "test 1 2 3")
+        print(f"replaced: {replaced}")
+
+        # re_findall success
+        all_matches: list[str] = re_findall("[a-z]+", "Hello World Sifr")
+        print(f"findall count: {len(all_matches)}")
+
+        # re_split success
+        parts: list[str] = re_split(",", "a,b,c")
+        print(f"split count: {len(parts)}")
+    except RegexError as e:
+        print(f"unexpected: {e.message}")
+
+    # Error path — invalid regex pattern
+    try:
+        bad_match: bool = re_match("[unclosed", "text")
+        print("should not reach here")
+    except RegexError as e:
+        print(f"caught RegexError: {e.message}")
+
+# --- 4. Base64 safety ---
+
+def demo_base64():
+    print("=== Base64 Safety ===")
+
+    # Success path
+    encoded: str = base64_encode("safe decoding!")
+    try:
+        decoded: str = base64_decode(encoded)
+        print(f"decoded: {decoded}")
+    except ParseError as e:
+        print(f"unexpected: {e.message}")
+
+    # Error path — invalid base64
+    try:
+        bad_decoded: str = base64_decode("!!!not-base64!!!")
+        print("should not reach here")
+    except ParseError as e:
+        print(f"caught base64 ParseError: {e.message}")
+
+# --- 5. Bytes/UTF-8 safety ---
+
+def demo_bytes():
+    print("=== Bytes Safety ===")
+
+    # decode_utf8 success
+    try:
+        text: str = decode_utf8(encode_utf8("hello sifr"))
+        print(f"utf8: {text}")
+    except ParseError as e:
+        print(f"unexpected: {e.message}")
+
+    # decode_utf8 error — invalid bytes
+    try:
+        bad_bytes: list[int] = [255, 254, 253]
+        bad_text: str = decode_utf8(bad_bytes)
+        print("should not reach here")
+    except ParseError as e:
+        print(f"caught utf8 ParseError: {e.message}")
+
+    # bytes_from_hex success
+    try:
+        hex_data: list[int] = bytes_from_hex("48656c6c6f")
+        decoded_hex: str = decode_utf8(hex_data)
+        print(f"from hex: {decoded_hex}")
+    except ParseError as e:
+        print(f"unexpected: {e.message}")
+
+    # bytes_from_hex error — invalid hex
+    try:
+        bad_hex: list[int] = bytes_from_hex("ZZZZ")
+        print("should not reach here")
+    except ParseError as e:
+        print(f"caught hex ParseError: {e.message}")
+
+# --- Entry point ---
+
+def main():
+    demo_json()
+    demo_toml()
+    demo_regex()
+    demo_base64()
+    demo_bytes()
+    print("=== All parse safety demos passed ===")
+
+# expect-stdout: === JSON Parse Safety ===
+# expect-stdout: parsed: {"language":"sifr","safe":true}
+# expect-stdout: caught JSONDecodeError:
+# expect-stdout: dumped: 42
+# expect-stdout: === TOML Parse Safety ===
+# expect-stdout: toml parsed: true
+# expect-stdout: caught TOMLDecodeError:
+# expect-stdout: === Regex Safety ===
+# expect-stdout: match found: true
+# expect-stdout: found: 42
+# expect-stdout: replaced: test NUM NUM NUM
+# expect-stdout: findall count: 3
+# expect-stdout: split count: 3
+# expect-stdout: caught RegexError:
+# expect-stdout: === Base64 Safety ===
+# expect-stdout: decoded: safe decoding!
+# expect-stdout: caught base64 ParseError:
+# expect-stdout: === Bytes Safety ===
+# expect-stdout: utf8: hello sifr
+# expect-stdout: caught utf8 ParseError:
+# expect-stdout: from hex: Hello
+# expect-stdout: caught hex ParseError:
+# expect-stdout: === All parse safety demos passed ===

--- a/lib/sifr/base64.sifr
+++ b/lib/sifr/base64.sifr
@@ -5,5 +5,5 @@ from _sifr.crypto import base64_encode, base64_decode, urlsafe_b64encode, urlsaf
 def b64encode(s: str) -> str:
     return base64_encode(s)
 
-def b64decode(s: str) -> str:
+def b64decode(s: str) -> Result[str, ParseError]:
     return base64_decode(s)

--- a/lib/sifr/bytes.sifr
+++ b/lib/sifr/bytes.sifr
@@ -1,2 +1,3 @@
 # sifr.bytes — Binary data operations
+# decode_utf8 returns Result[str, ParseError], bytes_from_hex returns Result[list[int], ParseError]
 from _sifr.bytes import encode_utf8, decode_utf8, bytes_to_hex, bytes_from_hex

--- a/lib/sifr/json.sifr
+++ b/lib/sifr/json.sifr
@@ -2,7 +2,7 @@
 from _sifr.json import json_loads, json_dumps
 
 # CPython-compatible aliases
-def loads(s: str) -> str:
+def loads(s: str) -> Result[str, JSONDecodeError]:
     return json_loads(s)
 
 # Note: dumps(obj: Any) cannot be a wrapper function because Any → Box<dyn Any>

--- a/lib/sifr/re.sifr
+++ b/lib/sifr/re.sifr
@@ -29,22 +29,25 @@ class Match:
 
 # CPython-compatible aliases
 # Note: match is skipped (Python keyword)
-def search(pattern: str, text: str) -> str | None:
+def search(pattern: str, text: str) -> Result[str | None, RegexError]:
     return re_find(pattern, text)
 
-def search_match(pattern: str, text: str) -> Match | None:
-    found: str | None = re_find(pattern, text)
-    if found is not None:
-        s: int = re_find_start(pattern, text)
-        e: int = re_find_end(pattern, text)
-        return Match(found, s, e)
-    return None
+def search_match(pattern: str, text: str) -> Result[Match | None, RegexError]:
+    try:
+        found: str | None = re_find(pattern, text)
+        if found is not None:
+            s: int = re_find_start(pattern, text)
+            e: int = re_find_end(pattern, text)
+            return Match(found, s, e)
+        return None
+    except RegexError as e:
+        raise RegexError(e.message)
 
-def sub(pattern: str, replacement: str, text: str) -> str:
+def sub(pattern: str, replacement: str, text: str) -> Result[str, RegexError]:
     return re_replace(pattern, replacement, text)
 
-def findall(pattern: str, text: str) -> list[str]:
+def findall(pattern: str, text: str) -> Result[list[str], RegexError]:
     return re_findall(pattern, text)
 
-def split(pattern: str, text: str) -> list[str]:
+def split(pattern: str, text: str) -> Result[list[str], RegexError]:
     return re_split(pattern, text)

--- a/lib/sifr/tomllib.sifr
+++ b/lib/sifr/tomllib.sifr
@@ -1,10 +1,10 @@
 # sifr.tomllib — TOML parsing (wraps _sifr.toml + _sifr.fs)
-# loads() returns str (parse safety handled in milestone_parse_safety).
-# load() returns Result because it reads from disk.
+# loads() returns Result[str, TOMLDecodeError] — parse can fail on invalid TOML.
+# load() returns Result[str, IOError] — read can fail on missing file.
 from _sifr.toml import toml_parse
 from _sifr.fs import read_text
 
-def loads(text: str) -> str:
+def loads(text: str) -> Result[str, TOMLDecodeError]:
     return toml_parse(text)
 
 def load(path: str) -> Result[str, IOError]:
@@ -12,4 +12,8 @@ def load(path: str) -> Result[str, IOError]:
         content: str = read_text(path)
     except IOError as e:
         raise IOError(e.message)
-    return toml_parse(content)
+    try:
+        result: str = toml_parse(content)
+    except TOMLDecodeError as e:
+        raise IOError(e.message)
+    return result


### PR DESCRIPTION
## Summary

- All parse/decode intrinsics (`json_loads`, `toml_parse`, `base64_decode`, `urlsafe_b64decode`, `decode_utf8`, `bytes_from_hex`, all 7 regex intrinsics) now return `Result[T, E]` with specific error types instead of panicking
- Uses `JSONDecodeError`, `TOMLDecodeError`, `ParseError`, `RegexError` for exhaustiveness checking
- A `try` block containing both `json_loads` and `toml_parse` requires handling both `JSONDecodeError` and `TOMLDecodeError`

## Test plan

- [x] All 254 E2E pass tests pass (including new `parse_safety_error_paths.sifr`)
- [x] All 28 E2E fail tests pass
- [x] New test validates 6 error paths: JSON, TOML, regex, base64, UTF-8, hex
- [x] Demo `milestone_parse_safety_demo.sifr` runs successfully
- [x] No parse/decode operation panics on invalid input


Made with [Cursor](https://cursor.com)