### PR TITLE
feat(milestone_borrow_stdlib): apply mut/own ownership model to stdlib

### DIFF
--- a/.cursor/plans/main/phases/10_borrow_by_default.md
+++ b/.cursor/plans/main/phases/10_borrow_by_default.md
@@ -74,7 +74,7 @@ status: completed
 
 ## milestone_borrow_stdlib: Stdlib Ownership Patterns
 
-status: pending
+status: completed
 
 **Goal:** Exercise `mut` and `own` in the stdlib to prove the model works in real code.
 

--- a/crates/sifr/tests/e2e/fail/stdlib_counter_wrong_type.sifr
+++ b/crates/sifr/tests/e2e/fail/stdlib_counter_wrong_type.sifr
@@ -5,4 +5,4 @@ def main():
     c: Counter = Counter(42)
     print(c.total())
 
-# expect-error: argument 1 ('data') of function 'Counter': expected 'str', got 'int'
+# expect-error: argument 1 ('counts') of function 'Counter': expected 'dict[str, int]', got 'int'

--- a/crates/sifr/tests/e2e/pass/bisect_insort_mut.sifr
+++ b/crates/sifr/tests/e2e/pass/bisect_insort_mut.sifr
@@ -1,0 +1,21 @@
+# Test bisect insort in-place API -- mut parameter borrow-by-default
+from sifr.bisect import insort_left, insort_right
+
+def main():
+    # insort_left in-place
+    nums: list[int] = [1, 3, 5, 7]
+    insort_left(nums, 4)
+    print(nums)
+
+    # insort_right in-place
+    data: list[int] = [1, 3, 3, 5]
+    insort_right(data, 3)
+    print(data)
+
+    # Caller retains ownership after in-place insert
+    insort_left(nums, 6)
+    print(nums)
+
+# expect-stdout: [1, 3, 4, 5, 7]
+# expect-stdout: [1, 3, 3, 3, 5]
+# expect-stdout: [1, 3, 4, 5, 6, 7]

--- a/crates/sifr/tests/e2e/pass/counter_dict_native.sifr
+++ b/crates/sifr/tests/e2e/pass/counter_dict_native.sifr
@@ -1,0 +1,33 @@
+# Test Counter class -- native dict[str, int] implementation
+# This replaces the old JSON-string workaround with real dict operations.
+from sifr.collections import Counter, from_list
+
+def main():
+    # Build from list
+    words: list[str] = ["hello", "world", "hello", "sifr", "hello", "world"]
+    c: Counter = from_list(words)
+
+    # Get counts
+    print(c.get("hello"))
+    print(c.get("world"))
+    print(c.get("sifr"))
+    print(c.get("missing"))
+
+    # Total
+    print(c.total())
+
+    # In-place increment (uses self.counts[key] = val + 1 via AttributeSubscriptAssign)
+    c.increment("sifr")
+    print(c.get("sifr"))
+
+    # Most common top-1 (clear winner: hello with 3)
+    top: list[str] = c.most_common(1)
+    print(top)
+
+# expect-stdout: 3
+# expect-stdout: 2
+# expect-stdout: 1
+# expect-stdout: 0
+# expect-stdout: 6
+# expect-stdout: 2
+# expect-stdout: ["hello"]

--- a/crates/sifr/tests/e2e/pass/cpython_bisect.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_bisect.sifr
@@ -51,22 +51,26 @@ def main():
     assert_eq(bisect_left(dups, 3), 3)
     assert_eq(bisect_right(dups, 3), 6)
 
-    # --- insort_left (returns new list) ---
-    ins1: list[int] = insort_left([], 5)
+    # --- insort_left (in-place, mut parameter) ---
+    ins1: list[int] = []
+    insort_left(ins1, 5)
     assert_eq(len(ins1), 1)
     print(ins1)
 
-    ins2: list[int] = insort_left([1, 3, 5], 2)
+    ins2: list[int] = [1, 3, 5]
+    insort_left(ins2, 2)
     assert_eq(len(ins2), 4)
     print(ins2)
 
-    # --- insort_right (returns new list) ---
-    ins3: list[int] = insort_right([1, 3, 5], 4)
+    # --- insort_right (in-place, mut parameter) ---
+    ins3: list[int] = [1, 3, 5]
+    insort_right(ins3, 4)
     assert_eq(len(ins3), 4)
     print(ins3)
 
     # insort with duplicates
-    ins4: list[int] = insort_left([1, 3, 3, 5], 3)
+    ins4: list[int] = [1, 3, 3, 5]
+    insort_left(ins4, 3)
     assert_eq(len(ins4), 5)
     print(ins4)
 

--- a/crates/sifr/tests/e2e/pass/cpython_collections.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_collections.sifr
@@ -1,11 +1,10 @@
 # CPython test_collections.py — ported assertions for sifr.collections
-# Note: Set operations return new lists (functional style)
+# Updated to use native dict[str, int] Counter class (borrow-by-default milestone)
 from sifr.test import assert_eq, assert_true, assert_false
 from sifr.collections import (
+    Counter, from_list,
     new_set, set_from_list, set_add, set_contains, set_remove,
-    set_len, set_union, set_intersection,
-    counter_from_list, counter_get, counter_most_common, counter_total,
-    counter_values, counter_keys, counter_increment
+    set_len, set_union, set_intersection
 )
 
 def main():
@@ -48,33 +47,32 @@ def main():
     inter: list[int] = set_intersection(a_set, b_set)
     assert_eq(set_len(inter), 2)
 
-    # --- Counter operations (counter handle is str) ---
+    # --- Counter operations (native dict[str, int] class) ---
     words: list[str] = ["apple", "banana", "apple", "cherry", "banana", "apple"]
-    c: str = counter_from_list(words)
+    c: Counter = from_list(words)
 
-    assert_eq(counter_get(c, "apple"), 3)
-    assert_eq(counter_get(c, "banana"), 2)
-    assert_eq(counter_get(c, "cherry"), 1)
-    assert_eq(counter_get(c, "missing"), 0)
-    assert_eq(counter_total(c), 6)
+    assert_eq(c.get("apple"), 3)
+    assert_eq(c.get("banana"), 2)
+    assert_eq(c.get("cherry"), 1)
+    assert_eq(c.get("missing"), 0)
+    assert_eq(c.total(), 6)
 
-    # counter_most_common
-    mc: str = counter_most_common(c, 2)
+    # most_common returns list of keys sorted by count descending
+    mc: list[str] = c.most_common(2)
     print(mc)
 
-    # counter_keys
-    keys: list[str] = counter_keys(c)
+    # keys and values
+    keys: list[str] = c.keys()
     assert_eq(len(keys), 3)
 
-    # counter_values
-    vals: list[int] = counter_values(c)
+    vals: list[int] = c.values()
     assert_eq(len(vals), 3)
 
-    # counter_increment
-    c = counter_increment(c, "banana")
-    assert_eq(counter_get(c, "banana"), 3)
+    # increment
+    c.increment("banana")
+    assert_eq(c.get("banana"), 3)
 
     print("cpython_collections: all 26 assertions passed")
 
-# expect-stdout: [["apple",3],["banana",2]]
+# expect-stdout: ["apple", "banana"]
 # expect-stdout: cpython_collections: all 26 assertions passed

--- a/crates/sifr/tests/e2e/pass/cpython_heapq.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_heapq.sifr
@@ -1,43 +1,39 @@
 # CPython test_heapq.py — ported assertions for sifr.heapq
-# Note: Sifr's heapq uses functional style (returns new lists)
+# Updated to use the in-place mut-parameter API (borrow-by-default milestone)
 from sifr.test import assert_eq
 from sifr.heapq import heapify, heappush, heappop, heappop_rest, nsmallest, nlargest, heappushpop, heapreplace
 
 def main():
-    # --- heappush / heappop ---
+    # --- heappush / heappop (in-place) ---
     h1: list[int] = []
-    h1 = heappush(h1, 5)
+    heappush(h1, 5)
     assert_eq(len(h1), 1)
 
-    h1 = heappush(h1, 3)
-    h1 = heappush(h1, 7)
-    h1 = heappush(h1, 1)
+    heappush(h1, 3)
+    heappush(h1, 7)
+    heappush(h1, 1)
     assert_eq(len(h1), 4)
 
     v1: int | None = heappop(h1)
     if v1 is not None:
         assert_eq(v1, 1)
-    h1 = heappop_rest(h1)
 
     v2: int | None = heappop(h1)
     if v2 is not None:
         assert_eq(v2, 3)
-    h1 = heappop_rest(h1)
 
     v3: int | None = heappop(h1)
     if v3 is not None:
         assert_eq(v3, 5)
-    h1 = heappop_rest(h1)
 
     v4: int | None = heappop(h1)
     if v4 is not None:
         assert_eq(v4, 7)
-    h1 = heappop_rest(h1)
     assert_eq(len(h1), 0)
 
-    # --- heapify ---
+    # --- heapify (in-place) ---
     h2: list[int] = [3, 1, 4, 1, 5, 9, 2, 6]
-    h2 = heapify(h2)
+    heapify(h2)
 
     # Pop all to verify sorted order
     sorted_vals: list[int] = []
@@ -45,16 +41,15 @@ def main():
         val: int | None = heappop(h2)
         if val is not None:
             sorted_vals.append(val)
-        h2 = heappop_rest(h2)
     assert_eq(len(sorted_vals), 8)
     print(sorted_vals)
 
     # Empty heapify
     h3: list[int] = []
-    h3 = heapify(h3)
+    heapify(h3)
     assert_eq(len(h3), 0)
 
-    # --- nsmallest / nlargest ---
+    # --- nsmallest / nlargest (borrow data, return new list) ---
     data: list[int] = [4, 1, 5, 2, 3]
     sm: list[int] = nsmallest(3, data)
     assert_eq(len(sm), 3)
@@ -72,7 +67,7 @@ def main():
     assert_eq(len(lg1), 1)
     print(lg1)
 
-    # --- heappushpop ---
+    # --- heappushpop (uses functional API internally) ---
     h5: list[int] = [3, 5, 7]
     r1: int | None = heappushpop(h5, 1)
     if r1 is not None:
@@ -83,17 +78,17 @@ def main():
     if r2 is not None:
         assert_eq(r2, 3)
 
-    # --- heapreplace ---
+    # --- heapreplace (uses functional API internally) ---
     h7: list[int] = [1, 5, 7]
     r3: int | None = heapreplace(h7, 10)
     if r3 is not None:
         assert_eq(r3, 1)
 
-    print("cpython_heapq: all 18 assertions passed")
+    print("cpython_heapq: all assertions passed")
 
 # expect-stdout: [1, 1, 2, 3, 4, 5, 6, 9]
 # expect-stdout: [1, 2, 3]
 # expect-stdout: [5, 4, 3]
 # expect-stdout: [1]
 # expect-stdout: [5]
-# expect-stdout: cpython_heapq: all 18 assertions passed
+# expect-stdout: cpython_heapq: all assertions passed

--- a/crates/sifr/tests/e2e/pass/heapq_mut_param.sifr
+++ b/crates/sifr/tests/e2e/pass/heapq_mut_param.sifr
@@ -1,0 +1,21 @@
+# Test heapq in-place API -- mut parameter borrow-by-default
+from sifr.heapq import heapify, heappush, heappop
+
+def main():
+    # heapify in-place: data remains valid and usable after call
+    data: list[int] = [5, 3, 8, 1, 2, 7, 4]
+    heapify(data)
+
+    # heappush in-place: heap grows
+    heappush(data, 0)
+
+    # heappop in-place: extracts minimum
+    min_val: int | None = heappop(data)
+    if min_val is not None:
+        print(min_val)
+
+    # Verify callers retain ownership of data list
+    print(len(data))
+
+# expect-stdout: 0
+# expect-stdout: 7

--- a/crates/sifr/tests/e2e/pass/itertools_chain_own.sifr
+++ b/crates/sifr/tests/e2e/pass/itertools_chain_own.sifr
@@ -1,0 +1,23 @@
+# Test itertools chain_own -- own parameter (transfer ownership)
+from sifr.itertools import chain, chain_own
+
+def main():
+    # chain (borrow both, returns new list)
+    a: list[int] = [1, 2, 3]
+    b: list[int] = [4, 5, 6]
+    result: list[int] = chain(a, b)
+    print(result)
+    # a and b are still usable after chain (borrow semantics)
+    print(len(a))
+    print(len(b))
+
+    # chain_own (transfers ownership of both lists)
+    x: list[int] = [10, 20]
+    y: list[int] = [30, 40]
+    combined: list[int] = chain_own(x, y)
+    print(combined)
+
+# expect-stdout: [1, 2, 3, 4, 5, 6]
+# expect-stdout: 3
+# expect-stdout: 3
+# expect-stdout: [10, 20, 30, 40]

--- a/crates/sifr/tests/e2e/pass/stdlib_bisect_expanded.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_bisect_expanded.sifr
@@ -1,9 +1,9 @@
-# Test expanded sifr.bisect functions
+# Test expanded sifr.bisect functions -- in-place API
 from sifr.bisect import insort_left
 
 def main():
     data: list[int] = [1, 3, 5, 7]
-    result: list[int] = insort_left(data, 4)
-    print(result)
+    insort_left(data, 4)
+    print(data)
 
 # expect-stdout: [1, 3, 4, 5, 7]

--- a/crates/sifr/tests/e2e/pass/stdlib_bisect_generic.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_bisect_generic.sifr
@@ -1,7 +1,7 @@
 # Test generic bisect with float list
 # expect-stdout: bisect_left = 2
 # expect-stdout: bisect_right = 3
-# expect-stdout: insort = [1.0, 2.0, 2.5, 3.0, 4.0, 5.0]
+# expect-stdout: [1.0, 2.0, 2.5, 3.0, 4.0, 5.0]
 
 from sifr.bisect import bisect_left, bisect_right, insort_left
 
@@ -9,5 +9,5 @@ def main():
     data: list[float] = [1.0, 2.0, 3.0, 4.0, 5.0]
     print("bisect_left = " + str(bisect_left(data, 2.5)))
     print("bisect_right = " + str(bisect_right(data, 3.0)))
-    result: list[float] = insort_left(data, 2.5)
-    print("insort = " + str(result))
+    insort_left(data, 2.5)
+    print(data)

--- a/crates/sifr/tests/e2e/pass/stdlib_bisect_insort_right.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_bisect_insort_right.sifr
@@ -1,9 +1,9 @@
-# Test sifr.bisect insort_right
+# Test sifr.bisect insort_right -- in-place API
 # expect-stdout: [1, 2, 3, 3, 4, 5]
 
 from sifr.bisect import insort_right
 
 def main():
     data: list[int] = [1, 2, 3, 4, 5]
-    result: list[int] = insort_right(data, 3)
-    print(str(result))
+    insort_right(data, 3)
+    print(data)

--- a/crates/sifr/tests/e2e/pass/stdlib_collections_counter.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_collections_counter.sifr
@@ -1,4 +1,4 @@
-# Test sifr.collections Counter class — basic construction and read methods
+# Test sifr.collections Counter class — native dict[str, int] implementation
 from sifr.collections import Counter, from_list
 
 def main():
@@ -14,12 +14,27 @@ def main():
     # Total count
     print(c.total())
 
-    # Most common (top 2)
-    print(c.most_common(2))
+    # Most common (top 2) -- returns list of keys sorted by count descending
+    top2: list[str] = c.most_common(2)
+    print(top2)
+
+    # Keys and values
+    keys: list[str] = c.keys()
+    print(len(keys))
+    vals: list[int] = c.values()
+    print(len(vals))
+
+    # Increment
+    c.increment("cherry")
+    c.increment("cherry")
+    print(c.get("cherry"))
 
 # expect-stdout: 3
 # expect-stdout: 2
 # expect-stdout: 1
 # expect-stdout: 0
 # expect-stdout: 6
-# expect-stdout: [["apple",3],["banana",2]]
+# expect-stdout: ["apple", "banana"]
+# expect-stdout: 3
+# expect-stdout: 3
+# expect-stdout: 3

--- a/crates/sifr/tests/e2e/pass/stdlib_heapq.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_heapq.sifr
@@ -1,29 +1,29 @@
-# Test sifr.heapq module
+# Test sifr.heapq module -- in-place API (mut parameters)
 from sifr.heapq import heappush, heappop, heapify, nsmallest, nlargest
 
 def main():
-    # heappush and heappop
+    # In-place heappush and heappop (mut params)
     heap: list[int] = []
-    heap = heappush(heap, 5)
-    heap = heappush(heap, 1)
-    heap = heappush(heap, 3)
+    heappush(heap, 5)
+    heappush(heap, 1)
+    heappush(heap, 3)
     val: int | None = heappop(heap)
     if val is not None:
         print(val)
 
-    # heapify
+    # In-place heapify (mut param)
     data: list[int] = [4, 2, 7, 1, 5]
-    data = heapify(data)
+    heapify(data)
     top: int | None = heappop(data)
     if top is not None:
         print(top)
 
-    # nsmallest
+    # nsmallest (borrows data, returns new list)
     items: list[int] = [9, 3, 7, 1, 5]
     small: list[int] = nsmallest(3, items)
     print(small)
 
-    # nlargest
+    # nlargest (borrows data, returns new list)
     big: list[int] = nlargest(2, items)
     print(big)
 

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -763,6 +763,10 @@ struct RustEmitter {
     /// Set of parameter names that are borrowed (&T) in the current function.
     /// Used to emit dereference (*name) in comparisons where &String != String.
     borrowed_params: HashSet<String>,
+    /// Set of parameter names that are mutably borrowed (&mut T) in the current function.
+    /// Used to avoid double-borrowing: when a &mut param is passed to another &mut param,
+    /// we must NOT emit `&mut name` (it's already &mut T); just pass `name` directly.
+    mut_borrowed_params: HashSet<String>,
     /// Map of module_name -> set of names that are intrinsic re-exports (from _sifr.*)
     /// Used to distinguish intrinsic function calls from pure Sifr function calls
     stdlib_intrinsic_names: HashMap<String, HashSet<String>>,
@@ -810,6 +814,7 @@ impl RustEmitter {
             module_constants: HashMap::new(),
             generic_classes: HashSet::new(),
             borrowed_params: HashSet::new(),
+            mut_borrowed_params: HashSet::new(),
             stdlib_intrinsic_names: HashMap::new(),
             generator_functions: HashSet::new(),
             imported_stdlib_names: HashMap::new(),
@@ -1910,9 +1915,28 @@ impl RustEmitter {
                     self.write(" {\n");
                     self.indent += 1;
 
+                    // Track borrowed/mut-borrowed params for correct key-ref and borrow-prefix logic
+                    self.borrowed_params.clear();
+                    self.mut_borrowed_params.clear();
+                    for param in &method.params {
+                        if param.convention == ParamConvention::Borrow
+                            && param.ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                        {
+                            self.borrowed_params.insert(param.name.clone());
+                        }
+                        if param.convention == ParamConvention::MutBorrow
+                            && param.ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                        {
+                            self.mut_borrowed_params.insert(param.name.clone());
+                        }
+                    }
+
                     for stmt in &method.body {
                         self.emit_stmt(stmt);
                     }
+
+                    self.borrowed_params.clear();
+                    self.mut_borrowed_params.clear();
 
                     self.indent -= 1;
                     self.write_indent();
@@ -1940,6 +1964,7 @@ impl RustEmitter {
 
         // Track borrowed parameters for dereference in comparisons
         self.borrowed_params.clear();
+        self.mut_borrowed_params.clear();
         // Track Callable-typed params/locals so we can emit correct borrow prefixes when calling them
         self.callable_var_conventions.clear();
         for param in &func.params {
@@ -1947,6 +1972,11 @@ impl RustEmitter {
                 && param.ty.ownership() != sifr_type_system::OwnershipKind::Copy
             {
                 self.borrowed_params.insert(param.name.clone());
+            }
+            if param.convention == ParamConvention::MutBorrow
+                && param.ty.ownership() != sifr_type_system::OwnershipKind::Copy
+            {
+                self.mut_borrowed_params.insert(param.name.clone());
             }
             // Register Callable-typed params for convention-aware call emission
             if let Type::Callable(ref param_types, ref conventions, _) = param.ty {
@@ -3225,6 +3255,55 @@ impl RustEmitter {
                 self.emit_expr(value);
                 self.write(";\n");
             }
+            HirStmt::AttributeSubscriptAssign { object, field, index, value, field_ty } => {
+                self.write_indent();
+                let field_access = format!("{}.{}", object, field);
+                match field_ty {
+                    Type::List(_) => {
+                        // self.field[i] = val -> bounds-checked assignment
+                        self.write("{ let __idx = ");
+                        self.emit_expr(index);
+                        self.write(" as usize; if let Some(__elem) = ");
+                        self.write(&field_access);
+                        self.write(".get_mut(__idx) { *__elem = ");
+                        self.emit_expr(value);
+                        self.write("; } }\n");
+                    }
+                    Type::Dict(ref key_ty, _) => {
+                        // self.field[key] = val -> self.field.insert(key_owned, val)
+                        // For string keys: if key is a borrowed param (&String), we clone it for owned insert.
+                        self.write(&field_access);
+                        self.write(".insert(");
+                        if matches!(key_ty.as_ref(), Type::Str) {
+                            // String key: emit key with .clone() if it's a borrowed param
+                            if let HirExpr::Name { name, .. } = index {
+                                if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()) {
+                                    self.emit_expr(index);
+                                    self.write(".clone()");
+                                } else {
+                                    self.emit_expr(index);
+                                }
+                            } else {
+                                self.emit_expr(index);
+                            }
+                        } else {
+                            self.emit_expr(index);
+                        }
+                        self.write(", ");
+                        self.emit_expr(value);
+                        self.write(");\n");
+                    }
+                    _ => {
+                        // Fallback: direct subscript
+                        self.write(&field_access);
+                        self.write("[");
+                        self.emit_expr(index);
+                        self.write("] = ");
+                        self.emit_expr(value);
+                        self.write(";\n");
+                    }
+                }
+            }
             HirStmt::Delete { object, index } => {
                 let obj_ty = object.ty();
                 self.write_indent();
@@ -3856,7 +3935,18 @@ impl RustEmitter {
                 if args.len() >= 2 {
                     self.emit_expr(&args[0]);
                     self.write(" as usize, ");
+                    // If the value arg is a borrowed/mut-borrowed param with Move ownership,
+                    // we need to clone it since Vec::insert requires an owned value.
+                    let needs_clone = if let HirExpr::Name { name, ty } = &args[1] {
+                        (self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()))
+                            && ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                    } else {
+                        false
+                    };
                     self.emit_expr(&args[1]);
+                    if needs_clone {
+                        self.write(".clone()");
+                    }
                 }
                 self.write(")");
             }
@@ -4203,9 +4293,22 @@ impl RustEmitter {
         // This handles the case where a Callable call passes a borrowed param:
         //   fn apply(f: Callable[[list[int]], int], items: &Vec<i64>) { f(items) }
         // Here items is already &Vec<i64>, so we pass it as-is (no extra &).
+        //
+        // Similarly, if the argument is already a mutably borrowed parameter (&mut T),
+        // don't add another &mut. E.g.:
+        //   fn heapify(data: &mut Vec<i64>) { _sift_down(data, 0, n); }
+        // Here data is already &mut Vec<i64>; passing &mut data would be &&mut Vec<i64> error.
         if let Some(name) = arg_name {
             if self.borrowed_params.contains(name) && convention == ParamConvention::Borrow {
                 return; // already &T, no additional borrow needed
+            }
+            if self.mut_borrowed_params.contains(name) {
+                if convention == ParamConvention::MutBorrow {
+                    return; // already &mut T, no additional &mut needed
+                }
+                if convention == ParamConvention::Borrow {
+                    return; // &mut T -> &T is implicit reborrow in Rust; no extra & needed
+                }
             }
         }
         match convention {
@@ -4948,8 +5051,9 @@ impl RustEmitter {
                 let obj_ty = object.ty();
                 match obj_ty {
                     Type::Dict(_, _) => {
-                        // Safe dict indexing: d[key] -> d.get(&key).cloned()
-                        // Returns Option<V> which maps to our V | None union
+                        // Safe dict indexing: d[key] -> d.get(key_ref).cloned()
+                        // For self.field dict, we don't need to clone the field -- just borrow it.
+                        self.suppress_field_clone = true;
                         self.emit_expr(object);
                         self.write(".get(");
                         self.emit_key_ref_expr(index);
@@ -6259,6 +6363,26 @@ impl RustEmitter {
     fn emit_key_ref_expr(&mut self, expr: &HirExpr) {
         if let HirExpr::StringLiteral(val) = expr {
             self.write(&format!("{:?}", val));
+        } else if let HirExpr::Name { name, ty } = expr {
+            // If the name is already a borrowed parameter (&String or &mut String),
+            // emitting `&name` would produce `&&String` which fails Borrow<str> bounds.
+            // For borrowed string params, emit `name.as_str()` or just `name` (deref coerces).
+            if (self.borrowed_params.contains(name.as_str())
+                || self.mut_borrowed_params.contains(name.as_str()))
+                && matches!(ty, Type::Str)
+            {
+                // already &String -- deref-coerces to &str via as_str()
+                self.write(name);
+                self.write(".as_str()");
+            } else if self.borrowed_params.contains(name.as_str())
+                || self.mut_borrowed_params.contains(name.as_str())
+            {
+                // already a reference -- pass directly (no extra &)
+                self.emit_expr(expr);
+            } else {
+                self.write("&");
+                self.emit_expr(expr);
+            }
         } else {
             self.write("&");
             self.emit_expr(expr);
@@ -6547,7 +6671,9 @@ fn collect_string_concat_parts<'a>(expr: &'a HirExpr, parts: &mut Vec<&'a HirExp
 fn body_contains_field_assign_codegen(stmts: &[HirStmt]) -> bool {
     stmts.iter().any(|s| {
         match s {
-            HirStmt::FieldAssign { .. } | HirStmt::AttributeAugAssign { .. } => true,
+            HirStmt::FieldAssign { .. }
+            | HirStmt::AttributeAugAssign { .. }
+            | HirStmt::AttributeSubscriptAssign { .. } => true,
             HirStmt::If { then_body, elif_clauses, else_body, .. } => {
                 body_contains_field_assign_codegen(then_body)
                     || elif_clauses.iter().any(|(_, body)| body_contains_field_assign_codegen(body))

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -203,6 +203,14 @@ pub enum HirStmt {
         op: String,
         value: HirExpr,
     },
+    /// Subscript assignment on an attribute: self.field[key] = val
+    AttributeSubscriptAssign {
+        object: String,
+        field: String,
+        index: HirExpr,
+        value: HirExpr,
+        field_ty: Type,
+    },
     /// Delete statement: del d[key] or del a[i]
     Delete {
         object: HirExpr,

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -2609,6 +2609,48 @@ fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
                 object_ty: obj_ty,
             });
         }
+        // Handle attribute subscript assignment: self.field[key] = val
+        if let Expr::Attribute(attr) = sub.value.as_ref() {
+            let obj_name = match attr.value.as_ref() {
+                Expr::Name(n) => n.id.to_string(),
+                _ => {
+                    ctx.error("subscript assignment target must be a simple name".to_string());
+                    return None;
+                }
+            };
+            let field_name = attr.attr.to_string();
+            // Look up field type from the object's class definition
+            let field_ty = ctx.scope.lookup(&obj_name)
+                .and_then(|info| {
+                    let obj_ty = info.effective_type();
+                    // The object may be typed as Type::Class directly (e.g. `self`)
+                    // or as Type::Unknown for unresolved types.
+                    if let Type::Class { fields, .. } = obj_ty {
+                        fields.iter().find(|(n, _)| n == &field_name).map(|(_, t)| t.clone())
+                    } else if let Type::Class { name: class_name, .. } = obj_ty {
+                        // Class by name reference
+                        ctx.class_types.get(class_name).and_then(|class_ty| {
+                            if let Type::Class { fields, .. } = class_ty {
+                                fields.iter().find(|(n, _)| n == &field_name).map(|(_, t)| t.clone())
+                            } else {
+                                None
+                            }
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(Type::Unknown);
+            let index = lower_expr(&sub.slice, ctx)?;
+            let value = lower_expr(&assign.value, ctx)?;
+            return Some(HirStmt::AttributeSubscriptAssign {
+                object: obj_name,
+                field: field_name,
+                index,
+                value,
+                field_ty,
+            });
+        }
         let obj_name = match sub.value.as_ref() {
             Expr::Name(n) => n.id.to_string(),
             _ => {

--- a/demos/milestone_borrow_stdlib_demo/borrow_stdlib_demo.sifr
+++ b/demos/milestone_borrow_stdlib_demo/borrow_stdlib_demo.sifr
@@ -1,0 +1,161 @@
+# milestone_borrow_stdlib demo
+# Demonstrates Sifr's borrow-by-default model applied to the standard library.
+#
+# Three ownership conventions:
+#   (default)    -- borrow: caller retains ownership, function reads only
+#   mut param    -- mutable borrow: function modifies in-place, caller retains ownership
+#   own param    -- ownership transfer: function consumes the value
+
+from sifr.heapq import heapify, heappush, heappop, nsmallest, nlargest
+from sifr.bisect import bisect_left, bisect_right, insort_left, insort_right
+from sifr.itertools import chain, chain_own
+from sifr.collections import Counter, from_list
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 1: heapq -- in-place operations with mut parameters
+# ─────────────────────────────────────────────────────────────────────────────
+
+def demo_heapq() -> None:
+    print("=== Section 1: heapq with mut params ===")
+
+    # heapify(mut data) -- converts list to min-heap in-place
+    data: list[int] = [5, 3, 8, 1, 2, 7, 4]
+    heapify(data)
+    # data is now a valid min-heap (root is the minimum)
+    print("heapified (min at root):")
+    min_val: int | None = data[0]
+    if min_val is not None:
+        print(min_val)  # prints 1
+
+    # heappush(mut heap, item) -- push onto heap in-place
+    heappush(data, 0)
+    print("after push(0), new min:")
+    new_min: int | None = data[0]
+    if new_min is not None:
+        print(new_min)  # prints 0
+
+    # heappop(mut heap) -- pop minimum in-place
+    popped: int | None = heappop(data)
+    if popped is not None:
+        print("popped:")
+        print(popped)  # prints 0
+
+    # data is still owned and usable by caller
+    print("remaining size:")
+    print(len(data))  # prints 7
+
+    # nsmallest / nlargest: borrow data, return new list
+    items: list[int] = [9, 3, 7, 1, 5, 6, 2, 8, 4]
+    small3: list[int] = nsmallest(3, items)
+    large3: list[int] = nlargest(3, items)
+    print("3 smallest:")
+    print(small3)
+    print("3 largest:")
+    print(large3)
+    # items is still intact (borrowed, not consumed)
+    print("items still valid, length:")
+    print(len(items))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 2: bisect -- in-place sorted insert with mut parameters
+# ─────────────────────────────────────────────────────────────────────────────
+
+def demo_bisect() -> None:
+    print("=== Section 2: bisect insort with mut params ===")
+
+    sorted_ints: list[int] = [1, 3, 5, 7, 9]
+
+    # bisect_left / bisect_right: borrow list, return insertion position
+    pos_left: int = bisect_left(sorted_ints, 6)
+    pos_right: int = bisect_right(sorted_ints, 5)
+    print("insert 6 at position (left):")
+    print(pos_left)
+    print("insert after 5 at position (right):")
+    print(pos_right)
+
+    # insort_left(mut a, x): insert in-place, maintaining sorted order
+    insort_left(sorted_ints, 6)
+    print("after insort_left(6):")
+    print(sorted_ints)
+
+    # insort_right(mut a, x): insert in-place (after duplicates)
+    data: list[int] = [1, 2, 2, 3]
+    insort_right(data, 2)
+    print("after insort_right(2) with duplicates:")
+    print(data)
+
+    # Caller retains ownership of sorted_ints -- can insert more
+    insort_left(sorted_ints, 0)
+    insort_right(sorted_ints, 10)
+    print("after more inserts:")
+    print(sorted_ints)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 3: itertools -- chain (borrow) vs chain_own (ownership transfer)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def demo_itertools() -> None:
+    print("=== Section 3: itertools chain vs chain_own ===")
+
+    a: list[int] = [1, 2, 3]
+    b: list[int] = [4, 5, 6]
+
+    # chain(a, b): borrows both, returns a new combined list
+    # a and b remain usable after the call
+    result: list[int] = chain(a, b)
+    print("chain (borrow both):")
+    print(result)
+    print("a still usable:")
+    print(len(a))
+    print("b still usable:")
+    print(len(b))
+
+    # chain_own(own a, own b): consumes both, returns combined list
+    # More efficient: extends a directly (no extra allocation)
+    x: list[int] = [10, 20, 30]
+    y: list[int] = [40, 50, 60]
+    combined: list[int] = chain_own(x, y)
+    print("chain_own (consume both):")
+    print(combined)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 4: Counter -- native dict[str, int] (no JSON workaround)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def demo_counter() -> None:
+    print("=== Section 4: Counter with native dict[str, int] ===")
+
+    words: list[str] = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+    c: Counter = from_list(words)
+
+    print("apple count:")
+    print(c.get("apple"))
+    print("banana count:")
+    print(c.get("banana"))
+    print("missing key returns 0:")
+    print(c.get("missing"))
+    print("total elements:")
+    print(c.total())
+
+    # In-place increment uses self.counts[key] = val + 1 (AttributeSubscriptAssign)
+    c.increment("cherry")
+    c.increment("cherry")
+    print("cherry after 2 increments:")
+    print(c.get("cherry"))
+
+    # most_common returns top keys by count
+    top: list[str] = c.most_common(1)
+    print("top 1 most common:")
+    print(top)
+
+    # keys and values
+    keys: list[str] = c.keys()
+    print("unique keys count:")
+    print(len(keys))
+
+def main() -> None:
+    demo_heapq()
+    demo_bisect()
+    demo_itertools()
+    demo_counter()
+    print("=== milestone_borrow_stdlib demo complete ===")

--- a/lib/sifr/bisect.sifr
+++ b/lib/sifr/bisect.sifr
@@ -1,4 +1,16 @@
 # sifr.bisect — Array bisection algorithm (pure Sifr, generic)
+#
+# Binary search functions:
+#   bisect_left(a, x) -> int   -- index for inserting x before any existing entries
+#   bisect_right(a, x) -> int  -- index for inserting x after any existing entries
+#
+# In-place sorted-insert (borrow-by-default with `mut`):
+#   insort_left(mut a, x)    -- insert x into sorted list a in-place (left variant)
+#   insort_right(mut a, x)   -- insert x into sorted list a in-place (right variant)
+#
+# Functional sorted-insert (backward compatibility):
+#   insort_left_copy(a, x) -> list   -- returns new sorted list
+#   insort_right_copy(a, x) -> list  -- returns new sorted list
 T = TypeVar("T")
 
 def bisect_left(a: list[T], x: T) -> int:
@@ -31,7 +43,21 @@ def bisect_right(a: list[T], x: T) -> int:
             lo = mid + 1
     return lo
 
-def insort_left(a: list[T], x: T) -> list[T]:
+# ── In-place API (mut parameters) ────────────────────────────────────────────
+
+def insort_left(mut a: list[T], x: T) -> None:
+    # Insert x into sorted list a in-place (left/stable position). O(n) time.
+    pos: int = bisect_left(a, x)
+    a.insert(pos, x)
+
+def insort_right(mut a: list[T], x: T) -> None:
+    # Insert x into sorted list a in-place (right position). O(n) time.
+    pos: int = bisect_right(a, x)
+    a.insert(pos, x)
+
+# ── Functional API (backward compatibility) ───────────────────────────────────
+
+def insort_left_copy(a: list[T], x: T) -> list[T]:
     pos: int = bisect_left(a, x)
     result: list[T] = []
     i: int = 0
@@ -46,7 +72,7 @@ def insort_left(a: list[T], x: T) -> list[T]:
         result.append(x)
     return result
 
-def insort_right(a: list[T], x: T) -> list[T]:
+def insort_right_copy(a: list[T], x: T) -> list[T]:
     pos: int = bisect_right(a, x)
     result: list[T] = []
     i: int = 0

--- a/lib/sifr/collections.sifr
+++ b/lib/sifr/collections.sifr
@@ -1,32 +1,89 @@
 # sifr.collections — Extended collection types
-from _sifr.collections import new_set, set_from_list, set_add, set_contains, set_remove, set_len, set_union, set_intersection, counter_from_list, counter_get, counter_most_common, counter_total, counter_values, counter_keys, counter_items, counter_increment, defaultdict_new, defaultdict_get, defaultdict_set
+from _sifr.collections import new_set, set_from_list, set_add, set_contains, set_remove, set_len, set_union, set_intersection, defaultdict_new, defaultdict_get, defaultdict_set
 
 class Counter:
-    data: str
+    # A multiset (bag) mapping elements to their counts.
+    # Backed by a native dict[str, int] field.
+    # Methods that modify counts use self.counts[key] = val (in-place dict mutation).
+    counts: dict[str, int]
 
-    def __init__(self, data: str):
-        self.data = data
+    def __init__(self, counts: dict[str, int]):
+        self.counts = counts
 
     def get(self, key: str) -> int:
-        return counter_get(self.data, key)
-
-    def most_common(self, n: int) -> str:
-        return counter_most_common(self.data, n)
-
-    def total(self) -> int:
-        return counter_total(self.data)
-
-    def values(self) -> list[int]:
-        return counter_values(self.data)
-
-    def keys(self) -> list[str]:
-        return counter_keys(self.data)
-
-    def items(self) -> str:
-        return counter_items(self.data)
+        val: int | None = self.counts[key]
+        if val is not None:
+            return val
+        return 0
 
     def increment(self, key: str) -> None:
-        self.data = counter_increment(self.data, key)
+        val: int | None = self.counts[key]
+        if val is not None:
+            self.counts[key] = val + 1
+        else:
+            self.counts[key] = 1
+
+    def total(self) -> int:
+        total: int = 0
+        for count in self.counts.values():
+            total = total + count
+        return total
+
+    def most_common(self, n: int) -> list[str]:
+        # Return top-n keys sorted by count descending.
+        # Uses a simple selection sort on the keys.
+        all_keys: list[str] = self.counts.keys()
+        # Collect and sort by count descending (bubble sort for simplicity)
+        result: list[str] = []
+        for k in all_keys:
+            result.append(k)
+        # Sort by count descending (bubble sort)
+        sz: int = len(result)
+        i: int = 0
+        while i < sz:
+            j: int = i + 1
+            while j < sz:
+                ki: str | None = result[i]
+                kj: str | None = result[j]
+                if ki is not None:
+                    if kj is not None:
+                        ci: int | None = self.counts[ki]
+                        cj: int | None = self.counts[kj]
+                        ci_val: int = 0
+                        cj_val: int = 0
+                        if ci is not None:
+                            ci_val = ci
+                        if cj is not None:
+                            cj_val = cj
+                        if cj_val > ci_val:
+                            result[i] = kj
+                            result[j] = ki
+                j = j + 1
+            i = i + 1
+        # Take top n
+        top: list[str] = []
+        count: int = 0
+        while count < n:
+            if count >= len(result):
+                return top
+            val: str | None = result[count]
+            if val is not None:
+                top.append(val)
+            count = count + 1
+        return top
+
+    def keys(self) -> list[str]:
+        return self.counts.keys()
+
+    def values(self) -> list[int]:
+        return self.counts.values()
 
 def from_list(items: list[str]) -> Counter:
-    return Counter(counter_from_list(items))
+    counts: dict[str, int] = {}
+    for item in items:
+        val: int | None = counts[item]
+        if val is not None:
+            counts[item] = val + 1
+        else:
+            counts[item] = 1
+    return Counter(counts)

--- a/lib/sifr/heapq.sifr
+++ b/lib/sifr/heapq.sifr
@@ -1,6 +1,104 @@
 # sifr.heapq — Heap queue algorithm (pure Sifr)
-# Implements a min-heap. Functions return new lists (functional style)
-# to work with Sifr's borrow-by-default parameter convention.
+# Implements a min-heap.
+#
+# In-place API (borrow-by-default with `mut`):
+#   heapify(mut data)   -- convert list to a min-heap in-place
+#   heappush(mut heap, item) -- push item onto heap in-place
+#   heappop(mut heap) -> item | None -- pop smallest item, heapify in-place
+#
+# Functional API (for backward compatibility):
+#   heapify_copy(data) -> list   -- returns a new heap (copy)
+#   heappush_copy(heap, item) -> list
+#   heappop_val(heap) -> item | None   -- returns only the popped value
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+def _sift_down(mut data: list[int], pos: int, n: int) -> None:
+    done: bool = False
+    while not done:
+        smallest: int = pos
+        left: int = 2 * pos + 1
+        right: int = 2 * pos + 2
+        if left < n:
+            s_val: int | None = data[smallest]
+            l_val: int | None = data[left]
+            if s_val is not None:
+                if l_val is not None:
+                    if l_val < s_val:
+                        smallest = left
+        if right < n:
+            s_val2: int | None = data[smallest]
+            r_val: int | None = data[right]
+            if s_val2 is not None:
+                if r_val is not None:
+                    if r_val < s_val2:
+                        smallest = right
+        if smallest == pos:
+            done = True
+        else:
+            tmp_pos: int | None = data[pos]
+            tmp_sm: int | None = data[smallest]
+            if tmp_pos is not None:
+                if tmp_sm is not None:
+                    data[pos] = tmp_sm
+                    data[smallest] = tmp_pos
+            pos = smallest
+
+def _sift_up(mut heap: list[int], pos: int) -> None:
+    done: bool = False
+    while not done:
+        if pos <= 0:
+            done = True
+        else:
+            parent: int = (pos - 1) // 2
+            p_val: int | None = heap[parent]
+            c_val: int | None = heap[pos]
+            if p_val is not None:
+                if c_val is not None:
+                    if c_val < p_val:
+                        heap[parent] = c_val
+                        heap[pos] = p_val
+                        pos = parent
+                    else:
+                        done = True
+                else:
+                    done = True
+            else:
+                done = True
+
+# ── In-place API (mut parameters) ────────────────────────────────────────────
+
+def heapify(mut data: list[int]) -> None:
+    """Convert list to a min-heap in-place. O(n) time."""
+    n: int = len(data)
+    i: int = n // 2 - 1
+    while i >= 0:
+        _sift_down(data, i, n)
+        i = i - 1
+
+def heappush(mut heap: list[int], item: int) -> None:
+    """Push item onto the heap in-place. O(log n) time."""
+    heap.append(item)
+    pos: int = len(heap) - 1
+    _sift_up(heap, pos)
+
+def heappop(mut heap: list[int]) -> int | None:
+    """Pop and return the smallest item. Heap is modified in-place. O(log n) time.
+    Returns None if the heap is empty."""
+    n: int = len(heap)
+    if n == 0:
+        return None
+    top: int | None = heap[0]
+    last: int | None = heap[n - 1]
+    heap.pop()
+    n2: int = len(heap)
+    if n2 > 0:
+        if last is not None:
+            heap[0] = last
+        _sift_down(heap, 0, n2)
+    return top
+
+# ── Functional API (backward compatibility) ───────────────────────────────────
 
 def _swap(data: list[int], i: int, j: int) -> list[int]:
     result: list[int] = []
@@ -27,118 +125,36 @@ def _swap(data: list[int], i: int, j: int) -> list[int]:
         k = k + 1
     return result
 
-def heapify(data: list[int]) -> list[int]:
+def heapify_copy(data: list[int]) -> list[int]:
     result: list[int] = []
     for val in data:
         result.append(val)
-    n: int = len(result)
-    i: int = n // 2 - 1
-    while i >= 0:
-        # sift down at position i
-        pos: int = i
-        done: bool = False
-        while not done:
-            smallest: int = pos
-            left: int = 2 * pos + 1
-            right: int = 2 * pos + 2
-            if left < n:
-                s_val: int | None = result[smallest]
-                l_val: int | None = result[left]
-                if s_val is not None:
-                    if l_val is not None:
-                        if l_val < s_val:
-                            smallest = left
-            if right < n:
-                s_val2: int | None = result[smallest]
-                r_val: int | None = result[right]
-                if s_val2 is not None:
-                    if r_val is not None:
-                        if r_val < s_val2:
-                            smallest = right
-            if smallest == pos:
-                done = True
-            else:
-                result = _swap(result, pos, smallest)
-                pos = smallest
-        i = i - 1
+    heapify(result)
     return result
 
-def heappush(heap: list[int], item: int) -> list[int]:
+def heappush_copy(heap: list[int], item: int) -> list[int]:
     result: list[int] = []
     for val in heap:
         result.append(val)
-    result.append(item)
-    # sift up
-    pos: int = len(result) - 1
-    while pos > 0:
-        parent: int = (pos - 1) // 2
-        p_val: int | None = result[parent]
-        c_val: int | None = result[pos]
-        if p_val is not None:
-            if c_val is not None:
-                if c_val < p_val:
-                    result = _swap(result, parent, pos)
-                    pos = parent
-                else:
-                    return result
-            else:
-                return result
-        else:
-            return result
+    heappush(result, item)
     return result
 
-def heappop(heap: list[int]) -> int | None:
+def heappop_val(heap: list[int]) -> int | None:
+    """Return the smallest item without modifying the original heap.
+    Creates a temporary copy."""
     if len(heap) == 0:
         return None
-    top: int | None = heap[0]
-    if top is not None:
-        return top
-    return None
+    tmp: list[int] = []
+    for val in heap:
+        tmp.append(val)
+    return heappop(tmp)
 
 def heappop_rest(heap: list[int]) -> list[int]:
-    n: int = len(heap)
-    if n <= 1:
-        result: list[int] = []
-        return result
-    # Put last element at root, remove last
-    last: int | None = heap[n - 1]
-    result2: list[int] = []
-    if last is not None:
-        result2.append(last)
-    i: int = 1
-    while i < n - 1:
-        val: int | None = heap[i]
-        if val is not None:
-            result2.append(val)
-        i = i + 1
-    # sift down at position 0
-    pos: int = 0
-    done: bool = False
-    sz: int = len(result2)
-    while not done:
-        smallest: int = pos
-        left: int = 2 * pos + 1
-        right: int = 2 * pos + 2
-        if left < sz:
-            s_val: int | None = result2[smallest]
-            l_val: int | None = result2[left]
-            if s_val is not None:
-                if l_val is not None:
-                    if l_val < s_val:
-                        smallest = left
-        if right < sz:
-            s_val2: int | None = result2[smallest]
-            r_val: int | None = result2[right]
-            if s_val2 is not None:
-                if r_val is not None:
-                    if r_val < s_val2:
-                        smallest = right
-        if smallest == pos:
-            done = True
-        else:
-            result2 = _swap(result2, pos, smallest)
-            pos = smallest
-    return result2
+    result: list[int] = []
+    for val in heap:
+        result.append(val)
+    heappop(result)
+    return result
 
 def heapreplace(heap: list[int], item: int) -> int | None:
     if len(heap) == 0:
@@ -148,7 +164,7 @@ def heapreplace(heap: list[int], item: int) -> int | None:
     if top is not None:
         result = top
     rest: list[int] = heappop_rest(heap)
-    rest = heappush(rest, item)
+    rest = heappush_copy(rest, item)
     return result
 
 def heappushpop(heap: list[int], item: int) -> int | None:
@@ -158,12 +174,12 @@ def heappushpop(heap: list[int], item: int) -> int | None:
     if top is not None:
         if item <= top:
             return item
-    pushed: list[int] = heappush(heap, item)
-    val: int | None = heappop(pushed)
+    pushed: list[int] = heappush_copy(heap, item)
+    val: int | None = heappop_val(pushed)
     return val
 
 def nsmallest(n: int, data: list[int]) -> list[int]:
-    heap: list[int] = heapify(data)
+    heap: list[int] = heapify_copy(data)
     result: list[int] = []
     count: int = 0
     while count < n:
@@ -172,7 +188,6 @@ def nsmallest(n: int, data: list[int]) -> list[int]:
         val: int | None = heappop(heap)
         if val is not None:
             result.append(val)
-        heap = heappop_rest(heap)
         count = count + 1
     return result
 

--- a/lib/sifr/itertools.sifr
+++ b/lib/sifr/itertools.sifr
@@ -8,13 +8,22 @@
 # expressions or for-loop-based generators.
 
 def chain(a: list[int], b: list[int]) -> list[int]:
-    # Eager: uses for-loop iteration (generator codegen requires while+yield)
+    # Borrow both lists and return a new combined list.
+    # Callers retain ownership of a and b after the call.
     result: list[int] = []
     for val in a:
         result.append(val)
     for val2 in b:
         result.append(val2)
     return result
+
+def chain_own(own a: list[int], own b: list[int]) -> list[int]:
+    # Consume both lists and return the combined result.
+    # Ownership of a and b is transferred -- they cannot be used after this call.
+    # More efficient than chain() because it extends a directly (no extra allocation).
+    for val in b:
+        a.append(val)
+    return a
 
 def chain_str(a: list[str], b: list[str]) -> list[str]:
     # Eager: uses for-loop iteration
@@ -24,6 +33,12 @@ def chain_str(a: list[str], b: list[str]) -> list[str]:
     for val2 in b:
         result.append(val2)
     return result
+
+def chain_str_own(own a: list[str], own b: list[str]) -> list[str]:
+    # Consume both string lists and return the combined result.
+    for val in b:
+        a.append(val)
+    return a
 
 def repeat_val(value: int, times: int) -> list[int]:
     # Lazy generator: simple while+yield pattern


### PR DESCRIPTION
## Summary

Closes #171 (milestone_borrow_stdlib: Stdlib Ownership Patterns)

This PR exercises Sifr's borrow-by-default model in real standard library code, proving the ownership system works end-to-end in practical programs. It also introduces several compiler improvements needed to support `mut` and `own` parameters in more complex scenarios.

## Compiler Improvements

### `mut_borrowed_params` tracking
- Added `mut_borrowed_params: HashSet<String>` to `RustEmitter`, parallel to `borrowed_params` for `&T` params.
- Prevents double-borrows: when a `mut`-param is passed to another `mut` or `borrow` param, the extra `&`/`&mut` prefix is suppressed (already a reference).
- Applied in both `emit_function` and `emit_class_method`.

### `AttributeSubscriptAssign` HIR node (new)
- Supports `self.field[key] = val` inside class methods (e.g., `self.counts["key"] = val + 1`).
- Lowering detects `Expr::Attribute` as subscript target; codegen emits `self.field.insert(key, val)` for dicts.
- `body_contains_field_assign_codegen` updated so methods with field subscript mutation get `&mut self`.

### Dict field access fixes
- `emit_key_ref_expr`: borrowed/mut-borrowed `String` params now emit `key.as_str()` instead of `&key` (prevents `&&String` errors).
- Dict index access (`self.counts[key]`): suppresses spurious `.clone()` on field access when just borrowing for `.get()`.
- `list.insert()` codegen: appends `.clone()` when value arg is a borrowed param with Move ownership.

## Standard Library Changes

### `heapq.sifr` — in-place API with `mut` parameters
- `heapify(mut data)`, `heappush(mut heap, item)`, `heappop(mut heap)`: O(n)/O(log n) in-place heap operations.
- Functional API preserved as `heapify_copy`, `heappush_copy`, `heappop_val`.

### `bisect.sifr` — in-place sorted insert with `mut` parameters
- `insort_left(mut a, x)` and `insort_right(mut a, x)`: generic in-place sorted insert.
- Old functional variants preserved as `insort_left_copy` / `insort_right_copy`.

### `itertools.sifr` — `chain_own` with `own` parameters
- `chain_own(own a, own b)`: consume both lists and extend `a` with `b` (no extra allocation).

### `collections.sifr` — Counter with native `dict[str, int]`
- Replaces `Counter.data: str` (JSON string workaround) with `Counter.counts: dict[str, int]`.
- `increment()`, `get()`, `total()`, `keys()`, `values()`, `most_common()` all use real dict ops.

## Tests

- All 262 E2E tests pass (0 failures).
- New tests: `heapq_mut_param`, `bisect_insort_mut`, `itertools_chain_own`, `counter_dict_native`.
- Updated 8 existing stdlib E2E tests to use the new in-place APIs.

## Demo

`demos/milestone_borrow_stdlib_demo/borrow_stdlib_demo.sifr` showcases all four sections with running output.

## Test plan

- [x] All 262 E2E tests pass
- [x] Demo runs successfully and shows correct output for all 4 sections
- [x] `cargo build` compiles with no errors

Made with [Cursor](https://cursor.com)