### PR TITLE
feat: expand sifr.test core assertion parity APIs

### DIFF
--- a/crates/sifr/tests/e2e/fail/stdlib_test_assert_gt_uncomparable.sifr
+++ b/crates/sifr/tests/e2e/fail/stdlib_test_assert_gt_uncomparable.sifr
@@ -1,0 +1,12 @@
+# Test: assert_gt requires Comparable values
+from sifr.test import assert_gt
+
+class Blob:
+    data: int
+
+def main():
+    a: Blob = Blob(1)
+    b: Blob = Blob(2)
+    assert_gt(a, b)
+
+# expect-error: does not implement protocol 'Comparable'

--- a/crates/sifr/tests/e2e/pass/stdlib_test_almost_eq.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_test_almost_eq.sifr
@@ -1,8 +1,12 @@
-# Tests: assert_almost_eq with known float values
-from sifr.test import assert_almost_eq
+# Tests: assert_almost_eq / assert_not_almost_eq with known float values
+from sifr.math import inf, nan
+from sifr.test import assert_almost_eq, assert_not_almost_eq
 
 def main():
     assert_almost_eq(3.14159, 3.14159, 0.001)
     assert_almost_eq(1.0, 1.0000001, 0.001)
     assert_almost_eq(0.1 + 0.2, 0.3, 0.0001)
     assert_almost_eq(100.0, 100.0, 0.0001)
+    assert_almost_eq(inf, inf, 0.0)
+    assert_not_almost_eq(1.0, 1.2, 0.01)
+    assert_not_almost_eq(nan, nan, 0.01)

--- a/crates/sifr/tests/e2e/pass/stdlib_test_gt_lt.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_test_gt_lt.sifr
@@ -1,10 +1,16 @@
-# Tests: assert_gt and assert_lt
-from sifr.test import assert_gt, assert_lt
+# Tests: assert_gt/assert_ge and assert_lt/assert_le
+from sifr.test import assert_gt, assert_ge, assert_lt, assert_le
 
 def main():
     assert_gt(10, 5)
     assert_gt(1, 0)
     assert_gt(100, 99)
+    assert_ge(10, 10)
+    assert_ge(11, 10)
     assert_lt(5, 10)
     assert_lt(0, 1)
     assert_lt(-1, 0)
+    assert_le(10, 10)
+    assert_le(9, 10)
+    assert_gt("b", "a")
+    assert_lt("a", "b")

--- a/crates/sifr/tests/e2e/pass/stdlib_test_result_option_assertions.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_test_result_option_assertions.sifr
@@ -1,0 +1,15 @@
+# Tests: Result/Option-oriented assertions
+from sifr.test import assert_ok, assert_err, assert_some, assert_none
+
+def parse_num(s: str) -> Result[int, ValueError]:
+    if s == "bad":
+        raise ValueError("parse failure")
+    return 123
+
+def main():
+    assert_ok(parse_num("123"))
+    assert_err(parse_num("bad"))
+    maybe_name: str | None = "sifr"
+    assert_some(maybe_name)
+    maybe_missing: str | None = None
+    assert_none(maybe_missing)

--- a/lib/sifr/test.sifr
+++ b/lib/sifr/test.sifr
@@ -1,8 +1,68 @@
 # sifr.test — Test assertion functions
-#
-# User-facing wrappers keep CPython-style names while enforcing stronger
-# Sifr type checking (for example, assert_eq requires both args to be same T).
-from _sifr.test import assert_ne, assert_true, assert_false, assert_almost_eq, assert_gt, assert_lt
 
 def assert_eq[T](actual: T, expected: T) -> None:
     assert actual == expected
+
+def assert_ne[T](actual: T, expected: T) -> None:
+    assert actual != expected
+
+def assert_true(value: bool) -> None:
+    assert value
+
+def assert_false(value: bool) -> None:
+    assert not value
+
+def assert_almost_eq(actual: float, expected: float, tolerance: float) -> None:
+    assert tolerance >= 0.0
+    if actual == expected:
+        return
+    diff: float = actual - expected
+    if diff < 0.0:
+        diff = 0.0 - diff
+    # NaN should never compare as almost-equal.
+    if diff != diff:
+        assert False
+    assert diff <= tolerance
+
+def assert_not_almost_eq(actual: float, expected: float, tolerance: float) -> None:
+    assert tolerance >= 0.0
+    if actual == expected:
+        assert False
+    diff: float = actual - expected
+    if diff < 0.0:
+        diff = 0.0 - diff
+    # NaN comparisons are treated as not-almost-equal.
+    if diff != diff:
+        return
+    assert diff > tolerance
+
+def assert_gt[T: Comparable](a: T, b: T) -> None:
+    assert a > b
+
+def assert_ge[T: Comparable](a: T, b: T) -> None:
+    assert a >= b
+
+def assert_lt[T: Comparable](a: T, b: T) -> None:
+    assert a < b
+
+def assert_le[T: Comparable](a: T, b: T) -> None:
+    assert a <= b
+
+def assert_some[T](value: T | None) -> None:
+    assert value is not None
+
+def assert_none[T](value: T | None) -> None:
+    assert value is None
+
+def assert_ok[T](value: Result[T, Error]) -> None:
+    try:
+        out: T = value
+    except Error as e:
+        assert False
+
+def assert_err[T](value: Result[T, Error]) -> None:
+    try:
+        out: T = value
+        assert False
+    except Error as e:
+        pass


### PR DESCRIPTION
## Summary
- expand `sifr.test` with parity-oriented assertion helpers:
  - `assert_ne`, `assert_true`, `assert_false`
  - `assert_almost_eq` + `assert_not_almost_eq` (with equality fast-path and inclusive tolerance)
  - `assert_gt`, `assert_ge`, `assert_lt`, `assert_le` with `Comparable` bounds
  - `assert_some`, `assert_none`, `assert_ok`, `assert_err`
- add focused e2e pass coverage for:
  - float edge cases (`inf`, `nan`) and not-almost-eq
  - full comparison assertion surface (including string ordering)
  - Result/Option assertion helpers
- add compile-fail coverage for non-Comparable usage in `assert_gt`

Closes #219
Related: #218

## Test plan
- [x] `cargo run -- run tests/e2e/pass/stdlib_test_almost_eq.sifr`
- [x] `cargo run -- run tests/e2e/pass/stdlib_test_gt_lt.sifr`
- [x] `cargo run -- run tests/e2e/pass/stdlib_test_result_option_assertions.sifr`
- [x] `cargo run -- check tests/e2e/fail/stdlib_test_assert_eq_type_mismatch.sifr`
- [x] `cargo run -- check tests/e2e/fail/stdlib_test_assert_gt_uncomparable.sifr`
- [x] `cargo test --test e2e test_e2e_fail -- --nocapture`

Made with [Cursor](https://cursor.com)