### PR TITLE
feat: Phase 13 — Type System Completion (stdlib generification, protocol bounds, Counter/deque generics)

### DIFF
--- a/.cursor/plans/main/architecture.md
+++ b/.cursor/plans/main/architecture.md
@@ -121,7 +121,6 @@ Several stdlib functions intentionally diverge from CPython names due to Rust ke
 | `sifr.math.min_val` / `sifr.math.max_val` | `min` / `max` | `min`/`max` are Sifr built-ins; `min_val`/`max_val` are the float-specific intrinsics |
 | `sifr.math.round_val` | `round` | `round` is a Sifr built-in; `round_val` is the float intrinsic |
 | `sifr.itertools.repeat` | `itertools.repeat` | CPython-compatible name; `repeat_val` was the old non-CPython name (removed) |
-| `sifr.itertools.chain_str` | `itertools.chain` (str variant) | Type-specialised variant; `chain` handles `list[int]`, `chain_str` handles `list[str]` due to monomorphisation |
 | `sifr.itertools.count_from` | `itertools.count` | `count` conflicts with `list.count` method name in some contexts; `count_from` is the finite-list approximation |
 | `sifr.os.remove_file` | `os.remove` | `remove` is used as a method name on collections; `remove_file` avoids ambiguity |
 | `sifr.random.shuffle` | `random.shuffle` | CPython-compatible name; returns a new shuffled list (Sifr is immutable-by-default) instead of mutating in place |

--- a/crates/sifr/tests/e2e/fail/enum_duplicate_value.sifr
+++ b/crates/sifr/tests/e2e/fail/enum_duplicate_value.sifr
@@ -1,0 +1,13 @@
+# Test: enum with duplicate integer values
+from enum import Enum
+
+class Status(Enum):
+    OK = 200
+    SUCCESS = 200
+    NOT_FOUND = 404
+
+def main():
+    s: Status = Status.OK
+    print(s)
+
+# expect-error: duplicate

--- a/crates/sifr/tests/e2e/fail/enum_invalid_variant.sifr
+++ b/crates/sifr/tests/e2e/fail/enum_invalid_variant.sifr
@@ -1,0 +1,13 @@
+# Test: accessing a non-existent enum variant
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+def main():
+    c: Color = Color.YELLOW
+    print(c)
+
+# expect-error: undefined variable

--- a/crates/sifr/tests/e2e/fail/generic_bounds_not_satisfied.sifr
+++ b/crates/sifr/tests/e2e/fail/generic_bounds_not_satisfied.sifr
@@ -1,0 +1,12 @@
+# Test: calling a function with Comparable bound using a non-comparable type
+from sifr.bisect import bisect_left
+
+class Blob:
+    data: int
+
+def main():
+    items: list[Blob] = [Blob(1), Blob(2), Blob(3)]
+    idx: int = bisect_left(items, Blob(2))
+    print(idx)
+
+# expect-error: does not implement protocol 'Comparable'

--- a/crates/sifr/tests/e2e/fail/generic_class_missing_type_arg.sifr
+++ b/crates/sifr/tests/e2e/fail/generic_class_missing_type_arg.sifr
@@ -1,0 +1,6 @@
+# Test: using unknown generic type in annotation
+def main():
+    x: UnknownType[int] = 42
+    print(x)
+
+# expect-error: unknown generic type

--- a/crates/sifr/tests/e2e/fail/generic_counter_unhashable.sifr
+++ b/crates/sifr/tests/e2e/fail/generic_counter_unhashable.sifr
@@ -1,0 +1,9 @@
+# Test: float as Counter key should fail (float is not Hashable)
+from sifr.collections import Counter, from_list
+
+def main():
+    items: list[float] = [1.0, 2.0, 3.0]
+    c: Counter[float] = from_list(items)
+    print(c.total())
+
+# expect-error: does not implement protocol 'Hashable'

--- a/crates/sifr/tests/e2e/fail/generic_heapq_uncomparable.sifr
+++ b/crates/sifr/tests/e2e/fail/generic_heapq_uncomparable.sifr
@@ -1,0 +1,11 @@
+# Test: using heapq with a non-Comparable type should fail
+from sifr.heapq import heapify
+
+class Blob:
+    data: int
+
+def main():
+    items: list[Blob] = [Blob(3), Blob(1), Blob(2)]
+    heapify(items)
+
+# expect-error: does not implement protocol 'Comparable'

--- a/crates/sifr/tests/e2e/fail/generic_wrong_type_arg.sifr
+++ b/crates/sifr/tests/e2e/fail/generic_wrong_type_arg.sifr
@@ -1,0 +1,13 @@
+# Test: passing wrong type to a bounded generic function
+from sifr.bisect import bisect_left
+
+class Point:
+    x: int
+    y: int
+
+def main():
+    points: list[Point] = [Point(1, 2), Point(3, 4)]
+    idx: int = bisect_left(points, Point(2, 3))
+    print(idx)
+
+# expect-error: does not implement protocol

--- a/crates/sifr/tests/e2e/fail/stdlib_counter_wrong_type.sifr
+++ b/crates/sifr/tests/e2e/fail/stdlib_counter_wrong_type.sifr
@@ -5,4 +5,4 @@ def main():
     c: Counter = Counter(42)
     print(c.total())
 
-# expect-error: argument 1 ('counts') of function 'Counter': expected 'dict[str, int]', got 'int'
+# expect-error: argument 1 ('counts') of function 'Counter': expected 'dict[T, int]', got 'int'

--- a/crates/sifr/tests/e2e/pass/generic_accumulate_bigint.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_accumulate_bigint.sifr
@@ -1,0 +1,11 @@
+# Test accumulate with bigint values
+from sifr.itertools import accumulate
+from sifr.test import assert_eq
+
+def main():
+    data: list[bigint] = [bigint(10), bigint(20), bigint(30)]
+    acc: list[bigint] = accumulate(data)
+    assert_eq(len(acc), 3)
+    print("generic_accumulate_bigint: passed")
+
+# expect-stdout: generic_accumulate_bigint: passed

--- a/crates/sifr/tests/e2e/pass/generic_counter_bigint.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_counter_bigint.sifr
@@ -1,0 +1,13 @@
+# Test Counter[bigint] — generic counter with bigint keys
+from sifr.collections import Counter, from_list
+from sifr.test import assert_eq
+
+def main():
+    items: list[bigint] = [bigint(1), bigint(2), bigint(2), bigint(3)]
+    c: Counter[bigint] = from_list(items)
+    assert_eq(c.get(bigint(1)), 1)
+    assert_eq(c.get(bigint(2)), 2)
+    assert_eq(c.total(), 4)
+    print("generic_counter_bigint: passed")
+
+# expect-stdout: generic_counter_bigint: passed

--- a/crates/sifr/tests/e2e/pass/generic_counter_custom_class.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_counter_custom_class.sifr
@@ -1,0 +1,20 @@
+# Test Counter[str] with custom operations (most_common, elements)
+from sifr.collections import Counter, from_list
+from sifr.test import assert_eq
+
+def main():
+    c: Counter[str] = from_list(["apple", "banana", "apple", "cherry", "apple", "banana"])
+    assert_eq(c.get("apple"), 3)
+    assert_eq(c.get("banana"), 2)
+    assert_eq(c.get("cherry"), 1)
+    assert_eq(c.total(), 6)
+
+    top: list[str] = c.most_common(2)
+    assert_eq(len(top), 2)
+
+    elems: list[str] = c.elements()
+    assert_eq(len(elems), 6)
+
+    print("generic_counter_custom_class: passed")
+
+# expect-stdout: generic_counter_custom_class: passed

--- a/crates/sifr/tests/e2e/pass/generic_counter_int.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_counter_int.sifr
@@ -1,10 +1,10 @@
-# Test IntCounter for int keys
-from sifr.collections import IntCounter, int_counter_from_list
+# Test Counter[int] — generic counter with int keys
+from sifr.collections import Counter, from_list
 from sifr.test import assert_eq
 
 def main():
     items: list[int] = [1, 2, 2, 3, 3, 3]
-    c: IntCounter = int_counter_from_list(items)
+    c: Counter[int] = from_list(items)
     assert_eq(c.get(1), 1)
     assert_eq(c.get(2), 2)
     assert_eq(c.get(3), 3)

--- a/crates/sifr/tests/e2e/pass/generic_deque_float.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_deque_float.sifr
@@ -1,0 +1,17 @@
+# Test deque[float] — generic deque with float values
+from sifr.collections import deque
+from sifr.test import assert_eq
+
+def main():
+    d: deque[float] = deque(4)
+    d.append(1.1)
+    d.append(2.2)
+    d.append(3.3)
+    assert_eq(d.len(), 3)
+    val: float | None = d.popleft()
+    if val is not None:
+        assert_eq(val, 1.1)
+    assert_eq(d.len(), 2)
+    print("generic_deque_float: passed")
+
+# expect-stdout: generic_deque_float: passed

--- a/crates/sifr/tests/e2e/pass/generic_deque_str.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_deque_str.sifr
@@ -1,20 +1,34 @@
-# Test deque with int values (basic operations)
+# Test deque[T] with int and str values (generic operations)
 from sifr.collections import deque
 from sifr.test import assert_eq
 
 def main():
-    d: deque = deque(5)
+    # Test with int
+    d: deque[int] = deque(5)
     d.append(10)
     d.append(20)
     d.append(30)
     assert_eq(d.len(), 3)
-    val: int = d.popleft()
-    assert_eq(val, 10)
+    val: int | None = d.popleft()
+    if val is not None:
+        assert_eq(val, 10)
     assert_eq(d.len(), 2)
     d.appendleft(5)
     assert_eq(d.len(), 3)
     items: list[int] = d.to_list()
     assert_eq(len(items), 3)
+
+    # Test with str
+    ds: deque[str] = deque(3)
+    ds.append("hello")
+    ds.append("world")
+    ds.append("foo")
+    assert_eq(ds.len(), 3)
+    sv: str | None = ds.popleft()
+    if sv is not None:
+        assert_eq(sv, "hello")
+    assert_eq(ds.len(), 2)
+
     print("generic_deque_operations: passed")
 
 # expect-stdout: generic_deque_operations: passed

--- a/crates/sifr/tests/e2e/pass/generic_heapq_bigint.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_heapq_bigint.sifr
@@ -1,0 +1,16 @@
+# Test heapq with bigint values
+from sifr.heapq import heapify, heappop, nsmallest
+
+def main():
+    data: list[bigint] = [bigint(30), bigint(10), bigint(40), bigint(20)]
+    heapify(data)
+    v: bigint | None = heappop(data)
+    if v is not None:
+        print(v)
+    smallest: list[bigint] = nsmallest(2, data)
+    for x in smallest:
+        print(x)
+
+# expect-stdout: 10
+# expect-stdout: 20
+# expect-stdout: 30

--- a/crates/sifr/tests/e2e/pass/generic_reduce_str.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_reduce_str.sifr
@@ -1,0 +1,14 @@
+# Test generic reduce with str accumulator
+from sifr.functools import reduce
+from sifr.test import assert_eq
+
+def concat(acc: str, item: str) -> str:
+    return acc + item
+
+def main():
+    parts: list[str] = ["hello", " ", "world"]
+    result: str = reduce(concat, parts, "")
+    assert_eq(result, "hello world")
+    print("generic_reduce_str: passed")
+
+# expect-stdout: generic_reduce_str: passed

--- a/crates/sifr/tests/e2e/pass/generic_type_alias.sifr
+++ b/crates/sifr/tests/e2e/pass/generic_type_alias.sifr
@@ -1,0 +1,31 @@
+# Test generic type aliases (type Pair[T] = tuple[T, T])
+from sifr.test import assert_eq
+
+type Pair[T] = tuple[T, T]
+type Triple[T] = tuple[T, T, T]
+
+def swap(p: Pair[int]) -> Pair[int]:
+    a: int = p[0]
+    b: int = p[1]
+    return (b, a)
+
+def main():
+    p: Pair[int] = (1, 2)
+    assert_eq(p[0], 1)
+    assert_eq(p[1], 2)
+
+    swapped: Pair[int] = swap(p)
+    assert_eq(swapped[0], 2)
+    assert_eq(swapped[1], 1)
+
+    sp: Pair[str] = ("hello", "world")
+    assert_eq(sp[0], "hello")
+    assert_eq(sp[1], "world")
+
+    t: Triple[int] = (10, 20, 30)
+    assert_eq(t[0], 10)
+    assert_eq(t[2], 30)
+
+    print("generic_type_alias: all tests passed")
+
+# expect-stdout: generic_type_alias: all tests passed

--- a/crates/sifr/tests/e2e/pass/stdlib_collections_counter_new.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_collections_counter_new.sifr
@@ -1,40 +1,40 @@
-# Test new Counter methods: update, subtract, elements, counter_add, counter_sub
-from sifr.collections import Counter, from_list, counter_add, counter_sub
+# Test new Counter methods: update, subtract, elements, operator overloads
+from sifr.collections import Counter, from_list
 from sifr.test import assert_eq
 
 def main():
     # update
-    c1: Counter = from_list(["a", "b", "a"])
-    c2: Counter = from_list(["b", "c"])
+    c1: Counter[str] = from_list(["a", "b", "a"])
+    c2: Counter[str] = from_list(["b", "c"])
     c1.update(c2)
     assert_eq(c1.get("a"), 2)
     assert_eq(c1.get("b"), 2)
     assert_eq(c1.get("c"), 1)
 
     # subtract
-    c3: Counter = from_list(["x", "x", "y"])
-    c4: Counter = from_list(["x"])
+    c3: Counter[str] = from_list(["x", "x", "y"])
+    c4: Counter[str] = from_list(["x"])
     c3.subtract(c4)
     assert_eq(c3.get("x"), 1)
     assert_eq(c3.get("y"), 1)
 
     # elements
-    c5: Counter = from_list(["a", "a", "b"])
+    c5: Counter[str] = from_list(["a", "a", "b"])
     elems: list[str] = c5.elements()
     assert_eq(len(elems), 3)
 
-    # counter_add
-    ca: Counter = from_list(["a", "b"])
-    cb: Counter = from_list(["b", "c"])
-    cc: Counter = counter_add(ca, cb)
+    # operator + (counter_add replacement)
+    ca: Counter[str] = from_list(["a", "b"])
+    cb: Counter[str] = from_list(["b", "c"])
+    cc: Counter[str] = ca + cb
     assert_eq(cc.get("a"), 1)
     assert_eq(cc.get("b"), 2)
     assert_eq(cc.get("c"), 1)
 
-    # counter_sub
-    cd: Counter = from_list(["a", "a", "b"])
-    ce: Counter = from_list(["a"])
-    cf: Counter = counter_sub(cd, ce)
+    # operator - (counter_sub replacement)
+    cd: Counter[str] = from_list(["a", "a", "b"])
+    ce: Counter[str] = from_list(["a"])
+    cf: Counter[str] = cd - ce
     assert_eq(cf.get("a"), 1)
     assert_eq(cf.get("b"), 1)
 

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -146,6 +146,8 @@ pub struct StdlibCode {
     /// Map of module_name -> set of function names that are generators (contain yield).
     /// Used to emit .collect() when assigning generator results to list[T] in user code.
     pub generator_functions: HashMap<String, HashSet<String>>,
+    /// Set of class names that have generic type parameters across all stdlib modules.
+    pub generic_classes: HashSet<String>,
 }
 
 impl Default for StdlibCode {
@@ -157,6 +159,7 @@ impl Default for StdlibCode {
             func_signatures: HashMap::new(),
             transitive_deps: HashMap::new(),
             generator_functions: HashMap::new(),
+            generic_classes: HashSet::new(),
         }
     }
 }
@@ -330,7 +333,8 @@ fn parse_rust_blocks(rust_code: &str) -> Vec<(String, String)> {
                 while let Some(next_line) = lines.next() {
                     block_code.push_str(next_line);
                     block_code.push('\n');
-                    depth += count_braces(next_line);
+                    let delta = count_braces(next_line);
+                    depth += delta;
                     if depth <= 0 {
                         break;
                     }
@@ -373,20 +377,34 @@ fn extract_top_level_item_name(line: &str) -> Option<String> {
         return Some(name.to_string());
     }
     // impl Name or impl Display for Name
-    if let Some(rest) = trimmed.strip_prefix("impl ") {
+    if let Some(rest) = trimmed.strip_prefix("impl") {
+        // Skip generic params: impl<T: Bound> ... → skip past the closing '>'
+        let rest = if rest.starts_with('<') {
+            let mut depth = 0i32;
+            let mut end = 0;
+            for (i, ch) in rest.char_indices() {
+                if ch == '<' { depth += 1; }
+                if ch == '>' { depth -= 1; }
+                if depth == 0 { end = i + 1; break; }
+            }
+            rest[end..].trim_start()
+        } else {
+            rest.trim_start()
+        };
         // "impl Display for Name {" or "impl std::ops::Add<&Name> for &Name {"
         if let Some(for_idx) = rest.find(" for ") {
             let after_for = &rest[for_idx + 5..];
-            // Strip leading & (reference types in trait impls)
             let after_for = after_for.trim_start_matches('&');
             let name = after_for.split(|c: char| !c.is_alphanumeric() && c != '_').next()?;
             if !name.is_empty() {
                 return Some(name.to_string());
             }
         }
-        // "impl Name {"
+        // "impl Name {" or "Name<T> {"
         let name = rest.split(|c: char| !c.is_alphanumeric() && c != '_').next()?;
-        return Some(name.to_string());
+        if !name.is_empty() {
+            return Some(name.to_string());
+        }
     }
     None
 }
@@ -410,6 +428,8 @@ pub fn generate_rust_with_metadata(module: &HirModule) -> CodegenResult {
 pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -> CodegenResult {
     let mut emitter = RustEmitter::new();
     emitter.stdlib_intrinsic_names = stdlib_code.intrinsic_names.clone();
+    // Register stdlib generic classes so user code skips explicit type annotations
+    emitter.generic_classes.extend(stdlib_code.generic_classes.iter().cloned());
 
     // Pre-register stdlib constants and function signatures so user code can reference them correctly
     for import in &module.imports {
@@ -976,6 +996,8 @@ struct RustEmitter {
     module_constants: HashMap<String, (Type, String)>,
     /// Set of class names that have generic type parameters
     generic_classes: HashSet<String>,
+    /// Map of generic class name -> list of type parameter names (e.g., "Counter" -> ["T"])
+    generic_class_params: HashMap<String, Vec<String>>,
     /// Set of parameter names that are borrowed (&T) in the current function.
     /// Used to emit dereference (*name) in comparisons where &String != String.
     borrowed_params: HashSet<String>,
@@ -1036,6 +1058,7 @@ impl RustEmitter {
             nested_fn_captures: HashMap::new(),
             module_constants: HashMap::new(),
             generic_classes: HashSet::new(),
+            generic_class_params: HashMap::new(),
             borrowed_params: HashSet::new(),
             mut_borrowed_params: HashSet::new(),
             stdlib_intrinsic_names: HashMap::new(),
@@ -1048,6 +1071,62 @@ impl RustEmitter {
             try_closure_depth: 0,
             callable_var_conventions: HashMap::new(),
         }
+    }
+
+    /// Check if a generic class needs Hash + Eq bounds on its type parameters.
+    /// This is true when a type parameter is used as a HashMap key (dict field with TypeVar key).
+    fn class_needs_hash_eq(class: &HirClass) -> bool {
+        fn type_has_typevar_dict_key(ty: &Type) -> bool {
+            match ty {
+                Type::Dict(key, _) => matches!(key.as_ref(), Type::TypeVar(_)),
+                Type::List(inner) => type_has_typevar_dict_key(inner),
+                Type::Union(members) => members.iter().any(type_has_typevar_dict_key),
+                _ => false,
+            }
+        }
+        class.fields.iter().any(|(_, ty)| type_has_typevar_dict_key(ty))
+    }
+
+    /// Check if a generic function needs Hash + Eq bounds (uses TypeVar as dict key
+    /// or returns a generic class that needs Hash + Eq).
+    fn func_needs_hash_eq(func: &HirFunction) -> bool {
+        fn type_has_typevar_dict_key(ty: &Type) -> bool {
+            match ty {
+                Type::Dict(key, _) => matches!(key.as_ref(), Type::TypeVar(_)),
+                Type::List(inner) => type_has_typevar_dict_key(inner),
+                Type::Union(members) => members.iter().any(type_has_typevar_dict_key),
+                Type::Class { fields, .. } => fields.iter().any(|(_, t)| type_has_typevar_dict_key(t)),
+                _ => false,
+            }
+        }
+        // Check params
+        if func.params.iter().any(|p| type_has_typevar_dict_key(&p.ty)) {
+            return true;
+        }
+        // Check return type
+        if type_has_typevar_dict_key(&func.return_type) {
+            return true;
+        }
+        false
+    }
+
+    fn generic_bounds_for_class(class: &HirClass) -> String {
+        if Self::class_needs_hash_eq(class) {
+            "Clone + std::fmt::Display + PartialOrd + std::hash::Hash + Eq".to_string()
+        } else {
+            "Clone + std::fmt::Display + PartialOrd".to_string()
+        }
+    }
+
+    /// Convert a Type to its Rust representation, appending generic type params
+    /// for classes that are known to be generic (e.g., Counter → Counter<T>).
+    fn rust_type_with_generics(&self, ty: &Type) -> String {
+        if let Type::Class { name, .. } = ty {
+            if let Some(params) = self.generic_class_params.get(name) {
+                return format!("{}<{}>", name, params.join(", "));
+            }
+        }
+        ty.rust_type()
     }
 
     /// Detect self-referential class fields that need Box<T> wrapping.
@@ -1063,6 +1142,7 @@ impl RustEmitter {
             }
             if !class.type_params.is_empty() {
                 self.generic_classes.insert(class.name.clone());
+                self.generic_class_params.insert(class.name.clone(), class.type_params.clone());
             }
         }
     }
@@ -1372,11 +1452,12 @@ impl RustEmitter {
             self.write("struct ");
         }
         self.write(&class.name);
+        let class_bounds = Self::generic_bounds_for_class(class);
         if !class.type_params.is_empty() {
             self.write("<");
             for (i, tp) in class.type_params.iter().enumerate() {
                 if i > 0 { self.write(", "); }
-                self.write(&format!("{}: Clone + std::fmt::Display + PartialOrd", tp));
+                self.write(&format!("{}: {}", tp, class_bounds));
             }
             self.write(">");
         }
@@ -1428,7 +1509,7 @@ impl RustEmitter {
             self.write("<");
             for (i, tp) in class.type_params.iter().enumerate() {
                 if i > 0 { self.write(", "); }
-                self.write(&format!("{}: Clone + std::fmt::Display + PartialOrd", tp));
+                self.write(&format!("{}: {}", tp, class_bounds));
             }
             self.write(">");
         }
@@ -1842,21 +1923,42 @@ impl RustEmitter {
     /// Emit `impl std::ops::Trait for ClassName` for binary operators.
     /// Uses reference-based impl to avoid consuming the operands.
     fn emit_binop_trait_impl(&mut self, class: &HirClass, func: &HirFunction, trait_name: &str, method_name: &str, _op: &str) {
+        let is_generic = !class.type_params.is_empty();
+        let bounds = Self::generic_bounds_for_class(class);
+        let generic_suffix = if is_generic {
+            let params: Vec<String> = class.type_params.iter().map(|p| p.clone()).collect();
+            format!("<{}>", params.join(", "))
+        } else {
+            String::new()
+        };
+        let class_with_generics = format!("{}{}", class.name, generic_suffix);
+
         let rhs_ty = if let Some(param) = func.params.first() {
-            // If the param type is the same class, use &ClassName
             if param.ty.rust_type() == class.name {
-                format!("&{}", class.name)
+                format!("&{}", class_with_generics)
             } else {
                 param.ty.rust_type()
             }
         } else {
-            format!("&{}", class.name)
+            format!("&{}", class_with_generics)
         };
-        let output_ty = func.return_type.rust_type();
+        let output_ty = if func.return_type.rust_type() == class.name {
+            class_with_generics.clone()
+        } else {
+            func.return_type.rust_type()
+        };
 
         self.output.push('\n');
         self.write_indent();
-        self.write(&format!("impl std::ops::{}<{}> for &{} {{\n", trait_name, rhs_ty, class.name));
+        if is_generic {
+            let bounded_params: Vec<String> = class.type_params.iter()
+                .map(|p| format!("{}: {}", p, bounds))
+                .collect();
+            self.write(&format!("impl<{}> std::ops::{}<{}> for &{} {{\n",
+                bounded_params.join(", "), trait_name, rhs_ty, class_with_generics));
+        } else {
+            self.write(&format!("impl std::ops::{}<{}> for &{} {{\n", trait_name, rhs_ty, class.name));
+        }
         self.indent += 1;
         self.write_indent();
         self.write(&format!("type Output = {};\n\n", output_ty));
@@ -1872,10 +1974,12 @@ impl RustEmitter {
         self.write(") -> Self::Output {\n");
         self.indent += 1;
 
-        // Emit the body
+        let saved_mutated = std::mem::take(&mut self.mutated_vars);
+        self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
         for stmt in &func.body {
             self.emit_stmt(stmt);
         }
+        self.mutated_vars = saved_mutated;
 
         self.indent -= 1;
         self.write_indent();
@@ -2265,8 +2369,7 @@ impl RustEmitter {
                         self.write(", ");
                         self.write(&param.name);
                         self.write(": ");
-                        // Emit parameter type based on convention
-                        let rust_ty = param.ty.rust_type();
+                        let rust_ty = self.rust_type_with_generics(&param.ty);
                         match param.convention {
                             ParamConvention::Borrow => {
                                 if param.ty.ownership() == sifr_type_system::OwnershipKind::Copy {
@@ -2474,13 +2577,19 @@ impl RustEmitter {
         self.write(&func.name);
         // Emit generic type parameters if this is a generic function
         if !func.type_params.is_empty() {
+            let needs_hash_eq = Self::func_needs_hash_eq(func);
             self.write("<");
             for (i, tp) in func.type_params.iter().enumerate() {
                 if i > 0 {
                     self.write(", ");
                 }
                 let extra = Self::extra_bounds_for_type_param(tp, &func.body);
-                self.write(&format!("{}: Clone + std::fmt::Display + PartialOrd{}", tp, extra));
+                let base = if needs_hash_eq {
+                    "Clone + std::fmt::Display + PartialOrd + std::hash::Hash + Eq"
+                } else {
+                    "Clone + std::fmt::Display + PartialOrd"
+                };
+                self.write(&format!("{}: {}{}", tp, base, extra));
             }
             self.write(">");
         }
@@ -2535,7 +2644,25 @@ impl RustEmitter {
                     };
                     self.write(&format!("impl Iterator<Item = {}>", yield_ty));
                 } else {
-                    self.write(&func.return_type.rust_type());
+                    // If return type is a generic class and this function has type params,
+                    // include the type params in the return type
+                    let ret_type = if let Type::Class { name: ref ret_name, .. } = func.return_type {
+                        if self.generic_classes.contains(ret_name) && !func.type_params.is_empty() {
+                            let type_params_in_ret: Vec<&String> = func.type_params.iter()
+                                .filter(|tp| type_contains_typevar(&func.return_type, tp))
+                                .collect();
+                            if !type_params_in_ret.is_empty() {
+                                format!("{}<{}>", ret_name, type_params_in_ret.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "))
+                            } else {
+                                func.return_type.rust_type()
+                            }
+                        } else {
+                            func.return_type.rust_type()
+                        }
+                    } else {
+                        func.return_type.rust_type()
+                    };
+                    self.write(&ret_type);
                 }
             }
         }
@@ -3808,11 +3935,11 @@ impl RustEmitter {
                     }
                     Type::Dict(ref key_ty, _) => {
                         // self.field[key] = val -> self.field.insert(key_owned, val)
-                        // For string keys: if key is a borrowed param (&String), we clone it for owned insert.
+                        // For move-type keys: if key is a borrowed param (&T), clone for owned insert.
                         self.write(&field_access);
                         self.write(".insert(");
-                        if matches!(key_ty.as_ref(), Type::Str) {
-                            // String key: emit key with .clone() if it's a borrowed param
+                        let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_));
+                        if key_needs_clone {
                             if let HirExpr::Name { name, .. } = index {
                                 if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()) {
                                     self.emit_expr(index);
@@ -5934,6 +6061,14 @@ impl RustEmitter {
                         self.write(", ");
                     }
                     self.emit_expr(elem);
+                    if let HirExpr::Name { name, ty } = elem {
+                        if matches!(ty, Type::TypeVar(_))
+                            && (self.borrowed_params.contains(name.as_str())
+                                || self.mut_borrowed_params.contains(name.as_str()))
+                        {
+                            self.write(".clone()");
+                        }
+                    }
                 }
                 self.write("]");
             }
@@ -8097,7 +8232,7 @@ impl RustEmitter {
 
 fn is_hashable_type_codegen(ty: &Type) -> bool {
     match ty {
-        Type::Int | Type::Bool | Type::Str | Type::None => true,
+        Type::Int | Type::Bool | Type::Str | Type::None | Type::BigInt => true,
         Type::Float => false,
         _ => false,
     }
@@ -8200,6 +8335,27 @@ fn expr_contains_self_field_mutation(expr: &HirExpr) -> bool {
             }
             // Recurse into the object
             expr_contains_self_field_mutation(object)
+        }
+        _ => false,
+    }
+}
+
+/// Check if a type contains a specific type variable name.
+fn type_contains_typevar(ty: &Type, tv_name: &str) -> bool {
+    match ty {
+        Type::TypeVar(name) => name == tv_name,
+        Type::List(inner) => type_contains_typevar(inner, tv_name),
+        Type::Set(inner) => type_contains_typevar(inner, tv_name),
+        Type::Dict(key, val) => type_contains_typevar(key, tv_name) || type_contains_typevar(val, tv_name),
+        Type::Tuple(elems) => elems.iter().any(|e| type_contains_typevar(e, tv_name)),
+        Type::Union(members) => members.iter().any(|m| type_contains_typevar(m, tv_name)),
+        Type::Result(ok, err) => type_contains_typevar(ok, tv_name) || type_contains_typevar(err, tv_name),
+        Type::Class { fields, methods, .. } => {
+            fields.iter().any(|(_, t)| type_contains_typevar(t, tv_name))
+                || methods.iter().any(|(_, ft)| {
+                    ft.params.iter().any(|(_, t, _)| type_contains_typevar(t, tv_name))
+                        || type_contains_typevar(&ft.return_type, tv_name)
+                })
         }
         _ => false,
     }
@@ -8889,6 +9045,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -8922,6 +9080,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -8961,6 +9121,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -8995,6 +9157,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9038,6 +9202,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9067,6 +9233,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9099,6 +9267,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9148,6 +9318,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9186,6 +9358,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9231,6 +9405,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);
@@ -9259,6 +9435,8 @@ mod tests {
             classes: vec![],
             imports: vec![],
             constants: vec![],
+            generic_functions: std::collections::HashMap::new(),
+            type_param_bounds: std::collections::HashMap::new(),
         };
 
         let rust_code = generate_rust(&module);

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -228,6 +228,7 @@ fn compile_stdlib() -> Result<StdlibCompiled, Vec<CompileError>> {
                 func_signatures: stdlib_code.func_signatures.clone(),
                 transitive_deps: stdlib_code.transitive_deps.clone(),
                 generator_functions: stdlib_code.generator_functions.clone(),
+                generic_classes: stdlib_code.generic_classes.clone(),
             };
             let codegen_result = sifr_codegen::generate_rust_with_stdlib(&result.module, &codegen_stdlib);
             stdlib_code.module_rust_code.insert(module_name.to_string(), codegen_result.rust_source);
@@ -273,6 +274,13 @@ fn compile_stdlib() -> Result<StdlibCompiled, Vec<CompileError>> {
             if !gen_fns.is_empty() {
                 stdlib_code.generator_functions.insert(module_name.to_string(), gen_fns);
             }
+
+            // Track generic classes for correct type annotation skipping in user code
+            for class in &result.module.classes {
+                if !class.type_params.is_empty() {
+                    stdlib_code.generic_classes.insert(class.name.clone());
+                }
+            }
         }
 
         stdlib_code.intrinsic_names.insert(module_name.to_string(), intrinsic_names_for_module);
@@ -284,6 +292,12 @@ fn compile_stdlib() -> Result<StdlibCompiled, Vec<CompileError>> {
         stdlib_defs.classes.insert(module_name.to_string(), class_exports);
         if !const_exports.is_empty() {
             stdlib_defs.constants.insert(module_name.to_string(), const_exports);
+        }
+        if !result.module.generic_functions.is_empty() {
+            stdlib_defs.generic_functions.insert(module_name.to_string(), result.module.generic_functions.clone());
+        }
+        if !result.module.type_param_bounds.is_empty() {
+            stdlib_defs.type_param_bounds.insert(module_name.to_string(), result.module.type_param_bounds.clone());
         }
     }
 
@@ -605,7 +619,7 @@ pub fn build_project(main_file: &Path, output_dir: &Path) -> Result<PathBuf, Vec
 
     // Write Cargo.toml
     let (cargo_toml, _) = generate_project(
-        &HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![] },
+        &HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![], generic_functions: HashMap::new(), type_param_bounds: HashMap::new() },
         "sifr_output",
     );
     std::fs::write(project_path.join("Cargo.toml"), cargo_toml).map_err(|e| {
@@ -708,7 +722,7 @@ pub fn build(source: &str, output_dir: &Path) -> Result<PathBuf, Vec<CompileErro
         effective_stdlib_modules.insert("_bigint".to_string());
     }
     let (cargo_toml, _) = generate_project_with_deps(
-        &sifr_hir::HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![] },
+        &sifr_hir::HirModule { functions: vec![], classes: vec![], imports: vec![], constants: vec![], generic_functions: HashMap::new(), type_param_bounds: HashMap::new() },
         "sifr_output",
         &effective_stdlib_modules,
     );

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -10,6 +10,10 @@ pub struct HirModule {
     pub imports: Vec<HirImport>,
     /// Module-level constants (name, type, value)
     pub constants: Vec<(String, Type, HirExpr)>,
+    /// Generic function info: function_name -> type_var_names
+    pub generic_functions: std::collections::HashMap<String, Vec<String>>,
+    /// Type parameter bounds: owner_name (function or class) -> (type_var_name -> protocol_names)
+    pub type_param_bounds: std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>>,
 }
 
 /// An import statement.

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -66,11 +66,15 @@ struct LowerCtx {
     type_vars: std::collections::HashSet<String>,
     /// Map of generic function names to their type variable names
     generic_functions: HashMap<String, Vec<String>>,
+    /// Map of owner (function or class name) -> (type_var_name -> protocol bounds)
+    type_param_bounds: HashMap<String, HashMap<String, Vec<String>>>,
     /// Whether _sifr.* intrinsic imports are allowed (true for stdlib .sifr files)
     allow_intrinsic_imports: bool,
     /// Set of parameter names that are immutably borrowed (&T) in the current function.
     /// Used for escape analysis: returning or storing a borrowed param is a compile error.
     borrowed_params: std::collections::HashSet<String>,
+    /// Map of class names to their declared type parameters (from PEP 695 class C[T])
+    class_declared_type_params: HashMap<String, Vec<String>>,
 }
 
 impl LowerCtx {
@@ -93,8 +97,10 @@ impl LowerCtx {
             vararg_functions: std::collections::HashSet::new(),
             type_vars: std::collections::HashSet::new(),
             generic_functions: HashMap::new(),
+            type_param_bounds: HashMap::new(),
             allow_intrinsic_imports: false,
             borrowed_params: std::collections::HashSet::new(),
+            class_declared_type_params: HashMap::new(),
         }
     }
 
@@ -202,6 +208,30 @@ fn infer_type_var_bindings(param_ty: &Type, arg_ty: &Type, bindings: &mut HashMa
     }
 }
 
+/// Check if a concrete type satisfies a protocol bound.
+fn type_satisfies_bound(ty: &Type, bound: &str) -> bool {
+    // TypeVars are not concrete — bounds are checked when they're instantiated
+    if matches!(ty, Type::TypeVar(_)) {
+        return true;
+    }
+    match bound {
+        "Comparable" => matches!(
+            ty,
+            Type::Int | Type::Float | Type::Str | Type::Bool | Type::BigInt
+        ),
+        "Addable" => matches!(
+            ty,
+            Type::Int | Type::Float | Type::Str | Type::BigInt
+        ),
+        "Hashable" => matches!(
+            ty,
+            Type::Int | Type::Str | Type::Bool | Type::BigInt | Type::None
+                | Type::Enum { .. } | Type::LiteralStr(_) | Type::LiteralInt(_) | Type::LiteralBool(_)
+        ),
+        _ => true,
+    }
+}
+
 /// Result of lowering, including the HIR module and any diagnostics.
 pub struct LoweringResult {
     pub module: HirModule,
@@ -222,6 +252,10 @@ pub struct ExternalDefs {
     pub constants: std::collections::HashMap<String, std::collections::HashMap<String, Type>>,
     /// Set of class names that are error types (class Foo(Error)) across all modules
     pub error_types: std::collections::HashSet<String>,
+    /// Map of module_name -> (owner_name -> (type_var_name -> bounds))
+    pub type_param_bounds: std::collections::HashMap<String, std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>>>,
+    /// Map of module_name -> (function_name -> type_var_names)
+    pub generic_functions: std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>>,
 }
 
 /// Lower a parsed module AST into a typed HIR module.
@@ -314,8 +348,25 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                         continue;
                     }
                 };
+                let mut alias_type_params = Vec::new();
+                if let Some(ref tps) = type_alias.type_params {
+                    for tp in tps.iter() {
+                        if let sifr_python_ast::TypeParam::TypeVar(tv) = tp {
+                            let tp_name = tv.name.to_string();
+                            ctx.type_vars.insert(tp_name.clone());
+                            alias_type_params.push(tp_name);
+                        }
+                    }
+                }
                 let ty = resolve_annotation_expr(&type_alias.value, &mut ctx);
-                ctx.scope.define_type_alias(name, ty);
+                if alias_type_params.is_empty() {
+                    ctx.scope.define_type_alias(name, ty);
+                } else {
+                    ctx.scope.define_generic_type_alias(name, alias_type_params.clone(), ty);
+                }
+                for tp_name in &alias_type_params {
+                    ctx.type_vars.remove(tp_name.as_str());
+                }
             }
             _ => {}
         }
@@ -329,7 +380,19 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                     if let sifr_python_ast::TypeParam::TypeVar(tv) = tp {
                         let name = tv.name.to_string();
                         ctx.type_vars.insert(name.clone());
-                        pep695_type_vars.push(name);
+                        pep695_type_vars.push(name.clone());
+                        if let Some(ref bound) = tv.bound {
+                            let bound_name = match bound.as_ref() {
+                                Expr::Name(n) => n.id.to_string(),
+                                _ => continue,
+                            };
+                            ctx.type_param_bounds
+                                .entry(func.name.to_string())
+                                .or_insert_with(HashMap::new)
+                                .entry(name)
+                                .or_insert_with(Vec::new)
+                                .push(bound_name);
+                        }
                     }
                 }
             }
@@ -469,6 +532,17 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                                 if let Some(ft) = module_fns.get(name) {
                                     ctx.functions.insert(local.clone(), ft.clone());
                                     found = true;
+                                    // Import generic function info and bounds
+                                    if let Some(module_gf) = externals.generic_functions.get(&stdlib_module_key) {
+                                        if let Some(type_vars) = module_gf.get(name) {
+                                            ctx.generic_functions.insert(local.clone(), type_vars.clone());
+                                        }
+                                    }
+                                    if let Some(module_bounds) = externals.type_param_bounds.get(&stdlib_module_key) {
+                                        if let Some(owner_bounds) = module_bounds.get(name) {
+                                            ctx.type_param_bounds.insert(local.clone(), owner_bounds.clone());
+                                        }
+                                    }
                                 }
                             }
                             // Check classes
@@ -492,6 +566,12 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
                                                 FunctionType::new(params, class_ty.clone())
                                             };
                                             ctx.functions.insert(local.clone(), ft);
+                                        }
+                                        // Import class type parameter bounds
+                                        if let Some(module_bounds) = externals.type_param_bounds.get(&stdlib_module_key) {
+                                            if let Some(owner_bounds) = module_bounds.get(name) {
+                                                ctx.type_param_bounds.insert(local.clone(), owner_bounds.clone());
+                                            }
                                         }
                                         found = true;
                                     }
@@ -646,7 +726,14 @@ fn lower_module_impl(stmts: &[Stmt], externals: &ExternalDefs, mut ctx: LowerCtx
 
     if ctx.errors.is_empty() {
         Ok(LoweringResult {
-            module: HirModule { functions, classes, imports, constants },
+            module: HirModule {
+                functions,
+                classes,
+                imports,
+                constants,
+                generic_functions: ctx.generic_functions.clone(),
+                type_param_bounds: ctx.type_param_bounds.clone(),
+            },
             reveal_types: ctx.reveal_types,
             warnings: ctx.warnings,
         })
@@ -956,10 +1043,26 @@ fn collect_class_type(class_def: &StmtClassDef, ctx: &mut LowerCtx) {
 
     // PEP 695: register inline type params (class C[T]) as type variables
     if let Some(ref type_params) = class_def.type_params {
+        let mut declared_params = Vec::new();
         for tp in type_params.iter() {
             if let sifr_python_ast::TypeParam::TypeVar(tv) = tp {
-                ctx.type_vars.insert(tv.name.to_string());
+                let tp_name = tv.name.to_string();
+                ctx.type_vars.insert(tp_name.clone());
+                declared_params.push(tp_name.clone());
+                if let Some(ref bound) = tv.bound {
+                    if let Expr::Name(n) = bound.as_ref() {
+                        ctx.type_param_bounds
+                            .entry(class_name.clone())
+                            .or_insert_with(HashMap::new)
+                            .entry(tp_name)
+                            .or_insert_with(Vec::new)
+                            .push(n.id.to_string());
+                    }
+                }
             }
+        }
+        if !declared_params.is_empty() {
+            ctx.class_declared_type_params.insert(class_name.clone(), declared_params);
         }
     }
 
@@ -983,6 +1086,23 @@ fn collect_class_type(class_def: &StmtClassDef, ctx: &mut LowerCtx) {
     // For enum declarations, register as an Enum type
     if is_enum_class(class_def) {
         let variants = collect_enum_variants(class_def);
+        // Check for duplicate variant values
+        {
+            let mut seen_values: std::collections::HashMap<i64, String> = std::collections::HashMap::new();
+            for (vname, vval) in &variants {
+                let val = vval.unwrap_or(0);
+                if let Some(existing) = seen_values.get(&val) {
+                    if vval.is_some() {
+                        ctx.error(format!(
+                            "enum '{}' has duplicate value {}: variants '{}' and '{}'",
+                            class_name, val, existing, vname
+                        ));
+                    }
+                } else if vval.is_some() {
+                    seen_values.insert(val, vname.clone());
+                }
+            }
+        }
         let enum_ty = Type::Enum {
             name: class_name.clone(),
             variants: variants.iter().map(|(n, v)| (n.clone(), *v)).collect(),
@@ -1596,7 +1716,7 @@ fn lower_class(class_def: &StmtClassDef, ctx: &mut LowerCtx) -> Option<HirClass>
 /// Check if a type is hashable (can derive Hash + Eq).
 fn is_hashable_type(ty: &Type) -> bool {
     match ty {
-        Type::Int | Type::Bool | Type::Str | Type::None => true,
+        Type::Int | Type::Bool | Type::Str | Type::None | Type::BigInt => true,
         Type::Float => false, // f64 doesn't implement Hash
         Type::LiteralInt(_) | Type::LiteralBool(_) | Type::LiteralStr(_) => true,
         Type::Tuple(elems) => elems.iter().all(is_hashable_type),
@@ -2065,6 +2185,20 @@ fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
                     }
                 }
                 _ => {
+                    // Check if it's a generic type alias (e.g., Pair[int])
+                    if let Some((alias_params, alias_body)) = ctx.scope.lookup_generic_type_alias(&base_name).cloned() {
+                        let type_args: Vec<Type> = match sub.slice.as_ref() {
+                            Expr::Tuple(tup) => tup.elts.iter().map(|e| resolve_annotation_expr(e, ctx)).collect(),
+                            single => vec![resolve_annotation_expr(single, ctx)],
+                        };
+                        let mut bindings = HashMap::new();
+                        for (i, tp) in alias_params.iter().enumerate() {
+                            if let Some(arg) = type_args.get(i) {
+                                bindings.insert(tp.clone(), arg.clone());
+                            }
+                        }
+                        return substitute_type_vars(&alias_body, &bindings);
+                    }
                     // Check if it's a generic class instantiation (e.g., Stack[int])
                     if let Some(class_ty) = ctx.class_types.get(&base_name).cloned() {
                         // Resolve type arguments and substitute into the class type
@@ -2074,16 +2208,23 @@ fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
                         };
                         // Build substitution map from class type params to concrete args
                         if let Type::Class { ref fields, ref methods, .. } = class_ty {
-                            let class_type_params: Vec<String> = fields.iter()
-                                .flat_map(|(_, ty)| { let mut vars = Vec::new(); collect_type_vars(ty, &mut vars); vars })
-                                .chain(methods.iter().flat_map(|(_, ft)| {
-                                    let mut vars = Vec::new();
-                                    for (_, pt, _) in &ft.params { collect_type_vars(pt, &mut vars); }
-                                    collect_type_vars(&ft.return_type, &mut vars);
-                                    vars
-                                }))
-                                .collect::<std::collections::HashSet<_>>()
-                                .into_iter().collect::<Vec<_>>();
+                            // Use declared type parameters (from class C[T]) when available,
+                            // falling back to scanning fields/methods for backward compatibility.
+                            let class_type_params: Vec<String> = ctx.class_declared_type_params
+                                .get(&base_name)
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    fields.iter()
+                                        .flat_map(|(_, ty)| { let mut vars = Vec::new(); collect_type_vars(ty, &mut vars); vars })
+                                        .chain(methods.iter().flat_map(|(_, ft)| {
+                                            let mut vars = Vec::new();
+                                            for (_, pt, _) in &ft.params { collect_type_vars(pt, &mut vars); }
+                                            collect_type_vars(&ft.return_type, &mut vars);
+                                            vars
+                                        }))
+                                        .collect::<std::collections::HashSet<_>>()
+                                        .into_iter().collect::<Vec<_>>()
+                                });
                             if !class_type_params.is_empty() && !type_args.is_empty() {
                                 let mut bindings = HashMap::new();
                                 for (i, tp) in class_type_params.iter().enumerate() {
@@ -2755,6 +2896,25 @@ fn lower_match(
             let mut covered_none = false;
             let mut covered_classes: std::collections::HashSet<String> = std::collections::HashSet::new();
             let mut covered_types: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut covered_literal_strs: std::collections::HashSet<String> = std::collections::HashSet::new();
+            let mut covered_literal_ints: std::collections::HashSet<i64> = std::collections::HashSet::new();
+            let mut covered_literal_bools: std::collections::HashSet<bool> = std::collections::HashSet::new();
+
+            fn collect_literal_coverage(
+                pattern: &HirPattern,
+                covered_literal_strs: &mut std::collections::HashSet<String>,
+                covered_literal_ints: &mut std::collections::HashSet<i64>,
+                covered_literal_bools: &mut std::collections::HashSet<bool>,
+            ) {
+                if let HirPattern::Literal { value } = pattern {
+                    match value {
+                        HirExpr::StringLiteral(s) => { covered_literal_strs.insert(s.clone()); }
+                        HirExpr::IntLiteral(n) => { covered_literal_ints.insert(*n); }
+                        HirExpr::BoolLiteral(b) => { covered_literal_bools.insert(*b); }
+                        _ => {}
+                    }
+                }
+            }
 
             for arm in &arms {
                 match &arm.pattern {
@@ -2763,11 +2923,17 @@ fn lower_match(
                     HirPattern::Capture { ty, .. } if arm.guard.is_none() => {
                         covered_types.insert(ty.display_name());
                     }
+                    HirPattern::Literal { .. } => {
+                        collect_literal_coverage(&arm.pattern, &mut covered_literal_strs, &mut covered_literal_ints, &mut covered_literal_bools);
+                    }
                     HirPattern::Or { patterns } => {
                         for p in patterns {
                             match p {
                                 HirPattern::None => { covered_none = true; }
                                 HirPattern::Class { class_name, .. } => { covered_classes.insert(class_name.clone()); }
+                                HirPattern::Literal { .. } => {
+                                    collect_literal_coverage(p, &mut covered_literal_strs, &mut covered_literal_ints, &mut covered_literal_bools);
+                                }
                                 _ => {}
                             }
                         }
@@ -2806,6 +2972,21 @@ fn lower_match(
                     Type::Bool => {
                         if !covered_types.contains("bool") && !covered_classes.contains("bool") {
                             uncovered.push("bool".to_string());
+                        }
+                    }
+                    Type::LiteralStr(s) => {
+                        if !covered_literal_strs.contains(s) {
+                            uncovered.push(format!("\"{}\"", s));
+                        }
+                    }
+                    Type::LiteralInt(n) => {
+                        if !covered_literal_ints.contains(n) {
+                            uncovered.push(n.to_string());
+                        }
+                    }
+                    Type::LiteralBool(b) => {
+                        if !covered_literal_bools.contains(b) {
+                            uncovered.push(b.to_string());
                         }
                     }
                     _ => {}
@@ -5252,6 +5433,27 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         let mut bindings = HashMap::new();
         for (arg, (_, param_ty, _)) in args.iter().zip(ft.params.iter()) {
             infer_type_var_bindings(param_ty, arg.ty(), &mut bindings);
+        }
+        // Check protocol bounds on type parameters (scoped to this function)
+        let func_bounds = ctx.type_param_bounds.get(&func_name);
+        let bound_errors: Vec<String> = bindings.iter().flat_map(|(tv_name, concrete_ty)| {
+            func_bounds.into_iter().flat_map(move |owner_bounds| {
+                owner_bounds.get(tv_name).into_iter().flat_map(move |bounds| {
+                    bounds.iter().filter_map(move |bound| {
+                        if !type_satisfies_bound(concrete_ty, bound) {
+                            Some(format!(
+                                "type '{}' does not implement protocol '{}' required by type parameter '{}'",
+                                concrete_ty.display_name(), bound, tv_name
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                })
+            })
+        }).collect();
+        for err in bound_errors {
+            ctx.error(err);
         }
         if bindings.is_empty() {
             *ft.return_type

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -41,6 +41,8 @@ pub struct Scope {
     frames: Vec<HashMap<String, VarInfo>>,
     /// Type alias registry.
     type_aliases: HashMap<String, Type>,
+    /// Generic type alias registry: name -> (type_params, body_type).
+    generic_type_aliases: HashMap<String, (Vec<String>, Type)>,
 }
 
 impl Scope {
@@ -48,6 +50,7 @@ impl Scope {
         Self {
             frames: vec![HashMap::new()],
             type_aliases: HashMap::new(),
+            generic_type_aliases: HashMap::new(),
         }
     }
 
@@ -245,6 +248,16 @@ impl Scope {
     /// Look up a type alias.
     pub fn lookup_type_alias(&self, name: &str) -> Option<&Type> {
         self.type_aliases.get(name)
+    }
+
+    /// Register a generic type alias (e.g., `type Pair[T] = tuple[T, T]`).
+    pub fn define_generic_type_alias(&mut self, name: String, type_params: Vec<String>, ty: Type) {
+        self.generic_type_aliases.insert(name, (type_params, ty));
+    }
+
+    /// Look up a generic type alias.
+    pub fn lookup_generic_type_alias(&self, name: &str) -> Option<&(Vec<String>, Type)> {
+        self.generic_type_aliases.get(name)
     }
 }
 

--- a/demos/milestone_stdlib_generic_rewrite_demo.sifr
+++ b/demos/milestone_stdlib_generic_rewrite_demo.sifr
@@ -1,10 +1,12 @@
 # Demo: milestone_stdlib_generic_rewrite
 # Showcases generic stdlib functions working with multiple types,
-# predicate-based itertools, IntCounter, and generic heapq.
+# predicate-based itertools, generic Counter[T] with operator overloads,
+# generic deque[T], generic heapq with Comparable bounds, and bigint support.
 
 from sifr.itertools import chain, take, flatten, cycle, islice, compress, pairwise, repeat, zip_longest, accumulate, dropwhile, takewhile, filterfalse
 from sifr.heapq import heapify, heappop, heappush, nsmallest, nlargest, heapify_copy
-from sifr.collections import IntCounter, int_counter_from_list
+from sifr.collections import Counter, from_list, deque
+from sifr.functools import reduce
 from sifr.random import shuffle
 
 def is_small(x: int) -> bool:
@@ -12,6 +14,9 @@ def is_small(x: int) -> bool:
 
 def is_even(x: int) -> bool:
     return x % 2 == 0
+
+def concat(a: str, b: str) -> str:
+    return a + b
 
 def main():
     # --- 1. Generic chain: works with any type ---
@@ -34,7 +39,7 @@ def main():
     flat_int: list[int] = flatten(nested_int)
     print(flat_int)
 
-    # --- 4. Generic accumulate (now works with int and float) ---
+    # --- 4. Generic accumulate (Addable bound: works with int, float, str) ---
     print("=== Generic accumulate ===")
     sums: list[int] = accumulate([1, 2, 3, 4, 5])
     print(sums)
@@ -57,7 +62,7 @@ def main():
     odds: list[int] = filterfalse(is_even, [1, 2, 3, 4, 5, 6])
     print(odds)
 
-    # --- 8. Generic heapq (nsmallest, nlargest) ---
+    # --- 8. Generic heapq (Comparable bound) ---
     print("=== Generic heapq ===")
     items: list[int] = [9, 3, 7, 1, 5]
     small: list[int] = nsmallest(3, items)
@@ -65,28 +70,52 @@ def main():
     big: list[int] = nlargest(2, items)
     print(big)
 
-    # --- 9. IntCounter (counter for int keys) ---
-    print("=== IntCounter ===")
-    nums: list[int] = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
-    c: IntCounter = int_counter_from_list(nums)
-    print(c.get(3))
-    print(c.get(4))
+    # --- 9. Generic Counter[T] with operator overloads ---
+    print("=== Generic Counter[T] ===")
+    words: list[str] = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+    c: Counter[str] = from_list(words)
+    print(c.get("apple"))
     print(c.total())
+    top: list[str] = c.most_common(2)
+    print(top)
 
-    # --- 10. Generic compress ---
+    nums: list[int] = [1, 2, 2, 3, 3, 3]
+    ci: Counter[int] = from_list(nums)
+    print(ci.get(3))
+
+    c2: Counter[str] = from_list(["banana", "date"])
+    combined: Counter[str] = c + c2
+    print(combined.get("banana"))
+
+    # --- 10. Generic deque[T] ---
+    print("=== Generic deque[T] ===")
+    d: deque[str] = deque(0)
+    d.append("first")
+    d.append("second")
+    d.appendleft("zero")
+    items_d: list[str] = d.to_list()
+    print(items_d)
+    print(d.len())
+
+    # --- 11. Generic functools.reduce ---
+    print("=== Generic reduce ===")
+    sentence: str = reduce(concat, ["hello", " ", "world"], "")
+    print(sentence)
+
+    # --- 12. Generic compress ---
     print("=== Generic compress ===")
     data_c: list[str] = ["a", "b", "c", "d", "e"]
     sel: list[bool] = [True, False, True, False, True]
     compressed: list[str] = compress(data_c, sel)
     print(compressed)
 
-    # --- 11. Generic zip_longest ---
+    # --- 13. Generic zip_longest ---
     print("=== Generic zip_longest ===")
     zl_str: list[list[str]] = zip_longest(["a", "b", "c"], ["x", "y"], "-")
     for pair in zl_str:
         print(pair)
 
-    # --- 12. Generic shuffle ---
+    # --- 14. Generic shuffle ---
     print("=== Generic shuffle ===")
     shuffled_str: list[str] = shuffle(["a", "b", "c", "d", "e"])
     print(len(shuffled_str))

--- a/lib/sifr/bisect.sifr
+++ b/lib/sifr/bisect.sifr
@@ -11,9 +11,7 @@
 # Functional sorted-insert (backward compatibility):
 #   insort_left_copy(a, x) -> list   -- returns new sorted list
 #   insort_right_copy(a, x) -> list  -- returns new sorted list
-T = TypeVar("T")
-
-def bisect_left(a: list[T], x: T) -> int:
+def bisect_left[T: Comparable](a: list[T], x: T) -> int:
     lo: int = 0
     hi: int = len(a)
     while lo < hi:
@@ -28,7 +26,7 @@ def bisect_left(a: list[T], x: T) -> int:
             lo = mid + 1
     return lo
 
-def bisect_right(a: list[T], x: T) -> int:
+def bisect_right[T: Comparable](a: list[T], x: T) -> int:
     lo: int = 0
     hi: int = len(a)
     while lo < hi:
@@ -45,19 +43,19 @@ def bisect_right(a: list[T], x: T) -> int:
 
 # ── In-place API (mut parameters) ────────────────────────────────────────────
 
-def insort_left(mut a: list[T], x: T) -> None:
+def insort_left[T: Comparable](mut a: list[T], x: T) -> None:
     # Insert x into sorted list a in-place (left/stable position). O(n) time.
     pos: int = bisect_left(a, x)
     a.insert(pos, x)
 
-def insort_right(mut a: list[T], x: T) -> None:
+def insort_right[T: Comparable](mut a: list[T], x: T) -> None:
     # Insert x into sorted list a in-place (right position). O(n) time.
     pos: int = bisect_right(a, x)
     a.insert(pos, x)
 
 # ── Functional API (backward compatibility) ───────────────────────────────────
 
-def insort_left_copy(a: list[T], x: T) -> list[T]:
+def insort_left_copy[T: Comparable](a: list[T], x: T) -> list[T]:
     pos: int = bisect_left(a, x)
     result: list[T] = []
     i: int = 0
@@ -72,7 +70,7 @@ def insort_left_copy(a: list[T], x: T) -> list[T]:
         result.append(x)
     return result
 
-def insort_right_copy(a: list[T], x: T) -> list[T]:
+def insort_right_copy[T: Comparable](a: list[T], x: T) -> list[T]:
     pos: int = bisect_right(a, x)
     result: list[T] = []
     i: int = 0

--- a/lib/sifr/collections.sifr
+++ b/lib/sifr/collections.sifr
@@ -1,19 +1,17 @@
 # sifr.collections — Extended collection types
 from _sifr.collections import new_set, set_from_list, set_add, set_contains, set_remove, set_len, set_union, set_intersection, defaultdict_new, defaultdict_get, defaultdict_set
-T = TypeVar("T")
 
-class Counter:
+class Counter[T: Hashable]:
     # A multiset (bag) mapping elements to their counts.
-    # Operates on str keys (use IntCounter for int keys).
-    counts: dict[str, int]
+    counts: dict[T, int]
 
-    def get(self, key: str) -> int:
+    def get(self, key: T) -> int:
         val: int | None = self.counts[key]
         if val is not None:
             return val
         return 0
 
-    def increment(self, key: str) -> None:
+    def increment(self, key: T) -> None:
         val: int | None = self.counts[key]
         if val is not None:
             self.counts[key] = val + 1
@@ -26,9 +24,9 @@ class Counter:
             total = total + count
         return total
 
-    def most_common(self, n: int) -> list[str]:
-        all_keys: list[str] = self.counts.keys()
-        result: list[str] = []
+    def most_common(self, n: int) -> list[T]:
+        all_keys: list[T] = self.counts.keys()
+        result: list[T] = []
         for k in all_keys:
             result.append(k)
         sz: int = len(result)
@@ -36,8 +34,8 @@ class Counter:
         while i < sz:
             j: int = i + 1
             while j < sz:
-                ki: str | None = result[i]
-                kj: str | None = result[j]
+                ki: T | None = result[i]
+                kj: T | None = result[j]
                 if ki is not None:
                     if kj is not None:
                         ci: int | None = self.counts[ki]
@@ -53,24 +51,24 @@ class Counter:
                             result[j] = ki
                 j = j + 1
             i = i + 1
-        top: list[str] = []
+        top: list[T] = []
         count: int = 0
         while count < n:
             if count >= len(result):
                 return top
-            val: str | None = result[count]
+            val: T | None = result[count]
             if val is not None:
                 top.append(val)
             count = count + 1
         return top
 
-    def keys(self) -> list[str]:
+    def keys(self) -> list[T]:
         return self.counts.keys()
 
     def values(self) -> list[int]:
         return self.counts.values()
 
-    def update(self, other: Counter) -> None:
+    def update(self, other: Counter[T]) -> None:
         for key in other.counts.keys():
             other_val: int | None = other.counts[key]
             if other_val is not None:
@@ -80,7 +78,7 @@ class Counter:
                 else:
                     self.counts[key] = other_val
 
-    def subtract(self, other: Counter) -> None:
+    def subtract(self, other: Counter[T]) -> None:
         for key in other.counts.keys():
             other_val: int | None = other.counts[key]
             if other_val is not None:
@@ -90,94 +88,62 @@ class Counter:
                 else:
                     self.counts[key] = 0 - other_val
 
-    def elements(self) -> list[str]:
-        result: list[str] = []
-        all_keys: list[str] = self.counts.keys()
+    def elements(self) -> list[T]:
+        result: list[T] = []
+        all_keys: list[T] = self.counts.keys()
         ki: int = 0
         while ki < len(all_keys):
-            key_opt: str | None = all_keys[ki]
+            key_opt: T | None = all_keys[ki]
             if key_opt is not None:
                 cnt: int | None = self.counts[key_opt]
                 if cnt is not None:
                     i: int = 0
                     while i < cnt:
-                        key_copy: str | None = all_keys[ki]
+                        key_copy: T | None = all_keys[ki]
                         if key_copy is not None:
                             result.append(key_copy)
                         i = i + 1
             ki = ki + 1
         return result
 
+    def __add__(self, other: Counter[T]) -> Counter[T]:
+        new_counts: dict[T, int] = {}
+        for key in self.counts.keys():
+            a_val: int | None = self.counts[key]
+            if a_val is not None:
+                b_val: int | None = other.counts[key]
+                b_count: int = 0
+                if b_val is not None:
+                    b_count = b_val
+                total: int = a_val + b_count
+                if total > 0:
+                    new_counts[key] = total
+        for key2 in other.counts.keys():
+            already: int | None = new_counts[key2]
+            if already is None:
+                b_val2: int | None = other.counts[key2]
+                if b_val2 is not None:
+                    if b_val2 > 0:
+                        new_counts[key2] = b_val2
+        return Counter(new_counts)
 
-class IntCounter:
-    # Counter specialized for int keys.
-    counts: dict[int, int]
-
-    def get(self, key: int) -> int:
-        val: int | None = self.counts[key]
-        if val is not None:
-            return val
-        return 0
-
-    def increment(self, key: int) -> None:
-        val: int | None = self.counts[key]
-        if val is not None:
-            self.counts[key] = val + 1
-        else:
-            self.counts[key] = 1
-
-    def total(self) -> int:
-        total: int = 0
-        for count in self.counts.values():
-            total = total + count
-        return total
-
-    def keys(self) -> list[int]:
-        return self.counts.keys()
-
-    def values(self) -> list[int]:
-        return self.counts.values()
-
-
-def counter_add(a: Counter, b: Counter) -> Counter:
-    new_counts: dict[str, int] = {}
-    for key in a.counts.keys():
-        a_val: int | None = a.counts[key]
-        if a_val is not None:
-            b_val: int | None = b.counts[key]
-            b_count: int = 0
-            if b_val is not None:
-                b_count = b_val
-            total: int = a_val + b_count
-            if total > 0:
-                new_counts[key] = total
-    for key2 in b.counts.keys():
-        already: int | None = new_counts[key2]
-        if already is None:
-            b_val2: int | None = b.counts[key2]
-            if b_val2 is not None:
-                if b_val2 > 0:
-                    new_counts[key2] = b_val2
-    return Counter(new_counts)
+    def __sub__(self, other: Counter[T]) -> Counter[T]:
+        new_counts: dict[T, int] = {}
+        for key in self.counts.keys():
+            a_val: int | None = self.counts[key]
+            if a_val is not None:
+                b_val: int | None = other.counts[key]
+                b_count: int = 0
+                if b_val is not None:
+                    b_count = b_val
+                diff: int = a_val - b_count
+                if diff > 0:
+                    new_counts[key] = diff
+        return Counter(new_counts)
 
 
-def counter_sub(a: Counter, b: Counter) -> Counter:
-    new_counts: dict[str, int] = {}
-    for key in a.counts.keys():
-        a_val: int | None = a.counts[key]
-        if a_val is not None:
-            b_val: int | None = b.counts[key]
-            b_count: int = 0
-            if b_val is not None:
-                b_count = b_val
-            diff: int = a_val - b_count
-            if diff > 0:
-                new_counts[key] = diff
-    return Counter(new_counts)
-
-
-def from_list(items: list[str]) -> Counter:
-    counts: dict[str, int] = {}
+def from_list[T: Hashable](items: list[T]) -> Counter[T]:
+    counts: dict[T, int] = {}
     for item in items:
         val: int | None = counts[item]
         if val is not None:
@@ -187,42 +153,30 @@ def from_list(items: list[str]) -> Counter:
     return Counter(counts)
 
 
-def int_counter_from_list(items: list[int]) -> IntCounter:
-    counts: dict[int, int] = {}
-    for item in items:
-        val: int | None = counts[item]
-        if val is not None:
-            counts[item] = val + 1
-        else:
-            counts[item] = 1
-    return IntCounter(counts)
-
-
-class deque:
+class deque[T]:
     # A double-ended queue backed by a list.
-    # Currently operates on int values.
-    _data: list[int]
+    _data: list[T]
     _maxlen: int
 
     def __init__(self, maxlen: int) -> None:
         self._data = []
         self._maxlen = maxlen
 
-    def append(self, val: int) -> None:
+    def append(self, val: T) -> None:
         self._data.append(val)
         if self._maxlen > 0 and len(self._data) > self._maxlen:
-            new_data: list[int] = []
+            new_data: list[T] = []
             for i, v in enumerate(self._data):
                 if i > 0:
                     new_data.append(v)
             self._data = new_data
 
-    def appendleft(self, val: int) -> None:
-        new_data: list[int] = [val]
+    def appendleft(self, val: T) -> None:
+        new_data: list[T] = [val]
         for v in self._data:
             new_data.append(v)
         if self._maxlen > 0 and len(new_data) > self._maxlen:
-            trimmed: list[int] = []
+            trimmed: list[T] = []
             for i, v in enumerate(new_data):
                 if i < self._maxlen:
                     trimmed.append(v)
@@ -230,36 +184,34 @@ class deque:
         else:
             self._data = new_data
 
-    def pop(self) -> int:
-        result: int = 0
+    def pop(self) -> T | None:
         if len(self._data) > 0:
             last_idx: int = len(self._data) - 1
-            new_data: list[int] = []
+            result: T | None = self._data[last_idx]
+            new_data: list[T] = []
             for i, v in enumerate(self._data):
-                if i == last_idx:
-                    result = v
-                else:
+                if i < last_idx:
                     new_data.append(v)
             self._data = new_data
-        return result
+            return result
+        return None
 
-    def popleft(self) -> int:
-        result: int = 0
+    def popleft(self) -> T | None:
         if len(self._data) > 0:
-            new_data: list[int] = []
+            result: T | None = self._data[0]
+            new_data: list[T] = []
             for i, v in enumerate(self._data):
-                if i == 0:
-                    result = v
-                else:
+                if i > 0:
                     new_data.append(v)
             self._data = new_data
-        return result
+            return result
+        return None
 
     def len(self) -> int:
         return len(self._data)
 
-    def to_list(self) -> list[int]:
-        result: list[int] = []
+    def to_list(self) -> list[T]:
+        result: list[T] = []
         for v in self._data:
             result.append(v)
         return result
@@ -267,25 +219,25 @@ class deque:
     def clear(self) -> None:
         self._data = []
 
-    def extend(self, items: list[int]) -> None:
+    def extend(self, items: list[T]) -> None:
         for v in items:
             self._data.append(v)
         if self._maxlen > 0 and len(self._data) > self._maxlen:
-            new_data: list[int] = []
+            new_data: list[T] = []
             start: int = len(self._data) - self._maxlen
             for i, v in enumerate(self._data):
                 if i >= start:
                     new_data.append(v)
             self._data = new_data
 
-    def extendleft(self, items: list[int]) -> None:
+    def extendleft(self, items: list[T]) -> None:
         for v in items:
-            new_data: list[int] = [v]
+            new_data: list[T] = [v]
             for existing in self._data:
                 new_data.append(existing)
             self._data = new_data
         if self._maxlen > 0 and len(self._data) > self._maxlen:
-            trimmed: list[int] = []
+            trimmed: list[T] = []
             for i, v in enumerate(self._data):
                 if i < self._maxlen:
                     trimmed.append(v)

--- a/lib/sifr/functools.sifr
+++ b/lib/sifr/functools.sifr
@@ -1,11 +1,10 @@
 # sifr.functools — Functional programming tools (pure Sifr)
 from typing import Callable
-T = TypeVar("T")
 
-def reduce(func: Callable[[T, T], T], data: list[T], initial: T) -> T:
+def reduce[T, U](func: Callable[[U, T], U], data: list[T], initial: U) -> U:
     # Applies func cumulatively to items of data, starting with initial.
     # Matches CPython's functools.reduce(func, iterable, initializer).
-    result: T = initial
+    result: U = initial
     for val in data:
         result = func(result, val)
     return result

--- a/lib/sifr/heapq.sifr
+++ b/lib/sifr/heapq.sifr
@@ -14,7 +14,7 @@ T = TypeVar("T")
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
-def _sift_down(mut data: list[T], pos: int, n: int) -> None:
+def _sift_down[T: Comparable](mut data: list[T], pos: int, n: int) -> None:
     done: bool = False
     while not done:
         smallest: int = pos
@@ -45,7 +45,7 @@ def _sift_down(mut data: list[T], pos: int, n: int) -> None:
                     data[smallest] = tmp_pos
             pos = smallest
 
-def _sift_up(mut heap: list[T], pos: int) -> None:
+def _sift_up[T: Comparable](mut heap: list[T], pos: int) -> None:
     done: bool = False
     while not done:
         if pos <= 0:
@@ -69,7 +69,7 @@ def _sift_up(mut heap: list[T], pos: int) -> None:
 
 # ── In-place API (mut parameters) ────────────────────────────────────────────
 
-def heapify(mut data: list[T]) -> None:
+def heapify[T: Comparable](mut data: list[T]) -> None:
     """Convert list to a min-heap in-place. O(n) time."""
     n: int = len(data)
     i: int = n // 2 - 1
@@ -77,13 +77,13 @@ def heapify(mut data: list[T]) -> None:
         _sift_down(data, i, n)
         i = i - 1
 
-def heappush(mut heap: list[T], item: T) -> None:
+def heappush[T: Comparable](mut heap: list[T], item: T) -> None:
     """Push item onto the heap in-place. O(log n) time."""
     heap.append(item)
     pos: int = len(heap) - 1
     _sift_up(heap, pos)
 
-def heappop(mut heap: list[T]) -> T | None:
+def heappop[T: Comparable](mut heap: list[T]) -> T | None:
     """Pop and return the smallest item. Heap is modified in-place. O(log n) time.
     Returns None if the heap is empty."""
     n: int = len(heap)
@@ -101,7 +101,7 @@ def heappop(mut heap: list[T]) -> T | None:
 
 # ── Functional API (backward compatibility) ───────────────────────────────────
 
-def _swap(data: list[T], i: int, j: int) -> list[T]:
+def _swap[T: Comparable](data: list[T], i: int, j: int) -> list[T]:
     result: list[T] = []
     k: int = 0
     while k < len(data):
@@ -120,21 +120,21 @@ def _swap(data: list[T], i: int, j: int) -> list[T]:
         k = k + 1
     return result
 
-def heapify_copy(data: list[T]) -> list[T]:
+def heapify_copy[T: Comparable](data: list[T]) -> list[T]:
     result: list[T] = []
     for val in data:
         result.append(val)
     heapify(result)
     return result
 
-def heappush_copy(heap: list[T], item: T) -> list[T]:
+def heappush_copy[T: Comparable](heap: list[T], item: T) -> list[T]:
     result: list[T] = []
     for val in heap:
         result.append(val)
     heappush(result, item)
     return result
 
-def heappop_val(heap: list[T]) -> T | None:
+def heappop_val[T: Comparable](heap: list[T]) -> T | None:
     """Return the smallest item without modifying the original heap.
     Creates a temporary copy."""
     if len(heap) == 0:
@@ -144,14 +144,14 @@ def heappop_val(heap: list[T]) -> T | None:
         tmp.append(val)
     return heappop(tmp)
 
-def heappop_rest(heap: list[T]) -> list[T]:
+def heappop_rest[T: Comparable](heap: list[T]) -> list[T]:
     result: list[T] = []
     for val in heap:
         result.append(val)
     heappop(result)
     return result
 
-def heapreplace(heap: list[T], item: T) -> T | None:
+def heapreplace[T: Comparable](heap: list[T], item: T) -> T | None:
     if len(heap) == 0:
         return None
     top: T | None = heap[0]
@@ -159,13 +159,13 @@ def heapreplace(heap: list[T], item: T) -> T | None:
     rest = heappush_copy(rest, item)
     return top
 
-def heappushpop(heap: list[T], item: T) -> T | None:
+def heappushpop[T: Comparable](heap: list[T], item: T) -> T | None:
     # Push item then pop smallest. Equivalent to heappush + heappop but more efficient.
     pushed: list[T] = heappush_copy(heap, item)
     val: T | None = heappop(pushed)
     return val
 
-def nsmallest(n: int, data: list[T]) -> list[T]:
+def nsmallest[T: Comparable](n: int, data: list[T]) -> list[T]:
     heap: list[T] = heapify_copy(data)
     result: list[T] = []
     count: int = 0
@@ -178,7 +178,7 @@ def nsmallest(n: int, data: list[T]) -> list[T]:
         count = count + 1
     return result
 
-def nlargest(n: int, data: list[T]) -> list[T]:
+def nlargest[T: Comparable](n: int, data: list[T]) -> list[T]:
     # Uses a selection approach: find n largest by repeated scanning.
     if n <= 0:
         return []

--- a/lib/sifr/itertools.sifr
+++ b/lib/sifr/itertools.sifr
@@ -83,7 +83,7 @@ def islice(data: list[T], stop: int) -> list[T]:
         i = i + 1
     return result
 
-def accumulate(data: list[T]) -> list[T]:
+def accumulate[T: Addable](data: list[T]) -> list[T]:
     # Running sum of data (matches CPython itertools.accumulate default operator=add).
     result: list[T] = []
     if len(data) == 0:


### PR DESCRIPTION
## Summary

- **Generic stdlib rewrite**: `Counter[T: Hashable]` with `__add__`/`__sub__` operator overloads, `deque[T]` generic, `functools.reduce[T, U]` two-type generic, `bisect` migrated to PEP 695 with `Comparable` bound, `accumulate` with `Addable` bound, all `heapq` functions with `Comparable` bound
- **Protocol bounds scoping fix**: Changed type parameter bounds storage from global (keyed by type var name) to per-owner (keyed by function/class name) to prevent cross-function bound leakage when multiple stdlib modules are imported
- **Codegen improvements**: Generic class operator overload impls, method parameter type substitution, HashMap key cloning for TypeVar keys, correct `extract_top_level_item_name` parsing for generic impl blocks, conditional `Hash + Eq` bounds only when TypeVar is used as HashMap key
- **14 new E2E pass tests** and **7 new E2E fail tests** covering generic Counter/deque/heapq/accumulate with bigint, custom classes, unhashable types, and uncomparable types
- **Demo updated** to showcase all new generic stdlib features including Counter[T] operator overloads, deque[T], and generic reduce

## Test plan

- [x] All E2E pass tests passing (203s, includes 14 new tests)
- [x] All E2E fail tests passing (includes 7 new tests)
- [x] Full `cargo test` suite passing
- [x] Demo `demos/milestone_stdlib_generic_rewrite_demo.sifr` runs successfully
- [x] Existing Counter/deque/heapq/bisect/accumulate tests still pass after generification
- [x] Protocol bounds correctly scoped (accumulate[T: Addable] no longer inherits Counter's Hashable bound)


Made with [Cursor](https://cursor.com)