### PR TITLE
feat: add overflow warning infrastructure for int expressions

### DIFF
--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -406,6 +406,11 @@ pub fn compile_with_metadata(source: &str) -> CompileResultFull {
         eprintln!("{}", diag);
     }
 
+    // Print compiler warnings to stderr
+    for warning in &lowering_result.warnings {
+        eprintln!("{}", warning);
+    }
+
     // Phase 3: Generate Rust code with stdlib code
     let codegen_result = generate_rust_with_stdlib(&lowering_result.module, &stdlib_compiled.code);
 

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -45,6 +45,8 @@ struct LowerCtx {
     loop_depth: usize,
     /// reveal_type() diagnostics (informational, not errors)
     reveal_types: Vec<String>,
+    /// Compiler warnings (non-fatal diagnostics printed to stderr)
+    warnings: Vec<String>,
     /// Whether we're currently inside a class method (tracks `self` type)
     current_class: Option<String>,
     /// The parent class name of the current class (for super() resolution)
@@ -81,6 +83,7 @@ impl LowerCtx {
             errors: Vec::new(),
             loop_depth: 0,
             reveal_types: Vec::new(),
+            warnings: Vec::new(),
             current_class: None,
             current_parent_class: None,
             in_try_block: false,
@@ -93,6 +96,10 @@ impl LowerCtx {
             allow_intrinsic_imports: false,
             borrowed_params: std::collections::HashSet::new(),
         }
+    }
+
+    fn warn(&mut self, message: String) {
+        self.warnings.push(message);
     }
 
     fn error(&mut self, message: String) {
@@ -200,6 +207,8 @@ pub struct LoweringResult {
     pub module: HirModule,
     /// reveal_type() diagnostics (informational, printed to stderr)
     pub reveal_types: Vec<String>,
+    /// Compiler warnings (non-fatal, printed to stderr)
+    pub warnings: Vec<String>,
 }
 
 /// External module definitions that can be imported.
@@ -639,6 +648,7 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
         Ok(LoweringResult {
             module: HirModule { functions, classes, imports, constants },
             reveal_types: ctx.reveal_types,
+            warnings: ctx.warnings,
         })
     } else {
         Err(ctx.errors)
@@ -4128,12 +4138,17 @@ fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirExpr> {
     };
 
     match type_check_binary_op(left.ty(), op_str, right.ty()) {
-        Ok(result_ty) => Some(HirExpr::BinOp {
-            left: Box::new(left),
-            op: op_str.to_string(),
-            right: Box::new(right),
-            ty: result_ty,
-        }),
+        Ok(result_ty) => {
+            if result_ty == Type::Int {
+                check_int_overflow_risk(op_str, &left, &right, ctx);
+            }
+            Some(HirExpr::BinOp {
+                left: Box::new(left),
+                op: op_str.to_string(),
+                right: Box::new(right),
+                ty: result_ty,
+            })
+        }
         Err(e) => {
             // Check for operator overloading on class types
             if let Type::Class { methods, .. } = left.ty() {
@@ -4152,6 +4167,50 @@ fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirExpr> {
             ctx.error(e.message);
             None
         }
+    }
+}
+
+fn check_int_overflow_risk(op: &str, left: &HirExpr, right: &HirExpr, ctx: &mut LowerCtx) {
+    let is_left_const = matches!(left, HirExpr::IntLiteral(_));
+    let is_right_const = matches!(right, HirExpr::IntLiteral(_));
+
+    match op {
+        "**" => {
+            if let HirExpr::IntLiteral(exp) = right {
+                if *exp > 40 {
+                    ctx.warn(format!(
+                        "warning: int exponentiation with large exponent ({}) may overflow i64; consider using bigint",
+                        exp
+                    ));
+                }
+            } else {
+                ctx.warn(
+                    "warning: int exponentiation (**) with non-constant exponent may overflow i64 at runtime; consider using bigint".to_string()
+                );
+            }
+        }
+        "*" => {
+            if !is_left_const && !is_right_const {
+                ctx.warn(
+                    "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values".to_string()
+                );
+            }
+        }
+        "<<" => {
+            if !is_right_const {
+                ctx.warn(
+                    "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint".to_string()
+                );
+            } else if let HirExpr::IntLiteral(shift) = right {
+                if *shift >= 63 {
+                    ctx.warn(format!(
+                        "warning: int left shift by {} exceeds i64 range; consider using bigint",
+                        shift
+                    ));
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/demos/milestone_integer_safety_demo.sifr
+++ b/demos/milestone_integer_safety_demo.sifr
@@ -1,5 +1,6 @@
 # Demo: milestone_integer_safety
-# Showcases bigint type for arbitrary-precision arithmetic.
+# Showcases bigint type for arbitrary-precision arithmetic,
+# and compiler overflow warnings for risky int operations.
 
 def factorial(n: int) -> bigint:
     if n <= 1:
@@ -63,3 +64,21 @@ def main():
     print("=== Fibonacci ===")
     print(fibonacci(50))
     print(fibonacci(100))
+
+    # --- 8. Overflow warnings ---
+    # The compiler emits warnings (to stderr) for risky int operations:
+    #   - int ** <non-constant> warns about potential overflow
+    #   - int ** <large constant> warns about potential overflow
+    #   - int * int with non-constant operands warns about potential overflow
+    # These are non-fatal warnings — the program still compiles and runs.
+    print("=== Overflow Warnings (check stderr) ===")
+    base: int = 2
+    exp: int = 10
+    risky_pow: int = base ** exp
+    print(risky_pow)
+    a2: int = 1000000
+    b2: int = 1000000
+    risky_mul: int = a2 * b2
+    print(risky_mul)
+    safe_mul: int = 5 * 10
+    print(safe_mul)


### PR DESCRIPTION
## Summary
- Adds compiler warning infrastructure (`warnings` vector in `LowerCtx` and `LoweringResult`, printed to stderr by the driver)
- Implements overflow risk detection for `int` (i64) operations: exponentiation with non-constant/large exponents, multiplication with non-constant operands, left shifts with large/non-constant amounts
- Updates the `milestone_integer_safety` demo to showcase overflow warnings

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all existing tests)
- [x] Demo `demos/milestone_integer_safety_demo.sifr` runs successfully with warnings on stderr
- [x] Verified: constant-only operations (e.g., `5 * 10`) do NOT trigger warnings
- [x] Verified: risky operations (`x ** y`, `a * b` with variables) DO trigger warnings

Made with [Cursor](https://cursor.com)