### PR TITLE
[codex] Rewrite LeetCode 0212 with trie board search

### DIFF
--- a/audits/leetcode/0212_word_search_ii.sifr
+++ b/audits/leetcode/0212_word_search_ii.sifr
@@ -1,49 +1,75 @@
 # LeetCode 212: Word Search Ii
 
-def _word_exists(board: list[list[str]], word: str) -> bool:
-    if len(word) == 0:
-        return True
-    if len(board) == 0 or len(board[0]) == 0:
-        return False
+from sifr.trie import Trie
 
-    rows = len(board)
-    cols = len(board[0])
+def boardChar(board: list[list[str]], r: int, c: int) -> str | None:
+    row: list[str] | None = board[r]
+    if row is None:
+        return None
+    return row[c]
 
-    def dfs(r: int, c: int, idx: int, mut visit: set[tuple[int, int]]) -> bool:
-        if idx == len(word):
-            return True
-        if r < 0 or c < 0 or r >= rows or c >= cols:
-            return False
-        if (r, c) in visit:
-            return False
-
-        letter = word[idx]
-        if letter is None:
-            return False
-        if board[r][c] != letter:
-            return False
-
-        visit.add((r, c))
-        found = (
-            dfs(r + 1, c, idx + 1, visit)
-            or dfs(r - 1, c, idx + 1, visit)
-            or dfs(r, c + 1, idx + 1, visit)
-            or dfs(r, c - 1, idx + 1, visit)
-        )
-        visit.remove((r, c))
+def collectWords(
+    board: list[list[str]],
+    rows: int,
+    cols: int,
+    trie: Trie,
+    node: int,
+    prefix: str,
+    r: int,
+    c: int,
+    mut visit: set[tuple[int, int]],
+    own mut found: dict[str, bool],
+) -> dict[str, bool]:
+    if r < 0 or c < 0 or r >= rows or c >= cols:
+        return found
+    if (r, c) in visit:
         return found
 
-    for r in range(rows):
-        for c in range(cols):
-            if dfs(r, c, 0, set()):
-                return True
-    return False
+    letter: str | None = boardChar(board, r, c)
+    if letter is None:
+        return found
+
+    next_node: int | None = trie.child(node, letter)
+    if next_node is None:
+        return found
+
+    next_prefix: str = prefix + letter
+    if trie.is_terminal(next_node):
+        found[next_prefix] = True
+
+    visit.add((r, c))
+    found = collectWords(board, rows, cols, trie, next_node, next_prefix, r + 1, c, visit, found)
+    found = collectWords(board, rows, cols, trie, next_node, next_prefix, r - 1, c, visit, found)
+    found = collectWords(board, rows, cols, trie, next_node, next_prefix, r, c + 1, visit, found)
+    found = collectWords(board, rows, cols, trie, next_node, next_prefix, r, c - 1, visit, found)
+    visit.remove((r, c))
+    return found
 
 def findWords(board: list[list[str]], words: list[str]) -> list[str]:
+    if len(board) == 0:
+        return []
+    first_row: list[str] | None = board[0]
+    if first_row is None:
+        return []
+    if len(first_row) == 0:
+        return []
+
+    rows = len(board)
+    cols = len(first_row)
+    trie = Trie()
+    for word in words:
+        trie.insert(word)
+
+    found: dict[str, bool] = {}
+    for r in range(rows):
+        for c in range(cols):
+            found = collectWords(board, rows, cols, trie, 0, "", r, c, set(), found)
+
     out: list[str] = []
-    for w in words:
-        if _word_exists(board, w):
-            out.append(w)
+    for word in words:
+        present: bool | None = found[word]
+        if present is not None:
+            out.append(word)
     return out
 
 def main():

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -548,6 +548,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws4-0212-trie-board-search`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1619`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -497,9 +497,10 @@ Local gate:
 
 ## WS4 0211 Trie Wildcard Rewrite
 
-Status: validated locally
+Status: merged
 Branch: `ws4-0211-trie-wildcard-rewrite`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1618`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1618`
 
 ### Scope
 
@@ -536,6 +537,53 @@ Targeted validation:
 - `python3 audits/leetcode/0211_design_add_and_search_words_data_structure.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0211_design_add_and_search_words_data_structure.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0211_design_add_and_search_words_data_structure.sifr` PASS
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0212 Trie Board-Search Rewrite
+
+Status: validated locally
+Branch: `ws4-0212-trie-board-search`
+
+### Scope
+
+Use the WS2 S6 trie API to replace per-word board searches with prefix-pruned trie traversal:
+
+- `audits/leetcode/0212_word_search_ii.sifr`
+
+### Changes
+
+- Replaced `_word_exists` per-word full-board search with one trie build and board DFS from each cell.
+- Added prefix-pruned traversal through `Trie.child` and terminal detection through `Trie.is_terminal`.
+- Used an owned `found` accumulator map through recursive DFS to avoid mutable nonlocal capture.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0212_word_search_ii` | 127 | 83 | 44 | 90/51 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0212_word_search_ii` | 149 | 81 | 68 | 90/77 |
+
+The raw line diff increases because the previous Sifr fixture was a shorter per-word search. This wave closes the structural rewrite criterion: the fixture now builds one trie and prunes board DFS by prefix instead of running a full-board search for each word.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0212_word_search_ii.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0212_word_search_ii.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0212_word_search_ii.sifr` PASS
 - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -65,6 +65,18 @@
       "similarity_ratio": 0.12643678160919541
     },
     {
+      "stem": "0212_word_search_ii",
+      "py_relpath": "audits/leetcode/0212_word_search_ii.py",
+      "sifr_relpath": "audits/leetcode/0212_word_search_ii.sifr",
+      "py_lines": 90,
+      "sifr_lines": 77,
+      "changed_py_lines": 81,
+      "changed_sifr_lines": 68,
+      "changed_total_lines": 149,
+      "length_delta": 13,
+      "similarity_ratio": 0.10778443113772455
+    },
+    {
       "stem": "1631_path_with_minimum_effort",
       "py_relpath": "audits/leetcode/1631_path_with_minimum_effort.py",
       "sifr_relpath": "audits/leetcode/1631_path_with_minimum_effort.sifr",
@@ -123,18 +135,6 @@
       "changed_total_lines": 130,
       "length_delta": 32,
       "similarity_ratio": 0.29347826086956524
-    },
-    {
-      "stem": "0212_word_search_ii",
-      "py_relpath": "audits/leetcode/0212_word_search_ii.py",
-      "sifr_relpath": "audits/leetcode/0212_word_search_ii.sifr",
-      "py_lines": 90,
-      "sifr_lines": 51,
-      "changed_py_lines": 83,
-      "changed_sifr_lines": 44,
-      "changed_total_lines": 127,
-      "length_delta": 39,
-      "similarity_ratio": 0.09929078014184398
     },
     {
       "stem": "0143_reorder_list",


### PR DESCRIPTION
## Summary
- replace the LeetCode 0212 per-word full-board search with one `sifr.trie.Trie` build
- add prefix-pruned board DFS through `Trie.child` and terminal detection through `Trie.is_terminal`
- use an owned `found` accumulator map through recursion instead of mutable nonlocal capture
- regenerate the LeetCode pair-diff scan and record WS4 0212 status in the execution ledger

## Note
The raw line diff increases because the previous Sifr fixture was a shorter per-word search. This PR closes the structural rewrite criterion: 0212 now builds one trie and prunes board DFS by prefix instead of running a full-board search for each word.

## Validation
- `python3 audits/leetcode/0212_word_search_ii.py`
- `cargo run -q -p sifr -- check audits/leetcode/0212_word_search_ii.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0212_word_search_ii.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_trie.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`