### PR TITLE
[codex] Add trie stdlib API and consume LeetCode 0208

### DIFF
--- a/audits/leetcode/0208_implement_trie_prefix_tree.sifr
+++ b/audits/leetcode/0208_implement_trie_prefix_tree.sifr
@@ -1,25 +1,6 @@
 # LeetCode 208: Implement Trie Prefix Tree
 
-class Trie:
-    words: list[str]
-
-    def __init__(self):
-        self.words = []
-
-    def insert(self, word: str) -> None:
-        self.words.append(str(word))
-
-    def search(self, word: str) -> bool:
-        for value in self.words:
-            if value == word:
-                return True
-        return False
-
-    def startsWith(self, prefix: str) -> bool:
-        for value in self.words:
-            if value.startswith(str(prefix)):
-                return True
-        return False
+from sifr.trie import Trie
 
 def main():
     obj = Trie()

--- a/crates/sifr/tests/e2e/pass/stdlib_trie.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_trie.sifr
@@ -1,0 +1,30 @@
+from sifr.trie import Trie
+
+def main():
+    trie = Trie()
+
+    assert trie.node_count() == 1
+    assert trie.contains("apple") == False
+    assert trie.starts_with("") == True
+
+    trie.insert("apple")
+    assert trie.contains("apple") == True
+    assert trie.contains("app") == False
+    assert trie.starts_with("app") == True
+
+    app_node: int | None = trie.find_node("app")
+    assert app_node is not None
+    if app_node is not None:
+        assert trie.is_terminal(app_node) == False
+        assert len(trie.children(app_node)) == 1
+
+    trie.insert("app")
+    assert trie.contains("app") == True
+    if app_node is not None:
+        assert trie.is_terminal(app_node) == True
+
+    root_child: int | None = trie.child(0, "a")
+    assert root_child is not None
+    assert trie.child(0, "z") is None
+    assert trie.child(-1, "a") is None
+    assert len(trie.children(-1)) == 0

--- a/crates/sifr_driver/src/stdlib/registry.rs
+++ b/crates/sifr_driver/src/stdlib/registry.rs
@@ -47,6 +47,7 @@ pub(super) const STDLIB_FILES: &[(&str, &str)] = &[
         "sifr.graphlib",
         include_str!("../../../../lib/sifr/graphlib.sifr"),
     ),
+    ("sifr.trie", include_str!("../../../../lib/sifr/trie.sifr")),
     ("sifr.uuid", include_str!("../../../../lib/sifr/uuid.sifr")),
     (
         "sifr.platform",

--- a/crates/sifr_driver/src/tests/stdlib_exports.rs
+++ b/crates/sifr_driver/src/tests/stdlib_exports.rs
@@ -31,3 +31,18 @@ fn stdlib_dsu_exports_union_find_class() {
         "expected sifr.dsu export 'UnionFind' to be visible for stdlib imports"
     );
 }
+
+#[test]
+fn stdlib_trie_exports_trie_class() {
+    let compiled = compile_stdlib().expect("stdlib should compile");
+    let trie_classes = compiled
+        .defs
+        .classes
+        .get("sifr.trie")
+        .expect("sifr.trie exports should exist");
+
+    assert!(
+        trie_classes.contains_key("Trie"),
+        "expected sifr.trie export 'Trie' to be visible for stdlib imports"
+    );
+}

--- a/internal_docs/trie_stdlib_design.md
+++ b/internal_docs/trie_stdlib_design.md
@@ -1,0 +1,41 @@
+# Trie Stdlib Decision
+
+Status: accepted for WS2 S6
+
+## Decision
+
+Add an explicit `sifr.trie.Trie` type instead of nested-dict auto-insert helpers.
+
+The trie is backed by owned node indices:
+
+- `list[list[tuple[str, int]]]` stores outgoing edges by character.
+- `list[bool]` stores terminal-word markers.
+- Public methods expose whole-word operations and proof-friendly node traversal helpers.
+
+## API
+
+- `insert(word: str) -> None`
+- `contains(word: str) -> bool`
+- `search(word: str) -> bool`
+- `starts_with(prefix: str) -> bool`
+- `startsWith(prefix: str) -> bool`
+- `find_node(text: str) -> int | None`
+- `child(node: int, ch: str) -> int | None`
+- `children(node: int) -> list[int]`
+- `is_terminal(node: int) -> bool`
+- `node_count() -> int`
+
+## Rationale
+
+Recursive trie node objects would require self-referential class fields and shared mutable child aliases that are not part of Sifr's current ownership model. Nested-dict helpers would make the canonical LeetCode rewrites possible, but they invite Python-style auto-insert-on-read semantics unless every call site is carefully constrained.
+
+The chosen API keeps mutation explicit: `insert` is the only operation that creates nodes. Reads return `Option` values for missing edges or invalid node indices, so wildcard DFS and board-search rewrites can remain proof-gated without implicit unwraps or user-triggerable panics.
+
+The implementation uses owned edge lists instead of nested dictionaries because current string-key dictionary lookup lowering is not yet a safe dependency for stdlib codegen. This preserves trie traversal semantics and avoids auto-insert-on-read behavior. A later internal representation swap to maps can be made behind the same API when dictionary lowering is ready.
+
+## Fixture Implications
+
+- `0208_implement_trie_prefix_tree` can import `sifr.trie.Trie` directly with LeetCode-compatible method names.
+- `0211_design_add_and_search_words_data_structure` can use `child`, `children`, and `is_terminal` for wildcard DFS without per-word linear scans.
+- `0212_word_search_ii` can use node indices to prune board DFS by prefix.
+- `1397_find_all_good_strings` remains better served by KMP/lps state than by a trie for this phase.

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -392,6 +392,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws2-s6-trie-decision`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1616`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -343,9 +343,10 @@ Local gate:
 
 ## WS2 S5 Integer Parse Consumption
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s5-int-parse-consumption`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1615`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1615`
 
 ### Scope
 
@@ -381,6 +382,60 @@ Targeted validation:
 - `cargo run -q -p sifr -- check audits/leetcode/0150_evaluate_reverse_polish_notation.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0150_evaluate_reverse_polish_notation.sifr` PASS
 - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/result_basic.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS2 S6 Trie Decision And API
+
+Status: validated locally
+Branch: `ws2-s6-trie-decision`
+
+### Scope
+
+Add an explicit trie stdlib surface and consume it in the first trie-dependent fixture:
+
+- `internal_docs/trie_stdlib_design.md`
+- `lib/sifr/trie.sifr`
+- `audits/leetcode/0208_implement_trie_prefix_tree.sifr`
+
+### Decision
+
+`sifr.trie.Trie` uses owned node indices backed by owned edge lists plus terminal markers. `insert` is the only node-creating operation; traversal APIs return `int | None` for missing edges or invalid node indices. This rejects auto-insert-on-read while leaving enough API surface for later `0211` wildcard DFS and `0212` board-prefix pruning rewrites.
+
+### Changes
+
+- Added `sifr.trie.Trie` with whole-word APIs (`insert`, `contains`, `search`, `starts_with`, `startsWith`) and node traversal APIs (`find_node`, `child`, `children`, `is_terminal`, `node_count`).
+- Registered `sifr.trie` in the embedded stdlib registry and added an export regression for the class.
+- Added `stdlib_trie` e2e coverage for word lookup, prefix lookup, terminal markers, child traversal, and invalid node handling.
+- Rewrote `0208_implement_trie_prefix_tree.sifr` to import `sifr.trie.Trie` directly instead of scanning a word list.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0208_implement_trie_prefix_tree` | 79 | 63 | 16 | 78/31 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0208_implement_trie_prefix_tree` | 70 | 68 | 2 | 78/12 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0208_implement_trie_prefix_tree.py` PASS
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/stdlib_trie.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0208_implement_trie_prefix_tree.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0208_implement_trie_prefix_tree.sifr` PASS
+- `cargo test -p sifr_driver stdlib_trie_exports_trie_class -- --nocapture` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:

--- a/lib/sifr/trie.sifr
+++ b/lib/sifr/trie.sifr
@@ -1,0 +1,96 @@
+# sifr.trie - Explicit trie helpers backed by owned node indices.
+
+class Trie:
+    _children: list[list[tuple[str, int]]]
+    _terminal: list[bool]
+
+    def __init__(self) -> None:
+        self._children = [[]]
+        self._terminal = [False]
+
+    def insert(self, word: str) -> None:
+        node: int = 0
+        children: list[list[tuple[str, int]]] = self._children
+        terminal: list[bool] = self._terminal
+
+        for ch in word:
+            row: list[tuple[str, int]] | None = children[node]
+            if row is None:
+                self._children = children
+                self._terminal = terminal
+                return
+
+            existing: int | None = self._row_child(row, ch)
+            if existing is None:
+                created: int = len(children)
+                row.append((ch, created))
+                children[node] = row
+                children.append([])
+                terminal.append(False)
+                node = created
+            else:
+                node = existing
+
+        terminal[node] = True
+        self._children = children
+        self._terminal = terminal
+
+    def find_node(self, text: str) -> int | None:
+        node: int = 0
+        for ch in text:
+            next_node: int | None = self.child(node, ch)
+            if next_node is None:
+                return None
+            node = next_node
+        return node
+
+    def contains(self, word: str) -> bool:
+        node: int | None = self.find_node(word)
+        if node is None:
+            return False
+        return self.is_terminal(node)
+
+    def search(self, word: str) -> bool:
+        return self.contains(word)
+
+    def starts_with(self, prefix: str) -> bool:
+        return self.find_node(prefix) is not None
+
+    def startsWith(self, prefix: str) -> bool:
+        return self.starts_with(prefix)
+
+    def child(self, node: int, ch: str) -> int | None:
+        if node < 0 or node >= len(self._children):
+            return None
+        row: list[tuple[str, int]] | None = self._children[node]
+        if row is None:
+            return None
+        return self._row_child(row, ch)
+
+    def children(self, node: int) -> list[int]:
+        result: list[int] = []
+        if node < 0 or node >= len(self._children):
+            return result
+        row: list[tuple[str, int]] | None = self._children[node]
+        if row is None:
+            return result
+        for _key, child_node in row:
+            result.append(child_node)
+        return result
+
+    def is_terminal(self, node: int) -> bool:
+        if node < 0 or node >= len(self._terminal):
+            return False
+        value: bool | None = self._terminal[node]
+        if value is not None:
+            return value
+        return False
+
+    def node_count(self) -> int:
+        return len(self._children)
+
+    def _row_child(self, row: list[tuple[str, int]], ch: str) -> int | None:
+        for edge_ch, edge_node in row:
+            if edge_ch == ch:
+                return edge_node
+        return None

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -617,18 +617,6 @@
       "similarity_ratio": 0.09195402298850575
     },
     {
-      "stem": "0208_implement_trie_prefix_tree",
-      "py_relpath": "audits/leetcode/0208_implement_trie_prefix_tree.py",
-      "sifr_relpath": "audits/leetcode/0208_implement_trie_prefix_tree.sifr",
-      "py_lines": 78,
-      "sifr_lines": 31,
-      "changed_py_lines": 63,
-      "changed_sifr_lines": 16,
-      "changed_total_lines": 79,
-      "length_delta": 47,
-      "similarity_ratio": 0.27522935779816515
-    },
-    {
       "stem": "1345_jump_game_iv",
       "py_relpath": "audits/leetcode/1345_jump_game_iv.py",
       "sifr_relpath": "audits/leetcode/1345_jump_game_iv.sifr",
@@ -855,6 +843,18 @@
       "changed_total_lines": 71,
       "length_delta": 15,
       "similarity_ratio": 0.5359477124183006
+    },
+    {
+      "stem": "0208_implement_trie_prefix_tree",
+      "py_relpath": "audits/leetcode/0208_implement_trie_prefix_tree.py",
+      "sifr_relpath": "audits/leetcode/0208_implement_trie_prefix_tree.sifr",
+      "py_lines": 78,
+      "sifr_lines": 12,
+      "changed_py_lines": 68,
+      "changed_sifr_lines": 2,
+      "changed_total_lines": 70,
+      "length_delta": 66,
+      "similarity_ratio": 0.2222222222222222
     },
     {
       "stem": "0127_word_ladder",


### PR DESCRIPTION
## Summary
- add an explicit `sifr.trie.Trie` stdlib API backed by owned node indices and edge lists
- document the WS2 S6 trie decision and reject auto-insert-on-read semantics
- register the module, add export/e2e coverage, and rewrite LeetCode 0208 to import the stdlib trie directly
- regenerate the LeetCode pair-diff scan and record WS2 S6 status in the execution ledger

## Validation
- `python3 audits/leetcode/0208_implement_trie_prefix_tree.py`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/stdlib_trie.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr`
- `cargo run -q -p sifr -- check audits/leetcode/0208_implement_trie_prefix_tree.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0208_implement_trie_prefix_tree.sifr`
- `cargo test -p sifr_driver stdlib_trie_exports_trie_class -- --nocapture`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`