### PR TITLE
[codex] Rewrite LeetCode 0024 with owned pair swaps

### DIFF
--- a/audits/leetcode/0024_swap_nodes_in_pairs.py
+++ b/audits/leetcode/0024_swap_nodes_in_pairs.py
@@ -17,26 +17,7 @@ def list_node_to_string(node: ListNode | None) -> str:
     return "->".join(parts) if parts else "None"
 
 
-class Node:
-    def __init__(
-        self,
-        val: int = 0,
-        next: 'Node | None' = None,
-        random: 'Node | None' = None,
-        left: 'Node | None' = None,
-        right: 'Node | None' = None,
-        neighbors: list['Node'] | None = None,
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = [] if neighbors is None else neighbors
-        self.key = key
-
-def swapPairs(head: ListNode) -> ListNode:
+def swapPairs(head: ListNode | None) -> ListNode | None:
     dummy = ListNode(0, head)
     prev, curr = dummy, head
 

--- a/audits/leetcode/0024_swap_nodes_in_pairs.sifr
+++ b/audits/leetcode/0024_swap_nodes_in_pairs.sifr
@@ -1,20 +1,54 @@
-# LeetCode 24: Swap Nodes In Pairs (residual Sifr-safe canonical form)
+# LeetCode 24: Swap Nodes In Pairs
 
-def swapPairs(values: list[int]) -> list[int]:
-    out = values.copy()
-    i = 0
-    while i + 1 < len(out):
-        first = out[i]
-        out[i] = out[i + 1]
-        out[i + 1] = first
-        i += 2
-    return out
+class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+
+def nodeVal(node: ListNode | None) -> int:
+    if node is None:
+        return 0
+    return node.val
+
+
+def nodeNext(node: ListNode | None) -> ListNode | None:
+    if node is None:
+        return None
+    return node.next
+
+
+def hasNode(node: ListNode | None) -> bool:
+    return node is not None
+
+
+def listNodeToString(own node: ListNode | None) -> str:
+    if node is None:
+        return "None"
+    parts: list[str] = []
+    cur: ListNode | None = node
+    while hasNode(cur):
+        parts.append(str(nodeVal(cur)))
+        cur = nodeNext(cur)
+    return "->".join(parts)
+
+
+def swapPairs(own mut head: ListNode | None) -> ListNode | None:
+    if head is None:
+        return None
+    second: ListNode | None = head.next
+    if second is None:
+        return head
+    rest: ListNode | None = second.next
+    head.next = swapPairs(rest)
+    second.next = head
+    return second
 
 
 def main():
-    expected0: list[int] = [2, 1, 4, 3]
-    expected1: list[int] = []
-    expected2: list[int] = [1]
-    assert swapPairs([1, 2, 3, 4]) == expected0
-    assert swapPairs([]) == expected1
-    assert swapPairs([1]) == expected2
+    assert listNodeToString(swapPairs(ListNode(1, ListNode(2, ListNode(3, ListNode(4, None)))))) == listNodeToString(ListNode(2, ListNode(1, ListNode(4, ListNode(3, None)))))
+    assert swapPairs(None) == None
+    assert listNodeToString(swapPairs(ListNode(1, None))) == listNodeToString(ListNode(1, None))

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -801,9 +801,10 @@ Local gate:
 
 ## WS4 0206 Reverse Linked List Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0206-reverse-linked-list`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1625`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1625`
 
 ### Scope
 
@@ -844,3 +845,56 @@ Targeted validation:
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 - `cargo fmt --check` PASS
 - `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0024 Swap Nodes In Pairs Rewrite
+
+Status: validated locally
+Branch: `ws4-0024-swap-pairs`
+
+### Scope
+
+Rewrite the swap-pairs fixture to use the canonical `ListNode` public model and owned node rewiring:
+
+- `audits/leetcode/0024_swap_nodes_in_pairs.py`
+- `audits/leetcode/0024_swap_nodes_in_pairs.sifr`
+
+### Changes
+
+- Replaced the Sifr `list[int]` public model with the shared `ListNode` fixture helper shape.
+- Implemented recursive pair swapping by rewiring `head.next` and `second.next`.
+- Removed the unused catch-all `Node` helper from the Python pair and made the Python signature explicitly nullable.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0024_swap_nodes_in_pairs` | 79 | 63 | 16 | 67/20 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0024_swap_nodes_in_pairs` | 66 | 30 | 36 | 48/54 |
+
+This wave closes the structural rewrite criterion: the Sifr fixture no longer exposes `list[int]` and swaps adjacent owned nodes by rewiring links.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0024_swap_nodes_in_pairs.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0024_swap_nodes_in_pairs.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0024_swap_nodes_in_pairs.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -852,8 +852,9 @@ Local gate:
 
 ## WS4 0024 Swap Nodes In Pairs Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0024-swap-pairs`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1626`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -653,18 +653,6 @@
       "similarity_ratio": 0.5061728395061729
     },
     {
-      "stem": "0024_swap_nodes_in_pairs",
-      "py_relpath": "audits/leetcode/0024_swap_nodes_in_pairs.py",
-      "sifr_relpath": "audits/leetcode/0024_swap_nodes_in_pairs.sifr",
-      "py_lines": 67,
-      "sifr_lines": 20,
-      "changed_py_lines": 63,
-      "changed_sifr_lines": 16,
-      "changed_total_lines": 79,
-      "length_delta": 47,
-      "similarity_ratio": 0.09195402298850575
-    },
-    {
       "stem": "1345_jump_game_iv",
       "py_relpath": "audits/leetcode/1345_jump_game_iv.py",
       "sifr_relpath": "audits/leetcode/1345_jump_game_iv.sifr",
@@ -1047,6 +1035,18 @@
       "changed_total_lines": 66,
       "length_delta": 6,
       "similarity_ratio": 0.3125
+    },
+    {
+      "stem": "0024_swap_nodes_in_pairs",
+      "py_relpath": "audits/leetcode/0024_swap_nodes_in_pairs.py",
+      "sifr_relpath": "audits/leetcode/0024_swap_nodes_in_pairs.sifr",
+      "py_lines": 48,
+      "sifr_lines": 54,
+      "changed_py_lines": 30,
+      "changed_sifr_lines": 36,
+      "changed_total_lines": 66,
+      "length_delta": 6,
+      "similarity_ratio": 0.35294117647058826
     },
     {
       "stem": "2101_detonate_the_maximum_bombs",


### PR DESCRIPTION
## Summary
- Replace the Sifr list-value public model with the `ListNode` fixture helper shape.
- Implement recursive owned-node pair swapping with direct `.next` rewiring.
- Remove the unused catch-all `Node` helper from the Python pair and make the Python signature explicitly nullable.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- `0024_swap_nodes_in_pairs` moves from `changed_total=79` to `changed_total=66` while closing the structural public-model debt.

## Validation
- `python3 audits/leetcode/0024_swap_nodes_in_pairs.py`
- `cargo run -q -p sifr -- check audits/leetcode/0024_swap_nodes_in_pairs.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0024_swap_nodes_in_pairs.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`