### PR TITLE
[codex] Rewrite LeetCode 0146 with map-backed LRU

### DIFF
--- a/audits/leetcode/0146_lru_cache.sifr
+++ b/audits/leetcode/0146_lru_cache.sifr
@@ -2,54 +2,116 @@
 
 class LRUCache:
     cap: int
-    keys: list[int]
-    values: list[int]
+    head: int
+    tail: int
+    next_id: int
+    key_to_node: dict[int, int]
+    node_key: dict[int, int]
+    node_value: dict[int, int]
+    prev: dict[int, int]
+    next: dict[int, int]
 
     def __init__(self, capacity: int):
         self.cap = capacity
-        self.keys = []
-        self.values = []
+        self.head = 0
+        self.tail = 1
+        self.next_id = 2
+        self.key_to_node = {}
+        self.node_key = {}
+        self.node_value = {}
+        self.prev = {1: 0}
+        self.next = {0: 1}
 
-    def findIndex(self, key: int) -> int:
-        i = 0
-        while i < len(self.keys):
-            key_i: int | None = self.keys[i]
-            if key_i is not None and key_i == key:
-                return i
-            i += 1
-        return -1
+    def detach(self, node: int) -> None:
+        prev: dict[int, int] = self.prev
+        next: dict[int, int] = self.next
+        left: int | None = prev[node]
+        right: int | None = next[node]
+        if left is None or right is None:
+            return
+        next[left] = right
+        prev[right] = left
+        del prev[node]
+        del next[node]
+        self.prev = prev
+        self.next = next
 
-    def moveToMostRecent(self, index: int) -> None:
-        key_value: int | None = self.keys.pop(index)
-        cached_value: int | None = self.values.pop(index)
-        if key_value is not None and cached_value is not None:
-            self.keys.append(key_value)
-            self.values.append(cached_value)
+    def insertAfter(self, node: int, left: int) -> None:
+        prev: dict[int, int] = self.prev
+        next: dict[int, int] = self.next
+        right: int | None = next[left]
+        if right is None:
+            return
+        prev[node] = left
+        next[node] = right
+        next[left] = node
+        prev[right] = node
+        self.prev = prev
+        self.next = next
+
+    def moveToFront(self, node: int) -> None:
+        self.detach(node)
+        self.insertAfter(node, self.head)
+
+    def evictLru(self) -> None:
+        node_opt: int | None = self.prev[self.tail]
+        if node_opt is None:
+            return
+        node: int = node_opt
+        if node == self.head:
+            return
+
+        key: int | None = self.node_key[node]
+        if key is not None:
+            key_to_node: dict[int, int] = self.key_to_node
+            del key_to_node[key]
+            self.key_to_node = key_to_node
+        node_key: dict[int, int] = self.node_key
+        node_value: dict[int, int] = self.node_value
+        del node_key[node]
+        del node_value[node]
+        self.node_key = node_key
+        self.node_value = node_value
+        self.detach(node)
 
     def get(self, key: int) -> int:
-        idx = self.findIndex(key)
-        if idx < 0:
+        node: int | None = self.key_to_node[key]
+        if node is None:
             return -1
 
-        value_opt: int | None = self.values[idx]
-        result = -1
-        if value_opt is not None:
-            result = value_opt
-        self.moveToMostRecent(idx)
-        return result
+        value: int | None = self.node_value[node]
+        if value is None:
+            return -1
+        self.moveToFront(node)
+        return value
 
     def put(self, key: int, value: int) -> None:
-        idx = self.findIndex(key)
-        if idx >= 0:
-            self.keys.pop(idx)
-            self.values.pop(idx)
+        if self.cap <= 0:
+            return
 
-        self.keys.append(key)
-        self.values.append(value)
+        existing: int | None = self.key_to_node[key]
+        if existing is not None:
+            node_value: dict[int, int] = self.node_value
+            node_value[existing] = value
+            self.node_value = node_value
+            self.moveToFront(existing)
+            return
 
-        if len(self.keys) > self.cap:
-            self.keys.pop(0)
-            self.values.pop(0)
+        if len(self.key_to_node) >= self.cap:
+            self.evictLru()
+
+        node = self.next_id
+        self.next_id = self.next_id + 1
+        key_to_node: dict[int, int] = self.key_to_node
+        node_key: dict[int, int] = self.node_key
+        node_value: dict[int, int] = self.node_value
+        key_to_node[key] = node
+        node_key[node] = key
+        node_value[node] = value
+        self.key_to_node = key_to_node
+        self.node_key = node_key
+        self.node_value = node_value
+        self.insertAfter(node, self.head)
 
 def main():
     obj = LRUCache(2)
@@ -62,3 +124,9 @@ def main():
     assert obj.get(1) == -1
     assert obj.get(3) == 3
     assert obj.get(4) == 4
+    obj2 = LRUCache(1)
+    obj2.put(8, -1)
+    assert obj2.get(8) == -1
+    obj2.put(9, 9)
+    assert obj2.get(8) == -1
+    assert obj2.get(9) == 9

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -651,9 +651,10 @@ Local gate:
 
 ## WS4 0706 HashMap Rewrite
 
-Status: validated locally
+Status: merged
 Branch: `ws4-0706-hashmap-rewrite`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1622`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1622`
 
 ### Scope
 
@@ -691,6 +692,53 @@ Targeted validation:
 - `python3 audits/leetcode/0706_design_hashmap.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0706_design_hashmap.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0706_design_hashmap.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0146 LRU Cache Rewrite
+
+Status: validated locally
+Branch: `ws4-0146-lru-rewrite`
+
+### Scope
+
+Rewrite the LRU cache fixture to use the accepted O(1) recency representation:
+
+- `audits/leetcode/0146_lru_cache.sifr`
+
+### Changes
+
+- Replaced parallel `keys` / `values` arrays and shifting/popping recency operations with map-backed integer node handles.
+- Added `detach`, `insertAfter`, `moveToFront`, and `evictLru` helper methods over `prev` / `next` maps.
+- Preserved explicit field write-back for mutated maps to avoid copied-field mutation loss.
+- Added assertions for storing, reading, updating, and evicting a real `-1` value.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0146_lru_cache` | 79 | 33 | 46 | 51/64 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0146_lru_cache` | 147 | 33 | 114 | 51/132 |
+
+The raw line diff increases because the previous Sifr fixture used compact array shifts. This wave closes the structural rewrite criterion: `get`, `put`, update, and eviction use map lookups plus recency-list rewiring instead of linear scans or array shifts.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0146_lru_cache.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0146_lru_cache.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0146_lru_cache.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 
 Local gate:

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -700,8 +700,9 @@ Local gate:
 
 ## WS4 0146 LRU Cache Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0146-lru-rewrite`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1623`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -77,6 +77,18 @@
       "similarity_ratio": 0.10778443113772455
     },
     {
+      "stem": "0146_lru_cache",
+      "py_relpath": "audits/leetcode/0146_lru_cache.py",
+      "sifr_relpath": "audits/leetcode/0146_lru_cache.sifr",
+      "py_lines": 51,
+      "sifr_lines": 132,
+      "changed_py_lines": 33,
+      "changed_sifr_lines": 114,
+      "changed_total_lines": 147,
+      "length_delta": 81,
+      "similarity_ratio": 0.19672131147540983
+    },
+    {
       "stem": "1631_path_with_minimum_effort",
       "py_relpath": "audits/leetcode/1631_path_with_minimum_effort.py",
       "sifr_relpath": "audits/leetcode/1631_path_with_minimum_effort.sifr",
@@ -651,18 +663,6 @@
       "changed_total_lines": 79,
       "length_delta": 17,
       "similarity_ratio": 0.27522935779816515
-    },
-    {
-      "stem": "0146_lru_cache",
-      "py_relpath": "audits/leetcode/0146_lru_cache.py",
-      "sifr_relpath": "audits/leetcode/0146_lru_cache.sifr",
-      "py_lines": 51,
-      "sifr_lines": 64,
-      "changed_py_lines": 33,
-      "changed_sifr_lines": 46,
-      "changed_total_lines": 79,
-      "length_delta": 13,
-      "similarity_ratio": 0.3130434782608696
     },
     {
       "stem": "0141_linked_list_cycle",


### PR DESCRIPTION
## Summary
- Replace the 0146 array-shift LRU fixture with map-backed integer node handles.
- Add `detach`, `insertAfter`, `moveToFront`, and `evictLru` helpers for recency rewiring.
- Preserve explicit field write-back for mutated maps and add real `-1` value assertions.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- Raw diff increases because the previous fixture used compact array shifts; this closes the structural criterion by using map lookups plus recency-list rewiring for get/put/update/eviction.

## Validation
- `python3 audits/leetcode/0146_lru_cache.py`
- `cargo run -q -p sifr -- check audits/leetcode/0146_lru_cache.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0146_lru_cache.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`