### PR TITLE
[codex] Rewrite LeetCode 0206 with owned node reversal

### DIFF
--- a/audits/leetcode/0206_reverse_linked_list.py
+++ b/audits/leetcode/0206_reverse_linked_list.py
@@ -17,26 +17,7 @@ def list_node_to_string(node: ListNode | None) -> str:
     return "->".join(parts) if parts else "None"
 
 
-class Node:
-    def __init__(
-        self,
-        val: int = 0,
-        next: 'Node | None' = None,
-        random: 'Node | None' = None,
-        left: 'Node | None' = None,
-        right: 'Node | None' = None,
-        neighbors: list['Node'] | None = None,
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = [] if neighbors is None else neighbors
-        self.key = key
-
-def reverseList(head: ListNode) -> ListNode:
+def reverseList(head: ListNode | None) -> ListNode | None:
     prev, curr = None, head
 
     while curr:

--- a/audits/leetcode/0206_reverse_linked_list.sifr
+++ b/audits/leetcode/0206_reverse_linked_list.sifr
@@ -1,20 +1,54 @@
-# LeetCode 206: Reverse Linked List (residual Sifr-safe canonical form)
+# LeetCode 206: Reverse Linked List
 
-def reverseList(values: list[int]) -> list[int]:
-    out = values.copy()
-    left, right = 0, len(out) - 1
-    while left < right:
-        temp = out[left]
-        out[left] = out[right]
-        out[right] = temp
-        left += 1
-        right -= 1
-    return out
+class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+
+def nodeVal(node: ListNode | None) -> int:
+    if node is None:
+        return 0
+    return node.val
+
+
+def nodeNext(node: ListNode | None) -> ListNode | None:
+    if node is None:
+        return None
+    return node.next
+
+
+def hasNode(node: ListNode | None) -> bool:
+    return node is not None
+
+
+def listNodeToString(own node: ListNode | None) -> str:
+    if node is None:
+        return "None"
+    parts: list[str] = []
+    cur: ListNode | None = node
+    while hasNode(cur):
+        parts.append(str(nodeVal(cur)))
+        cur = nodeNext(cur)
+    return "->".join(parts)
+
+
+def reverseInto(own mut cur: ListNode | None, own prev: ListNode | None) -> ListNode | None:
+    if cur is None:
+        return prev
+    next_node: ListNode | None = cur.next
+    cur.next = prev
+    return reverseInto(next_node, cur)
+
+
+def reverseList(own head: ListNode | None) -> ListNode | None:
+    return reverseInto(head, None)
+
 
 def main():
-    expected0: list[int] = [5, 4, 3, 2, 1]
-    expected1: list[int] = [2, 1]
-    expected2: list[int] = []
-    assert reverseList([1, 2, 3, 4, 5]) == expected0
-    assert reverseList([1, 2]) == expected1
-    assert reverseList([]) == expected2
+    assert listNodeToString(reverseList(ListNode(1, ListNode(2, ListNode(3, ListNode(4, ListNode(5, None))))))) == listNodeToString(ListNode(5, ListNode(4, ListNode(3, ListNode(2, ListNode(1, None))))))
+    assert listNodeToString(reverseList(ListNode(1, ListNode(2, None)))) == listNodeToString(ListNode(2, ListNode(1, None)))
+    assert reverseList(None) == None

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -799,10 +799,6 @@ Local gate:
 
 - `scripts/run_all_tests.sh --profile quick` PASS
 
-Local gate:
-
-- `scripts/run_all_tests.sh --profile quick` PASS
-
 ## WS4 0206 Reverse Linked List Rewrite
 
 Status: opened PR

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -749,9 +749,10 @@ Local gate:
 
 ## WS4 0004 Binary Median Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0004-binary-median`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1624`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1624`
 
 ### Scope
 
@@ -797,3 +798,52 @@ Targeted validation:
 Local gate:
 
 - `scripts/run_all_tests.sh --profile quick` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0206 Reverse Linked List Rewrite
+
+Status: validated locally
+Branch: `ws4-0206-reverse-linked-list`
+
+### Scope
+
+Rewrite the reverse-linked-list fixture to use the canonical `ListNode` public model and owned node rewiring:
+
+- `audits/leetcode/0206_reverse_linked_list.py`
+- `audits/leetcode/0206_reverse_linked_list.sifr`
+
+### Changes
+
+- Replaced the Sifr `list[int]` public model with the shared `ListNode` fixture helper shape.
+- Implemented recursive owned-node reversal with `reverseInto(own mut cur, own prev)` and direct `.next` rewiring.
+- Removed the unused catch-all `Node` helper from the Python pair and made the Python signature explicitly nullable.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0206_reverse_linked_list` | 71 | 54 | 17 | 57/20 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0206_reverse_linked_list` | 62 | 23 | 39 | 38/54 |
+
+This wave closes the structural rewrite criterion: the Sifr fixture no longer exposes `list[int]` and reverses the owned node chain by rewiring links rather than copying values through an array.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0206_reverse_linked_list.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0206_reverse_linked_list.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0206_reverse_linked_list.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -805,8 +805,9 @@ Local gate:
 
 ## WS4 0206 Reverse Linked List Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0206-reverse-linked-list`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1625`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -845,18 +845,6 @@
       "similarity_ratio": 0.4857142857142857
     },
     {
-      "stem": "0206_reverse_linked_list",
-      "py_relpath": "audits/leetcode/0206_reverse_linked_list.py",
-      "sifr_relpath": "audits/leetcode/0206_reverse_linked_list.sifr",
-      "py_lines": 57,
-      "sifr_lines": 20,
-      "changed_py_lines": 54,
-      "changed_sifr_lines": 17,
-      "changed_total_lines": 71,
-      "length_delta": 37,
-      "similarity_ratio": 0.07792207792207792
-    },
-    {
       "stem": "0535_encode_and_decode_tinyurl",
       "py_relpath": "audits/leetcode/0535_encode_and_decode_tinyurl.py",
       "sifr_relpath": "audits/leetcode/0535_encode_and_decode_tinyurl.sifr",
@@ -1275,6 +1263,18 @@
       "changed_total_lines": 62,
       "length_delta": 16,
       "similarity_ratio": 0.27906976744186046
+    },
+    {
+      "stem": "0206_reverse_linked_list",
+      "py_relpath": "audits/leetcode/0206_reverse_linked_list.py",
+      "sifr_relpath": "audits/leetcode/0206_reverse_linked_list.sifr",
+      "py_lines": 38,
+      "sifr_lines": 54,
+      "changed_py_lines": 23,
+      "changed_sifr_lines": 39,
+      "changed_total_lines": 62,
+      "length_delta": 16,
+      "similarity_ratio": 0.32608695652173914
     },
     {
       "stem": "0094_binary_tree_inorder_traversal",


### PR DESCRIPTION
## Summary
- Replace the Sifr list-value public model with the `ListNode` fixture helper shape.
- Implement recursive owned-node reversal with direct `.next` rewiring.
- Remove the unused catch-all `Node` helper from the Python pair and make the Python signature explicitly nullable.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- `0206_reverse_linked_list` moves from `changed_total=71` to `changed_total=62` while closing the structural public-model debt.

## Validation
- `python3 audits/leetcode/0206_reverse_linked_list.py`
- `cargo run -q -p sifr -- check audits/leetcode/0206_reverse_linked_list.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0206_reverse_linked_list.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`