### PR TITLE
[codex] Document LeetCode 0706 hashmap storage design

### DIFF
--- a/internal_docs/leetcode_0706_hashmap_storage_design.md
+++ b/internal_docs/leetcode_0706_hashmap_storage_design.md
@@ -1,0 +1,54 @@
+# LeetCode 0706 HashMap Storage Design
+
+Status: accepted for WS4 0706 prerequisite
+
+## Decision
+
+Use separate chaining with explicit buckets.
+
+The rewrite should represent storage as:
+
+- `buckets: list[list[tuple[int, int]]]`
+- a fixed prime bucket count for the fixture, for example `769`
+
+Each bucket stores `(key, value)` pairs. The fixture must not delegate to Sifr's built-in `dict`.
+
+## Operations
+
+`hash_index(key)`:
+
+- compute `key % len(buckets)`
+- normalize negative results by adding `len(buckets)`
+
+`put(key, value)`:
+
+- find the target bucket
+- replace the tuple when the key already exists
+- append `(key, value)` when absent
+- assign the updated bucket back to `buckets[index]`
+
+`get(key)`:
+
+- scan only the target bucket
+- return the stored value when found
+- return `-1` when absent
+
+`remove(key)`:
+
+- scan only the target bucket
+- rebuild that bucket without the removed key
+- assign the rebuilt bucket back to `buckets[index]`
+
+## Rationale
+
+Separate chaining keeps the implementation explicit and reviewable in current Sifr without relying on unsafe aliases, interior mutability, or built-in dictionary delegation. Rebuilding a single bucket on `remove` avoids needing `take_at` for this fixture while still deleting entries rather than writing sentinel values.
+
+The design handles real stored value `-1`: absence is determined by key lookup, not by a value sentinel stored in the bucket.
+
+## Rewrite Constraints
+
+- Do not use built-in `dict` for storage.
+- Do not implement `remove` by writing `-1`.
+- Do not scan all buckets for `get`, `put`, or `remove`.
+- Keep missing index and bucket access explicit through `None` checks.
+- The final fixture should include the LeetCode sample and a real stored `-1` value case.

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -621,10 +621,6 @@ Local gate:
 
 - `scripts/run_all_tests.sh --profile quick` PASS
 
-Local gate:
-
-- `scripts/run_all_tests.sh --profile quick` PASS
-
 ## WS4 0706 HashMap Storage Design
 
 Status: validated locally
@@ -647,3 +643,7 @@ Docs/design validation:
 
 - `cargo fmt --check` PASS
 - `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -629,6 +629,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws4-0706-hashmap-storage-design`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1621`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -595,9 +595,10 @@ Local gate:
 
 ## WS4 0146 Recency Structure Design
 
-Status: validated locally
+Status: merged
 Branch: `ws4-0146-recency-design`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1620`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1620`
 
 ### Scope
 
@@ -619,3 +620,29 @@ Docs/design validation:
 Local gate:
 
 - `scripts/run_all_tests.sh --profile quick` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0706 HashMap Storage Design
+
+Status: validated locally
+Branch: `ws4-0706-hashmap-storage-design`
+
+### Scope
+
+Choose the storage representation before rewriting the design-hashmap fixture:
+
+- `internal_docs/leetcode_0706_hashmap_storage_design.md`
+
+### Decision
+
+Use separate chaining with explicit `list[list[tuple[int, int]]]` buckets and a fixed prime bucket count. `get`, `put`, and `remove` scan only one bucket; `remove` rebuilds the bucket without the key instead of writing a sentinel value. Real stored value `-1` remains representable because absence is determined by key lookup.
+
+### Validation
+
+Docs/design validation:
+
+- `cargo fmt --check` PASS
+- `git diff --check` PASS


### PR DESCRIPTION
## Summary
- document the WS4 prerequisite design for LeetCode 0706 hashmap storage
- choose explicit separate chaining with bucket-local scans and no built-in `dict` delegation
- record deletion semantics that remove entries rather than storing `-1`, preserving real stored `-1` values
- record the design and validation in the phase execution ledger

## Validation
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`