### PR TITLE
[codex] Add narrowing fact invalidation design

### DIFF
--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -324,15 +324,11 @@ pub(crate) fn collect_mutated_vars(
                             .map(|(param_convs, _)| param_convs.as_slice())
                     })
                 })
-                .or_else(|| {
-                    local_func_param_conventions
-                        .get(func)
-                        .map(|param_convs| param_convs.as_slice())
-                })
+                .or_else(|| local_func_param_conventions.get(func).map(Vec::as_slice))
                 .or_else(|| {
                     local_func_param_conventions
                         .get(canonical_func)
-                        .map(|param_convs| param_convs.as_slice())
+                        .map(Vec::as_slice)
                 });
             if let Some(param_convs) = param_convs {
                 for (idx, arg) in args.iter().enumerate() {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -830,6 +830,7 @@ impl RustEmitter {
         Some(lowered_expr)
     }
 
+    #[allow(clippy::unused_self)]
     fn unwrap_compiler_verified_nonempty_pop_result(
         &self,
         object_ty: &Type,

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1066,6 +1066,7 @@ struct CollectionNeeds {
     needs_vecdeque: bool,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 struct RuntimeNeeds {
     needs_file_handles: bool,

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -2217,6 +2217,7 @@ fn try_lower_simple_while_stmt(
     }])
 }
 
+#[allow(clippy::too_many_arguments)]
 fn try_lower_simple_for_stmt(
     target: &str,
     target_ty: &Type,

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -225,12 +225,12 @@ impl RustEmitter {
             ));
         }
         let value_ty = if let HirExpr::Name { name, ty } = value {
-            if self.none_widened_local_bindings.contains(name) {
-                self.local_binding_types.get(name).unwrap_or(ty)
-            } else if matches!(
-                crate::resolve_alias_type_for_plain_call(ty),
-                Type::Any | Type::Unknown
-            ) {
+            if self.none_widened_local_bindings.contains(name)
+                || matches!(
+                    crate::resolve_alias_type_for_plain_call(ty),
+                    Type::Any | Type::Unknown
+                )
+            {
                 self.local_binding_types.get(name).unwrap_or(ty)
             } else {
                 ty
@@ -1284,9 +1284,7 @@ impl RustEmitter {
                 },
             });
         }
-        let Some(rust_op) = op.strip_suffix('=') else {
-            return None;
-        };
+        let rust_op = op.strip_suffix('=')?;
         Some(crate::RustStmt::AugAssign {
             target: crate::RustExpr::Deref(Box::new(crate::RustExpr::Ident("__elem".to_string()))),
             op: rust_op.to_string(),
@@ -1873,8 +1871,10 @@ impl RustEmitter {
                 let Some(lowered_element) = self.lower_stmt_expr_for_ir(element)? else {
                     return Ok(None);
                 };
-                lowered_elements
-                    .push(Self::clone_non_copy_name_expr_for_ir(element, lowered_element));
+                lowered_elements.push(Self::clone_non_copy_name_expr_for_ir(
+                    element,
+                    lowered_element,
+                ));
             }
             return Ok(Some(crate::RustExpr::Tuple(lowered_elements)));
         }
@@ -6337,10 +6337,10 @@ impl RustEmitter {
     fn option_binding_pattern_for_ir(&self, option_var: &str) -> String {
         let is_borrowed_param = self.borrowed_params.contains(option_var)
             || self.mut_borrowed_params.contains(option_var);
-        if !is_borrowed_param {
-            format!("Some(mut {option_var})")
-        } else {
+        if is_borrowed_param {
             format!("Some({option_var})")
+        } else {
+            format!("Some(mut {option_var})")
         }
     }
 

--- a/crates/sifr_hir/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_hir/src/lower/aug_assign_lowering.rs
@@ -10,7 +10,7 @@ use super::statements::resolve_object_field_type;
 use super::subscript_type::resolve_subscript_result_type;
 use super::LowerCtx;
 
-fn op_to_augassign_string(op: &Operator, ctx: &mut LowerCtx) -> Option<&'static str> {
+fn op_to_augassign_string(op: Operator, ctx: &mut LowerCtx) -> Option<&'static str> {
     match op {
         Operator::Add => Some("+="),
         Operator::Sub => Some("-="),
@@ -45,9 +45,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
         }
         let field_name = attr.attr.to_string();
         let value = lower_expr(&aug.value, ctx)?;
-        let Some(op_str) = op_to_augassign_string(&aug.op, ctx) else {
-            return None;
-        };
+        let op_str = op_to_augassign_string(aug.op, ctx)?;
         return Some(HirStmt::AttributeAugAssign {
             object: obj_name,
             field: field_name,
@@ -112,9 +110,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
             let outer_index = lower_expr(&inner_sub.slice, ctx)?;
             let inner_index = lower_expr(&sub.slice, ctx)?;
             let value = lower_expr(&aug.value, ctx)?;
-            let Some(op_str) = op_to_augassign_string(&aug.op, ctx) else {
-                return None;
-            };
+            let op_str = op_to_augassign_string(aug.op, ctx)?;
             let outer_elem_ty = resolve_subscript_result_type(
                 inner_sub,
                 &obj_ty,
@@ -195,9 +191,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
             let object_expr = lower_expr(attr.value.as_ref(), ctx)?;
             let index = lower_expr(&sub.slice, ctx)?;
             let value = lower_expr(&aug.value, ctx)?;
-            let Some(op_str) = op_to_augassign_string(&aug.op, ctx) else {
-                return None;
-            };
+            let op_str = op_to_augassign_string(aug.op, ctx)?;
 
             let element_ty = resolve_subscript_result_type(sub, &field_ty, &index, index.ty(), ctx);
             let base_op = &op_str[..op_str.len() - 1];
@@ -256,9 +250,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
         }
         let index = lower_expr(&sub.slice, ctx)?;
         let value = lower_expr(&aug.value, ctx)?;
-        let Some(op_str) = op_to_augassign_string(&aug.op, ctx) else {
-            return None;
-        };
+        let op_str = op_to_augassign_string(aug.op, ctx)?;
         let object_ty = validate_subscript_augassign_target(
             ctx,
             &obj_name,
@@ -286,9 +278,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
     ctx.clear_sequence_pointer(&name);
     ctx.clear_len_alias(&name);
 
-    let Some(op_str) = op_to_augassign_string(&aug.op, ctx) else {
-        return None;
-    };
+    let op_str = op_to_augassign_string(aug.op, ctx)?;
 
     let var_info = if ctx.current_function_frame_start().is_some() {
         if let Some(info) = ctx.lookup_current_function_binding(&name) {

--- a/crates/sifr_hir/src/lower/class_field_inference.rs
+++ b/crates/sifr_hir/src/lower/class_field_inference.rs
@@ -177,7 +177,7 @@ fn infer_constructor_expr_type(
                 let elem_ty = iter_ty.iterable_element_type().unwrap_or(Type::Any);
                 match &generator.target {
                     Expr::Name(name) => {
-                        nested_locals.insert(name.id.to_string(), elem_ty);
+                        nested_locals.insert(name.id.clone(), elem_ty);
                     }
                     Expr::Tuple(tuple) => {
                         let Type::Tuple(elem_types) = elem_ty else {
@@ -186,7 +186,7 @@ fn infer_constructor_expr_type(
                         for (idx, target_elt) in tuple.elts.iter().enumerate() {
                             if let Expr::Name(name) = target_elt {
                                 let target_ty = elem_types.get(idx).cloned().unwrap_or(Type::Any);
-                                nested_locals.insert(name.id.to_string(), target_ty);
+                                nested_locals.insert(name.id.clone(), target_ty);
                             }
                         }
                     }
@@ -217,7 +217,7 @@ fn bind_simple_target_type(
     local_bindings: &mut HashMap<String, Type>,
 ) {
     if let Expr::Name(name) = target {
-        local_bindings.insert(name.id.to_string(), value_ty.clone());
+        local_bindings.insert(name.id.clone(), value_ty.clone());
     }
 }
 

--- a/crates/sifr_hir/src/lower/container_literal_specialization.rs
+++ b/crates/sifr_hir/src/lower/container_literal_specialization.rs
@@ -39,7 +39,7 @@ fn emit_empty_literal_type_conflict(
 pub(super) fn validate_subscript_assignment_target(
     ctx: &mut LowerCtx,
     object_name: &str,
-    object_ty: Type,
+    object_ty: &Type,
     index_ty: &Type,
     value_ty: &Type,
 ) -> Type {

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -548,12 +548,9 @@ pub(super) fn lower_boolop(boolop: &ExprBoolOp, ctx: &mut LowerCtx) -> Option<Hi
                 ctx.add_sequence_guard(guard);
             }
         }
-        let expr = match lower_expr(val, ctx) {
-            Some(expr) => expr,
-            None => {
-                ctx.restore_sequence_guards(&saved_sequence_guards);
-                return None;
-            }
+        let Some(expr) = lower_expr(val, ctx) else {
+            ctx.restore_sequence_guards(&saved_sequence_guards);
+            return None;
         };
         values.push(expr);
     }

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -701,6 +701,50 @@ fn test_inferred_local_can_widen_to_optional_on_reassignment() {
 }
 
 #[test]
+fn test_optional_reassignment_invalidates_non_none_narrowing() {
+    let result = lower_source(
+        "def bad(mut x: int | None) -> int:\n    if x is not None:\n        x = None\n        return x\n    return 0\n",
+    );
+    assert!(
+        result.is_err(),
+        "rebinding an Optional must invalidate prior non-None narrowing"
+    );
+}
+
+#[test]
+fn test_sequence_reassignment_invalidates_index_guard() {
+    let result = lower_source(
+        "def bad(mut values: list[int], i: int) -> int:\n    if i < len(values):\n        values = []\n        value: int = values[i]\n        return value\n    return 0\n",
+    );
+    assert!(
+        result.is_err(),
+        "rebinding a guarded sequence must invalidate prior index facts"
+    );
+}
+
+#[test]
+fn test_index_reassignment_invalidates_index_guard() {
+    let result = lower_source(
+        "def bad(values: list[int], mut i: int) -> int:\n    if i < len(values):\n        i = len(values)\n        value: int = values[i]\n        return value\n    return 0\n",
+    );
+    assert!(
+        result.is_err(),
+        "rebinding a guarded index variable must invalidate prior index facts"
+    );
+}
+
+#[test]
+fn test_shrinking_collection_method_invalidates_index_guard() {
+    let result = lower_source(
+        "def bad(mut values: list[int], i: int) -> int:\n    if i < len(values):\n        values.clear()\n        value: int = values[i]\n        return value\n    return 0\n",
+    );
+    assert!(
+        result.is_err(),
+        "a shrinking collection mutation must invalidate prior index facts"
+    );
+}
+
+#[test]
 fn test_annotated_local_does_not_widen_on_reassignment() {
     let result =
         lower_source("def bad() -> int:\n    value: int = 1\n    value = None\n    return value\n");

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -745,6 +745,17 @@ fn test_shrinking_collection_method_invalidates_index_guard() {
 }
 
 #[test]
+fn test_shrinking_field_collection_method_invalidates_index_guard() {
+    let result = lower_source(
+        "class Box:\n    values: list[int]\n\n    def __init__(self, values: list[int]):\n        self.values = values\n\n    def bad(mut self, i: int) -> int:\n        if i < len(self.values):\n            self.values.clear()\n            value: int = self.values[i]\n            return value\n        return 0\n",
+    );
+    assert!(
+        result.is_err(),
+        "a shrinking collection mutation on a field must invalidate field index facts"
+    );
+}
+
+#[test]
 fn test_annotated_local_does_not_widen_on_reassignment() {
     let result =
         lower_source("def bad() -> int:\n    value: int = 1\n    value = None\n    return value\n");

--- a/crates/sifr_hir/src/lower/if_branch_bindings.rs
+++ b/crates/sifr_hir/src/lower/if_branch_bindings.rs
@@ -8,14 +8,14 @@ fn top_level_assigned_name(stmt: &Stmt) -> Option<String> {
     match stmt {
         Stmt::Assign(assign) if assign.targets.len() == 1 => {
             if let Expr::Name(name) = &assign.targets[0] {
-                Some(name.id.to_string())
+                Some(name.id.clone())
             } else {
                 None
             }
         }
         Stmt::AnnAssign(ann) => {
             if let Expr::Name(name) = ann.target.as_ref() {
-                Some(name.id.to_string())
+                Some(name.id.clone())
             } else {
                 None
             }

--- a/crates/sifr_hir/src/lower/mutating_methods.rs
+++ b/crates/sifr_hir/src/lower/mutating_methods.rs
@@ -12,19 +12,17 @@ pub(super) fn reject_immutable_parameter_method_mutation(
         return false;
     }
 
-    let HirExpr::Name { name, .. } = object else {
-        return false;
-    };
-
-    if ctx
-        .scope
-        .lookup(name)
-        .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding)
-    {
-        ctx.error(format!(
-            "cannot mutate through immutable parameter `{name}`: add `mut` to the parameter declaration"
-        ));
-        return true;
+    if let HirExpr::Name { name, .. } = object {
+        if ctx
+            .scope
+            .lookup(name)
+            .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding)
+        {
+            ctx.error(format!(
+                "cannot mutate through immutable parameter `{name}`: add `mut` to the parameter declaration"
+            ));
+            return true;
+        }
     }
 
     invalidate_collection_flow_facts_for_method(ctx, object, object_ty, method);

--- a/crates/sifr_hir/src/lower/mutating_methods.rs
+++ b/crates/sifr_hir/src/lower/mutating_methods.rs
@@ -27,6 +27,7 @@ pub(super) fn reject_immutable_parameter_method_mutation(
         return true;
     }
 
+    invalidate_collection_flow_facts_for_method(ctx, object, object_ty, method);
     false
 }
 
@@ -62,5 +63,40 @@ pub(super) fn is_collection_mutating_method(object_ty: &Type, method: &str) -> b
                 | "symmetric_difference_update"
         ),
         _ => false,
+    }
+}
+
+pub(super) fn method_invalidates_collection_flow_facts(object_ty: &Type, method: &str) -> bool {
+    if let Type::Alias { body, .. } = object_ty {
+        return method_invalidates_collection_flow_facts(body, method);
+    }
+
+    match object_ty {
+        Type::List(_) => matches!(method, "clear" | "pop" | "popleft" | "remove"),
+        Type::Dict(_, _) => matches!(method, "clear" | "pop"),
+        Type::Set(_) => matches!(
+            method,
+            "remove"
+                | "discard"
+                | "clear"
+                | "intersection_update"
+                | "difference_update"
+                | "symmetric_difference_update"
+        ),
+        _ => false,
+    }
+}
+
+pub(super) fn invalidate_collection_flow_facts_for_method(
+    ctx: &mut LowerCtx,
+    object: &HirExpr,
+    object_ty: &Type,
+    method: &str,
+) {
+    if !method_invalidates_collection_flow_facts(object_ty, method) {
+        return;
+    }
+    if let Some(target) = super::sequence_guards::hir_sequence_guard_target_name(object) {
+        ctx.clear_sequence_guards_for_target(&target);
     }
 }

--- a/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
+++ b/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
@@ -31,9 +31,7 @@ pub(super) fn refine_nonempty_pop_return_type(
     if !is_narrowable_pop_call(method_name, args) {
         return None;
     }
-    let Some(sequence_name) = sequence_guard_name_from_hir_expr(object) else {
-        return None;
-    };
+    let sequence_name = sequence_guard_name_from_hir_expr(object)?;
     if ctx.min_length_guard(sequence_name.as_str()) == 0 {
         return None;
     }

--- a/crates/sifr_hir/src/lower/sequence_guards.rs
+++ b/crates/sifr_hir/src/lower/sequence_guards.rs
@@ -1,4 +1,5 @@
 use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
 use sifr_python_ast::{Expr, Number, Operator, UnaryOp};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,6 +117,16 @@ impl LowerCtx {
         self.sequence_guards = snapshot.to_vec();
     }
 
+    pub(super) fn clear_sequence_guards_for_binding(&mut self, binding: &str) {
+        self.sequence_guards
+            .retain(|guard| !guard_depends_on_binding(guard, binding));
+    }
+
+    pub(super) fn clear_sequence_guards_for_target(&mut self, target: &str) {
+        self.sequence_guards
+            .retain(|guard| !guard_depends_on_target(guard, target));
+    }
+
     pub(super) fn min_length_guard(&self, sequence: &str) -> usize {
         self.sequence_guards
             .iter()
@@ -185,12 +196,68 @@ impl LowerCtx {
     }
 }
 
+fn guard_depends_on_binding(guard: &SequenceGuard, binding: &str) -> bool {
+    match guard {
+        SequenceGuard::MinLength { sequence, .. } => path_depends_on_binding(sequence, binding),
+        SequenceGuard::IndexVarInRange {
+            sequence,
+            index_var,
+            ..
+        } => path_depends_on_binding(sequence, binding) || index_var == binding,
+        SequenceGuard::DictContains {
+            dict,
+            key_expr_debug,
+        } => path_depends_on_binding(dict, binding) || token_mentions_name(key_expr_debug, binding),
+        SequenceGuard::SubscriptPresent {
+            sequence,
+            index_expr_debug,
+        } => {
+            path_depends_on_binding(sequence, binding)
+                || token_mentions_name(index_expr_debug, binding)
+        }
+    }
+}
+
+fn guard_depends_on_target(guard: &SequenceGuard, target: &str) -> bool {
+    match guard {
+        SequenceGuard::MinLength { sequence, .. }
+        | SequenceGuard::IndexVarInRange { sequence, .. }
+        | SequenceGuard::SubscriptPresent { sequence, .. } => {
+            path_depends_on_target(sequence, target)
+        }
+        SequenceGuard::DictContains { dict, .. } => path_depends_on_target(dict, target),
+    }
+}
+
+fn path_depends_on_binding(path: &str, binding: &str) -> bool {
+    path == binding || path.starts_with(&format!("{binding}."))
+}
+
+fn path_depends_on_target(path: &str, target: &str) -> bool {
+    path == target || path.starts_with(&format!("{target}."))
+}
+
+fn token_mentions_name(token: &str, binding: &str) -> bool {
+    token == format!("name:{binding}") || token.contains(&format!("name:{binding}"))
+}
+
+pub(super) fn hir_sequence_guard_target_name(expr: &HirExpr) -> Option<String> {
+    match expr {
+        HirExpr::Name { name, .. } => Some(name.clone()),
+        HirExpr::FieldAccess { object, field, .. } => {
+            let base = hir_sequence_guard_target_name(object)?;
+            Some(format!("{base}.{field}"))
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn key_guard_token(expr: &Expr) -> Option<String> {
     match expr {
         Expr::Name(name) => Some(format!("name:{}", name.id)),
         Expr::BooleanLiteral(value) => Some(format!("bool:{}", value.value)),
         Expr::NumberLiteral(num) => match &num.value {
-            Number::Int(value) => Some(format!("int:{}", value)),
+            Number::Int(value) => Some(format!("int:{value}")),
             Number::Float(value) => Some(format!("float:{value}")),
             Number::Complex { .. } => None,
         },

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1084,6 +1084,11 @@ fn seed_binding_after_failed_initializer(
     ctx.clear_sequence_shape_fact(name);
 }
 
+fn invalidate_rebound_binding_facts(ctx: &mut LowerCtx, name: &str) {
+    ctx.scope.clear_narrowing(name);
+    ctx.clear_sequence_guards_for_binding(name);
+}
+
 pub(super) fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Option<HirStmt> {
     let name = if let Expr::Name(n) = ann.target.as_ref() {
         n.id.clone()
@@ -1218,6 +1223,7 @@ pub(super) fn lower_chained_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> V
                 let existing = ctx.scope.lookup(&name);
                 if existing.is_some() {
                     // Reassignment
+                    invalidate_rebound_binding_facts(ctx, &name);
                     ctx.empty_dict_specializations.remove(&name);
                     ctx.pending_container_specialization_patches.remove(&name);
                     result.push(HirStmt::Assign {
@@ -1248,6 +1254,7 @@ pub(super) fn lower_chained_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> V
                 };
                 let existing = ctx.scope.lookup(&name);
                 if existing.is_some() {
+                    invalidate_rebound_binding_facts(ctx, &name);
                     ctx.empty_dict_specializations.remove(&name);
                     ctx.pending_container_specialization_patches.remove(&name);
                     result.push(HirStmt::Assign {
@@ -1291,11 +1298,8 @@ fn resolve_field_type_from_type(object_ty: &Type, field_name: &str) -> Option<Ty
                     has_none = true;
                 }
                 Type::Class { fields, .. } => {
-                    let Some((_, member_field_ty)) =
-                        fields.iter().find(|(name, _)| name == field_name)
-                    else {
-                        return None;
-                    };
+                    let (_, member_field_ty) =
+                        fields.iter().find(|(name, _)| name == field_name)?;
                     field_members.push(member_field_ty.clone());
                 }
                 _ => return None,
@@ -1467,7 +1471,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
         let index = lower_expr(&sub.slice, ctx)?;
         let value = lower_expr(&assign.value, ctx)?;
         let object_ty =
-            validate_subscript_assignment_target(ctx, &obj_name, obj_ty, index.ty(), value.ty());
+            validate_subscript_assignment_target(ctx, &obj_name, &obj_ty, index.ty(), value.ty());
         maybe_record_dict_assignment_guard(ctx, &object_ty, &obj_name, &sub.slice);
         return Some(HirStmt::SubscriptAssign {
             object: obj_name,
@@ -1501,9 +1505,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
     } else {
         ctx.scope.lookup(&name).is_some()
     };
-    let value = if let Some(value) = lower_expr(&assign.value, ctx) {
-        value
-    } else {
+    let Some(value) = lower_expr(&assign.value, ctx) else {
         if !should_treat_as_existing_binding {
             let fallback_ty = ctx
                 .inferred_binding_hint(&name)
@@ -1551,6 +1553,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
         }
         // Reset moved state on reassignment
         ctx.scope.reset_moved(&name);
+        invalidate_rebound_binding_facts(ctx, &name);
         if ctx.numeric_sentinel_fact(&name).is_some() {
             if let Some(domain) = numeric_domain_for_type(&value_ty) {
                 ctx.resolve_numeric_sentinel_domain(&name, domain);
@@ -1597,15 +1600,14 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
     lower_aug_assign_impl(aug, ctx)
 }
 
+#[allow(clippy::unnecessary_wraps)]
 pub(super) fn lower_return(
     ret: &StmtReturn,
     func_type: &FunctionType,
     ctx: &mut LowerCtx,
 ) -> Option<HirStmt> {
     let value = if let Some(val) = &ret.value {
-        let expr = if let Some(expr) = lower_expr(val, ctx) {
-            expr
-        } else {
+        let Some(expr) = lower_expr(val, ctx) else {
             // Keep control-flow shape intact after expression diagnostics so
             // return-completeness analysis does not emit a cascade error.
             return Some(HirStmt::Return {

--- a/crates/sifr_hir/src/lower/tuple_unpack.rs
+++ b/crates/sifr_hir/src/lower/tuple_unpack.rs
@@ -117,6 +117,8 @@ pub(super) fn lower_tuple_unpack_assign(
                         ));
                     }
                     ctx.scope.reset_moved(&name);
+                    ctx.scope.clear_narrowing(&name);
+                    ctx.clear_sequence_guards_for_binding(&name);
                 } else {
                     ctx.scope.define(name.clone(), ty.clone());
                 }

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -13,6 +13,7 @@ pub enum BindingKind {
 }
 
 /// Tracks variable state for ownership and narrowing.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct VarInfo {
     /// The declared type (from annotation or inference).

--- a/internal_docs/narrowing_flow_facts_design.md
+++ b/internal_docs/narrowing_flow_facts_design.md
@@ -1,0 +1,76 @@
+# Narrowing Flow Facts And Invalidation
+
+Status: accepted for WS1 D0
+Phase: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
+
+## Goal
+
+Optional, index, and dictionary narrowing must remain proof-gated and local. A successful proof may remove `None` from an expression only while every dependency that made the proof true is unchanged.
+
+The base type of safe collection access remains optional:
+
+- `list[T][i] -> T | None`
+- `str[i] -> str | None`
+- `dict[K, V][k] -> V | None`
+- `dict.get(k) -> V | None`
+
+Narrowing is a local fact layered on top of those base types. It must not alter the language-level return type of subscript or lookup operations.
+
+## Fact Kinds
+
+The checker may track these facts:
+
+- Binding non-null fact: a local binding is known not to be `None` after `x is not None`, false-exit `x is None`, or equivalent dominated control flow.
+- Sequence length fact: a sequence path has a proven minimum length from truthiness, `len(seq) > n`, false-exit `len(seq) == n`, or equivalent bounds.
+- Index in-range fact: an index binding is proven in range for a sequence path, such as `i < len(values)` or `for i in range(len(values))`.
+- Subscript-present fact: `seq[i] is not None` proves that the same stable subscript expression can be used as non-optional while dependencies remain unchanged.
+- Dict-key fact: `key in d`, `key not in d` false-exit, or `d[key] = value` proves that the same stable key expression is present in that dict while dependencies remain unchanged.
+
+Facts are path-sensitive, not global. They may be saved/restored around branches and loops, but they must never cross a function boundary or escape into nested mutable closure state.
+
+## Dependency Model
+
+Every fact has dependencies:
+
+- Binding non-null facts depend on the binding itself.
+- Sequence length and index facts depend on the sequence path and any index binding in the proof.
+- Subscript-present facts depend on the sequence path and the index expression.
+- Dict-key facts depend on the dict path and the key expression.
+- Attribute-path facts such as `self.items` depend on both the full path and any rebinding of a prefix path such as `self`.
+
+Only stable key/index expressions are eligible for subscript or dict facts. Names, literals, tuples of stable tokens, and simple arithmetic over stable tokens are allowed. Calls, comprehensions, and object constructions are not stable proof tokens.
+
+## Invalidation Rules
+
+The checker must clear dependent facts when any dependency changes:
+
+- Rebinding `x` clears `x`'s non-null fact and all facts whose sequence/dict/index/key dependency mentions `x`.
+- Rebinding `seq` clears facts about `seq` and nested paths such as `seq.items`.
+- Rebinding an index/key binding clears facts that mention that binding in an index/key expression.
+- Mutations that may shrink or remove collection contents clear facts for that collection path. Examples: `list.clear`, `list.pop`, `list.remove`, `dict.clear`, `dict.pop`, and destructive set update methods.
+- Field assignment to a collection path clears facts for that field path. Rebinding a prefix object clears facts for nested field paths.
+- Calls through unknown or user-defined functions must not create new collection facts. Future interprocedural alias analysis may preserve facts only after proving no aliasing mutation.
+- Facts do not cross nested function boundaries. Mutable `nonlocal` capture remains unsupported.
+
+Monotonic collection mutations such as `append` may preserve existing index bounds only when the implementation can prove they do not invalidate the specific fact. Until then, invalidation may be conservative.
+
+## Diagnostics Contract
+
+When a proof cannot be maintained, the resulting type error should explain the missing proof instead of implying implicit unwrapping:
+
+- Optional binding access: "value may be None; narrow with `is not None` after the last assignment."
+- Sequence index access: "index access returns `T | None`; prove the index is in bounds after the last mutation/rebinding."
+- Dict lookup access: "dict lookup returns `V | None`; prove the key exists after the last dict mutation/rebinding."
+
+If the checker has tracked an invalidating operation, diagnostics should include the invalidator category and target, for example "previous index proof for `values[i]` was invalidated by rebinding `values`". The first implementation may use existing type mismatch diagnostics while preserving safety; richer invalidator spans are a follow-up requirement for WS1 diagnostics work.
+
+## Initial Guardrail
+
+WS1 D0 introduces the shared invalidation primitive for existing facts:
+
+- optional binding narrowing is cleared on rebinding,
+- sequence/dict guards are cleared when a dependent binding is rebound,
+- facts for a collection path are cleared after collection methods that may remove entries.
+
+This closes known unsound D0 holes before adding broader N1/I1/I2/N2-N4 narrowing rules.
+

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -107,12 +107,13 @@ Regression coverage:
 - Sequence rebinding invalidates prior index guards.
 - Index rebinding invalidates prior index guards.
 - Shrinking collection mutation invalidates prior index guards.
+- Shrinking field-collection mutation invalidates prior field index guards.
 
 ### Validation
 
 Targeted validation:
 
-- `cargo test -p sifr_hir invalidates -- --nocapture` PASS
+- `cargo test -p sifr_hir invalidates -- --nocapture` PASS (`5` tests)
 - CLI repro checks for optional rebinding, sequence rebinding, and shrinking collection mutation now reject unsafe access with type errors.
 
 Required Rust/HIR validation:

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -85,7 +85,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws1-narrowing-invalidation-design`
-PR: pending
+PR: `https://github.com/yaseralnajjar/sifr/pull/1610`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -16,9 +16,10 @@ Phase plan: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
 
 ## WS0 Corpus Normalization And Baseline Refresh
 
-Status: validated locally
+Status: merged
 Branch: `ws0-leetcode-corpus-noise-normalization`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1609`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1609`
 
 ### Scope
 
@@ -75,6 +76,50 @@ Targeted Sifr fixture checks:
 Scan regeneration:
 
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS1 D0 Narrowing Invalidation Design
+
+Status: validated locally
+Branch: `ws1-narrowing-invalidation-design`
+PR: pending
+
+### Scope
+
+Added the D0 design note and initial safety guardrails for existing narrowing facts.
+
+Design note:
+
+- `internal_docs/narrowing_flow_facts_design.md`
+
+Compiler changes:
+
+- Added shared sequence/dict guard invalidation when a dependent binding is rebound.
+- Cleared optional binding narrowing on rebinding.
+- Cleared collection flow facts after collection methods that can remove entries.
+
+Regression coverage:
+
+- Optional rebinding invalidates prior `is not None` narrowing.
+- Sequence rebinding invalidates prior index guards.
+- Index rebinding invalidates prior index guards.
+- Shrinking collection mutation invalidates prior index guards.
+
+### Validation
+
+Targeted validation:
+
+- `cargo test -p sifr_hir invalidates -- --nocapture` PASS
+- CLI repro checks for optional rebinding, sequence rebinding, and shrinking collection mutation now reject unsafe access with type errors.
+
+Required Rust/HIR validation:
+
+- `cargo fmt --check` PASS
+- `python3 scripts/check_hir_maintainability_guardrails.py` PASS
+- `cargo clippy --workspace -- -D warnings` PASS
 
 Local gate:
 


### PR DESCRIPTION
## Summary

- Adds the WS1 D0 design note for local narrowing flow facts, dependency tracking, invalidation, and diagnostics expectations.
- Introduces shared invalidation for existing optional and sequence/dict facts: rebinding clears dependent facts, optional rebinding clears non-None narrowing, and collection methods that can remove entries clear collection flow facts.
- Adds targeted HIR regression tests for optional rebinding, sequence rebinding, index rebinding, and shrinking collection mutation invalidation.
- Includes mechanical clippy cleanup required to make the workspace clippy gate pass on the current toolchain.

## Validation

- `cargo test -p sifr_hir invalidates -- --nocapture`
- CLI repro checks for optional rebinding, sequence rebinding, and shrinking collection mutation reject unsafe access with type errors
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`