### PR TITLE
Fix LeetCode 2554 dict-order semantic mismatch

### DIFF
--- a/audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr
+++ b/audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr
@@ -1,22 +1,20 @@
 # LeetCode 2554: Maximum Number Of Integers To Choose From A Range I
 
 def maxCount(banned: list[int], n: int, maxSum: int) -> int:
-    nums = {x:1 for x in range(1, n + 1)} # hashmap for storing the required elements
-    for i in banned:
-        if nums.get(i):
-            del nums[i]
+    # Do not iterate dict keys here: Sifr dict order is intentionally unspecified.
+    banned_set = {x for x in banned}
     sum = 0
     count = 0
-    for i in nums:
-        sum += i
-        if sum <= maxSum:
-            count += 1
-        else:
+    for i in range(1, n + 1):
+        if i in banned_set:
+            continue
+        if sum + i > maxSum:
             break
+        sum += i
+        count += 1
     return count
 
 def main():
     assert maxCount([1, 6, 5], 5, 6) == 2
     assert maxCount([1, 2, 3, 4, 5, 6, 7], 8, 1) == 0
     assert maxCount([11], 7, 50) == 7
-

--- a/issues/ad-hoc-dict-order-sensitive-leetcode-sweep-2026-04-08.md
+++ b/issues/ad-hoc-dict-order-sensitive-leetcode-sweep-2026-04-08.md
@@ -1,0 +1,27 @@
+# Ad-hoc: Dict-Order-Sensitive LeetCode Sweep (2026-04-08)
+
+## Why
+Sifr intentionally maps `dict` to Rust `HashMap`, and dict iteration order is unspecified by architecture. Some LeetCode fixtures may still accidentally rely on Python insertion-order dict iteration and pass nondeterministically.
+
+## Goal
+Audit the full `audits/leetcode/` corpus for order-sensitive patterns and rewrite fixtures to order-agnostic logic where needed.
+
+## Trigger
+Reviewer follow-up from `reviews/leetcode-2554-runtime-semantic-closure-review-pass5.md` (A2).
+
+## Scope
+- Search for patterns like dict-built-from-range followed by direct key iteration.
+- Search for any logic where correctness depends on deterministic dict key order.
+- Adapt fixtures to deterministic alternatives (`range`, `sorted(...)`, explicit ordered structures) based on intended algorithm.
+
+## Acceptance criteria
+- No fixture in `audits/leetcode/` relies on unspecified dict iteration order for correctness.
+- Corpus rerun remains green after adaptations.
+- Taxonomy/report updated if any additional fixtures are changed.
+
+## Checklist
+- [ ] Pattern scan completed
+- [ ] Candidate fixtures reviewed and classified
+- [ ] Required fixture adaptations implemented
+- [ ] Full corpus rerun completed
+- [ ] Results documented


### PR DESCRIPTION
## Summary
- adapt `2554_maximum_number_of_integers_to_choose_from_a_range_i` to avoid dict-iteration-order dependency
- add an inline guard comment documenting Sifr dict-order semantics
- add follow-up issue to sweep the corpus for similar dict-order-sensitive patterns

## Root cause
- fixture depended on Python insertion-ordered `dict` iteration
- Sifr `dict` is HashMap-backed with unspecified iteration order by architecture

## Validation
- `target/release/sifr check audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr`
- `target/release/sifr run audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr`
- full corpus rerun: `verification/leetcode/full_corpus_current_results_20260408_live_rerun5.json` => `PASS=411`
- reviewer closure: `reviews/leetcode-2554-runtime-semantic-closure-review-pass6.md` (no actionable findings)
