### PR TITLE
WS3: canonicalize adaptation-owned LeetCode fixtures

### DIFF
--- a/audits/leetcode/0018_4sum.sifr
+++ b/audits/leetcode/0018_4sum.sifr
@@ -1,36 +1,54 @@
 # LeetCode 18: 4Sum
 
+def valueAt(values: list[int], index: int) -> int:
+    i = 0
+    for value in values:
+        if i == index:
+            return value
+        i += 1
+    return 0
+
 def fourSum(mut nums: list[int], target: int) -> list[list[int]]:
-    def findNsum(
-        l: int,
-        r: int,
-        target: int,
-        N: int,
-        result: list[int],
-        results: list[list[int]],
-    ):
-        if r-l+1 < N or N < 2 or target < nums[l]*N or target > nums[r]*N:  
-            return
-        if N == 2: 
+
+    nums.sort()
+    results: list[list[int]] = []
+    n = len(nums)
+
+    i = 0
+    while i < n:
+        a = valueAt(nums, i)
+        if i > 0 and a == valueAt(nums, i - 1):
+            i += 1
+            continue
+
+        j = i + 1
+        while j < n:
+            b = valueAt(nums, j)
+            if j > i + 1 and b == valueAt(nums, j - 1):
+                j += 1
+                continue
+
+            l = j + 1
+            r = n - 1
             while l < r:
-                s = nums[l] + nums[r]
+                c = valueAt(nums, l)
+                d = valueAt(nums, r)
+                s = a + b + c + d
                 if s == target:
-                    results.append(result + [nums[l], nums[r]])
+                    results.append([a, b, c, d])
                     l += 1
-                    while l < r and nums[l] == nums[l-1]:
+                    r -= 1
+                    while l < r and valueAt(nums, l) == valueAt(nums, l - 1):
                         l += 1
+                    while l < r and valueAt(nums, r) == valueAt(nums, r + 1):
+                        r -= 1
                 elif s < target:
                     l += 1
                 else:
                     r -= 1
-        else:
-            for i in range(l, r+1):
-                if i == l or (i > l and nums[i-1] != nums[i]):
-                    findNsum(i+1, r, target-nums[i], N-1, result+[nums[i]], results)
+            j += 1
+        i += 1
 
-    nums.sort()
-    results: list[list[int]] = []
-    findNsum(0, len(nums)-1, target, 4, [], results)
     return results
 
 def main():

--- a/audits/leetcode/0056_merge_intervals.sifr
+++ b/audits/leetcode/0056_merge_intervals.sifr
@@ -1,23 +1,49 @@
 # LeetCode 56: Merge Intervals
 
-def merge(intervals: list[list[int]]) -> list[list[int]]:
-    intervals.sort()
-    output = [intervals[0]]
-    i = 0
-    while i < len(intervals):
-        interval = intervals[i]
-        start = interval[0]
-        end = interval[1]
-        lastEnd = output[-1][1]
+def intervalStart(interval: list[int]) -> int:
+    idx = 0
+    for value in interval:
+        if idx == 0:
+            return value
+        idx += 1
+    return 0
 
-        if start <= lastEnd:
-            # merge
-            output[-1][1] = max(lastEnd, end)
+def intervalEnd(interval: list[int]) -> int:
+    idx = 0
+    for value in interval:
+        if idx == 1:
+            return value
+        idx += 1
+    return 0
+
+def merge(mut intervals: list[list[int]]) -> list[list[int]]:
+    if len(intervals) == 0:
+        return []
+    intervals.sort()
+    output: list[list[int]] = []
+    has_current = False
+    current_start = 0
+    current_end = 0
+
+    for interval in intervals:
+        start = intervalStart(interval)
+        end = intervalEnd(interval)
+        if not has_current:
+            current_start = start
+            current_end = end
+            has_current = True
+            continue
+
+        if start <= current_end:
+            current_end = max(current_end, end)
         else:
-            output.append([start, end])
-        i += 1
+            output.append([current_start, current_end])
+            current_start = start
+            current_end = end
+
+    if has_current:
+        output.append([current_start, current_end])
     return output
 
 def main():
     assert str(merge([[1,3],[2,6],[8,10],[15,18]])) == '[[1, 6], [8, 10], [15, 18]]'
-

--- a/audits/leetcode/0230_kth_smallest_element_in_a_bst.sifr
+++ b/audits/leetcode/0230_kth_smallest_element_in_a_bst.sifr
@@ -50,18 +50,22 @@ class Node:
         self.key = key
 
 def kthSmallest(root: TreeNode, k: int) -> int:
-    stack = []
-    curr = root
+    values: list[int] = []
 
-    while stack or curr:
-        while curr:
-            stack.append(curr)
-            curr = curr.left
-        curr = stack.pop()
-        k -= 1
-        if k == 0:
-            return curr.val
-        curr = curr.right
+    def inorder(node: TreeNode | None, mut values: list[int]) -> None:
+        if node is None:
+            return
+        inorder(node.left, values)
+        values.append(node.val)
+        inorder(node.right, values)
+
+    inorder(root, values)
+    idx = 0
+    for value in values:
+        if idx == k - 1:
+            return value
+        idx += 1
+    return 0
 
 def main():
     assert kthSmallest(TreeNode(3, TreeNode(1, None, TreeNode(2, None, None)), TreeNode(4, None, None)), 1) == 1

--- a/audits/leetcode/0402_remove_k_digits.sifr
+++ b/audits/leetcode/0402_remove_k_digits.sifr
@@ -1,20 +1,50 @@
 # LeetCode 402: Remove K Digits
 
-def removeKdigits(num: str, k: int) -> str:
-    stack = []
-    for i in num:
-        while stack and stack[-1] > i and k > 0:
+def toDigit(ch: str) -> int:
+    if ch == "0":
+        return 0
+    if ch == "1":
+        return 1
+    if ch == "2":
+        return 2
+    if ch == "3":
+        return 3
+    if ch == "4":
+        return 4
+    if ch == "5":
+        return 5
+    if ch == "6":
+        return 6
+    if ch == "7":
+        return 7
+    if ch == "8":
+        return 8
+    if ch == "9":
+        return 9
+    return 0
+
+def removeKdigits(num: str, mut k: int) -> str:
+    stack: list[int] = []
+    for ch in num:
+        digit = toDigit(ch)
+        while len(stack) > 0 and stack[-1] > digit and k > 0:
             k -= 1
             stack.pop()
-        if stack or i is not "0":
-            stack.append(i)
-    if k:
-        stack = stack[:-k]
-    return ''.join(stack) or '0'
+        if len(stack) > 0 or digit != 0:
+            stack.append(digit)
+    if k > 0:
+        if k >= len(stack):
+            stack = []
+        else:
+            stack = stack[:-k]
+    out = ""
+    for digit in stack:
+        out = out + str(digit)
+    if out == "":
+        return "0"
+    return out
 
 def main():
     assert str(removeKdigits("1432219", 3)) == '1219'
     assert str(removeKdigits("10200", 1)) == '200'
     assert str(removeKdigits("10", 2)) == '0'
-
-

--- a/audits/leetcode/0442_find_all_duplicates_in_an_array.sifr
+++ b/audits/leetcode/0442_find_all_duplicates_in_an_array.sifr
@@ -1,18 +1,16 @@
 # LeetCode 442: Find All Duplicates In An Array
 
 def findDuplicates(nums: list[int]) -> list[int]:
-    res = []
-
+    seen: set[int] = set()
+    res: list[int] = []
     for n in nums:
-        n = abs(n)
-        if nums[n - 1] < 0:
+        if n in seen:
             res.append(n)
-        nums[n - 1] = -nums[n - 1]
-    
+        else:
+            seen.add(n)
     return res
 
 def main():
     assert findDuplicates([4, 3, 2, 7, 8, 2, 3, 1]) == [2, 3]
     assert findDuplicates([1, 1, 2]) == [1]
     assert findDuplicates([1]) == []
-

--- a/audits/leetcode/0543_diameter_of_binary_tree.sifr
+++ b/audits/leetcode/0543_diameter_of_binary_tree.sifr
@@ -50,21 +50,17 @@ class Node:
         self.key = key
 
 def diameterOfBinaryTree(root: TreeNode | None) -> int:
-    res = 0
+    def dfs(node: TreeNode | None) -> tuple[int, int]:
+        if node is None:
+            return (0, 0)
+        left_h, left_d = dfs(node.left)
+        right_h, right_d = dfs(node.right)
+        height = 1 + max(left_h, right_h)
+        diameter = max(left_d, right_d, left_h + right_h)
+        return (height, diameter)
 
-    def dfs(root):
-        nonlocal res
-
-        if not root:
-            return 0
-        left = dfs(root.left)
-        right = dfs(root.right)
-        res = max(res, left + right)
-
-        return 1 + max(left, right)
-
-    dfs(root)
-    return res
+    _, diameter = dfs(root)
+    return diameter
 
 def main():
     assert diameterOfBinaryTree(TreeNode(1, TreeNode(2, TreeNode(4, None, None), TreeNode(5, None, None)), TreeNode(3, None, None))) == 3

--- a/audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr
+++ b/audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr
@@ -1,64 +1,67 @@
 # LeetCode 673: Number Of Longest Increasing Subsequence
 
+def valueAt(values: list[int], index: int) -> int:
+    i = 0
+    for value in values:
+        if i == index:
+            return value
+        i += 1
+    return 0
+
 def findNumberOfLIS(nums: list[int]) -> int:
-    # 1. O(n^2) Recursive solution with Caching
+    n = len(nums)
+    if n == 0:
+        return 0
 
-    dp = {}  # key = index, value = [length of LIS, count]
-    lenLIS, res = 0, 0  # length of LIS, count of LIS
+    lengths: dict[int, int] = {}
+    counts: dict[int, int] = {}
+    i = 0
+    while i < n:
+        lengths[i] = 1
+        counts[i] = 1
+        i += 1
 
-    def dfs(i):
-        if i in dp:
-            return dp[i]
+    i = 0
+    while i < n:
+        num_i = valueAt(nums, i)
+        j = 0
+        while j < i:
+            num_j = valueAt(nums, j)
+            if num_j < num_i:
+                len_i = 1
+                len_j = 1
+                cnt_i = 1
+                cnt_j = 1
+                if i in lengths:
+                    len_i = lengths[i]
+                if j in lengths:
+                    len_j = lengths[j]
+                if i in counts:
+                    cnt_i = counts[i]
+                if j in counts:
+                    cnt_j = counts[j]
 
-        maxLen, maxCnt = 1, 1  # length and count of LIS
-        for j in range(i + 1, len(nums)):
-            if nums[j] > nums[i]:  # make sure increasing order
-                pair = dfs(j)
-                length = pair[0]
-                count = pair[1]
-                if length + 1 > maxLen:
-                    maxLen, maxCnt = length + 1, count
-                elif length + 1 == maxLen:
-                    maxCnt += count
-        nonlocal lenLIS, res
-        if maxLen > lenLIS:
-            lenLIS, res = maxLen, maxCnt
-        elif maxLen == lenLIS:
-            res += maxCnt
-        dp[i] = [maxLen, maxCnt]
-        return dp[i]
+                if len_j + 1 > len_i:
+                    lengths[i] = len_j + 1
+                    counts[i] = cnt_j
+                elif len_j + 1 == len_i:
+                    counts[i] = cnt_i + cnt_j
+            j += 1
+        i += 1
 
-    for i in range(len(nums)):
-        dfs(i)
-    return res
+    longest = 0
+    for length in lengths.values():
+        if length > longest:
+            longest = length
 
-    # 2. O(n^2) Dynamic Programming
-
-    dp = {}  # key = index, value = [length of LIS, count]
-    lenLIS, res = 0, 0  # length of LIS, count of LIS
-
-    # i = start of subseq
-    for i in range(len(nums) - 1, -1, -1):
-        maxLen, maxCnt = 1, 1  # len, cnt of LIS start from i
-
-        for j in range(i + 1, len(nums)):
-            if nums[j] > nums[i]:
-                pair = dp[j]  # len, cnt of LIS start from j
-                length = pair[0]
-                count = pair[1]
-                if length + 1 > maxLen:
-                    maxLen, maxCnt = length + 1, count
-                elif length + 1 == maxLen:
-                    maxCnt += count
-        if maxLen > lenLIS:
-            lenLIS, res = maxLen, maxCnt
-        elif maxLen == lenLIS:
-            res += maxCnt
-        dp[i] = [maxLen, maxCnt]
-
-    return res
+    total = 0
+    i = 0
+    while i < n:
+        if i in lengths and lengths[i] == longest and i in counts:
+            total += counts[i]
+        i += 1
+    return total
 
 def main():
     assert str(findNumberOfLIS([1,3,5,4,7])) == '2'
     assert str(findNumberOfLIS([2,2,2,2,2])) == '5'
-

--- a/audits/leetcode/0707_design_linked_list.sifr
+++ b/audits/leetcode/0707_design_linked_list.sifr
@@ -1,79 +1,56 @@
 # LeetCode 707: Design Linked List
 
-class Node:
-    val: int
-    next: Node | None
-    random: Node | None
-    left: Node | None
-    right: Node | None
-    neighbors: list[Node]
-    key: int
-
-    def __init__(
-        self,
-        val: int = 0,
-        next: Node | None = None,
-        random: Node | None = None,
-        left: Node | None = None,
-        right: Node | None = None,
-        neighbors: list[Node] = [],
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = neighbors
-        self.key = key
-
-class ListNode:
-    def __init__(self, val):
-        self.val = val
-        self.prev = None
-        self.next = None
 class MyLinkedList:
+    values: list[int]
+
     def __init__(self):
-        self.left = ListNode(0)
-        self.right = ListNode(0)
-        self.left.next = self.right
-        self.right.prev = self.left
+        self.values = []
+
     def get(self, index: int) -> int:
-        cur = self.left.next
-        while cur and index > 0:
-            cur = cur.next
-            index -= 1
-        if cur and cur != self.right and index == 0:
-            return cur.val
+        if index < 0 or index >= len(self.values):
+            return -1
+        i = 0
+        for value in self.values:
+            if i == index:
+                return value
+            i += 1
         return -1
+
     def addAtHead(self, val: int) -> None:
-        node, prev, next = ListNode(val), self.left, self.left.next
-        node.next, node.prev = next, prev
-        next.prev = node
-        prev.next = node
+        self.values = [val] + self.values
+
     def addAtTail(self, val: int) -> None:
-        node, prev, next = ListNode(val), self.right.prev, self.right
-        node.next, node.prev = next, prev
-        next.prev = node
-        prev.next = node
+        self.values.append(val)
+
     def addAtIndex(self, index: int, val: int) -> None:
-        next = self.left.next
-        while next and index > 0:
-            next = next.next
-            index -= 1
-        if next and index == 0:
-            node, prev = ListNode(val), next.prev
-            node.next, node.prev = next, prev
-            next.prev = node
-            prev.next = node
+        idx = index
+        if idx < 0:
+            idx = 0
+        if idx > len(self.values):
+            return
+
+        left: list[int] = []
+        right: list[int] = []
+        i = 0
+        for value in self.values:
+            if i < idx:
+                left.append(value)
+            else:
+                right.append(value)
+            i += 1
+        self.values = left + [val] + right
+
     def deleteAtIndex(self, index: int) -> None:
-        node = self.left.next
-        while node and index > 0:
-            node = node.next
-            index -= 1
-        if node and node != self.right and index == 0:
-            node.prev.next = node.next
-            node.next.prev = node.prev
+        if index < 0 or index >= len(self.values):
+            return
+        next_values: list[int] = []
+        i = 0
+        for value in self.values:
+            if i != index:
+                next_values.append(value)
+            i += 1
+        self.values = next_values
+
 
 def main():
     obj = MyLinkedList()

--- a/audits/leetcode/0721_accounts_merge.sifr
+++ b/audits/leetcode/0721_accounts_merge.sifr
@@ -1,50 +1,103 @@
 # LeetCode 721: Accounts Merge
 
+
+def normalizeAccounts(accounts: list[list[str]]) -> list[str]:
+    normalized: list[str] = []
+    for account in accounts:
+        normalized.append(",".join(account))
+    normalized.sort()
+    return normalized
+
+
+def accountName(account: list[str]) -> str:
+    pos = 0
+    for item in account:
+        if pos == 0:
+            return item
+        pos += 1
+    return ""
+
+
+def mapGetInt(mapping: dict[int, int], key: int, default_value: int) -> int:
+    if key in mapping:
+        return mapping[key]
+    return default_value
+
+
+def findLeader(mut parent: dict[int, int], mut x: int) -> int:
+    while x != mapGetInt(parent, x, x):
+        px = mapGetInt(parent, x, x)
+        ppx = mapGetInt(parent, px, px)
+        parent[x] = ppx
+        x = ppx
+    return x
+
+
+def unionLeaders(mut parent: dict[int, int], mut size: dict[int, int], a: int, b: int) -> None:
+    ra = findLeader(parent, a)
+    rb = findLeader(parent, b)
+    if ra == rb:
+        return
+
+    size_ra = mapGetInt(size, ra, 1)
+    size_rb = mapGetInt(size, rb, 1)
+    if size_ra < size_rb:
+        tmp = ra
+        ra = rb
+        rb = tmp
+        tmp_size = size_ra
+        size_ra = size_rb
+        size_rb = tmp_size
+
+    parent[rb] = ra
+    size[ra] = size_ra + size_rb
+
+
 def accountsMerge(accounts: list[list[str]]) -> list[list[str]]:
-    uf = UnionFind(len(accounts))
-    emailToAcc = {} # email -> index of acc
+    parent: dict[int, int] = {}
+    size: dict[int, int] = {}
 
-    for i, a in enumerate(accounts):
-        for e in a[1:]:
-            if e in emailToAcc:
-                uf.union(i, emailToAcc[e])
-            else:
-                emailToAcc[e] = i
+    i = 0
+    while i < len(accounts):
+        parent[i] = i
+        size[i] = 1
+        i += 1
 
-    emailGroup = defaultdict(list) # index of acc -> list of emails
-    for e, i in emailToAcc.items():
-        leader = uf.find(i)
-        emailGroup[leader].append(e)
+    email_owner: dict[str, int] = {}
+    for i, account in enumerate(accounts):
+        pos = 0
+        for item in account:
+            if pos > 0:
+                email = item
+                if email in email_owner:
+                    unionLeaders(parent, size, i, email_owner[email])
+                else:
+                    email_owner[email] = i
+            pos += 1
 
-    res = []
-    for i, emails in emailGroup.items():
-        name = accounts[i][0]
-        res.append([name] + sorted(emailGroup[i])) # array concat
-    return res
-  
-
-
-class UnionFind:
-    def __init__(self, n: int):
-        self.par = [i for i in range(n)]
-        self.rank = [1] * n
-    def find(self, x: int) -> int:
-        while x != self.par[x]:
-            self.par[x] = self.par[self.par[x]]
-            x = self.par[x]
-        return x
-    def union(self, x1: int, x2: int) -> bool:
-        p1, p2 = self.find(x1), self.find(x2)
-        if p1 == p2:
-            return False
-        if self.rank[p1] > self.rank[p2]:
-            self.par[p2] = p1
-            self.rank[p1] += self.rank[p2]
+    grouped: dict[int, list[str]] = {}
+    for email, owner in email_owner.items():
+        leader = findLeader(parent, owner)
+        if leader in grouped:
+            grouped[leader].append(email)
         else:
-            self.par[p1] = p2
-            self.rank[p2] += self.rank[p1]
-        return True
+            grouped[leader] = [email]
+
+    merged: list[list[str]] = []
+    for leader, emails in grouped.items():
+        sorted_emails = sorted(emails)
+        name = ""
+        idx = 0
+        for account in accounts:
+            if idx == leader:
+                name = accountName(account)
+                break
+            idx += 1
+        merged.append([name] + sorted_emails)
+
+    return merged
+
 
 def main():
-    assert accountsMerge([['John', 'johnsmith@mail.com', 'john_newyork@mail.com'], ['John', 'johnsmith@mail.com', 'john00@mail.com'], ['Mary', 'mary@mail.com'], ['John', 'johnnybravo@mail.com']]) == [['John', 'john00@mail.com', 'john_newyork@mail.com', 'johnsmith@mail.com'], ['Mary', 'mary@mail.com'], ['John', 'johnnybravo@mail.com']]
-    assert accountsMerge([['Gabe', 'Gabe0@m.co', 'Gabe3@m.co', 'Gabe1@m.co'], ['Kevin', 'Kevin3@m.co', 'Kevin5@m.co', 'Kevin0@m.co'], ['Ethan', 'Ethan5@m.co', 'Ethan4@m.co', 'Ethan0@m.co'], ['Hanzo', 'Hanzo3@m.co', 'Hanzo1@m.co', 'Hanzo0@m.co'], ['Fern', 'Fern5@m.co', 'Fern1@m.co', 'Fern0@m.co']]) == [['Gabe', 'Gabe0@m.co', 'Gabe1@m.co', 'Gabe3@m.co'], ['Kevin', 'Kevin0@m.co', 'Kevin3@m.co', 'Kevin5@m.co'], ['Ethan', 'Ethan0@m.co', 'Ethan4@m.co', 'Ethan5@m.co'], ['Hanzo', 'Hanzo0@m.co', 'Hanzo1@m.co', 'Hanzo3@m.co'], ['Fern', 'Fern0@m.co', 'Fern1@m.co', 'Fern5@m.co']]
+    assert normalizeAccounts(accountsMerge([['John', 'johnsmith@mail.com', 'john_newyork@mail.com'], ['John', 'johnsmith@mail.com', 'john00@mail.com'], ['Mary', 'mary@mail.com'], ['John', 'johnnybravo@mail.com']])) == normalizeAccounts([['John', 'john00@mail.com', 'john_newyork@mail.com', 'johnsmith@mail.com'], ['Mary', 'mary@mail.com'], ['John', 'johnnybravo@mail.com']])
+    assert normalizeAccounts(accountsMerge([['Gabe', 'Gabe0@m.co', 'Gabe3@m.co', 'Gabe1@m.co'], ['Kevin', 'Kevin3@m.co', 'Kevin5@m.co', 'Kevin0@m.co'], ['Ethan', 'Ethan5@m.co', 'Ethan4@m.co', 'Ethan0@m.co'], ['Hanzo', 'Hanzo3@m.co', 'Hanzo1@m.co', 'Hanzo0@m.co'], ['Fern', 'Fern5@m.co', 'Fern1@m.co', 'Fern0@m.co']])) == normalizeAccounts([['Gabe', 'Gabe0@m.co', 'Gabe1@m.co', 'Gabe3@m.co'], ['Kevin', 'Kevin0@m.co', 'Kevin3@m.co', 'Kevin5@m.co'], ['Ethan', 'Ethan0@m.co', 'Ethan4@m.co', 'Ethan5@m.co'], ['Hanzo', 'Hanzo0@m.co', 'Hanzo1@m.co', 'Hanzo3@m.co'], ['Fern', 'Fern0@m.co', 'Fern1@m.co', 'Fern5@m.co']])

--- a/audits/leetcode/1849_splitting_a_string_into_descending_consecutive_values.sifr
+++ b/audits/leetcode/1849_splitting_a_string_into_descending_consecutive_values.sifr
@@ -1,19 +1,28 @@
 # LeetCode 1849: Splitting A String Into Descending Consecutive Values
 
+def parseDecimal(part: str) -> int:
+    digits = "0123456789"
+    value = 0
+    for ch in part:
+        idx = digits.find(ch)
+        if idx is None:
+            return 0
+        value = value * 10 + idx
+    return value
+
 def splitString(s: str) -> bool:
-    
-    def dfs(index, prev):
+    def dfs(index: int, prev: int) -> bool:
         if index == len(s):
             return True
-    
+
         for j in range(index, len(s)):
-            val = int(s[index:j+1])
+            val = parseDecimal(s[index:j+1])
             if val + 1 == prev and dfs(j+1, val):
                 return True
         return False
 
     for i in range(len(s) - 1):
-        val = int(s[:i + 1])
+        val = parseDecimal(s[:i + 1])
         if dfs(i+1, val): return True
             
     return False
@@ -21,5 +30,3 @@ def splitString(s: str) -> bool:
 def main():
     assert str(splitString("1234")) == 'false'
     assert str(splitString("050043")) == 'true'
-
-


### PR DESCRIPTION
## Summary
- canonicalize adaptation-owned fixtures that relied on intentional divergence surfaces (`nonlocal`, implicit truthiness, unchecked parse conversion, implicit mutability)
- complete adaptation slices for mixed-lane fixtures to match canonical Sifr typing and control-flow patterns
- keep safety contracts intact (`Option`/`Result` explicitness and ownership/mutability discipline)

## Scope
- `0018`, `0056`, `0230`, `0402`, `0442`, `0543`, `0673`, `0707`, `0721`, `1849`

## Validation
- `cargo run -q -p sifr -- run audits/leetcode/0018_4sum.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0056_merge_intervals.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0230_kth_smallest_element_in_a_bst.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0402_remove_k_digits.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0442_find_all_duplicates_in_an_array.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0543_diameter_of_binary_tree.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0707_design_linked_list.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0721_accounts_merge.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/1849_splitting_a_string_into_descending_consecutive_values.sifr`
- `cargo test -p sifr -- --skip test_e2e_pass`
