### PR TITLE
[codex] Rewrite LeetCode 0004 with binary median

### DIFF
--- a/audits/leetcode/0004_median_of_two_sorted_arrays.py
+++ b/audits/leetcode/0004_median_of_two_sorted_arrays.py
@@ -37,6 +37,11 @@ def findMedianSortedArrays(nums1: list[int], nums2: list[int]) -> float:
 def main():
     assert findMedianSortedArrays([1,3], [2]) == 2
     assert findMedianSortedArrays([1,2], [3,4]) == 2.5
+    assert findMedianSortedArrays([], [1]) == 1
+    assert findMedianSortedArrays([2], []) == 2
+    assert findMedianSortedArrays([], [2,3]) == 2.5
+    assert findMedianSortedArrays([0,0], [0,0]) == 0
+    assert findMedianSortedArrays([-5,-3], [-4]) == -4
 
 if __name__ == "__main__":
     main()

--- a/audits/leetcode/0004_median_of_two_sorted_arrays.sifr
+++ b/audits/leetcode/0004_median_of_two_sorted_arrays.sifr
@@ -19,7 +19,7 @@ def findMedianSortedArrays(nums1: list[int], nums2: list[int]) -> float:
     min_sentinel = -2147483648
     max_sentinel = 2147483647
 
-    while True:
+    while lo <= hi:
         a_count = (lo + hi) // 2
         b_count = half - a_count
 

--- a/audits/leetcode/0004_median_of_two_sorted_arrays.sifr
+++ b/audits/leetcode/0004_median_of_two_sorted_arrays.sifr
@@ -1,41 +1,86 @@
-# LeetCode 4: Median Of Two Sorted Arrays (residual Sifr-safe canonical form)
+# LeetCode 4: Median Of Two Sorted Arrays
 
 def findMedianSortedArrays(nums1: list[int], nums2: list[int]) -> float:
-    merged: list[int] = []
-    i, j = 0, 0
+    if len(nums1) + len(nums2) == 0:
+        return 0.0
 
-    while i < len(nums1) and j < len(nums2):
-        if nums1[i] <= nums2[j]:
-            merged.append(nums1[i])
-            i += 1
+    a_is_nums1 = True
+    a_len = len(nums1)
+    b_len = len(nums2)
+    if len(nums2) < len(nums1):
+        a_is_nums1 = False
+        a_len = len(nums2)
+        b_len = len(nums1)
+
+    total = a_len + b_len
+    half = total // 2
+    lo = 0
+    hi = a_len
+    min_sentinel = -2147483648
+    max_sentinel = 2147483647
+
+    while True:
+        a_count = (lo + hi) // 2
+        b_count = half - a_count
+
+        a_left = min_sentinel
+        if a_count > 0:
+            maybe_a_left: int | None = nums1[a_count - 1]
+            if not a_is_nums1:
+                maybe_a_left = nums2[a_count - 1]
+            if maybe_a_left is not None:
+                a_left = maybe_a_left
+
+        a_right = max_sentinel
+        if a_count < a_len:
+            maybe_a_right: int | None = nums1[a_count]
+            if not a_is_nums1:
+                maybe_a_right = nums2[a_count]
+            if maybe_a_right is not None:
+                a_right = maybe_a_right
+
+        b_left = min_sentinel
+        if b_count > 0:
+            maybe_b_left: int | None = nums2[b_count - 1]
+            if not a_is_nums1:
+                maybe_b_left = nums1[b_count - 1]
+            if maybe_b_left is not None:
+                b_left = maybe_b_left
+
+        b_right = max_sentinel
+        if b_count < b_len:
+            maybe_b_right: int | None = nums2[b_count]
+            if not a_is_nums1:
+                maybe_b_right = nums1[b_count]
+            if maybe_b_right is not None:
+                b_right = maybe_b_right
+
+        if a_left <= b_right and b_left <= a_right:
+            if total % 2 == 1:
+                if a_right < b_right:
+                    return float(a_right)
+                return float(b_right)
+
+            left_max = a_left
+            if b_left > left_max:
+                left_max = b_left
+            right_min = a_right
+            if b_right < right_min:
+                right_min = b_right
+            return (float(left_max) + float(right_min)) / 2.0
+
+        if a_left > b_right:
+            hi = a_count - 1
         else:
-            merged.append(nums2[j])
-            j += 1
+            lo = a_count + 1
 
-    while i < len(nums1):
-        merged.append(nums1[i])
-        i += 1
-
-    while j < len(nums2):
-        merged.append(nums2[j])
-        j += 1
-
-    n = len(merged)
-    mid = n // 2
-    left_value = 0
-    right_value = 0
-    idx = 0
-    for value in merged:
-        if idx == mid - 1:
-            left_value = value
-        if idx == mid:
-            right_value = value
-        idx += 1
-
-    if n % 2 == 1:
-        return float(right_value)
-    return (float(left_value) + float(right_value)) / 2.0
+    return 0.0
 
 def main():
     assert findMedianSortedArrays([1,3], [2]) == 2.0
     assert findMedianSortedArrays([1,2], [3,4]) == 2.5
+    assert findMedianSortedArrays([], [1]) == 1.0
+    assert findMedianSortedArrays([2], []) == 2.0
+    assert findMedianSortedArrays([], [2,3]) == 2.5
+    assert findMedianSortedArrays([0,0], [0,0]) == 0.0
+    assert findMedianSortedArrays([-5,-3], [-4]) == -4.0

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -700,9 +700,10 @@ Local gate:
 
 ## WS4 0146 LRU Cache Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0146-lru-rewrite`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1623`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1623`
 
 ### Scope
 
@@ -741,6 +742,56 @@ Targeted validation:
 - `cargo run -q -p sifr -- check audits/leetcode/0146_lru_cache.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0146_lru_cache.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0004 Binary Median Rewrite
+
+Status: validated locally
+Branch: `ws4-0004-binary-median`
+
+### Scope
+
+Rewrite the median-of-two-sorted-arrays fixture to use binary partitioning:
+
+- `audits/leetcode/0004_median_of_two_sorted_arrays.py`
+- `audits/leetcode/0004_median_of_two_sorted_arrays.sifr`
+
+### Changes
+
+- Replaced the Sifr full merge with a count-based binary partition over the shorter input.
+- Used explicit numeric sentinels for empty partition sides instead of merged-array indexing.
+- Added odd, even, empty-side, all-zero, and negative-value assertions to the paired fixtures.
+- Avoided storing borrowed parameter lists into local list variables by selecting the shorter input with lengths and a boolean selector.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0004_median_of_two_sorted_arrays` | 63 | 32 | 31 | 42/41 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0004_median_of_two_sorted_arrays` | 105 | 33 | 72 | 47/86 |
+
+The raw line diff increases because the canonical binary-partition algorithm needs explicit optional indexing and boundary sentinels in Sifr. This wave closes the structural rewrite criterion: the Sifr fixture no longer performs a full merge and covers odd/even plus empty-side cases.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0004_median_of_two_sorted_arrays.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0004_median_of_two_sorted_arrays.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0004_median_of_two_sorted_arrays.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
 
 Local gate:
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -749,8 +749,9 @@ Local gate:
 
 ## WS4 0004 Binary Median Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0004-binary-median`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1624`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -329,6 +329,18 @@
       "similarity_ratio": 0.33540372670807456
     },
     {
+      "stem": "0004_median_of_two_sorted_arrays",
+      "py_relpath": "audits/leetcode/0004_median_of_two_sorted_arrays.py",
+      "sifr_relpath": "audits/leetcode/0004_median_of_two_sorted_arrays.sifr",
+      "py_lines": 47,
+      "sifr_lines": 86,
+      "changed_py_lines": 33,
+      "changed_sifr_lines": 72,
+      "changed_total_lines": 105,
+      "length_delta": 39,
+      "similarity_ratio": 0.21052631578947367
+    },
+    {
       "stem": "0355_design_twitter",
       "py_relpath": "audits/leetcode/0355_design_twitter.py",
       "sifr_relpath": "audits/leetcode/0355_design_twitter.sifr",
@@ -1179,18 +1191,6 @@
       "changed_total_lines": 63,
       "length_delta": 11,
       "similarity_ratio": 0.2222222222222222
-    },
-    {
-      "stem": "0004_median_of_two_sorted_arrays",
-      "py_relpath": "audits/leetcode/0004_median_of_two_sorted_arrays.py",
-      "sifr_relpath": "audits/leetcode/0004_median_of_two_sorted_arrays.sifr",
-      "py_lines": 42,
-      "sifr_lines": 41,
-      "changed_py_lines": 32,
-      "changed_sifr_lines": 31,
-      "changed_total_lines": 63,
-      "length_delta": 1,
-      "similarity_ratio": 0.24096385542168675
     },
     {
       "stem": "0018_4sum",


### PR DESCRIPTION
## Summary
- Replace the Sifr full-merge median fixture with a count-based binary partition over the shorter input.
- Use explicit numeric sentinels for empty partition sides.
- Add odd, even, empty-side, all-zero, and negative-value assertions to both paired fixtures.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- Raw diff increases because the canonical binary-partition algorithm needs explicit optional indexing and boundary sentinels in Sifr; structurally, the Sifr fixture no longer does a full merge.

## Validation
- `python3 audits/leetcode/0004_median_of_two_sorted_arrays.py`
- `cargo run -q -p sifr -- check audits/leetcode/0004_median_of_two_sorted_arrays.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0004_median_of_two_sorted_arrays.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`