### PR TITLE
[codex] Document LeetCode fixture helper convention

### DIFF
--- a/audits/leetcode/0021_merge_two_sorted_lists.sifr
+++ b/audits/leetcode/0021_merge_two_sorted_lists.sifr
@@ -41,34 +41,6 @@ def listNodeToString(own node: ListNode | None) -> str:
         cur = nodeNext(cur)
     return "->".join(parts)
 
-
-class Node:
-    val: int
-    next: Node | None
-    random: Node | None
-    left: Node | None
-    right: Node | None
-    neighbors: list[Node]
-    key: int
-
-    def __init__(
-        self,
-        val: int = 0,
-        next: Node | None = None,
-        random: Node | None = None,
-        left: Node | None = None,
-        right: Node | None = None,
-        neighbors: list[Node] = [],
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = neighbors
-        self.key = key
-
 def mergeTwoLists(own list1: ListNode | None, own list2: ListNode | None) -> ListNode | None:
     vals1: list[int] = []
     vals2: list[int] = []

--- a/internal_docs/leetcode_fixture_helper_convention.md
+++ b/internal_docs/leetcode_fixture_helper_convention.md
@@ -1,0 +1,42 @@
+# LeetCode Fixture Helper Convention
+
+Status: accepted for WS3 B1
+
+## Decision
+
+Use self-contained fixture boilerplate with a strict shared template for `ListNode` and `TreeNode` helpers.
+
+Root LeetCode fixtures are not named `main.sifr`, so the CLI intentionally treats them as single-file entries. That means sibling fixture-helper imports are not available without changing frontend mode resolution. Until that compiler behavior changes, linked-list and tree fixtures keep their structural helpers inline.
+
+The approved convention is:
+
+- keep a single `ListNode` or `TreeNode` definition at the top of each structural fixture
+- keep only the helper functions the fixture actually uses
+- use the same helper names across fixtures (`nodeVal`, `nodeNext`, `hasNode`, `listNodeToString`, `treeToString`)
+- delete unrelated catch-all `Node` scaffolding unless the fixture itself needs it
+- do not hide algorithm logic in helpers
+
+## Scope
+
+Inline helpers may contain:
+
+- canonical fixture data structures such as `ListNode` and `TreeNode`
+- value/next accessors needed until narrowing and cursor ergonomics remove that ceremony
+- assertion and serialization helpers used only by fixture tests
+
+Inline helpers must not contain:
+
+- algorithm implementations for a LeetCode problem
+- alternate solutions
+- hidden mutable global state
+- ownership shortcuts or object-identity emulation
+
+## Rationale
+
+Self-contained duplication made early fixture generation simple, but inconsistent boilerplate obscures the actual algorithm deltas and makes linked-list/tree rewrites noisy. A strict inline template keeps structural scaffolding consistent while preserving each root fixture as the source of the algorithm under review.
+
+The original preferred import-based approach is blocked by current single-file entry semantics for non-`main.sifr` files. The strict inline template keeps the phase moving without changing CLI mode resolution as a side effect of fixture cleanup. A later compiler/frontend slice can revisit shared imports for non-main fixture entries.
+
+## Pilot
+
+`0021_merge_two_sorted_lists.sifr` is the pilot migration. It keeps the current drain/sort/rebuild algorithm unchanged, retains only the helpers that algorithm uses, and removes unrelated catch-all `Node` scaffolding. Cursor and owned-chain algorithm improvements belong to later WS3 slices.

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -448,6 +448,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws3-b1-fixture-helper-convention`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1617`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -390,9 +390,10 @@ Local gate:
 
 ## WS2 S6 Trie Decision And API
 
-Status: validated locally
+Status: merged
 Branch: `ws2-s6-trie-decision`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1616`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1616`
 
 ### Scope
 
@@ -437,6 +438,55 @@ Targeted validation:
 - `cargo run -q -p sifr -- check audits/leetcode/0208_implement_trie_prefix_tree.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0208_implement_trie_prefix_tree.sifr` PASS
 - `cargo test -p sifr_driver stdlib_trie_exports_trie_class -- --nocapture` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS3 B1 Fixture Helper Convention
+
+Status: validated locally
+Branch: `ws3-b1-fixture-helper-convention`
+
+### Scope
+
+Choose the linked-list/tree fixture helper strategy and pilot it without introducing new cursor semantics:
+
+- `internal_docs/leetcode_fixture_helper_convention.md`
+- `audits/leetcode/0021_merge_two_sorted_lists.sifr`
+
+### Decision
+
+Use self-contained fixture boilerplate with a strict inline helper template. Import-based helper modules are blocked for current LeetCode root fixtures because non-`main.sifr` entries intentionally compile in single-file mode, so sibling imports are not resolved by the CLI. The accepted convention keeps only used structural helpers inline and removes unrelated catch-all node scaffolding.
+
+### Changes
+
+- Documented the WS3 B1 helper convention and the current CLI constraint that prevents shared sibling helper imports for non-`main.sifr` fixture entries.
+- Removed unused catch-all `Node` scaffolding from the `0021` pilot.
+- Kept the existing drain/sort/rebuild algorithm unchanged; owned-chain cursor behavior belongs to later WS3 slices.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0021_merge_two_sorted_lists` | 121 | 45 | 76 | 74/105 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0021_merge_two_sorted_lists` | 123 | 60 | 63 | 74/77 |
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0021_merge_two_sorted_lists.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0021_merge_two_sorted_lists.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0021_merge_two_sorted_lists.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -173,6 +173,18 @@
       "similarity_ratio": 0.43119266055045874
     },
     {
+      "stem": "0021_merge_two_sorted_lists",
+      "py_relpath": "audits/leetcode/0021_merge_two_sorted_lists.py",
+      "sifr_relpath": "audits/leetcode/0021_merge_two_sorted_lists.sifr",
+      "py_lines": 74,
+      "sifr_lines": 77,
+      "changed_py_lines": 60,
+      "changed_sifr_lines": 63,
+      "changed_total_lines": 123,
+      "length_delta": 3,
+      "similarity_ratio": 0.18543046357615894
+    },
+    {
       "stem": "0092_reverse_linked_list_ii",
       "py_relpath": "audits/leetcode/0092_reverse_linked_list_ii.py",
       "sifr_relpath": "audits/leetcode/0092_reverse_linked_list_ii.sifr",
@@ -195,18 +207,6 @@
       "changed_total_lines": 123,
       "length_delta": 63,
       "similarity_ratio": 0.4225352112676056
-    },
-    {
-      "stem": "0021_merge_two_sorted_lists",
-      "py_relpath": "audits/leetcode/0021_merge_two_sorted_lists.py",
-      "sifr_relpath": "audits/leetcode/0021_merge_two_sorted_lists.sifr",
-      "py_lines": 74,
-      "sifr_lines": 105,
-      "changed_py_lines": 45,
-      "changed_sifr_lines": 76,
-      "changed_total_lines": 121,
-      "length_delta": 31,
-      "similarity_ratio": 0.3240223463687151
     },
     {
       "stem": "1669_merge_in_between_linked_lists",


### PR DESCRIPTION
## Summary
- document the WS3 B1 linked-list/tree fixture helper convention
- record why import-based fixture helpers are currently blocked for non-`main.sifr` LeetCode entries
- pilot the strict inline template on LeetCode 0021 by removing unused catch-all `Node` scaffolding while keeping the algorithm unchanged
- regenerate the LeetCode pair-diff scan and record WS3 B1 status in the execution ledger

## Validation
- `python3 audits/leetcode/0021_merge_two_sorted_lists.py`
- `cargo run -q -p sifr -- check audits/leetcode/0021_merge_two_sorted_lists.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0021_merge_two_sorted_lists.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`