### PR TITLE
[codex] Rewrite LeetCode 0295 using heapq

### DIFF
--- a/audits/leetcode/0295_find_median_from_data_stream.sifr
+++ b/audits/leetcode/0295_find_median_from_data_stream.sifr
@@ -1,37 +1,51 @@
 # LeetCode 295: Find Median From Data Stream
+from sifr.heapq import heappush, heappop
 
 class MedianFinder:
-    nums: list[int]
+    small: list[int]
+    large: list[int]
 
     def __init__(self):
-        self.nums = []
+        self.small = []
+        self.large = []
 
     def addNum(self, num: int) -> None:
-        i = 0
-        while i < len(self.nums):
-            cur = self.nums[i]
-            if cur is not None:
-                cur_val = cur
-                if num <= cur_val:
-                    break
-            i += 1
-        left = self.nums[:i]
-        right = self.nums[i:]
-        self.nums = left + [num] + right
+        small: list[int] = self.small
+        large: list[int] = self.large
+        large_top: int | None = large[0]
+        if large_top is not None and num > large_top:
+            heappush(large, num)
+        else:
+            heappush(small, -num)
+
+        if len(small) > len(large) + 1:
+            moved: int | None = heappop(small)
+            if moved is not None:
+                heappush(large, -moved)
+
+        if len(large) > len(small) + 1:
+            moved2: int | None = heappop(large)
+            if moved2 is not None:
+                heappush(small, -moved2)
+
+        self.small = small
+        self.large = large
 
     def findMedian(self) -> float:
-        n = len(self.nums)
-        if n == 0:
+        if len(self.small) > len(self.large):
+            small_top: int | None = self.small[0]
+            if small_top is not None:
+                return -small_top / 1.0
             return 0.0
-        if n % 2 == 1:
-            mid = self.nums[n // 2]
-            if mid is not None:
-                return mid / 1.0
+        if len(self.large) > len(self.small):
+            large_top: int | None = self.large[0]
+            if large_top is not None:
+                return large_top / 1.0
             return 0.0
-        left = self.nums[(n // 2) - 1]
-        right = self.nums[n // 2]
+        left: int | None = self.small[0]
+        right: int | None = self.large[0]
         if left is not None and right is not None:
-            return (left + right) / 2.0
+            return (-left + right) / 2.0
         return 0.0
 
 def main():

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -131,7 +131,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws2-s1-heap-stdlib`
-PR: pending
+PR: `https://github.com/yaseralnajjar/sifr/pull/1611`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -7,7 +7,7 @@ Phase plan: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
 ## Wave Checklist
 
 - [x] WS0 corpus normalization and baseline refresh
-- [ ] WS1 narrowing design and first compiler slices
+- [x] WS1 narrowing design and first compiler slices
 - [ ] WS2 heap / DSU / collection stdlib parity
 - [ ] WS3 owned-chain helper convention and cursor slices
 - [ ] WS4 canonical rewrite debt
@@ -83,9 +83,10 @@ Local gate:
 
 ## WS1 D0 Narrowing Invalidation Design
 
-Status: validated locally
+Status: merged
 Branch: `ws1-narrowing-invalidation-design`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1610`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1610`
 
 ### Scope
 
@@ -121,6 +122,54 @@ Required Rust/HIR validation:
 - `cargo fmt --check` PASS
 - `python3 scripts/check_hir_maintainability_guardrails.py` PASS
 - `cargo clippy --workspace -- -D warnings` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS2 S1 Heap Stdlib Consumption
+
+Status: validated locally
+Branch: `ws2-s1-heap-stdlib`
+PR: pending
+
+### Scope
+
+The repo already had a pure Sifr `sifr.heapq` implementation with min-heap, max-heap helpers, CPython heapq compatibility imports, and e2e coverage. This wave consumes that existing stdlib surface in a representative rewrite:
+
+- `audits/leetcode/0295_find_median_from_data_stream.sifr`
+
+### Changes
+
+- Rewrote `0295` from sorted-array insertion to the canonical two-heap median finder shape.
+- Uses `sifr.heapq.heappush` / `heappop`.
+- Keeps the max side as negated integers, matching the canonical Python fixture's max-heap-over-min-heap encoding.
+- Uses local heap copies before assigning fields back, because direct mutating calls on field access do not currently mutate the stored field in place.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0295_find_median_from_data_stream` | 56 | 26 | 30 | 39/43 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0295_find_median_from_data_stream` | 66 | 24 | 42 | 39/57 |
+
+The raw diff grows because the Sifr fixture now preserves the canonical two-heap public model instead of using a shorter sorted-array workaround.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0295_find_median_from_data_stream.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0295_find_median_from_data_stream.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0295_find_median_from_data_stream.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -1025,6 +1025,18 @@
       "similarity_ratio": 0.15384615384615385
     },
     {
+      "stem": "0295_find_median_from_data_stream",
+      "py_relpath": "audits/leetcode/0295_find_median_from_data_stream.py",
+      "sifr_relpath": "audits/leetcode/0295_find_median_from_data_stream.sifr",
+      "py_lines": 39,
+      "sifr_lines": 57,
+      "changed_py_lines": 24,
+      "changed_sifr_lines": 42,
+      "changed_total_lines": 66,
+      "length_delta": 18,
+      "similarity_ratio": 0.3125
+    },
+    {
       "stem": "0931_minimum_falling_path_sum",
       "py_relpath": "audits/leetcode/0931_minimum_falling_path_sum.py",
       "sifr_relpath": "audits/leetcode/0931_minimum_falling_path_sum.sifr",
@@ -1515,18 +1527,6 @@
       "changed_total_lines": 56,
       "length_delta": 8,
       "similarity_ratio": 0.24324324324324326
-    },
-    {
-      "stem": "0295_find_median_from_data_stream",
-      "py_relpath": "audits/leetcode/0295_find_median_from_data_stream.py",
-      "sifr_relpath": "audits/leetcode/0295_find_median_from_data_stream.sifr",
-      "py_lines": 39,
-      "sifr_lines": 43,
-      "changed_py_lines": 26,
-      "changed_sifr_lines": 30,
-      "changed_total_lines": 56,
-      "length_delta": 4,
-      "similarity_ratio": 0.3170731707317073
     },
     {
       "stem": "0621_task_scheduler",


### PR DESCRIPTION
## Summary

- Rewrites `audits/leetcode/0295_find_median_from_data_stream.sifr` from sorted-array insertion to the canonical two-heap median finder shape.
- Uses the existing `sifr.heapq` stdlib surface (`heappush` / `heappop`) rather than adding new heap runtime code.
- Regenerates `verification/leetcode/leetcode_pair_diff_scan_20260424.json` and records the wave in the phase execution report.

## Notes

The raw pair-diff total for `0295` increases (`56 -> 66`) because the Sifr fixture now preserves the canonical two-heap model instead of using a shorter sorted-array workaround.

## Validation

- `python3 audits/leetcode/0295_find_median_from_data_stream.py`
- `cargo run -q -p sifr -- check audits/leetcode/0295_find_median_from_data_stream.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0295_find_median_from_data_stream.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `scripts/run_all_tests.sh --profile quick`