### PR TITLE
feat: add runtime-fail e2e lane and assertion parity demo

### DIFF
--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -25,6 +25,14 @@ fn extract_expect_stdout(source: &str) -> Option<String> {
     }
 }
 
+/// Collect all `# expect-stderr: <value>` lines.
+fn extract_expect_stderr(source: &str) -> Vec<String> {
+    source
+        .lines()
+        .filter_map(|line| line.strip_prefix("# expect-stderr:").map(|rest| rest.trim().to_string()))
+        .collect()
+}
+
 /// Extract expected error substrings from `# expect-error: <value>` comments.
 fn extract_expect_errors(source: &str) -> Vec<String> {
     let mut errors = Vec::new();
@@ -150,7 +158,12 @@ edition = "2021"
 }
 
 /// Build the generated Rust source with stdlib dependencies into a binary and run it.
-fn build_and_run_with_deps(rust_source: &str, test_name: &str, stdlib_modules: &HashSet<String>) -> Result<String, String> {
+/// Returns (stdout, stderr, success_status).
+fn build_and_run_capture_with_deps(
+    rust_source: &str,
+    test_name: &str,
+    stdlib_modules: &HashSet<String>,
+) -> Result<(String, String, bool), String> {
     let tmp_dir = std::env::temp_dir().join("sifr_e2e_tests").join(test_name);
     let src_dir = tmp_dir.join("src");
     fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create dir: {}", e))?;
@@ -195,13 +208,27 @@ fn build_and_run_with_deps(rust_source: &str, test_name: &str, stdlib_modules: &
         .output()
         .map_err(|e| format!("failed to run binary: {}", e))?;
 
-    if !run_output.status.success() {
-        let stderr = String::from_utf8_lossy(&run_output.stderr);
-        return Err(format!("binary exited with error:\n{}", stderr));
-    }
-
     let stdout = String::from_utf8_lossy(&run_output.stdout).to_string();
-    Ok(stdout)
+    let stderr = String::from_utf8_lossy(&run_output.stderr).to_string();
+    Ok((stdout, stderr, run_output.status.success()))
+}
+
+/// Build and run, requiring successful process exit.
+fn build_and_run_with_deps(
+    rust_source: &str,
+    test_name: &str,
+    stdlib_modules: &HashSet<String>,
+) -> Result<String, String> {
+    match build_and_run_capture_with_deps(rust_source, test_name, stdlib_modules) {
+        Ok((stdout, stderr, success)) => {
+            if success {
+                Ok(stdout)
+            } else {
+                Err(format!("binary exited with error:\n{}", stderr))
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[test]
@@ -332,4 +359,81 @@ fn test_e2e_fail() {
 
     assert!(test_count > 0, "No fail tests found");
     eprintln!("  {} fail tests completed", test_count);
+}
+
+#[test]
+fn test_e2e_runtime_fail() {
+    let runtime_fail_dir = Path::new("tests/e2e/runtime_fail");
+    if !runtime_fail_dir.exists() {
+        return;
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(runtime_fail_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |ext| ext == "sifr"))
+        .collect();
+    entries.sort_by_key(|e| e.path());
+
+    let mut test_count = 0;
+    let mut failures: Vec<String> = Vec::new();
+
+    for entry in &entries {
+        let path = entry.path();
+        let test_name = path.file_stem().unwrap().to_string_lossy().to_string();
+        let source = fs::read_to_string(&path).unwrap();
+        let expected_stderr = extract_expect_stderr(&source);
+
+        let (rust_source, used_stdlib_modules) = match compile_source_with_metadata(&source) {
+            Ok(result) => result,
+            Err(errors) => {
+                failures.push(format!(
+                    "FAIL [{}]: sifr compilation failed (runtime-fail tests must compile):\n  {}",
+                    test_name,
+                    errors.join("\n  ")
+                ));
+                continue;
+            }
+        };
+
+        match build_and_run_capture_with_deps(&rust_source, &test_name, &used_stdlib_modules) {
+            Ok((_stdout, stderr, success)) => {
+                if success {
+                    failures.push(format!(
+                        "FAIL [{}]: expected runtime failure but binary exited successfully",
+                        test_name
+                    ));
+                    continue;
+                }
+
+                for expected in &expected_stderr {
+                    if !stderr.contains(expected) {
+                        failures.push(format!(
+                            "FAIL [{}]: expected stderr containing {:?} but got:\n{}",
+                            test_name, expected, stderr
+                        ));
+                    }
+                }
+            }
+            Err(err) => {
+                failures.push(format!("FAIL [{}]: {}", test_name, err));
+                continue;
+            }
+        }
+
+        test_count += 1;
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "\n{} E2E runtime-fail test(s) failed:\n\n{}\n\n({} passed, {} failed)",
+            failures.len(),
+            failures.join("\n\n"),
+            test_count,
+            failures.len()
+        );
+    }
+
+    assert!(test_count > 0, "No runtime_fail tests found");
+    eprintln!("  {} runtime_fail tests completed", test_count);
 }

--- a/crates/sifr/tests/e2e/pass/cpython_unittest_assertions_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_unittest_assertions_subset.sifr
@@ -1,0 +1,44 @@
+# Portable subset inspired by CPython Lib/test/test_unittest/test_assertions.py
+# expect-stdout: cpython unittest assertion subset ok
+from sifr.math import inf
+from sifr.test import (
+    assert_eq, assert_ne, assert_true, assert_false,
+    assert_almost_eq, assert_not_almost_eq,
+    assert_gt, assert_ge, assert_lt, assert_le,
+    assert_some, assert_none, assert_ok, assert_err
+)
+
+def parse_num(s: str) -> Result[int, ValueError]:
+    if s == "bad":
+        raise ValueError("parse failure")
+    return 7
+
+def main():
+    # assertEqual / assertNotEqual style
+    assert_eq(3, 3)
+    assert_ne(3, 2)
+
+    # assertTrue / assertFalse style
+    assert_true(1 < 2)
+    assert_false(2 < 1)
+
+    # assertAlmostEqual / assertNotAlmostEqual style
+    assert_almost_eq(1.00000001, 1.0, 0.000001)
+    assert_almost_eq(inf, inf, 0.0)
+    assert_not_almost_eq(1.1, 1.0, 0.05)
+
+    # assertGreater/Less (+ equal variants)
+    assert_gt(3, 2)
+    assert_ge(3, 3)
+    assert_lt("a", "b")
+    assert_le("b", "b")
+
+    # Sifr-adapted Result/Option assertions (assertRaises analogue)
+    assert_ok(parse_num("ok"))
+    assert_err(parse_num("bad"))
+    maybe_a: int | None = 42
+    maybe_b: int | None = None
+    assert_some(maybe_a)
+    assert_none(maybe_b)
+
+    print("cpython unittest assertion subset ok")

--- a/crates/sifr/tests/e2e/runtime_fail/assert_err_failure.sifr
+++ b/crates/sifr/tests/e2e/runtime_fail/assert_err_failure.sifr
@@ -1,0 +1,9 @@
+# expect-stderr: assertion failed
+from sifr.test import assert_err
+
+def parse_ok() -> Result[int, ValueError]:
+    return 5
+
+def main():
+    # Must fail because value is Ok(...), not Err(...)
+    assert_err(parse_ok())

--- a/crates/sifr/tests/e2e/runtime_fail/assert_true_failure.sifr
+++ b/crates/sifr/tests/e2e/runtime_fail/assert_true_failure.sifr
@@ -1,0 +1,5 @@
+# expect-stderr: assertion failed
+from sifr.test import assert_true
+
+def main():
+    assert_true(False)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -6149,6 +6149,22 @@ impl RustEmitter {
                                     self.emit_expr(arg);
                                     continue;
                                 }
+                                // Result[T, Error] param with a concrete Result[T, SomeError] arg:
+                                // convert the error branch so Rust types line up (Result invariance).
+                                if convention == ParamConvention::Own {
+                                    if let (Type::Result(_, param_err), Type::Result(_, arg_err)) =
+                                        (param_ty, arg.ty())
+                                    {
+                                        if param_err.display_name() == "Error"
+                                            && arg_err.display_name() != "Error"
+                                        {
+                                            self.write("(");
+                                            self.emit_expr(arg);
+                                            self.write(").map_err(|e| Error::new(e.to_string()))");
+                                            continue;
+                                        }
+                                    }
+                                }
                                 // Non-Option union param -> wrap in enum variant
                                 if let Type::Union(members) = param_ty {
                                     if !is_option_type(param_ty) {

--- a/demos/milestone_test_assertions_parity_demo.sifr
+++ b/demos/milestone_test_assertions_parity_demo.sifr
@@ -1,0 +1,49 @@
+# Demo: milestone_test_assertions_parity
+# Showcases:
+# 1) Core assertion helpers
+# 2) Almost-equality edge behavior
+# 3) Comparable assertions
+# 4) Result/Option adapted assertions
+
+from sifr.math import inf
+from sifr.test import (
+    assert_eq, assert_ne, assert_true, assert_false,
+    assert_almost_eq, assert_not_almost_eq,
+    assert_gt, assert_ge, assert_lt, assert_le,
+    assert_some, assert_none, assert_ok, assert_err
+)
+
+def parse_num(s: str) -> Result[int, ValueError]:
+    if s == "bad":
+        raise ValueError("parse failure")
+    return 10
+
+def main():
+    print("=== Core equality/truth assertions ===")
+    assert_eq("sifr", "sifr")
+    assert_ne("sifr", "rust")
+    assert_true(2 > 1)
+    assert_false(1 > 2)
+    print("core assertions ok")
+
+    print("=== Almost-equality semantics ===")
+    assert_almost_eq(0.1 + 0.2, 0.3, 0.0001)
+    assert_almost_eq(inf, inf, 0.0)
+    assert_not_almost_eq(1.1, 1.0, 0.05)
+    print("almost assertions ok")
+
+    print("=== Comparable assertions ===")
+    assert_gt(5, 4)
+    assert_ge(5, 5)
+    assert_lt("a", "b")
+    assert_le("b", "b")
+    print("comparison assertions ok")
+
+    print("=== Result/Option adapted assertions ===")
+    assert_ok(parse_num("ok"))
+    assert_err(parse_num("bad"))
+    maybe_name: str | None = "sifr"
+    maybe_missing: str | None = None
+    assert_some(maybe_name)
+    assert_none(maybe_missing)
+    print("result/option assertions ok")

--- a/lib/sifr/test.sifr
+++ b/lib/sifr/test.sifr
@@ -1,18 +1,18 @@
 # sifr.test — Test assertion functions
 
-def assert_eq[T](actual: T, expected: T) -> None:
+def assert_eq[T](own actual: T, own expected: T) -> None:
     assert actual == expected
 
-def assert_ne[T](actual: T, expected: T) -> None:
+def assert_ne[T](own actual: T, own expected: T) -> None:
     assert actual != expected
 
-def assert_true(value: bool) -> None:
+def assert_true(own value: bool) -> None:
     assert value
 
-def assert_false(value: bool) -> None:
+def assert_false(own value: bool) -> None:
     assert not value
 
-def assert_almost_eq(actual: float, expected: float, tolerance: float) -> None:
+def assert_almost_eq(own actual: float, own expected: float, own tolerance: float) -> None:
     assert tolerance >= 0.0
     if actual == expected:
         return
@@ -24,7 +24,7 @@ def assert_almost_eq(actual: float, expected: float, tolerance: float) -> None:
         assert False
     assert diff <= tolerance
 
-def assert_not_almost_eq(actual: float, expected: float, tolerance: float) -> None:
+def assert_not_almost_eq(own actual: float, own expected: float, own tolerance: float) -> None:
     assert tolerance >= 0.0
     if actual == expected:
         assert False
@@ -36,31 +36,31 @@ def assert_not_almost_eq(actual: float, expected: float, tolerance: float) -> No
         return
     assert diff > tolerance
 
-def assert_gt[T: Comparable](a: T, b: T) -> None:
+def assert_gt[T: Comparable](own a: T, own b: T) -> None:
     assert a > b
 
-def assert_ge[T: Comparable](a: T, b: T) -> None:
+def assert_ge[T: Comparable](own a: T, own b: T) -> None:
     assert a >= b
 
-def assert_lt[T: Comparable](a: T, b: T) -> None:
+def assert_lt[T: Comparable](own a: T, own b: T) -> None:
     assert a < b
 
-def assert_le[T: Comparable](a: T, b: T) -> None:
+def assert_le[T: Comparable](own a: T, own b: T) -> None:
     assert a <= b
 
-def assert_some[T](value: T | None) -> None:
+def assert_some[T](own value: T | None) -> None:
     assert value is not None
 
-def assert_none[T](value: T | None) -> None:
+def assert_none[T](own value: T | None) -> None:
     assert value is None
 
-def assert_ok[T](value: Result[T, Error]) -> None:
+def assert_ok[T](own value: Result[T, Error]) -> None:
     try:
         out: T = value
     except Error as e:
         assert False
 
-def assert_err[T](value: Result[T, Error]) -> None:
+def assert_err[T](own value: Result[T, Error]) -> None:
     try:
         out: T = value
         assert False


### PR DESCRIPTION
## Summary
- add `tests/e2e/runtime_fail` support in `crates/sifr/tests/e2e.rs` with:
  - `# expect-stderr: ...` directives
  - compile-success + runtime-failure validation flow
- add initial runtime-fail fixtures for assertion failures:
  - `assert_true_failure.sifr`
  - `assert_err_failure.sifr`
- port a portable CPython `unittest` assertion subset to Sifr e2e:
  - `cpython_unittest_assertions_subset.sifr`
- add milestone demo at `demos/milestone_test_assertions_parity_demo.sifr`
- harden assertion interop by:
  - using `own` conventions in `lib/sifr/test.sifr` wrappers to avoid borrow/codegen regressions
  - coercing `Result[T, ConcreteError]` to `Result[T, Error]` at codegen call sites for `own` params

Closes #220
Closes #221
Related: #218

## Test plan
- [x] `cargo test --test e2e test_e2e_runtime_fail -- --nocapture`
- [x] `cargo test --test e2e test_e2e_fail -- --nocapture`
- [x] `cargo run -- run tests/e2e/pass/cpython_unittest_assertions_subset.sifr`
- [x] `cargo run -- run tests/e2e/pass/stdlib_import_test.sifr`
- [x] `cargo run -- run tests/e2e/pass/cpython_math.sifr`
- [x] `cargo run -- run ../../demos/milestone_test_assertions_parity_demo.sifr`

Made with [Cursor](https://cursor.com)