### PR TITLE
[codex] Add Sifr DSU stdlib helper

### DIFF
--- a/audits/leetcode/0261_graph_valid_tree.sifr
+++ b/audits/leetcode/0261_graph_valid_tree.sifr
@@ -1,21 +1,10 @@
+from sifr.dsu import UnionFind
+
 def validTreeDsu(n: int, edges: list[list[int]]) -> bool:
     if n == 0:
         return True
 
-    parents = [i for i in range(n)]
-    ranks = [1] * n
-    components = n
-
-    def find(node: int) -> int:
-        parent0 = parents[node]
-        if parent0 is None:
-            return node
-        parent = parent0
-        if parent == node:
-            return node
-        root = find(parent)
-        parents[node] = root
-        return root
+    dsu = UnionFind(n)
 
     for edge in edges:
         a0 = edge[0]
@@ -28,31 +17,10 @@ def validTreeDsu(n: int, edges: list[list[int]]) -> bool:
         else:
             continue
 
-        rootA = find(a)
-        rootB = find(b)
-        if rootA == rootB:
+        if not dsu.union(a, b):
             return False
 
-        rankA0 = ranks[rootA]
-        rankB0 = ranks[rootB]
-        rankA = 0
-        rankB = 0
-        if rankA0 is not None and rankB0 is not None:
-            rankA = rankA0
-            rankB = rankB0
-        else:
-            continue
-
-        if rankA < rankB:
-            parents[rootA] = rootB
-        elif rankA > rankB:
-            parents[rootB] = rootA
-        else:
-            parents[rootB] = rootA
-            ranks[rootA] = rankA + 1
-        components -= 1
-
-    return components == 1
+    return dsu.component_count() == 1
 
 # Canonical entrypoint for this fixture.
 def validTree(n: int, edges: list[list[int]]) -> bool:

--- a/crates/sifr/tests/e2e/pass/stdlib_dsu.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_dsu.sifr
@@ -1,0 +1,13 @@
+from sifr.dsu import UnionFind
+
+def main():
+    dsu = UnionFind(5)
+    assert dsu.component_count() == 5
+    assert dsu.union(0, 1) == True
+    assert dsu.union(1, 2) == True
+    assert dsu.union(0, 2) == False
+    assert dsu.connected(0, 2) == True
+    assert dsu.connected(0, 3) == False
+    assert dsu.component_count() == 3
+    assert dsu.union(3, 4) == True
+    assert dsu.component_count() == 2

--- a/crates/sifr/tests/e2e/pass/stdlib_dsu.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_dsu.sifr
@@ -11,3 +11,9 @@ def main():
     assert dsu.component_count() == 3
     assert dsu.union(3, 4) == True
     assert dsu.component_count() == 2
+    assert dsu.union(-1, 4) == False
+    assert dsu.union(0, 9) == False
+    assert dsu.connected(-1, 0) == False
+    empty = UnionFind(-3)
+    assert empty.component_count() == 0
+    assert empty.union(0, 1) == False

--- a/crates/sifr_driver/src/stdlib/registry.rs
+++ b/crates/sifr_driver/src/stdlib/registry.rs
@@ -64,6 +64,7 @@ pub(super) const STDLIB_FILES: &[(&str, &str)] = &[
         "sifr.heapq",
         include_str!("../../../../lib/sifr/heapq.sifr"),
     ),
+    ("sifr.dsu", include_str!("../../../../lib/sifr/dsu.sifr")),
     (
         "sifr.itertools",
         include_str!("../../../../lib/sifr/itertools.sifr"),

--- a/crates/sifr_driver/src/tests/stdlib_exports.rs
+++ b/crates/sifr_driver/src/tests/stdlib_exports.rs
@@ -16,3 +16,18 @@ fn stdlib_heapq_exports_allowlisted_private_max_heap_helpers() {
         );
     }
 }
+
+#[test]
+fn stdlib_dsu_exports_union_find_class() {
+    let compiled = compile_stdlib().expect("stdlib should compile");
+    let dsu_classes = compiled
+        .defs
+        .classes
+        .get("sifr.dsu")
+        .expect("sifr.dsu exports should exist");
+
+    assert!(
+        dsu_classes.contains_key("UnionFind"),
+        "expected sifr.dsu export 'UnionFind' to be visible for stdlib imports"
+    );
+}

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -180,6 +180,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws2-s2-dsu-stdlib`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1612`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -129,9 +129,10 @@ Local gate:
 
 ## WS2 S1 Heap Stdlib Consumption
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s1-heap-stdlib`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1611`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1611`
 
 ### Scope
 
@@ -174,3 +175,62 @@ Targeted validation:
 Local gate:
 
 - `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS2 S2 DSU Stdlib And First Fixture Consumption
+
+Status: validated locally
+Branch: `ws2-s2-dsu-stdlib`
+
+### Scope
+
+Added a pure Sifr integer union-find helper and consumed it in one representative DSU fixture:
+
+- `lib/sifr/dsu.sifr`
+- `audits/leetcode/0261_graph_valid_tree.sifr`
+
+Registry and regression coverage:
+
+- `crates/sifr_driver/src/stdlib/registry.rs`
+- `crates/sifr_driver/src/tests/stdlib_exports.rs`
+- `crates/sifr/tests/e2e/pass/stdlib_dsu.sifr`
+
+### Changes
+
+- Added `sifr.dsu.UnionFind` with `find`, `union`, `connected`, and `component_count`.
+- Uses union-by-size and path compression.
+- Keeps list-field mutation explicit by copying list fields into locals and assigning fields back after mutation, matching the field-mutation constraint observed in `S1`.
+- Rewrote `0261_graph_valid_tree` to use `UnionFind` instead of fixture-local parent/rank helpers.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0261_graph_valid_tree` | 117 | 67 | 50 | 82/65 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0261_graph_valid_tree` | 95 | 72 | 23 | 82/33 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0261_graph_valid_tree.py` PASS
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/stdlib_dsu.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_dsu.sifr` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0261_graph_valid_tree.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0261_graph_valid_tree.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Targeted Rust export tests:
+
+- `cargo test -p sifr_driver stdlib_dsu_exports_union_find_class -- --nocapture` PASS
+- `cargo test -p sifr_driver stdlib_heapq_exports_allowlisted_private_max_heap_helpers -- --nocapture` PASS
+
+Known unrelated validation note:
+
+- `cargo test -p sifr_driver stdlib -- --nocapture` FAILS in existing `tests::project_build_check::test_build_project_includes_reachable_support_module_stdlib_crates_in_manifest` with `[helper] type mismatch: expected 'str', got 'Result[TomlValue, TOMLDecodeError]`; this broad filter failure is unrelated to the DSU module and is not introduced by this slice.

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -199,6 +199,7 @@ Registry and regression coverage:
 
 - Added `sifr.dsu.UnionFind` with `find`, `union`, `connected`, and `component_count`.
 - Uses union-by-size and path compression.
+- Treats negative, out-of-range, and negative-size inputs as safe no-op/empty cases rather than relying on list subscript behavior.
 - Keeps list-field mutation explicit by copying list fields into locals and assigning fields back after mutation, matching the field-mutation constraint observed in `S1`.
 - Rewrote `0261_graph_valid_tree` to use `UnionFind` instead of fixture-local parent/rank helpers.
 

--- a/lib/sifr/dsu.sifr
+++ b/lib/sifr/dsu.sifr
@@ -6,30 +6,46 @@ class UnionFind:
     components: int
 
     def __init__(self, n: int) -> None:
-        self.parent = [i for i in range(n)]
-        self.size = [1] * n
-        self.components = n
+        count: int = n
+        if count < 0:
+            count = 0
+        self.parent = [i for i in range(count)]
+        self.size = [1] * count
+        self.components = count
 
     def find(self, x: int) -> int:
         parent: list[int] = self.parent
+        if x < 0 or x >= len(parent):
+            return x
         cur: int = x
         done: bool = False
-        while not done:
+        steps: int = 0
+        limit: int = len(parent) + 1
+        while not done and steps < limit:
             next_parent: int | None = parent[cur]
             if next_parent is None:
                 self.parent = parent
                 return cur
             if next_parent == cur:
                 done = True
+            elif next_parent < 0 or next_parent >= len(parent):
+                self.parent = parent
+                return cur
             else:
                 grand_parent: int | None = parent[next_parent]
                 if grand_parent is not None:
                     parent[cur] = grand_parent
                 cur = next_parent
+            steps = steps + 1
         self.parent = parent
         return cur
 
     def union(self, x: int, y: int) -> bool:
+        if x < 0 or y < 0:
+            return False
+        if x >= len(self.parent) or y >= len(self.parent):
+            return False
+
         root_x: int = self.find(x)
         root_y: int = self.find(y)
         if root_x == root_y:
@@ -54,6 +70,10 @@ class UnionFind:
         return True
 
     def connected(self, x: int, y: int) -> bool:
+        if x < 0 or y < 0:
+            return False
+        if x >= len(self.parent) or y >= len(self.parent):
+            return False
         return self.find(x) == self.find(y)
 
     def component_count(self) -> int:

--- a/lib/sifr/dsu.sifr
+++ b/lib/sifr/dsu.sifr
@@ -1,0 +1,60 @@
+# sifr.dsu - Disjoint-set union / union-find helpers.
+
+class UnionFind:
+    parent: list[int]
+    size: list[int]
+    components: int
+
+    def __init__(self, n: int) -> None:
+        self.parent = [i for i in range(n)]
+        self.size = [1] * n
+        self.components = n
+
+    def find(self, x: int) -> int:
+        parent: list[int] = self.parent
+        cur: int = x
+        done: bool = False
+        while not done:
+            next_parent: int | None = parent[cur]
+            if next_parent is None:
+                self.parent = parent
+                return cur
+            if next_parent == cur:
+                done = True
+            else:
+                grand_parent: int | None = parent[next_parent]
+                if grand_parent is not None:
+                    parent[cur] = grand_parent
+                cur = next_parent
+        self.parent = parent
+        return cur
+
+    def union(self, x: int, y: int) -> bool:
+        root_x: int = self.find(x)
+        root_y: int = self.find(y)
+        if root_x == root_y:
+            return False
+
+        parent: list[int] = self.parent
+        size: list[int] = self.size
+        size_x: int | None = size[root_x]
+        size_y: int | None = size[root_y]
+        if size_x is None or size_y is None:
+            return False
+
+        if size_x < size_y:
+            parent[root_x] = root_y
+            size[root_y] = size_x + size_y
+        else:
+            parent[root_y] = root_x
+            size[root_x] = size_x + size_y
+        self.components = self.components - 1
+        self.parent = parent
+        self.size = size
+        return True
+
+    def connected(self, x: int, y: int) -> bool:
+        return self.find(x) == self.find(y)
+
+    def component_count(self) -> int:
+        return self.components

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -245,18 +245,6 @@
       "similarity_ratio": 0.18055555555555555
     },
     {
-      "stem": "0261_graph_valid_tree",
-      "py_relpath": "audits/leetcode/0261_graph_valid_tree.py",
-      "sifr_relpath": "audits/leetcode/0261_graph_valid_tree.sifr",
-      "py_lines": 82,
-      "sifr_lines": 65,
-      "changed_py_lines": 67,
-      "changed_sifr_lines": 50,
-      "changed_total_lines": 117,
-      "length_delta": 17,
-      "similarity_ratio": 0.20408163265306123
-    },
-    {
       "stem": "0673_number_of_longest_increasing_subsequence",
       "py_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.py",
       "sifr_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr",
@@ -483,6 +471,18 @@
       "changed_total_lines": 96,
       "length_delta": 44,
       "similarity_ratio": 0.22580645161290322
+    },
+    {
+      "stem": "0261_graph_valid_tree",
+      "py_relpath": "audits/leetcode/0261_graph_valid_tree.py",
+      "sifr_relpath": "audits/leetcode/0261_graph_valid_tree.sifr",
+      "py_lines": 82,
+      "sifr_lines": 33,
+      "changed_py_lines": 72,
+      "changed_sifr_lines": 23,
+      "changed_total_lines": 95,
+      "length_delta": 49,
+      "similarity_ratio": 0.17391304347826086
     },
     {
       "stem": "0417_pacific_atlantic_water_flow",


### PR DESCRIPTION
## Summary
- add `sifr.dsu.UnionFind` as a pure Sifr union-find helper
- register the new stdlib module and add an export regression
- rewrite LeetCode `0261_graph_valid_tree` to consume `UnionFind`
- regenerate the LeetCode pair-diff scan and update the phase execution ledger

## Validation
- `python3 audits/leetcode/0261_graph_valid_tree.py`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/stdlib_dsu.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_dsu.sifr`
- `cargo run -q -p sifr -- check audits/leetcode/0261_graph_valid_tree.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0261_graph_valid_tree.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo test -p sifr_driver stdlib_dsu_exports_union_find_class -- --nocapture`
- `cargo test -p sifr_driver stdlib_heapq_exports_allowlisted_private_max_heap_helpers -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

## Note
- `cargo test -p sifr_driver stdlib -- --nocapture` hits the existing `project_build_check` TOML type mismatch under the broad `stdlib` filter; this slice uses the narrow export tests plus the authoritative quick gate.