### PR TITLE
[codex] Rewrite LeetCode 0211 with trie wildcard DFS

### DIFF
--- a/audits/leetcode/0211_design_add_and_search_words_data_structure.sifr
+++ b/audits/leetcode/0211_design_add_and_search_words_data_structure.sifr
@@ -1,26 +1,39 @@
 # LeetCode 211: Design Add And Search Words Data Structure
 
-class WordDictionary:
-    words: list[str]
+from sifr.trie import Trie
 
-    def __init__(self):
-        self.words = []
+def searchFrom(trie: Trie, pattern: str, index: int, node: int) -> bool:
+    if index == len(pattern):
+        return trie.is_terminal(node)
 
-    def addWord(self, word: str) -> None:
-        self.words.append(word + "")
+    ch: str | None = pattern[index]
+    if ch is None:
+        return False
 
-    def search(self, pattern: str) -> bool:
-        for word in self.words:
-            if len(word) != len(pattern):
-                continue
-            ok = True
-            for pch, wch in zip(pattern, word):
-                if pch != "." and pch != wch:
-                    ok = False
-                    break
-            if ok:
+    if ch == ".":
+        for child in trie.children(node):
+            if searchFrom(trie, pattern, index + 1, child):
                 return True
         return False
+
+    next_node: int | None = trie.child(node, ch)
+    if next_node is None:
+        return False
+    return searchFrom(trie, pattern, index + 1, next_node)
+
+class WordDictionary:
+    trie: Trie
+
+    def __init__(self):
+        self.trie = Trie()
+
+    def addWord(self, word: str) -> None:
+        trie: Trie = self.trie
+        trie.insert(word)
+        self.trie = trie
+
+    def search(self, pattern: str) -> bool:
+        return searchFrom(self.trie, pattern, 0, 0)
 
 def main():
     obj = WordDictionary()

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -499,6 +499,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws4-0211-trie-wildcard-rewrite`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1618`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -446,9 +446,10 @@ Local gate:
 
 ## WS3 B1 Fixture Helper Convention
 
-Status: validated locally
+Status: merged
 Branch: `ws3-b1-fixture-helper-convention`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1617`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1617`
 
 ### Scope
 
@@ -488,6 +489,53 @@ Targeted validation:
 - `python3 audits/leetcode/0021_merge_two_sorted_lists.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0021_merge_two_sorted_lists.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0021_merge_two_sorted_lists.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0211 Trie Wildcard Rewrite
+
+Status: validated locally
+Branch: `ws4-0211-trie-wildcard-rewrite`
+
+### Scope
+
+Use the WS2 S6 trie API to rewrite the wildcard word dictionary fixture:
+
+- `audits/leetcode/0211_design_add_and_search_words_data_structure.sifr`
+
+### Changes
+
+- Replaced the fixture-local `list[str]` storage and per-word linear wildcard scan with a `sifr.trie.Trie`.
+- Added explicit wildcard DFS over trie node indices using `children`, `child`, and `is_terminal`.
+- Preserved explicit field write-back after insertion because mutating a copied class field value does not update the stored field.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0211_design_add_and_search_words_data_structure` | 71 | 52 | 19 | 66/33 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0211_design_add_and_search_words_data_structure` | 82 | 51 | 31 | 66/46 |
+
+The raw line diff increases because the previous Sifr fixture used a short word-list scan. This wave closes the structural rewrite criterion: the fixture now uses trie traversal with wildcard DFS and no per-word full scan.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0211_design_add_and_search_words_data_structure.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0211_design_add_and_search_words_data_structure.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0211_design_add_and_search_words_data_structure.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -593,6 +593,18 @@
       "similarity_ratio": 0.4779874213836478
     },
     {
+      "stem": "0211_design_add_and_search_words_data_structure",
+      "py_relpath": "audits/leetcode/0211_design_add_and_search_words_data_structure.py",
+      "sifr_relpath": "audits/leetcode/0211_design_add_and_search_words_data_structure.sifr",
+      "py_lines": 66,
+      "sifr_lines": 46,
+      "changed_py_lines": 51,
+      "changed_sifr_lines": 31,
+      "changed_total_lines": 82,
+      "length_delta": 20,
+      "similarity_ratio": 0.26785714285714285
+    },
+    {
       "stem": "0662_maximum_width_of_binary_tree",
       "py_relpath": "audits/leetcode/0662_maximum_width_of_binary_tree.py",
       "sifr_relpath": "audits/leetcode/0662_maximum_width_of_binary_tree.sifr",
@@ -819,18 +831,6 @@
       "changed_total_lines": 71,
       "length_delta": 37,
       "similarity_ratio": 0.07792207792207792
-    },
-    {
-      "stem": "0211_design_add_and_search_words_data_structure",
-      "py_relpath": "audits/leetcode/0211_design_add_and_search_words_data_structure.py",
-      "sifr_relpath": "audits/leetcode/0211_design_add_and_search_words_data_structure.sifr",
-      "py_lines": 66,
-      "sifr_lines": 33,
-      "changed_py_lines": 52,
-      "changed_sifr_lines": 19,
-      "changed_total_lines": 71,
-      "length_delta": 33,
-      "similarity_ratio": 0.2828282828282828
     },
     {
       "stem": "0535_encode_and_decode_tinyurl",


### PR DESCRIPTION
## Summary
- replace the LeetCode 0211 word-list scan with `sifr.trie.Trie`
- implement explicit wildcard DFS over trie node indices using `children`, `child`, and `is_terminal`
- preserve field write-back after insertion because mutating a copied class field value does not update the stored field
- regenerate the LeetCode pair-diff scan and record WS4 0211 status in the execution ledger

## Note
The raw line diff increases because the previous Sifr fixture was a short word-list scan. This PR closes the structural rewrite criterion: 0211 now uses trie traversal with wildcard DFS and no per-word full scan.

## Validation
- `python3 audits/leetcode/0211_design_add_and_search_words_data_structure.py`
- `cargo run -q -p sifr -- check audits/leetcode/0211_design_add_and_search_words_data_structure.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0211_design_add_and_search_words_data_structure.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`