### PR TITLE
[codex] Use deque for LeetCode 0752

### DIFF
--- a/audits/leetcode/0752_open_the_lock.sifr
+++ b/audits/leetcode/0752_open_the_lock.sifr
@@ -1,4 +1,5 @@
 # LeetCode 752: Open The Lock
+from sifr.collections import deque
 
 def nextDigit(ch: str) -> str:
     if ch == '0':
@@ -46,16 +47,12 @@ def openLock(deadends: list[str], target: str) -> int:
     if '0000' in deadends:
         return -1
 
-    q: list[tuple[str, int]] = [('0000', 0)]
+    q: deque[tuple[str, int]] = deque([('0000', 0)])
     visit: set[str] = set(deadends)
     visit.add('0000')
-    head: int = 0
 
-    while head < len(q):
-        state = q[head]
-        head += 1
-        if state is None:
-            continue
+    while q.len() > 0:
+        state: tuple[str, int] = q.popleft()
         wheel = state[0]
         turns = state[1]
         if wheel == target:

--- a/crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr
+++ b/crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr
@@ -1,0 +1,9 @@
+from sifr.collections import deque
+
+def main():
+    q: deque[int] = deque([1, 2, 3])
+    total: int = 0
+    while q.len() > 0:
+        item: int = q.popleft()
+        total = total + item
+    assert total == 6

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -4177,7 +4177,7 @@ impl RustEmitter {
 fn supports_nonempty_pop_narrowing_type_for_codegen(object_ty: &Type) -> bool {
     match crate::resolve_alias_type_for_plain_call(object_ty) {
         Type::List(_) => true,
-        Type::Class { name, .. } => name == "deque",
+        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
         _ => false,
     }
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -73,6 +73,55 @@ fn canonical_plain_call_name_for_ir(func: &str) -> &str {
         .unwrap_or(func)
 }
 
+fn supports_nonempty_pop_narrowing_type_for_ir(object_ty: &Type) -> bool {
+    match crate::resolve_alias_type_for_plain_call(object_ty) {
+        Type::List(_) => true,
+        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
+        _ => false,
+    }
+}
+
+fn is_narrowable_pop_call_for_ir(method: &str, args: &[HirExpr]) -> bool {
+    match method {
+        "pop" => matches!(args, [] | [HirExpr::IntLiteral(0)]),
+        "popleft" => args.is_empty(),
+        _ => false,
+    }
+}
+
+fn unwrap_compiler_verified_nonempty_pop_result_for_ir(
+    object_ty: &Type,
+    method: &str,
+    args: &[HirExpr],
+    method_return_ty: &Type,
+    lowered_expr: RustExpr,
+) -> RustExpr {
+    if !supports_nonempty_pop_narrowing_type_for_ir(object_ty) {
+        return lowered_expr;
+    }
+    if !is_narrowable_pop_call_for_ir(method, args) {
+        return lowered_expr;
+    }
+    if crate::helpers::is_option_type(method_return_ty) {
+        return lowered_expr;
+    }
+    RustExpr::Block {
+        stmts: vec![RustStmt::LetElse {
+            pattern: "Some(__sifr_nonempty_pop_value)".to_string(),
+            value: lowered_expr,
+            else_body: vec![RustStmt::Expr(RustExpr::MacroCall {
+                name: "unreachable".to_string(),
+                args: vec![RustExpr::Literal(crate::RustLiteral::Str(
+                    "compiler-verified non-empty pop should return Some".to_string(),
+                ))],
+            })],
+        }],
+        expr: Some(Box::new(RustExpr::Ident(
+            "__sifr_nonempty_pop_value".to_string(),
+        ))),
+    }
+}
+
 fn iterator_call_func_name(op: &HirIteratorOp) -> &'static str {
     match op {
         HirIteratorOp::Iter => "iter",
@@ -2225,6 +2274,13 @@ impl RustEmitter {
                 method: method.clone(),
                 args: lowered_args,
             };
+            let lowered_method = unwrap_compiler_verified_nonempty_pop_result_for_ir(
+                &effective_object_ty,
+                method,
+                args,
+                expr.ty(),
+                lowered_method,
+            );
             if matches!(
                 crate::resolve_alias_type_for_plain_call(expr.ty()),
                 Type::Int

--- a/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
+++ b/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
@@ -52,7 +52,7 @@ fn sequence_guard_name_from_hir_expr(expr: &HirExpr) -> Option<String> {
 fn supports_nonempty_pop_narrowing_on_type(object_ty: &Type) -> bool {
     match object_ty.resolve_alias() {
         Type::List(_) => true,
-        Type::Class { name, .. } => name == "deque",
+        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
         _ => false,
     }
 }
@@ -60,7 +60,7 @@ fn supports_nonempty_pop_narrowing_on_type(object_ty: &Type) -> bool {
 fn nonempty_pop_element_type(object_ty: &Type) -> Option<Type> {
     match object_ty.resolve_alias() {
         Type::List(elem) => Some(*elem.clone()),
-        Type::Class { name, fields, .. } if name == "deque" => {
+        Type::Class { name, fields, .. } if name == "deque" || name.ends_with(".deque") => {
             fields.iter().find_map(|(field_name, field_ty)| {
                 if field_name != "_data" {
                     return None;

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -242,6 +242,7 @@ Known unrelated validation note:
 
 Status: validated locally
 Branch: `ws2-s3-deque-consumption`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1613`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -178,9 +178,10 @@ Local gate:
 
 ## WS2 S2 DSU Stdlib And First Fixture Consumption
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s2-dsu-stdlib`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1612`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1612`
 
 ### Scope
 
@@ -236,3 +237,53 @@ Targeted Rust export tests:
 Known unrelated validation note:
 
 - `cargo test -p sifr_driver stdlib -- --nocapture` FAILS in existing `tests::project_build_check::test_build_project_includes_reachable_support_module_stdlib_crates_in_manifest` with `[helper] type mismatch: expected 'str', got 'Result[TomlValue, TOMLDecodeError]`; this broad filter failure is unrelated to the DSU module and is not introduced by this slice.
+
+## WS2 S3 Deque Consumption And Nonempty Popleft Codegen
+
+Status: validated locally
+Branch: `ws2-s3-deque-consumption`
+
+### Scope
+
+The repo already had `sifr.collections.deque` and e2e coverage. This wave consumes that existing stdlib surface in one representative BFS fixture and fixes the imported-deque lowering path needed for the canonical queue shape:
+
+- `audits/leetcode/0752_open_the_lock.sifr`
+- `crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr`
+
+Compiler support:
+
+- `crates/sifr_hir/src/lower/nonempty_method_narrowing.rs`
+- `crates/sifr_codegen/src/intrinsic_method_emitters.rs`
+- `crates/sifr_codegen/src/stmt_support_emitter.rs`
+
+### Changes
+
+- Rewrote `0752_open_the_lock` from `list + head` queue emulation to `sifr.collections.deque`.
+- Preserved explicit digit stepping because whole-token integer parsing belongs to `S5`.
+- Taught non-empty pop narrowing/codegen to recognize imported `sifr.collections.deque` class names, so `while q.len() > 0: item = q.popleft()` lowers with the existing compiler-verified unwrap instead of producing mismatched Rust.
+- Added a focused e2e regression for imported deque `popleft()` under a non-empty guard.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0752_open_the_lock` | 96 | 26 | 70 | 40/84 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0752_open_the_lock` | 93 | 26 | 67 | 40/81 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0752_open_the_lock.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0752_open_the_lock.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0752_open_the_lock.sifr` PASS
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -461,18 +461,6 @@
       "similarity_ratio": 0.17094017094017094
     },
     {
-      "stem": "0752_open_the_lock",
-      "py_relpath": "audits/leetcode/0752_open_the_lock.py",
-      "sifr_relpath": "audits/leetcode/0752_open_the_lock.sifr",
-      "py_lines": 40,
-      "sifr_lines": 84,
-      "changed_py_lines": 26,
-      "changed_sifr_lines": 70,
-      "changed_total_lines": 96,
-      "length_delta": 44,
-      "similarity_ratio": 0.22580645161290322
-    },
-    {
       "stem": "0261_graph_valid_tree",
       "py_relpath": "audits/leetcode/0261_graph_valid_tree.py",
       "sifr_relpath": "audits/leetcode/0261_graph_valid_tree.sifr",
@@ -495,6 +483,18 @@
       "changed_total_lines": 94,
       "length_delta": 34,
       "similarity_ratio": 0.265625
+    },
+    {
+      "stem": "0752_open_the_lock",
+      "py_relpath": "audits/leetcode/0752_open_the_lock.py",
+      "sifr_relpath": "audits/leetcode/0752_open_the_lock.sifr",
+      "py_lines": 40,
+      "sifr_lines": 81,
+      "changed_py_lines": 26,
+      "changed_sifr_lines": 67,
+      "changed_total_lines": 93,
+      "length_delta": 41,
+      "similarity_ratio": 0.23140495867768596
     },
     {
       "stem": "0150_evaluate_reverse_polish_notation",


### PR DESCRIPTION
## Summary
- rewrite LeetCode `0752_open_the_lock` to use `sifr.collections.deque` instead of `list + head` queue emulation
- extend non-empty pop narrowing/codegen to recognize imported `sifr.collections.deque` class names
- add an e2e regression for imported deque `popleft()` under a non-empty guard
- regenerate the LeetCode pair-diff scan and update the phase execution ledger

## Validation
- `python3 audits/leetcode/0752_open_the_lock.py`
- `cargo run -q -p sifr -- check audits/leetcode/0752_open_the_lock.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0752_open_the_lock.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`