### PR TITLE
[codex] Use int parsing in LeetCode 0150

### DIFF
--- a/audits/leetcode/0150_evaluate_reverse_polish_notation.sifr
+++ b/audits/leetcode/0150_evaluate_reverse_polish_notation.sifr
@@ -6,48 +6,12 @@ def popInt(mut stack: list[int]) -> int:
         return 0
     return value
 
-def digitValue(ch: str) -> int:
-    if ch == "0":
-        return 0
-    if ch == "1":
-        return 1
-    if ch == "2":
-        return 2
-    if ch == "3":
-        return 3
-    if ch == "4":
-        return 4
-    if ch == "5":
-        return 5
-    if ch == "6":
-        return 6
-    if ch == "7":
-        return 7
-    if ch == "8":
-        return 8
-    if ch == "9":
-        return 9
-    return 0
-
 def parseIntToken(token: str) -> int:
-    if len(token) == 0:
+    try:
+        value: int = int(token)
+        return value
+    except ParseError:
         return 0
-
-    sign = 1
-    start = 0
-    first = token[0]
-    if first is not None and first == "-":
-        sign = -1
-        start = 1
-
-    value = 0
-    for i in range(start, len(token)):
-        ch = token[i]
-        if ch is None:
-            continue
-        value = value * 10 + digitValue(ch)
-
-    return sign * value
 
 def truncDiv(dividend: int, divisor: int) -> int:
     if divisor == 0:

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -345,6 +345,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws2-s5-int-parse-consumption`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1615`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -296,9 +296,10 @@ Local gate:
 
 ## WS2 S4 Character Predicate Consumption
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s4-char-predicate-consumption`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1614`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1614`
 
 ### Scope
 
@@ -334,6 +335,51 @@ Targeted validation:
 - `cargo run -q -p sifr -- check audits/leetcode/0394_decode_string.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0394_decode_string.sifr` PASS
 - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/string_case_predicates.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS2 S5 Integer Parse Consumption
+
+Status: validated locally
+Branch: `ws2-s5-int-parse-consumption`
+
+### Scope
+
+The compiler already supports fallible `int(str)` parsing through `Result[int, ParseError]` / `try` handling. This wave consumes that surface in a representative RPN fixture:
+
+- `audits/leetcode/0150_evaluate_reverse_polish_notation.sifr`
+
+### Changes
+
+- Removed fixture-local digit-value and signed-token parsing boilerplate.
+- Replaced it with `int(token)` inside an explicit `try` / `except ParseError` block.
+- Preserved the fixture's existing invalid-token fallback behavior by returning `0` on parse failure.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0150_evaluate_reverse_polish_notation` | 90 | 16 | 74 | 28/86 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0150_evaluate_reverse_polish_notation` | 54 | 16 | 38 | 28/50 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0150_evaluate_reverse_polish_notation.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0150_evaluate_reverse_polish_notation.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0150_evaluate_reverse_polish_notation.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/result_basic.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -497,18 +497,6 @@
       "similarity_ratio": 0.23140495867768596
     },
     {
-      "stem": "0150_evaluate_reverse_polish_notation",
-      "py_relpath": "audits/leetcode/0150_evaluate_reverse_polish_notation.py",
-      "sifr_relpath": "audits/leetcode/0150_evaluate_reverse_polish_notation.sifr",
-      "py_lines": 28,
-      "sifr_lines": 86,
-      "changed_py_lines": 16,
-      "changed_sifr_lines": 74,
-      "changed_total_lines": 90,
-      "length_delta": 58,
-      "similarity_ratio": 0.21052631578947367
-    },
-    {
       "stem": "2709_greatest_common_divisor_traversal",
       "py_relpath": "audits/leetcode/2709_greatest_common_divisor_traversal.py",
       "sifr_relpath": "audits/leetcode/2709_greatest_common_divisor_traversal.sifr",
@@ -1599,6 +1587,18 @@
       "changed_total_lines": 54,
       "length_delta": 22,
       "similarity_ratio": 0.2702702702702703
+    },
+    {
+      "stem": "0150_evaluate_reverse_polish_notation",
+      "py_relpath": "audits/leetcode/0150_evaluate_reverse_polish_notation.py",
+      "sifr_relpath": "audits/leetcode/0150_evaluate_reverse_polish_notation.sifr",
+      "py_lines": 28,
+      "sifr_lines": 50,
+      "changed_py_lines": 16,
+      "changed_sifr_lines": 38,
+      "changed_total_lines": 54,
+      "length_delta": 22,
+      "similarity_ratio": 0.3076923076923077
     },
     {
       "stem": "2215_find_the_difference_of_two_arrays",


### PR DESCRIPTION
## Summary
- replace the LeetCode 0150 fixture-local signed integer parser with `int(token)` inside `try` / `except ParseError`
- preserve the fixture fallback behavior for invalid tokens
- regenerate the LeetCode pair-diff scan and record WS2 S5 status in the execution ledger

## Validation
- `python3 audits/leetcode/0150_evaluate_reverse_polish_notation.py`
- `cargo run -q -p sifr -- check audits/leetcode/0150_evaluate_reverse_polish_notation.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0150_evaluate_reverse_polish_notation.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/result_basic.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`