### PR TITLE
[codex] Rewrite LeetCode 0147 with owned insertion sort

### DIFF
--- a/audits/leetcode/0147_insertion_sort_list.py
+++ b/audits/leetcode/0147_insertion_sort_list.py
@@ -17,25 +17,6 @@ def list_node_to_string(node: ListNode | None) -> str:
     return "->".join(parts) if parts else "None"
 
 
-class Node:
-    def __init__(
-        self,
-        val: int = 0,
-        next: 'Node | None' = None,
-        random: 'Node | None' = None,
-        left: 'Node | None' = None,
-        right: 'Node | None' = None,
-        neighbors: list['Node'] | None = None,
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = [] if neighbors is None else neighbors
-        self.key = key
-
 def insertionSortList(head: ListNode | None) -> ListNode | None:
     if not head or not head.next:
         return head

--- a/audits/leetcode/0147_insertion_sort_list.sifr
+++ b/audits/leetcode/0147_insertion_sort_list.sifr
@@ -25,12 +25,6 @@ def hasNode(node: ListNode | None) -> bool:
     return node is not None
 
 
-def unwrapInt(value: int | None) -> int:
-    if value is None:
-        return 0
-    return value
-
-
 def listNodeToString(own node: ListNode | None) -> str:
     if node is None:
         return "None"
@@ -42,49 +36,27 @@ def listNodeToString(own node: ListNode | None) -> str:
     return "->".join(parts)
 
 
-class Node:
-    val: int
-    next: Node | None
-    random: Node | None
-    left: Node | None
-    right: Node | None
-    neighbors: list[Node]
-    key: int
+def insertSorted(own mut sorted: ListNode | None, own mut node: ListNode) -> ListNode | None:
+    if sorted is None:
+        node.next = None
+        return node
+    if node.val <= sorted.val:
+        node.next = sorted
+        return node
+    sorted_next: ListNode | None = sorted.next
+    sorted.next = insertSorted(sorted_next, node)
+    return sorted
 
-    def __init__(
-        self,
-        val: int = 0,
-        next: Node | None = None,
-        random: Node | None = None,
-        left: Node | None = None,
-        right: Node | None = None,
-        neighbors: list[Node] = [],
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = neighbors
-        self.key = key
+
+def sortInto(own mut cur: ListNode | None, own sorted: ListNode | None) -> ListNode | None:
+    if cur is None:
+        return sorted
+    next_node: ListNode | None = cur.next
+    cur.next = None
+    return sortInto(next_node, insertSorted(sorted, cur))
 
 def insertionSortList(own head: ListNode | None) -> ListNode | None:
-    values: list[int] = []
-    cur: ListNode | None = head
-    while hasNode(cur):
-        values.append(nodeVal(cur))
-        cur = nodeNext(cur)
-
-    ordered: list[int] = sorted(values)
-    result: ListNode | None = None
-    i: int = len(ordered) - 1
-    while i >= 0:
-        value: int = unwrapInt(ordered[i])
-        if True:
-            result = ListNode(value, result)
-        i = i - 1
-    return result
+    return sortInto(head, None)
 
 def main():
     assert listNodeToString(insertionSortList(ListNode(4, ListNode(2, ListNode(1, ListNode(3, None)))))) == listNodeToString(ListNode(1, ListNode(2, ListNode(3, ListNode(4, None)))))

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -852,9 +852,10 @@ Local gate:
 
 ## WS4 0024 Swap Nodes In Pairs Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0024-swap-pairs`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1626`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1626`
 
 ### Scope
 
@@ -892,6 +893,55 @@ Targeted validation:
 - `python3 audits/leetcode/0024_swap_nodes_in_pairs.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0024_swap_nodes_in_pairs.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0024_swap_nodes_in_pairs.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0147 Insertion Sort List Rewrite
+
+Status: validated locally
+Branch: `ws4-0147-insertion-sort-list`
+
+### Scope
+
+Rewrite the insertion-sort-list fixture to sort the owned node chain directly:
+
+- `audits/leetcode/0147_insertion_sort_list.py`
+- `audits/leetcode/0147_insertion_sort_list.sifr`
+
+### Changes
+
+- Replaced the Sifr drain/sort/rebuild implementation with recursive owned-node insertion sort.
+- Added `insertSorted` and `sortInto` helpers that move nodes by rewiring `.next`.
+- Removed unused `Node` / `unwrapInt` helper baggage from the paired fixtures.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0147_insertion_sort_list` | 102 | 36 | 66 | 61/91 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0147_insertion_sort_list` | 79 | 29 | 50 | 42/63 |
+
+This wave closes the structural rewrite criterion: the Sifr fixture no longer drains values into a list, calls `sorted`, or rebuilds a new result chain.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0147_insertion_sort_list.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0147_insertion_sort_list.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0147_insertion_sort_list.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 - `cargo fmt --check` PASS
 - `git diff --check` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -903,8 +903,9 @@ Local gate:
 
 ## WS4 0147 Insertion Sort List Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0147-insertion-sort-list`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1627`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -389,18 +389,6 @@
       "similarity_ratio": 0.35
     },
     {
-      "stem": "0147_insertion_sort_list",
-      "py_relpath": "audits/leetcode/0147_insertion_sort_list.py",
-      "sifr_relpath": "audits/leetcode/0147_insertion_sort_list.sifr",
-      "py_lines": 61,
-      "sifr_lines": 91,
-      "changed_py_lines": 36,
-      "changed_sifr_lines": 66,
-      "changed_total_lines": 102,
-      "length_delta": 30,
-      "similarity_ratio": 0.32894736842105265
-    },
-    {
       "stem": "0023_merge_k_sorted_lists",
       "py_relpath": "audits/leetcode/0023_merge_k_sorted_lists.py",
       "sifr_relpath": "audits/leetcode/0023_merge_k_sorted_lists.sifr",
@@ -651,6 +639,18 @@
       "changed_total_lines": 80,
       "length_delta": 24,
       "similarity_ratio": 0.5061728395061729
+    },
+    {
+      "stem": "0147_insertion_sort_list",
+      "py_relpath": "audits/leetcode/0147_insertion_sort_list.py",
+      "sifr_relpath": "audits/leetcode/0147_insertion_sort_list.sifr",
+      "py_lines": 42,
+      "sifr_lines": 63,
+      "changed_py_lines": 29,
+      "changed_sifr_lines": 50,
+      "changed_total_lines": 79,
+      "length_delta": 21,
+      "similarity_ratio": 0.24761904761904763
     },
     {
       "stem": "1345_jump_game_iv",


### PR DESCRIPTION
## Summary
- Replace the Sifr drain/sort/rebuild implementation with recursive owned-node insertion sort.
- Add `insertSorted` and `sortInto` helpers that move nodes by rewiring `.next`.
- Remove unused helper baggage from the paired fixtures.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- `0147_insertion_sort_list` moves from `changed_total=102` to `changed_total=79` while closing the structural no-drain/sort/rebuild criterion.

## Validation
- `python3 audits/leetcode/0147_insertion_sort_list.py`
- `cargo run -q -p sifr -- check audits/leetcode/0147_insertion_sort_list.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0147_insertion_sort_list.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`