### PR TITLE
feat: enforce generic assert_eq type consistency

### DIFF
--- a/crates/sifr/tests/e2e/fail/stdlib_test_assert_eq_type_mismatch.sifr
+++ b/crates/sifr/tests/e2e/fail/stdlib_test_assert_eq_type_mismatch.sifr
@@ -1,0 +1,7 @@
+# Test: generic assert_eq enforces same-type arguments
+from sifr.test import assert_eq
+
+def main():
+    assert_eq(1, "1")
+
+# expect-error: expected 'int', got 'str'

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -161,8 +161,12 @@ fn compile_stdlib() -> Result<StdlibCompiled, Vec<CompileError>> {
                 if let Some(intrinsic_mod) = sifr_hir::stdlib::get_intrinsic_module(&import.module) {
                     for name in &import.names {
                         if let Some(ft) = intrinsic_mod.functions.get(name) {
-                            fn_exports.insert(name.clone(), ft.clone());
-                            intrinsic_names_for_module.insert(name.clone());
+                            // Pure Sifr functions declared in the module should shadow
+                            // imported intrinsic names (e.g. generic wrappers in sifr.test).
+                            if !fn_exports.contains_key(name) {
+                                fn_exports.insert(name.clone(), ft.clone());
+                                intrinsic_names_for_module.insert(name.clone());
+                            }
                         }
                         if let Some(const_ty) = intrinsic_mod.constants.get(name) {
                             const_exports.insert(name.clone(), const_ty.clone());

--- a/crates/sifr_hir/src/lower.rs
+++ b/crates/sifr_hir/src/lower.rs
@@ -5417,6 +5417,23 @@ fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
         for (arg, (_, param_ty, _)) in args.iter().zip(ft.params.iter()) {
             infer_type_var_bindings(param_ty, arg.ty(), &mut bindings);
         }
+        // Re-check argument types after TypeVar substitution so repeated type
+        // parameters (e.g. assert_eq[T](a: T, b: T)) enforce consistent types.
+        if func_name != "print" {
+            for (i, (arg, (param_name, param_ty, _))) in args.iter().zip(ft.params.iter()).enumerate() {
+                let concrete_param_ty = substitute_type_vars(param_ty, &bindings);
+                if !arg.ty().is_assignable_to(&concrete_param_ty) {
+                    ctx.error(format!(
+                        "argument {} ('{}') of function '{}': expected '{}', got '{}'",
+                        i + 1,
+                        param_name,
+                        func_name,
+                        concrete_param_ty.display_name(),
+                        arg.ty().display_name()
+                    ));
+                }
+            }
+        }
         // Check protocol bounds on type parameters (scoped to this function)
         let func_bounds = ctx.type_param_bounds.get(&func_name);
         let bound_errors: Vec<String> = bindings.iter().flat_map(|(tv_name, concrete_ty)| {

--- a/lib/sifr/test.sifr
+++ b/lib/sifr/test.sifr
@@ -1,2 +1,8 @@
 # sifr.test — Test assertion functions
-from _sifr.test import assert_eq, assert_ne, assert_true, assert_false, assert_almost_eq, assert_gt, assert_lt
+#
+# User-facing wrappers keep CPython-style names while enforcing stronger
+# Sifr type checking (for example, assert_eq requires both args to be same T).
+from _sifr.test import assert_ne, assert_true, assert_false, assert_almost_eq, assert_gt, assert_lt
+
+def assert_eq[T](actual: T, expected: T) -> None:
+    assert actual == expected


### PR DESCRIPTION
## Summary
- make `sifr.test` expose a user-facing generic `assert_eq[T](actual: T, expected: T)` wrapper to align with milestone_stdlib_generic_rewrite scope
- fix generic-call checking in HIR lowering by validating argument compatibility after TypeVar substitution (enforces repeated-`T` consistency)
- prevent intrinsic export collection from overriding pure Sifr stdlib functions with the same public name
- add fail E2E case `stdlib_test_assert_eq_type_mismatch.sifr` to lock compile-time behavior

Closes #215
Related: #214, #216, #197

## Test plan
- [x] `cargo test --test e2e test_e2e_fail -- --nocapture`
- [x] `cargo run -- run tests/e2e/pass/stdlib_test.sifr`
- [x] `cargo run -- check tests/e2e/fail/stdlib_test_assert_eq_type_mismatch.sifr`
- [x] `cargo run -- run ../../demos/milestone_stdlib_generic_rewrite_demo.sifr`

Made with [Cursor](https://cursor.com)