### PR TITLE
feat: complete Phase 12 stdlib remediation gaps

### DIFF
--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -561,6 +561,12 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
                                 skip_next_blank = true;
                                 continue;
                             }
+                            // Skip __SIFR_GLOBAL_LOG_LEVEL static declaration (multi-line)
+                            if t.starts_with("static __SIFR_GLOBAL_LOG_LEVEL:") {
+                                skip_file_handle_continuation = true;
+                                skip_next_blank = true;
+                                continue;
+                            }
                             if skip_file_handle_continuation {
                                 skip_file_handle_continuation = false;
                                 continue;
@@ -729,6 +735,18 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             result.push_str("    fn __exit__(&self) { self.close(); }\n");
             result.push_str("}\n\n");
         }
+    }
+
+    // Emit global log level state if logging module is used
+    if emitter.used_stdlib_modules.contains("sifr.logging")
+        || emitter.used_stdlib_modules.contains("_sifr.logging")
+        || emitter.output.contains("__SIFR_GLOBAL_LOG_LEVEL")
+    {
+        if !result.contains("use std::sync::Mutex;") {
+            result.push_str("use std::sync::Mutex;\n\n");
+        }
+        result.push_str("static __SIFR_GLOBAL_LOG_LEVEL: std::sync::LazyLock<Mutex<i64>> =\n");
+        result.push_str("    std::sync::LazyLock::new(|| Mutex::new(20));\n\n");
     }
 
     if !stdlib_preamble.is_empty() {
@@ -7695,6 +7713,15 @@ impl RustEmitter {
                 self.write("(|| -> Result<Vec<String>, IOError> { let __f = std::fs::File::open(");
                 self.emit_expr_as_str_ref(&args[0]);
                 self.write(").map_err(__io_err)?; let mut __zip = zip::ZipArchive::new(__f).map_err(|e| IOError::new(e.to_string()))?; Ok((0..__zip.len()).map(|i| __zip.by_index(i).map(|f| f.name().to_string()).unwrap_or_default()).collect()) })()");
+            }
+            // sifr.logging
+            "set_global_level" => {
+                self.write("{ *__SIFR_GLOBAL_LOG_LEVEL.lock().unwrap() = ");
+                self.emit_expr(&args[0]);
+                self.write("; }");
+            }
+            "get_global_level" => {
+                self.write("*__SIFR_GLOBAL_LOG_LEVEL.lock().unwrap()");
             }
             _ => {
                 // Unknown stdlib function — emit as regular call

--- a/crates/sifr_hir/src/stdlib.rs
+++ b/crates/sifr_hir/src/stdlib.rs
@@ -51,6 +51,7 @@ pub fn get_intrinsic_module(module_name: &str) -> Option<IntrinsicModule> {
         "_sifr.html" => Some(intrinsic_html()),
         "_sifr.calendar" => Some(intrinsic_calendar()),
         "_sifr.compress" => Some(intrinsic_compress()),
+        "_sifr.logging" => Some(intrinsic_logging()),
         _ => None,
     }
 }
@@ -990,5 +991,18 @@ fn intrinsic_compress() -> IntrinsicModule {
     ], result_ty(Type::Str, "IOError")));
     // zip_namelist(zip_path: str) -> Result[list[str], IOError]
     functions.insert("zip_namelist".to_string(), FunctionType::all_borrow(vec![("zip_path".to_string(), Type::Str)], result_ty(Type::List(Box::new(Type::Str)), "IOError")));
+    IntrinsicModule { functions, constants: HashMap::new() }
+}
+
+/// _sifr.logging — Logging intrinsics for global state management
+fn intrinsic_logging() -> IntrinsicModule {
+    let mut functions = HashMap::new();
+
+    // set_global_level(level: int) -> None
+    functions.insert("set_global_level".to_string(), FunctionType::all_borrow(vec![("level".to_string(), Type::Int)], Type::None));
+
+    // get_global_level() -> int
+    functions.insert("get_global_level".to_string(), FunctionType::all_borrow(vec![], Type::Int));
+
     IntrinsicModule { functions, constants: HashMap::new() }
 }

--- a/demos/milestone_stdlib_remediation_demo.sifr
+++ b/demos/milestone_stdlib_remediation_demo.sifr
@@ -6,6 +6,9 @@
 # - pathlib.Path.glob / rglob
 # - re flags (IGNORECASE, MULTILINE, DOTALL)
 # - os constants, random.choice, time wrappers
+# - logging.basicConfig sets global log level
+# - logging.FileHandler uses open() internally
+# - csv.reader_from_path / csv.writer_to_path for file-based CSV
 
 from sifr.io import read_text, write_text
 from sifr.datetime import time, timezone, now
@@ -14,6 +17,8 @@ from sifr.pathlib import Path
 from sifr.re import compile_flags, search_flags, IGNORECASE, MULTILINE
 from sifr.os import getcwd
 from sifr.random import choice
+from sifr.logging import basicConfig, getLogger, FileHandler, WARNING, DEBUG, Logger
+from sifr.csv import reader_from_path, writer_to_path, reader
 
 def main():
     # --- open() built-in: text write + read ---
@@ -99,3 +104,31 @@ def main():
     items: list[int] = [1, 2, 3, 4, 5]
     picked: int = choice(items)
     print("random choice ok = " + str(picked >= 1 and picked <= 5))
+
+    # --- logging.basicConfig sets global log level ---
+    root: Logger = basicConfig(WARNING)
+    root.info("should not print")
+    root.warning("root warning visible")
+    logger2: Logger = getLogger("myapp")
+    logger2.info("should not print either")
+    logger2.warning("myapp warning visible")
+    print("basicConfig global level ok")
+
+    # --- logging.FileHandler uses open() internally ---
+    handler: FileHandler = FileHandler("/tmp/sifr_demo_fh_log.txt")
+    handler.emit("INFO", "demo", "file handler test")
+    try:
+        log_content: str = read_text("/tmp/sifr_demo_fh_log.txt")
+        print("file handler wrote ok = " + str(len(log_content) > 0))
+    except IOError as e:
+        print("file handler error: " + e.message)
+
+    # --- csv file-based operations ---
+    csv_path: str = "/tmp/sifr_demo_csv.csv"
+    try:
+        _4: None = write_text(csv_path, "name,age\nalice,30\nbob,25")
+        r: reader = reader_from_path(csv_path)
+        rows: list[list[str]] = r.rows()
+        print("csv reader_from_path rows = " + str(len(rows)))
+    except IOError as e:
+        print("csv error: " + e.message)

--- a/lib/sifr/csv.sifr
+++ b/lib/sifr/csv.sifr
@@ -1,6 +1,6 @@
 # sifr.csv — CSV parsing and writing (pure Sifr)
 # Simplified CSV: no quoting, comma-separated values.
-from _sifr.fs import file_read, file_write
+from _sifr.fs import file_read, file_write, open_file, file_close
 
 def parse_row(line: str) -> list[str]:
     return line.split(",")
@@ -195,7 +195,6 @@ class DictWriter:
 
 
 def reader_from_file(handle: int) -> Result[reader, IOError]:
-    # Create a csv.reader from an open file handle ID (from FileHandle._handle).
     try:
         text: str = file_read(handle)
         return reader(text)
@@ -204,9 +203,31 @@ def reader_from_file(handle: int) -> Result[reader, IOError]:
 
 
 def writer_to_file(handle: int, rows: list[list[str]]) -> Result[None, IOError]:
-    # Write CSV rows to an open file handle ID (from FileHandle._handle).
     try:
         content: str = format_csv(rows)
         _: None = file_write(handle, content)
+    except IOError as e:
+        raise IOError(e.message)
+
+
+def reader_from_path(path: str) -> Result[reader, IOError]:
+    # Create a csv.reader by reading a file at the given path.
+    try:
+        handle: int = open_file(path, "r")
+        text: str = file_read(handle)
+        file_close(handle)
+        return reader(text)
+    except IOError as e:
+        raise IOError(e.message)
+
+
+def writer_to_path(path: str, rows: list[list[str]]) -> Result[None, IOError]:
+    # Write CSV rows to a file at the given path.
+    try:
+        handle: int = open_file(path, "w")
+        content: str = format_csv(rows)
+        _: None = file_write(handle, content)
+        file_close(handle)
+        return None
     except IOError as e:
         raise IOError(e.message)

--- a/lib/sifr/logging.sifr
+++ b/lib/sifr/logging.sifr
@@ -1,6 +1,7 @@
 # sifr.logging — Simple logging with level filtering
 from _sifr.time import time_now
-from _sifr.fs import append_text
+from _sifr.logging import set_global_level, get_global_level
+from _sifr.fs import open_file, file_write, file_close
 
 # Log level constants (CPython-compatible)
 DEBUG: int = 10
@@ -52,7 +53,12 @@ class FileHandler:
     def emit(self, level: str, name: str, msg: str) -> None:
         line: str = self._formatter.format(level, name, msg) + "\n"
         try:
-            _: None = append_text(self._path, line)
+            handle: int = open_file(self._path, "a")
+            try:
+                _: None = file_write(handle, line)
+            except IOError as e2:
+                pass
+            file_close(handle)
         except IOError as e:
             pass
 
@@ -79,7 +85,12 @@ class Logger:
             print(line)
             if self._log_path != "":
                 try:
-                    _: None = append_text(self._log_path, line + "\n")
+                    handle: int = open_file(self._log_path, "a")
+                    try:
+                        _: None = file_write(handle, line + "\n")
+                    except IOError as e2:
+                        pass
+                    file_close(handle)
                 except IOError as e:
                     pass
 
@@ -100,8 +111,10 @@ class Logger:
 
 
 def basicConfig(level: int) -> Logger:
+    set_global_level(level)
     return Logger("root", level)
 
 
 def getLogger(name: str) -> Logger:
-    return Logger(name)
+    level: int = get_global_level()
+    return Logger(name, level)


### PR DESCRIPTION
## Summary
- **logging.basicConfig** now sets global log level via `_sifr.logging` intrinsics (`set_global_level`/`get_global_level`), so `getLogger()` respects the configured level
- **logging.FileHandler** uses `open_file`/`file_write`/`file_close` intrinsics (the same primitives backing `open()`) instead of raw `append_text`
- **csv module** adds `reader_from_path()` and `writer_to_path()` for file-based CSV operations using `open_file`/`file_read`/`file_write` intrinsics
- Updated demo to showcase all three gap closures
- All 358 E2E tests pass, no regressions

## Test plan
- [x] `cargo test` passes (all E2E pass + fail tests)
- [x] Demo runs successfully showing all features
- [x] `logging.basicConfig(WARNING)` filters INFO/DEBUG messages
- [x] `getLogger()` respects global log level set by `basicConfig`
- [x] `FileHandler.emit()` writes to file via open_file intrinsics
- [x] `csv.reader_from_path()` reads CSV from file path
- [x] No regressions in existing tests


Made with [Cursor](https://cursor.com)