### PR TITLE
[codex] Use string digit predicate in decode string

### DIFF
--- a/audits/leetcode/0394_decode_string.sifr
+++ b/audits/leetcode/0394_decode_string.sifr
@@ -14,29 +14,6 @@ def peekStr(stack: list[str]) -> str:
         return ""
     return value
 
-def isDigit(ch: str) -> bool:
-    if ch == "0":
-        return True
-    if ch == "1":
-        return True
-    if ch == "2":
-        return True
-    if ch == "3":
-        return True
-    if ch == "4":
-        return True
-    if ch == "5":
-        return True
-    if ch == "6":
-        return True
-    if ch == "7":
-        return True
-    if ch == "8":
-        return True
-    if ch == "9":
-        return True
-    return False
-
 def digitValue(ch: str) -> int:
     if ch == "0":
         return 0
@@ -93,7 +70,7 @@ def decodeString(s: str) -> str:
             _ = popStr(stack)
 
         multiplier = ""
-        while len(stack) > 0 and isDigit(peekStr(stack)):
+        while len(stack) > 0 and peekStr(stack).isdigit():
             multiplier = popStr(stack) + multiplier
 
         repeat = parsePositiveInt(multiplier)

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -298,6 +298,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws2-s4-char-predicate-consumption`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1614`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -240,9 +240,10 @@ Known unrelated validation note:
 
 ## WS2 S3 Deque Consumption And Nonempty Popleft Codegen
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s3-deque-consumption`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1613`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1613`
 
 ### Scope
 
@@ -288,3 +289,52 @@ Targeted validation:
 - `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr` PASS
 - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/deque_nonempty_popleft_narrowing.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS2 S4 Character Predicate Consumption
+
+Status: validated locally
+Branch: `ws2-s4-char-predicate-consumption`
+
+### Scope
+
+The compiler already supports string predicate methods including `.isdigit()`, with e2e coverage in `string_case_predicates`. This wave consumes that surface in a representative decode-stack fixture:
+
+- `audits/leetcode/0394_decode_string.sifr`
+
+### Changes
+
+- Removed the fixture-local `isDigit` digit ladder.
+- Replaced the multiplier scan guard with `peekStr(stack).isdigit()`.
+- Kept `digitValue` / manual integer accumulation in place because whole-token integer parsing belongs to `S5`.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0394_decode_string` | 119 | 22 | 97 | 32/107 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0394_decode_string` | 96 | 22 | 74 | 32/84 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0394_decode_string.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0394_decode_string.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0394_decode_string.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/string_case_predicates.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -221,18 +221,6 @@
       "similarity_ratio": 0.3258426966292135
     },
     {
-      "stem": "0394_decode_string",
-      "py_relpath": "audits/leetcode/0394_decode_string.py",
-      "sifr_relpath": "audits/leetcode/0394_decode_string.sifr",
-      "py_lines": 32,
-      "sifr_lines": 107,
-      "changed_py_lines": 22,
-      "changed_sifr_lines": 97,
-      "changed_total_lines": 119,
-      "length_delta": 75,
-      "similarity_ratio": 0.14388489208633093
-    },
-    {
       "stem": "0269_alien_dictionary",
       "py_relpath": "audits/leetcode/0269_alien_dictionary.py",
       "sifr_relpath": "audits/leetcode/0269_alien_dictionary.sifr",
@@ -459,6 +447,18 @@
       "changed_total_lines": 97,
       "length_delta": 39,
       "similarity_ratio": 0.17094017094017094
+    },
+    {
+      "stem": "0394_decode_string",
+      "py_relpath": "audits/leetcode/0394_decode_string.py",
+      "sifr_relpath": "audits/leetcode/0394_decode_string.sifr",
+      "py_lines": 32,
+      "sifr_lines": 84,
+      "changed_py_lines": 22,
+      "changed_sifr_lines": 74,
+      "changed_total_lines": 96,
+      "length_delta": 52,
+      "similarity_ratio": 0.1724137931034483
     },
     {
       "stem": "0261_graph_valid_tree",


### PR DESCRIPTION
## Summary
- remove the fixture-local digit predicate ladder from `0394_decode_string`
- use the existing `.isdigit()` string predicate for multiplier scanning
- regenerate the LeetCode pair-diff scan and update the phase execution ledger

## Validation
- `python3 audits/leetcode/0394_decode_string.py`
- `cargo run -q -p sifr -- check audits/leetcode/0394_decode_string.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0394_decode_string.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/string_case_predicates.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`