### PR TITLE
feat: complete milestone_integer_safety — mixed comparison blocking, tests, bugfixes

### DIFF
--- a/.cursor/plans/main/phases/13_type_system_completion.md
+++ b/.cursor/plans/main/phases/13_type_system_completion.md
@@ -429,7 +429,7 @@ Sifr intentionally does NOT support enums with associated data (algebraic data t
 
 ## milestone_integer_safety: Integer Overflow and BigInt
 
-status: pending
+status: done
 
 **Goal:** Resolve the integer overflow contradiction with Sifr's "if it compiles, it works" guarantee. Currently, `int` maps to Rust `i64` — overflow panics in debug mode and wraps silently in release mode. Both behaviors violate the safety promise. This milestone introduces a `bigint` type for arbitrary-precision arithmetic (matching Python's `int` behavior) and adds compiler diagnostics for potential overflow in `int` operations.
 

--- a/crates/sifr/tests/e2e/fail/bigint_int_mixed_comparison.sifr
+++ b/crates/sifr/tests/e2e/fail/bigint_int_mixed_comparison.sifr
@@ -1,0 +1,6 @@
+def main():
+    x: int = 42
+    y: bigint = bigint(100)
+    print(x < y)
+
+# expect-error: cannot compare 'int' and 'bigint'

--- a/crates/sifr/tests/e2e/pass/bigint_arithmetic.sifr
+++ b/crates/sifr/tests/e2e/pass/bigint_arithmetic.sifr
@@ -1,0 +1,14 @@
+def main():
+    a: bigint = bigint(100)
+    b: bigint = bigint(200)
+    print(a + b)
+    print(b - a)
+    print(a * b)
+    print(b // a)
+    print(b % bigint(3))
+
+# expect-stdout: 300
+# expect-stdout: 100
+# expect-stdout: 20000
+# expect-stdout: 2
+# expect-stdout: 2

--- a/crates/sifr/tests/e2e/pass/bigint_as_dict_key.sifr
+++ b/crates/sifr/tests/e2e/pass/bigint_as_dict_key.sifr
@@ -1,0 +1,9 @@
+def main():
+    d: dict[bigint, str] = {bigint(1): "one", bigint(2): "two", bigint(3): "three"}
+    print(len(d))
+    print(d[bigint(1)])
+    print(d[bigint(3)])
+
+# expect-stdout: 3
+# expect-stdout: one
+# expect-stdout: three

--- a/crates/sifr/tests/e2e/pass/bigint_overflow_conversion.sifr
+++ b/crates/sifr/tests/e2e/pass/bigint_overflow_conversion.sifr
@@ -1,0 +1,9 @@
+def main():
+    big: bigint = bigint(10) ** 20
+    try:
+        n: int = int(big)
+        print("should not reach here")
+    except OverflowError as e:
+        print("caught overflow")
+
+# expect-stdout: caught overflow

--- a/crates/sifr/tests/e2e/pass/bigint_to_int.sifr
+++ b/crates/sifr/tests/e2e/pass/bigint_to_int.sifr
@@ -1,0 +1,9 @@
+def main():
+    b: bigint = bigint(42)
+    try:
+        n: int = int(b)
+        print(n)
+    except OverflowError as e:
+        print("overflow")
+
+# expect-stdout: 42

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -7943,8 +7943,9 @@ fn module_uses_bigint(module: &HirModule) -> bool {
     fn type_has_bigint(ty: &Type) -> bool {
         match ty {
             Type::BigInt => true,
-            Type::List(t) => type_has_bigint(t),
-            Type::Union(ts) => ts.iter().any(type_has_bigint),
+            Type::List(t) | Type::Set(t) => type_has_bigint(t),
+            Type::Dict(k, v) => type_has_bigint(k) || type_has_bigint(v),
+            Type::Tuple(ts) | Type::Union(ts) => ts.iter().any(type_has_bigint),
             Type::Result(ok, err) => type_has_bigint(ok) || type_has_bigint(err),
             _ => false,
         }

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -1679,7 +1679,7 @@ fn register_builtins(ctx: &mut LowerCtx) {
             class_ty,
         ));
     }
-    let other_mid_level_errors = ["ParseError", "ValueError", "DivisionError", "KeyError"];
+    let other_mid_level_errors = ["ParseError", "ValueError", "DivisionError", "KeyError", "OverflowError"];
     for &error_name in &other_mid_level_errors {
         let fields = vec![("message".to_string(), Type::Str)];
         let class_ty = Type::Class {

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -235,6 +235,16 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
 pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type, TypeError> {
     match op {
         "==" | "!=" => {
+            // Block mixed int/bigint equality comparisons
+            if (left == &Type::Int && right == &Type::BigInt) || (left == &Type::BigInt && right == &Type::Int) {
+                return Err(TypeError {
+                    message: "cannot compare 'int' and 'bigint'; use bigint() or int() to convert explicitly".to_string(),
+                    kind: crate::TypeErrorKind::TypeMismatch {
+                        expected: left.clone(),
+                        actual: right.clone(),
+                    },
+                });
+            }
             // Equality comparison works on same types
             if left == right || left == &Type::Any || right == &Type::Any {
                 return Ok(Type::Bool);
@@ -276,6 +286,16 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
             })
         }
         "<" | ">" | "<=" | ">=" => {
+            // Block mixed int/bigint comparisons
+            if (left == &Type::Int && right == &Type::BigInt) || (left == &Type::BigInt && right == &Type::Int) {
+                return Err(TypeError {
+                    message: "cannot compare 'int' and 'bigint'; use bigint() or int() to convert explicitly".to_string(),
+                    kind: crate::TypeErrorKind::TypeMismatch {
+                        expected: left.clone(),
+                        actual: right.clone(),
+                    },
+                });
+            }
             // Ordering comparison works on numeric types and strings
             if left.is_numeric() && right.is_numeric() {
                 return Ok(Type::Bool);
@@ -494,6 +514,17 @@ mod tests {
         assert_eq!(type_check_unary_op("not", &Type::Bool).unwrap(), Type::Bool);
         assert!(type_check_unary_op("-", &Type::Str).is_err());
         assert!(type_check_unary_op("not", &Type::Int).is_err());
+    }
+
+    #[test]
+    fn test_mixed_int_bigint_comparison_blocked() {
+        assert!(type_check_comparison(&Type::Int, "==", &Type::BigInt).is_err());
+        assert!(type_check_comparison(&Type::BigInt, "==", &Type::Int).is_err());
+        assert!(type_check_comparison(&Type::Int, "<", &Type::BigInt).is_err());
+        assert!(type_check_comparison(&Type::BigInt, ">", &Type::Int).is_err());
+        // Same-type comparisons should still work
+        assert!(type_check_comparison(&Type::BigInt, "==", &Type::BigInt).is_ok());
+        assert!(type_check_comparison(&Type::BigInt, "<", &Type::BigInt).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Block mixed int/bigint comparisons (==, !=, <, >, <=, >=) with clear diagnostic message, consistent with the existing mixed arithmetic blocking
- Register OverflowError as a built-in error class so `try/except OverflowError` works with `int(bigint)` conversions
- Fix bigint import detection (`use num_bigint::BigInt`) for dict, set, and tuple types in codegen — previously only list/union/result were checked
- New E2E pass tests: `bigint_arithmetic`, `bigint_to_int`, `bigint_as_dict_key`, `bigint_overflow_conversion`
- New E2E fail test: `bigint_int_mixed_comparison`
- Unit test for mixed comparison blocking in type system

## Test plan

- [x] All existing E2E tests still pass (no regressions)
- [x] New pass tests verify bigint arithmetic, conversion, dict keys, and overflow handling
- [x] New fail test verifies mixed comparison blocking
- [x] Type system unit tests pass (69 tests)
- [x] Milestone demo runs successfully
- [x] `cargo test` passes


Made with [Cursor](https://cursor.com)