### PR TITLE
feat(milestone_stdlib_intrinsic_expansion): New intrinsics for existing stdlib modules

### DIFF
--- a/.cursor/plans/main/phases/11_stdlib_deepening.md
+++ b/.cursor/plans/main/phases/11_stdlib_deepening.md
@@ -76,7 +76,7 @@ status: completed
 
 ## milestone_stdlib_intrinsic_expansion: New Intrinsics for Existing Modules
 
-status: pending
+status: completed
 
 **Goal:** Add new Rust intrinsics to deepen existing stdlib modules.
 

--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -102,6 +102,7 @@ edition = "2021"
                 if !deps.contains(&"sha2 = \"0.10\"") {
                     deps.push("sha2 = \"0.10\"");
                     deps.push("md5 = \"0.7\"");
+                    deps.push("blake2 = \"0.10\"");
                 }
             }
             "sifr.encoding" | "sifr.base64" => {

--- a/crates/sifr/tests/e2e/pass/stdlib_base64_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_base64_intrinsics.sifr
@@ -1,0 +1,14 @@
+# expect-stdout: b32encode len > 0 = true
+# expect-stdout: b32decode = hello
+
+from sifr.base64 import b32encode, b32decode
+
+def main():
+    encoded: str = b32encode("hello")
+    print("b32encode len > 0 = " + str(len(encoded) > 0))
+
+    try:
+        decoded: str = b32decode(encoded)
+        print("b32decode = " + decoded)
+    except ParseError as e:
+        print("b32decode error: " + e.message)

--- a/crates/sifr/tests/e2e/pass/stdlib_hashlib_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_hashlib_intrinsics.sifr
@@ -1,0 +1,13 @@
+# expect-stdout: sha224 len = 56
+# expect-stdout: sha384 len = 96
+# expect-stdout: blake2b len = 128
+# expect-stdout: blake2s len = 64
+
+from sifr.hashlib import sha224, sha384, blake2b, blake2s
+
+def main():
+    s: str = "hello"
+    print("sha224 len = " + str(len(sha224(s))))
+    print("sha384 len = " + str(len(sha384(s))))
+    print("blake2b len = " + str(len(blake2b(s))))
+    print("blake2s len = " + str(len(blake2s(s))))

--- a/crates/sifr/tests/e2e/pass/stdlib_math_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_math_intrinsics.sifr
@@ -1,0 +1,38 @@
+# expect-stdout: erf(0) near 0 = true
+# expect-stdout: erfc(0) near 1 = true
+# expect-stdout: gamma(5) > 23.0 = true
+# expect-stdout: lgamma(5) > 3.0 = true
+# expect-stdout: frexp len = 2
+# expect-stdout: ldexp result > 0 = true
+# expect-stdout: modf len = 2
+# expect-stdout: nextafter > 1.0 = true
+# expect-stdout: ulp > 0 = true
+
+from sifr.math import erf, erfc, gamma, lgamma, frexp, ldexp, modf, nextafter, ulp
+
+def main():
+    e0: float = erf(0.0)
+    print("erf(0) near 0 = " + str(e0 < 0.001 and e0 > -0.001))
+    ec0: float = erfc(0.0)
+    print("erfc(0) near 1 = " + str(ec0 > 0.999 and ec0 < 1.001))
+
+    g: float = gamma(5.0)
+    print("gamma(5) > 23.0 = " + str(g > 23.0))
+
+    lg: float = lgamma(5.0)
+    print("lgamma(5) > 3.0 = " + str(lg > 3.0))
+
+    fp: list[float] = frexp(8.0)
+    print("frexp len = " + str(len(fp)))
+
+    ld: float = ldexp(0.5, 4)
+    print("ldexp result > 0 = " + str(ld > 0.0))
+
+    md: list[float] = modf(3.7)
+    print("modf len = " + str(len(md)))
+
+    na: float = nextafter(1.0, 2.0)
+    print("nextafter > 1.0 = " + str(na > 1.0))
+
+    u: float = ulp(1.0)
+    print("ulp > 0 = " + str(u > 0.0))

--- a/crates/sifr/tests/e2e/pass/stdlib_os_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_os_intrinsics.sifr
@@ -1,0 +1,11 @@
+# expect-stdout: pid > 0 = true
+# expect-stdout: cpu_count >= 1 = true
+
+from sifr.os import getpid, cpu_count
+
+def main():
+    pid: int = getpid()
+    print("pid > 0 = " + str(pid > 0))
+
+    cpus: int = cpu_count()
+    print("cpu_count >= 1 = " + str(cpus >= 1))

--- a/crates/sifr/tests/e2e/pass/stdlib_platform_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_platform_intrinsics.sifr
@@ -1,0 +1,15 @@
+# expect-stdout: system len > 0 = true
+# expect-stdout: machine len > 0 = true
+# expect-stdout: processor len > 0 = true
+
+from sifr.platform import system, machine, processor
+
+def main():
+    sys: str = system()
+    print("system len > 0 = " + str(len(sys) > 0))
+
+    mach: str = machine()
+    print("machine len > 0 = " + str(len(mach) > 0))
+
+    proc: str = processor()
+    print("processor len > 0 = " + str(len(proc) > 0))

--- a/crates/sifr/tests/e2e/pass/stdlib_shutil_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_shutil_intrinsics.sifr
@@ -1,0 +1,9 @@
+# expect-stdout: disk_usage len = 3
+# expect-stdout: disk_total > 0 = true
+
+from sifr.shutil import disk_usage
+
+def main():
+    usage: list[int] = disk_usage("/")
+    print("disk_usage len = " + str(len(usage)))
+    print("disk_total > 0 = " + str(usage[0] > 0))

--- a/crates/sifr/tests/e2e/pass/stdlib_time_intrinsics.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_time_intrinsics.sifr
@@ -1,0 +1,18 @@
+# expect-stdout: gmtime len > 0 = true
+# expect-stdout: localtime len > 0 = true
+# expect-stdout: strptime ok = true
+
+from sifr.time import gmtime, localtime, strptime
+
+def main():
+    gmt: str = gmtime(0.0)
+    print("gmtime len > 0 = " + str(len(gmt) > 0))
+
+    lt: str = localtime(0.0)
+    print("localtime len > 0 = " + str(len(lt) > 0))
+
+    try:
+        parsed: str = strptime("2024-01-15 10:30:00", "%Y-%m-%d %H:%M:%S")
+        print("strptime ok = " + str(len(parsed) > 0))
+    except ValueError as e:
+        print("strptime error: " + e.message)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -687,6 +687,7 @@ edition = "2021"
                     deps.push("sha2 = \"0.10\"".to_string());
                     deps.push("md5 = \"0.7\"".to_string());
                     deps.push("sha1 = \"0.10\"".to_string());
+                    deps.push("blake2 = \"0.10\"".to_string());
                 }
             }
             "sifr.encoding" | "sifr.base64" => {
@@ -6368,6 +6369,143 @@ impl RustEmitter {
                 self.write("{ let __ts = ");
                 self.emit_expr(&args[0]);
                 self.write(" as i64; chrono::DateTime::from_timestamp(__ts, 0).map(|dt| dt.format(\"%Y-%m-%dT%H:%M:%S\").to_string()).ok_or_else(|| ValueError { message: \"invalid timestamp\".to_string() }) }");
+            }
+            // sifr.math new intrinsics
+            "erf" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __t = 1.0 / (1.0 + 0.3275911 * __x.abs()); let __poly = __t * (0.254829592 + __t * (-0.284496736 + __t * (1.421413741 + __t * (-1.453152027 + __t * 1.061405429)))); let __r = 1.0 - __poly * (-__x * __x).exp(); if __x >= 0.0 { __r } else { -__r } }");
+            }
+            "erfc" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __t = 1.0 / (1.0 + 0.3275911 * __x.abs()); let __poly = __t * (0.254829592 + __t * (-0.284496736 + __t * (1.421413741 + __t * (-1.453152027 + __t * 1.061405429)))); let __r = __poly * (-__x * __x).exp(); if __x >= 0.0 { __r } else { 2.0 - __r } }");
+            }
+            "gamma" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; if __x <= 0.0 && __x == __x.floor() { f64::INFINITY } else { let __g = 7usize; let __c = [0.99999999999980993f64, 676.5203681218851, -1259.1392167224028, 771.32342877765313, -176.61502916214059, 12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7]; let __z = if __x < 0.5 { let __y = std::f64::consts::PI / ((__x * std::f64::consts::PI).sin() * { let __xn = 1.0 - __x; let mut __s = __c[0]; for __i in 1..=__g+1 { __s += __c[__i] / (__xn + __i as f64 - 1.0); } let __t2 = __xn + __g as f64 - 0.5; (2.0 * std::f64::consts::PI).sqrt() * __t2.powf(__xn - 0.5) * (-__t2).exp() * __s }); __y } else { let __xm = __x - 1.0; let mut __s = __c[0]; for __i in 1..=__g+1 { __s += __c[__i] / (__xm + __i as f64); } let __t2 = __xm + __g as f64 + 0.5; (2.0 * std::f64::consts::PI).sqrt() * __t2.powf(__xm + 0.5) * (-__t2).exp() * __s }; __z } }");
+            }
+            "lgamma" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; if __x <= 0.0 && __x == __x.floor() { f64::INFINITY } else { let __g = 7usize; let __c = [0.99999999999980993f64, 676.5203681218851, -1259.1392167224028, 771.32342877765313, -176.61502916214059, 12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7]; let __xm = if __x < 0.5 { 1.0 - __x } else { __x - 1.0 }; let mut __s = __c[0]; for __i in 1..=__g+1 { __s += __c[__i] / (__xm + __i as f64); } let __t2 = __xm + __g as f64 + 0.5; let __r = (2.0 * std::f64::consts::PI).sqrt().ln() + (__xm + 0.5) * __t2.ln() - __t2 + __s.ln(); if __x < 0.5 { (std::f64::consts::PI / ((__x * std::f64::consts::PI).sin() * __r.exp())).abs().ln() } else { __r } } }");
+            }
+            "frexp" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; if __x == 0.0 { vec![0.0f64, 0.0] } else { let __bits = __x.to_bits(); let __exp = ((__bits >> 52) & 0x7ff) as i64 - 1022; let __mant = f64::from_bits((__bits & 0x800fffffffffffff) | 0x3fe0000000000000); vec![__mant, __exp as f64] } }");
+            }
+            "ldexp" => {
+                self.write("{ let __m: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __e: i64 = ");
+                self.emit_expr(&args[1]);
+                self.write("; __m * (2.0f64).powi(__e as i32) }");
+            }
+            "modf" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __frac = __x.fract(); let __int = __x.trunc(); vec![__frac, __int] }");
+            }
+            "nextafter" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __y: f64 = ");
+                self.emit_expr(&args[1]);
+                self.write("; if __x == __y { __y } else if __x < __y { f64::from_bits(__x.to_bits() + 1) } else { f64::from_bits(__x.to_bits() - 1) } }");
+            }
+            "ulp" => {
+                self.write("{ let __x: f64 = ");
+                self.emit_expr(&args[0]);
+                self.write("; let __bits = __x.abs().to_bits(); f64::from_bits(if __bits == 0 { 1 } else { __bits & 0xfff0000000000000 }) - f64::from_bits(((__bits & 0xfff0000000000000) - 0x0010000000000000).max(0)) }");
+            }
+            // sifr.os new intrinsics
+            "chdir" => {
+                self.write("std::env::set_current_dir(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").map_err(__io_err)");
+            }
+            "getpid" => {
+                self.write("std::process::id() as i64");
+            }
+            "cpu_count" => {
+                self.write("{ let __n = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1); __n as i64 }");
+            }
+            "stat_size" => {
+                self.write("std::fs::metadata(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(").map(|m| m.len() as i64).map_err(__io_err)");
+            }
+            "which" => {
+                self.write("{ let __name = ");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write("; std::env::var(\"PATH\").ok().and_then(|__path| __path.split(':').map(|d| std::path::Path::new(d).join(__name)).find(|p| p.is_file()).map(|p| p.to_string_lossy().to_string())) }");
+            }
+            "disk_usage" => {
+                self.write("{ let __path = ");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write("; let __stat = std::fs::metadata(__path); match __stat { Ok(_) => { let __out = std::process::Command::new(\"df\").args([\"-k\", __path]).output(); match __out { Ok(__o) => { let __s = String::from_utf8_lossy(&__o.stdout); let __lines: Vec<&str> = __s.lines().collect(); if __lines.len() >= 2 { let __parts: Vec<&str> = __lines[1].split_whitespace().collect(); if __parts.len() >= 4 { let __total = __parts[1].parse::<i64>().unwrap_or(0) * 1024; let __used = __parts[2].parse::<i64>().unwrap_or(0) * 1024; let __free = __parts[3].parse::<i64>().unwrap_or(0) * 1024; vec![__total, __used, __free] } else { vec![0i64, 0, 0] } } else { vec![0i64, 0, 0] } }, Err(_) => vec![0i64, 0, 0] } }, Err(_) => vec![0i64, 0, 0] } }");
+            }
+            // sifr.hashlib new intrinsics
+            "sha224" => {
+                self.write("{ use sha2::Digest; let mut __h = sha2::Sha224::new(); __h.update(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(".as_bytes()); format!(\"{:x}\", __h.finalize()) }");
+            }
+            "sha384" => {
+                self.write("{ use sha2::Digest; let mut __h = sha2::Sha384::new(); __h.update(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(".as_bytes()); format!(\"{:x}\", __h.finalize()) }");
+            }
+            "blake2b" => {
+                self.write("{ use blake2::{Blake2b512, Digest}; let mut __h = Blake2b512::new(); __h.update(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(".as_bytes()); format!(\"{:x}\", __h.finalize()) }");
+            }
+            "blake2s" => {
+                self.write("{ use blake2::{Blake2s256, Digest}; let mut __h = Blake2s256::new(); __h.update(");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(".as_bytes()); format!(\"{:x}\", __h.finalize()) }");
+            }
+            // sifr.base64 new intrinsics
+            "b32encode" => {
+                self.write("{ let __b32_alpha = b\"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567\"; let __data = ");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write(".as_bytes(); let mut __out = String::new(); let mut __i = 0usize; while __i < __data.len() { let __b0 = __data[__i] as u64; let __b1 = if __i+1 < __data.len() { __data[__i+1] as u64 } else { 0 }; let __b2 = if __i+2 < __data.len() { __data[__i+2] as u64 } else { 0 }; let __b3 = if __i+3 < __data.len() { __data[__i+3] as u64 } else { 0 }; let __b4 = if __i+4 < __data.len() { __data[__i+4] as u64 } else { 0 }; let __buf = (__b0<<32)|(__b1<<24)|(__b2<<16)|(__b3<<8)|__b4; let __n = ((__data.len() - __i).min(5)) as u64; for __j in 0..8u64 { if __j < (__n*8+4)/5 { __out.push(__b32_alpha[((__buf >> (35 - __j*5)) & 0x1f) as usize] as char); } else { __out.push('='); } } __i += 5; } __out }");
+            }
+            "b32decode" => {
+                self.write("(|| -> Result<String, ParseError> { let __b32_alpha = b\"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567\"; let __s = ");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write("; let __s = __s.trim_end_matches('='); let mut __bits = 0u64; let mut __bit_count = 0u32; let mut __out: Vec<u8> = Vec::new(); for __c in __s.chars() { let __val = __b32_alpha.iter().position(|&b| b as char == __c.to_ascii_uppercase()).ok_or_else(|| ParseError { message: format!(\"invalid base32 char: {}\", __c) })? as u64; __bits = (__bits << 5) | __val; __bit_count += 5; if __bit_count >= 8 { __bit_count -= 8; __out.push(((__bits >> __bit_count) & 0xff) as u8); } } String::from_utf8(__out).map_err(|e| ParseError { message: e.to_string() }) })()");
+            }
+            // sifr.platform new intrinsics
+            "platform_release" => {
+                self.write("{ std::process::Command::new(\"uname\").arg(\"-r\").output().map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_default() }");
+            }
+            "platform_version" => {
+                self.write("{ std::process::Command::new(\"uname\").arg(\"-v\").output().map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_default() }");
+            }
+            "platform_processor" => {
+                self.write("std::env::consts::ARCH.to_string()");
+            }
+            // sifr.time new intrinsics
+            "strptime" => {
+                self.write("(|| -> Result<String, ValueError> { use chrono::NaiveDateTime; let __s = ");
+                self.emit_expr_as_str_ref(&args[0]);
+                self.write("; let __fmt = ");
+                self.emit_expr_as_str_ref(&args[1]);
+                self.write("; NaiveDateTime::parse_from_str(__s, __fmt).map(|dt| dt.format(\"%Y-%m-%dT%H:%M:%S\").to_string()).map_err(|e| ValueError { message: e.to_string() }) })()");
+            }
+            "gmtime" => {
+                self.write("{ use chrono::{DateTime, Utc}; let __ts = ");
+                self.emit_expr(&args[0]);
+                self.write(" as i64; DateTime::<Utc>::from_timestamp(__ts, 0).map(|dt| dt.format(\"%Y-%m-%dT%H:%M:%S\").to_string()).unwrap_or_default() }");
+            }
+            "localtime" => {
+                self.write("{ use chrono::{DateTime, Utc, Local}; let __ts = ");
+                self.emit_expr(&args[0]);
+                self.write(" as i64; DateTime::<Utc>::from_timestamp(__ts, 0).map(|dt| dt.with_timezone(&Local).format(\"%Y-%m-%dT%H:%M:%S\").to_string()).unwrap_or_default() }");
             }
             // sifr.sys extras
             "sys_exit" => {

--- a/crates/sifr_hir/src/stdlib.rs
+++ b/crates/sifr_hir/src/stdlib.rs
@@ -234,6 +234,33 @@ fn intrinsic_math() -> IntrinsicModule {
     // fsum(data: list[float]) -> float
     functions.insert("fsum".to_string(), FunctionType::all_borrow(vec![("data".to_string(), Type::List(Box::new(Type::Float)))], Type::Float));
 
+    // erf(x: float) -> float
+    functions.insert("erf".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::Float));
+
+    // erfc(x: float) -> float
+    functions.insert("erfc".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::Float));
+
+    // gamma(x: float) -> float
+    functions.insert("gamma".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::Float));
+
+    // lgamma(x: float) -> float
+    functions.insert("lgamma".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::Float));
+
+    // frexp(x: float) -> list[float] ([mantissa, exponent_as_float])
+    functions.insert("frexp".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::List(Box::new(Type::Float))));
+
+    // ldexp(m: float, e: int) -> float
+    functions.insert("ldexp".to_string(), FunctionType::all_borrow(vec![("m".to_string(), Type::Float), ("e".to_string(), Type::Int)], Type::Float));
+
+    // modf(x: float) -> list[float] ([fractional_part, integer_part])
+    functions.insert("modf".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::List(Box::new(Type::Float))));
+
+    // nextafter(x: float, y: float) -> float
+    functions.insert("nextafter".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float), ("y".to_string(), Type::Float)], Type::Float));
+
+    // ulp(x: float) -> float
+    functions.insert("ulp".to_string(), FunctionType::all_borrow(vec![("x".to_string(), Type::Float)], Type::Float));
+
     // Constants
     constants.insert("pi".to_string(), Type::Float);
     constants.insert("e".to_string(), Type::Float);
@@ -442,6 +469,18 @@ fn intrinsic_time() -> IntrinsicModule {
     // monotonic() -> float (guaranteed non-decreasing clock for timeouts)
     functions.insert("monotonic".to_string(), FunctionType::all_borrow(vec![], Type::Float));
 
+    // strptime(s: str, fmt: str) -> Result[str, ValueError] (parse time string, return ISO datetime)
+    functions.insert("strptime".to_string(), FunctionType::all_borrow(vec![
+        ("s".to_string(), Type::Str),
+        ("fmt".to_string(), Type::Str),
+    ], result_ty(Type::Str, "ValueError")));
+
+    // gmtime(epoch: float) -> str (UTC time as ISO string)
+    functions.insert("gmtime".to_string(), FunctionType::all_borrow(vec![("epoch".to_string(), Type::Float)], Type::Str));
+
+    // localtime(epoch: float) -> str (local time as ISO string)
+    functions.insert("localtime".to_string(), FunctionType::all_borrow(vec![("epoch".to_string(), Type::Float)], Type::Str));
+
     IntrinsicModule {
         functions,
         constants: HashMap::new(),
@@ -567,6 +606,24 @@ fn intrinsic_fs() -> IntrinsicModule {
     // makedirs(path: str) -> Result[None, IOError]
     functions.insert("makedirs".to_string(), FunctionType::all_borrow(vec![("path".to_string(), Type::Str)], result_ty(Type::None, "IOError")));
 
+    // chdir(path: str) -> Result[None, IOError]
+    functions.insert("chdir".to_string(), FunctionType::all_borrow(vec![("path".to_string(), Type::Str)], result_ty(Type::None, "IOError")));
+
+    // getpid() -> int
+    functions.insert("getpid".to_string(), FunctionType::all_borrow(vec![], Type::Int));
+
+    // cpu_count() -> int
+    functions.insert("cpu_count".to_string(), FunctionType::all_borrow(vec![], Type::Int));
+
+    // stat_size(path: str) -> Result[int, IOError] (file size in bytes)
+    functions.insert("stat_size".to_string(), FunctionType::all_borrow(vec![("path".to_string(), Type::Str)], result_ty(Type::Int, "IOError")));
+
+    // which(name: str) -> str | None (find executable in PATH)
+    functions.insert("which".to_string(), FunctionType::all_borrow(vec![("name".to_string(), Type::Str)], Type::Union(vec![Type::Str, Type::None])));
+
+    // disk_usage(path: str) -> list[int] ([total, used, free] in bytes)
+    functions.insert("disk_usage".to_string(), FunctionType::all_borrow(vec![("path".to_string(), Type::Str)], Type::List(Box::new(Type::Int))));
+
     IntrinsicModule {
         functions,
         constants: HashMap::new(),
@@ -640,6 +697,24 @@ fn intrinsic_crypto() -> IntrinsicModule {
             ("mu".to_string(), Type::Float),
             ("sigma".to_string(), Type::Float),
         ], Type::Float));
+
+    // sha224(s: str) -> str (hex digest)
+    functions.insert("sha224".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+
+    // sha384(s: str) -> str (hex digest)
+    functions.insert("sha384".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+
+    // blake2b(s: str) -> str (hex digest)
+    functions.insert("blake2b".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+
+    // blake2s(s: str) -> str (hex digest)
+    functions.insert("blake2s".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+
+    // b32encode(s: str) -> str
+    functions.insert("b32encode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], Type::Str));
+
+    // b32decode(s: str) -> Result[str, ParseError]
+    functions.insert("b32decode".to_string(), FunctionType::all_borrow(vec![("s".to_string(), Type::Str)], result_ty(Type::Str, "ParseError")));
 
     IntrinsicModule {
         functions,
@@ -719,6 +794,12 @@ fn intrinsic_platform() -> IntrinsicModule {
     functions.insert("platform_arch".to_string(), FunctionType::all_borrow(vec![], Type::Str));
     // platform_node() -> str (hostname)
     functions.insert("platform_node".to_string(), FunctionType::all_borrow(vec![], Type::Str));
+    // platform_release() -> str (OS release version)
+    functions.insert("platform_release".to_string(), FunctionType::all_borrow(vec![], Type::Str));
+    // platform_version() -> str (OS version string)
+    functions.insert("platform_version".to_string(), FunctionType::all_borrow(vec![], Type::Str));
+    // platform_processor() -> str (processor type)
+    functions.insert("platform_processor".to_string(), FunctionType::all_borrow(vec![], Type::Str));
     IntrinsicModule { functions, constants: HashMap::new() }
 }
 

--- a/demos/milestone_stdlib_intrinsic_expansion_demo.sifr
+++ b/demos/milestone_stdlib_intrinsic_expansion_demo.sifr
@@ -1,0 +1,120 @@
+# milestone_stdlib_intrinsic_expansion_demo.sifr
+# Demonstrates all new intrinsics added in milestone_stdlib_intrinsic_expansion
+
+# expect-stdout: === math new intrinsics ===
+# expect-stdout: erf near 0 = true
+# expect-stdout: erfc near 1 = true
+# expect-stdout: gamma(5) > 23 = true
+# expect-stdout: lgamma(5) > 3 = true
+# expect-stdout: frexp(8.0) mantissa = 0.5
+# expect-stdout: ldexp(0.5, 4) = 8
+# expect-stdout: modf(3.7) frac > 0 = true
+# expect-stdout: nextafter(1.0, 2.0) > 1.0 = true
+# expect-stdout: ulp(1.0) > 0 = true
+# expect-stdout: === os new intrinsics ===
+# expect-stdout: pid > 0 = true
+# expect-stdout: cpu_count >= 1 = true
+# expect-stdout: === hashlib new intrinsics ===
+# expect-stdout: sha224 len = 56
+# expect-stdout: sha384 len = 96
+# expect-stdout: blake2b len = 128
+# expect-stdout: blake2s len = 64
+# expect-stdout: === platform new intrinsics ===
+# expect-stdout: system len > 0 = true
+# expect-stdout: machine len > 0 = true
+# expect-stdout: processor len > 0 = true
+# expect-stdout: === time new intrinsics ===
+# expect-stdout: gmtime len > 0 = true
+# expect-stdout: localtime len > 0 = true
+# expect-stdout: strptime ok = true
+# expect-stdout: === base64 new intrinsics ===
+# expect-stdout: b32encode len > 0 = true
+# expect-stdout: b32decode = hello world
+# expect-stdout: === shutil new intrinsics ===
+# expect-stdout: disk_total > 0 = true
+
+from sifr.math import erf, erfc, gamma, lgamma, frexp, ldexp, modf, nextafter, ulp
+from sifr.os import getpid, cpu_count
+from sifr.hashlib import sha224, sha384, blake2b, blake2s
+from sifr.platform import system, machine, processor
+from sifr.time import gmtime, localtime, strptime
+from sifr.base64 import b32encode, b32decode
+from sifr.shutil import disk_usage
+
+def demo_math() -> None:
+    print("=== math new intrinsics ===")
+    e0: float = erf(0.0)
+    print("erf near 0 = " + str(e0 < 0.001 and e0 > -0.001))
+    ec0: float = erfc(0.0)
+    print("erfc near 1 = " + str(ec0 > 0.999 and ec0 < 1.001))
+    g: float = gamma(5.0)
+    print("gamma(5) > 23 = " + str(g > 23.0))
+    lg: float = lgamma(5.0)
+    print("lgamma(5) > 3 = " + str(lg > 3.0))
+    fp: list[float] = frexp(8.0)
+    print("frexp(8.0) mantissa = " + str(fp[0]))
+    ld: float = ldexp(0.5, 4)
+    print("ldexp(0.5, 4) = " + str(ld))
+    md: list[float] = modf(3.7)
+    print("modf(3.7) frac > 0 = " + str(md[0] > 0.0))
+    na: float = nextafter(1.0, 2.0)
+    print("nextafter(1.0, 2.0) > 1.0 = " + str(na > 1.0))
+    u: float = ulp(1.0)
+    print("ulp(1.0) > 0 = " + str(u > 0.0))
+
+def demo_os() -> None:
+    print("=== os new intrinsics ===")
+    pid: int = getpid()
+    print("pid > 0 = " + str(pid > 0))
+    cpus: int = cpu_count()
+    print("cpu_count >= 1 = " + str(cpus >= 1))
+
+def demo_hashlib() -> None:
+    print("=== hashlib new intrinsics ===")
+    s: str = "hello"
+    print("sha224 len = " + str(len(sha224(s))))
+    print("sha384 len = " + str(len(sha384(s))))
+    print("blake2b len = " + str(len(blake2b(s))))
+    print("blake2s len = " + str(len(blake2s(s))))
+
+def demo_platform() -> None:
+    print("=== platform new intrinsics ===")
+    print("system len > 0 = " + str(len(system()) > 0))
+    print("machine len > 0 = " + str(len(machine()) > 0))
+    print("processor len > 0 = " + str(len(processor()) > 0))
+
+def demo_time() -> None:
+    print("=== time new intrinsics ===")
+    gmt: str = gmtime(0.0)
+    print("gmtime len > 0 = " + str(len(gmt) > 0))
+    lt: str = localtime(0.0)
+    print("localtime len > 0 = " + str(len(lt) > 0))
+    try:
+        parsed: str = strptime("2024-01-15 10:30:00", "%Y-%m-%d %H:%M:%S")
+        print("strptime ok = " + str(len(parsed) > 0))
+    except ValueError as e:
+        print("strptime error: " + e.message)
+
+def demo_base64() -> None:
+    print("=== base64 new intrinsics ===")
+    encoded: str = b32encode("hello world")
+    print("b32encode len > 0 = " + str(len(encoded) > 0))
+    try:
+        decoded: str = b32decode(encoded)
+        print("b32decode = " + decoded)
+    except ParseError as e:
+        print("b32decode error: " + e.message)
+
+def demo_shutil() -> None:
+    print("=== shutil new intrinsics ===")
+    usage: list[int] = disk_usage("/")
+    print("disk_total > 0 = " + str(usage[0] > 0))
+
+def main():
+    demo_math()
+    demo_os()
+    demo_hashlib()
+    demo_platform()
+    demo_time()
+    demo_base64()
+    demo_shutil()

--- a/lib/sifr/base64.sifr
+++ b/lib/sifr/base64.sifr
@@ -1,5 +1,5 @@
 # sifr.base64 — Base64 encoding/decoding (renamed from sifr.encoding)
-from _sifr.crypto import base64_encode, base64_decode, urlsafe_b64encode, urlsafe_b64decode
+from _sifr.crypto import base64_encode, base64_decode, urlsafe_b64encode, urlsafe_b64decode, b32encode, b32decode
 
 # CPython-compatible aliases
 def b64encode(s: str) -> str:

--- a/lib/sifr/hashlib.sifr
+++ b/lib/sifr/hashlib.sifr
@@ -1,2 +1,2 @@
 # sifr.hashlib — Hashing functions (renamed from sifr.hash)
-from _sifr.crypto import sha256, md5, sha1, sha512
+from _sifr.crypto import sha256, md5, sha1, sha512, sha224, sha384, blake2b, blake2s

--- a/lib/sifr/math.sifr
+++ b/lib/sifr/math.sifr
@@ -1,5 +1,5 @@
 # sifr.math — Math functions and constants
-from _sifr.math import sqrt, floor, ceil, abs_val, log, sin, cos, tan, pow_val, min_val, max_val, round_val, pi, e, asin, acos, atan, atan2, sinh, cosh, tanh, log10, log2, degrees, radians, isnan, isinf, trunc, copysign, fmod, hypot, tau, inf, nan, exp, expm1, log1p, fabs, isfinite, acosh, asinh, atanh, isqrt, dist, fsum
+from _sifr.math import sqrt, floor, ceil, abs_val, log, sin, cos, tan, pow_val, min_val, max_val, round_val, pi, e, asin, acos, atan, atan2, sinh, cosh, tanh, log10, log2, degrees, radians, isnan, isinf, trunc, copysign, fmod, hypot, tau, inf, nan, exp, expm1, log1p, fabs, isfinite, acosh, asinh, atanh, isqrt, dist, fsum, erf, erfc, gamma, lgamma, frexp, ldexp, modf, nextafter, ulp
 
 def factorial(n: int) -> int:
     if n < 0:

--- a/lib/sifr/os.sifr
+++ b/lib/sifr/os.sifr
@@ -1,4 +1,8 @@
 # sifr.os — OS operations
 # File system operations return Result[T, IOError] for safe error handling.
 from _sifr.sys import run_command, get_args
-from _sifr.fs import getcwd, listdir, mkdir, rmdir, remove_file, rename, is_file, is_dir
+from _sifr.fs import getcwd, listdir, mkdir, rmdir, remove_file, rename, is_file, is_dir, chdir, getpid, cpu_count, stat_size, which, disk_usage
+
+def stat(path: str) -> Result[int, IOError]:
+    # Returns the file size in bytes (simplified stat).
+    return stat_size(path)

--- a/lib/sifr/platform.sifr
+++ b/lib/sifr/platform.sifr
@@ -1,5 +1,5 @@
 # sifr.platform — Platform information
-from _sifr.platform import platform_system, platform_arch, platform_node
+from _sifr.platform import platform_system, platform_arch, platform_node, platform_release, platform_version, platform_processor
 
 # CPython-compatible aliases
 def system() -> str:
@@ -7,3 +7,15 @@ def system() -> str:
 
 def machine() -> str:
     return platform_arch()
+
+def node() -> str:
+    return platform_node()
+
+def release() -> str:
+    return platform_release()
+
+def version() -> str:
+    return platform_version()
+
+def processor() -> str:
+    return platform_processor()

--- a/lib/sifr/shutil.sifr
+++ b/lib/sifr/shutil.sifr
@@ -1,6 +1,6 @@
 # sifr.shutil — High-level file operations (wraps _sifr.fs)
 # All operations return Result[None, IOError] for safe error handling.
-from _sifr.fs import copy_file, remove_file, rename, rmdir_all
+from _sifr.fs import copy_file, remove_file, rename, rmdir_all, which, disk_usage
 
 def copy(src: str, dst: str) -> Result[None, IOError]:
     return copy_file(src, dst)

--- a/lib/sifr/time.sifr
+++ b/lib/sifr/time.sifr
@@ -1,5 +1,5 @@
 # sifr.time — Time operations
-from _sifr.time import time_now, sleep, time_format, perf_counter, monotonic
+from _sifr.time import time_now, sleep, time_format, perf_counter, monotonic, strptime, gmtime, localtime
 
 # CPython-compatible aliases
 def time() -> float:


### PR DESCRIPTION
## Summary
- Adds 9 new math intrinsics: `erf`, `erfc`, `gamma`, `lgamma`, `frexp`, `ldexp`, `modf`, `nextafter`, `ulp`
- Adds 6 new os/fs intrinsics: `chdir`, `getpid`, `cpu_count`, `stat_size`, `which`, `disk_usage`
- Adds 4 new hashlib intrinsics: `sha224`, `sha384`, `blake2b`, `blake2s`
- Adds 3 new platform intrinsics: `release`, `version`, `processor`
- Adds 3 new time intrinsics: `strptime`, `gmtime`, `localtime`
- Adds 2 new base64 intrinsics: `b32encode`, `b32decode`
- Adds `blake2 = "0.10"` dependency

## Test plan
- [ ] Run `cargo test --test e2e` and verify all new E2E tests pass
- [ ] Run `./target/debug/sifr run demos/milestone_stdlib_intrinsic_expansion_demo.sifr` and verify output matches expected

Made with [Cursor](https://cursor.com)