### PR TITLE
[codex] Rewrite LeetCode 0706 with explicit buckets

### DIFF
--- a/audits/leetcode/0706_design_hashmap.sifr
+++ b/audits/leetcode/0706_design_hashmap.sifr
@@ -1,19 +1,75 @@
 # LeetCode 706: Design Hashmap
 
+BUCKET_COUNT = 769
+
+def makeBuckets() -> list[list[tuple[int, int]]]:
+    buckets: list[list[tuple[int, int]]] = []
+    for _i in range(BUCKET_COUNT):
+        bucket: list[tuple[int, int]] = []
+        buckets.append(bucket)
+    return buckets
+
 class MyHashMap:
-    map: dict[int, int]
+    buckets: list[list[tuple[int, int]]]
 
     def __init__(self):
-        self.map = {}
+        self.buckets = makeBuckets()
+
+    def hashcode(self, key: int) -> int:
+        size = len(self.buckets)
+        if size == 0:
+            return 0
+        index = key % size
+        if index < 0:
+            return index + size
+        return index
 
     def put(self, key: int, value: int) -> None:
-        self.map[key] = value
+        index = self.hashcode(key)
+        bucket: list[tuple[int, int]] | None = self.buckets[index]
+        if bucket is None:
+            return
+
+        next_bucket: list[tuple[int, int]] = []
+        replaced = False
+        for existing_key, existing_value in bucket:
+            if existing_key == key:
+                next_bucket.append((key, value))
+                replaced = True
+            else:
+                next_bucket.append((existing_key, existing_value))
+
+        if not replaced:
+            next_bucket.append((key, value))
+
+        buckets: list[list[tuple[int, int]]] = self.buckets
+        buckets[index] = next_bucket
+        self.buckets = buckets
 
     def get(self, key: int) -> int:
-        return self.map.get(key, -1)
+        index = self.hashcode(key)
+        bucket: list[tuple[int, int]] | None = self.buckets[index]
+        if bucket is None:
+            return -1
+        for existing_key, existing_value in bucket:
+            if existing_key == key:
+                return existing_value
+        return -1
 
     def remove(self, key: int) -> None:
-        self.map[key] = -1
+        index = self.hashcode(key)
+        bucket: list[tuple[int, int]] | None = self.buckets[index]
+        if bucket is None:
+            return
+
+        next_bucket: list[tuple[int, int]] = []
+        for existing_key, existing_value in bucket:
+            if existing_key != key:
+                next_bucket.append((existing_key, existing_value))
+
+        buckets: list[list[tuple[int, int]]] = self.buckets
+        buckets[index] = next_bucket
+        self.buckets = buckets
 
 
 def main():
@@ -26,3 +82,9 @@ def main():
     assert obj.get(2) == 1
     obj.remove(2)
     assert obj.get(2) == -1
+    obj.put(5, -1)
+    assert obj.get(5) == -1
+    obj.put(5, 7)
+    assert obj.get(5) == 7
+    obj.remove(5)
+    assert obj.get(5) == -1

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -653,6 +653,7 @@ Local gate:
 
 Status: validated locally
 Branch: `ws4-0706-hashmap-rewrite`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1622`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -623,9 +623,10 @@ Local gate:
 
 ## WS4 0706 HashMap Storage Design
 
-Status: validated locally
+Status: merged
 Branch: `ws4-0706-hashmap-storage-design`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1621`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1621`
 
 ### Scope
 
@@ -643,6 +644,53 @@ Docs/design validation:
 
 - `cargo fmt --check` PASS
 - `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0706 HashMap Rewrite
+
+Status: validated locally
+Branch: `ws4-0706-hashmap-rewrite`
+
+### Scope
+
+Rewrite the design-hashmap fixture to stop delegating storage to built-in `dict`:
+
+- `audits/leetcode/0706_design_hashmap.sifr`
+
+### Changes
+
+- Replaced `dict[int, int]` storage with explicit `list[list[tuple[int, int]]]` buckets.
+- Implemented bucket-local `put`, `get`, and `remove` operations.
+- Made `remove` rebuild the target bucket without the removed key instead of writing `-1`.
+- Added assertions for storing and updating a real `-1` value.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0706_design_hashmap` | 62 | 51 | 11 | 68/28 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0706_design_hashmap` | 118 | 48 | 70 | 68/90 |
+
+The raw line diff increases because the previous Sifr fixture delegated to a built-in dictionary. This wave closes the structural rewrite criterion: storage is explicit bucket chaining, `get` / `put` / `remove` scan only one bucket, and removal deletes entries rather than writing sentinel values.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0706_design_hashmap.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0706_design_hashmap.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0706_design_hashmap.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -233,6 +233,18 @@
       "similarity_ratio": 0.18055555555555555
     },
     {
+      "stem": "0706_design_hashmap",
+      "py_relpath": "audits/leetcode/0706_design_hashmap.py",
+      "sifr_relpath": "audits/leetcode/0706_design_hashmap.sifr",
+      "py_lines": 68,
+      "sifr_lines": 90,
+      "changed_py_lines": 48,
+      "changed_sifr_lines": 70,
+      "changed_total_lines": 118,
+      "length_delta": 22,
+      "similarity_ratio": 0.25316455696202533
+    },
+    {
       "stem": "0673_number_of_longest_increasing_subsequence",
       "py_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.py",
       "sifr_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr",
@@ -1263,18 +1275,6 @@
       "changed_total_lines": 62,
       "length_delta": 16,
       "similarity_ratio": 0.27906976744186046
-    },
-    {
-      "stem": "0706_design_hashmap",
-      "py_relpath": "audits/leetcode/0706_design_hashmap.py",
-      "sifr_relpath": "audits/leetcode/0706_design_hashmap.sifr",
-      "py_lines": 68,
-      "sifr_lines": 28,
-      "changed_py_lines": 51,
-      "changed_sifr_lines": 11,
-      "changed_total_lines": 62,
-      "length_delta": 40,
-      "similarity_ratio": 0.3541666666666667
     },
     {
       "stem": "0094_binary_tree_inorder_traversal",


### PR DESCRIPTION
## Summary
- replace LeetCode 0706 built-in `dict` storage with explicit separate-chaining buckets
- implement bucket-local `put`, `get`, and `remove`
- make `remove` delete entries rather than writing a `-1` sentinel
- add coverage for storing/updating a real `-1` value
- regenerate the LeetCode pair-diff scan and record WS4 0706 rewrite status in the execution ledger

## Note
The raw line diff increases because the previous Sifr fixture delegated to built-in `dict`. This PR closes the structural rewrite criterion: storage is explicit bucket chaining, operations scan one bucket, and removal deletes entries.

## Validation
- `python3 audits/leetcode/0706_design_hashmap.py`
- `cargo run -q -p sifr -- check audits/leetcode/0706_design_hashmap.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0706_design_hashmap.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`