### PR TITLE
feat: complete milestone_auto_init — inheritance diagnostic, field ordering, stdlib migration

### DIFF
--- a/.cursor/plans/main/phases/13_type_system_completion.md
+++ b/.cursor/plans/main/phases/13_type_system_completion.md
@@ -8,7 +8,7 @@
 
 ## milestone_auto_init: Auto-Generated Constructors
 
-status: pending
+status: done
 
 **Goal:** Eliminate the most common boilerplate in Sifr code. When a class declares typed fields but does not define an explicit `__init__`, the compiler auto-generates a constructor that accepts one positional argument per field (in declaration order) and assigns each to `self`. This is the single highest-impact ergonomic improvement — every class in the demos, stdlib, and user code currently repeats this pattern manually.
 

--- a/crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr
+++ b/crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr
@@ -1,0 +1,13 @@
+# expect-error: has fields but no __init__
+
+class Animal:
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+class Dog(Animal):
+    breed: str
+
+def main():
+    d: Dog = Dog("Rex", "Labrador")

--- a/crates/sifr/tests/e2e/fail/auto_init_required_after_default.sifr
+++ b/crates/sifr/tests/e2e/fail/auto_init_required_after_default.sifr
@@ -1,0 +1,8 @@
+# expect-error: required field 'name' declared after field with default value
+
+class BadConfig:
+    debug: bool = False
+    name: str
+
+def main():
+    c: BadConfig = BadConfig(True, "test")

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -1179,6 +1179,38 @@ fn collect_class_type(class_def: &StmtClassDef, ctx: &mut LowerCtx) {
         ft.return_type = Box::new(class_ty.clone());
     } else {
         // No __init__ defined -- create a default constructor from fields
+
+        // Validate field ordering: required fields must come before defaulted fields
+        let default_indices: std::collections::HashSet<usize> = field_defaults.iter().map(|(i, _)| *i).collect();
+        let mut seen_default = false;
+        for (i, (fname, _)) in fields.iter().enumerate() {
+            if default_indices.contains(&i) {
+                seen_default = true;
+            } else if seen_default {
+                ctx.error(format!(
+                    "class '{}': required field '{}' declared after field with default value",
+                    class_name, fname
+                ));
+            }
+        }
+
+        // Inheritance diagnostic: warn when child has own fields but no __init__ and extends a parent
+        if parent_class_name.is_some() {
+            let parent_field_count = if let Some(ref pname) = parent_class_name {
+                ctx.class_types.get(pname).map_or(0, |ty| {
+                    if let Type::Class { fields: pf, .. } = ty { pf.len() } else { 0 }
+                })
+            } else { 0 };
+            let has_own_fields = fields.len() > parent_field_count;
+            if has_own_fields {
+                ctx.error(format!(
+                    "class '{}' has fields but no __init__; parent fields will not be initialized. \
+                     Define an explicit __init__ with super().__init__(...)",
+                    class_name
+                ));
+            }
+        }
+
         let params: Vec<(String, Type)> = fields.clone();
         let ft = FunctionType::new(params, class_ty.clone());
         ctx.functions.insert(class_name.clone(), ft);

--- a/lib/sifr/collections.sifr
+++ b/lib/sifr/collections.sifr
@@ -6,9 +6,6 @@ class Counter:
     # Backed by a native dict[str, int] field.
     counts: dict[str, int]
 
-    def __init__(self, counts: dict[str, int]):
-        self.counts = counts
-
     def get(self, key: str) -> int:
         val: int | None = self.counts[key]
         if val is not None:

--- a/lib/sifr/datetime.sifr
+++ b/lib/sifr/datetime.sifr
@@ -43,14 +43,6 @@ class datetime:
     minute: int
     second: int
 
-    def __init__(self, year: int, month: int, day: int, hour: int, minute: int, second: int) -> None:
-        self.year = year
-        self.month = month
-        self.day = day
-        self.hour = hour
-        self.minute = minute
-        self.second = second
-
     def isoformat(self) -> str:
         # Returns ISO 8601 format: YYYY-MM-DDTHH:MM:SS
         y: str = str(self.year)
@@ -109,11 +101,6 @@ class date:
     month: int
     day: int
 
-    def __init__(self, year: int, month: int, day: int) -> None:
-        self.year = year
-        self.month = month
-        self.day = day
-
     def isoformat(self) -> str:
         y: str = str(self.year)
         mo: str = str(self.month)
@@ -135,11 +122,6 @@ class time:
     hour: int
     minute: int
     second: int
-
-    def __init__(self, hour: int, minute: int, second: int) -> None:
-        self.hour = hour
-        self.minute = minute
-        self.second = second
 
     def isoformat(self) -> str:
         h: str = str(self.hour)

--- a/lib/sifr/subprocess.sifr
+++ b/lib/sifr/subprocess.sifr
@@ -8,11 +8,6 @@ class CompletedProcess:
     stdout: str
     stderr: str
 
-    def __init__(self, returncode: int, stdout: str, stderr: str) -> None:
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
-
 
 def run(cmd: str) -> Result[CompletedProcess, IOError]:
     try:

--- a/lib/sifr/zipfile.sifr
+++ b/lib/sifr/zipfile.sifr
@@ -4,9 +4,6 @@ from _sifr.compress import zip_create, zip_add_file, zip_read_file, zip_namelist
 class ZipFile:
     path: str
 
-    def __init__(self, path: str) -> None:
-        self.path = path
-
     def create(self) -> Result[None, IOError]:
         return zip_create(self.path)
 


### PR DESCRIPTION
## Summary
- **Inheritance diagnostic**: Compile error when a child class has fields but no `__init__` and extends a parent class (prevents silent uninitialized parent fields)
- **Field ordering validation**: Compile error when required fields are declared after fields with default values (e.g., `debug: bool = False` before `name: str`)
- **Stdlib migration**: Removed boilerplate `__init__` from 6 stdlib classes that now use auto-init: `ZipFile`, `CompletedProcess`, `datetime`, `date`, `time`, `Counter`
- New fail tests: `auto_init_required_after_default`, `auto_init_inheritance_missing_super`
- `milestone_auto_init` status updated to `done`

## Test plan
- [x] All E2E pass tests pass (335 tests)
- [x] All E2E fail tests pass (including 2 new ones)
- [x] `milestone_auto_init_demo.sifr` runs successfully
- [x] `milestone_stdlib_remediation_demo.sifr` still runs (datetime/subprocess use auto-init now)
- [x] `cargo test` passes


Made with [Cursor](https://cursor.com)