### PR TITLE
[codex] Rewrite LeetCode 0707 with linked node storage

### DIFF
--- a/audits/leetcode/0707_design_linked_list.py
+++ b/audits/leetcode/0707_design_linked_list.py
@@ -2,25 +2,6 @@
 # LeetCode 707: Design Linked List
 # Python version
 
-class Node:
-    def __init__(
-        self,
-        val: int = 0,
-        next: 'Node | None' = None,
-        random: 'Node | None' = None,
-        left: 'Node | None' = None,
-        right: 'Node | None' = None,
-        neighbors: list['Node'] | None = None,
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = [] if neighbors is None else neighbors
-        self.key = key
-
 class ListNode:
     def __init__(self, val):
         self.val = val
@@ -32,7 +13,11 @@ class MyLinkedList:
         self.right = ListNode(0)
         self.left.next = self.right
         self.right.prev = self.left
+        self.size = 0
+
     def get(self, index: int) -> int:
+        if index < 0 or index >= self.size:
+            return -1
         cur = self.left.next
         while cur and index > 0:
             cur = cur.next
@@ -45,12 +30,20 @@ class MyLinkedList:
         node.next, node.prev = next, prev
         next.prev = node
         prev.next = node
+        self.size += 1
+
     def addAtTail(self, val: int) -> None:
         node, prev, next = ListNode(val), self.right.prev, self.right
         node.next, node.prev = next, prev
         next.prev = node
         prev.next = node
+        self.size += 1
+
     def addAtIndex(self, index: int, val: int) -> None:
+        if index < 0:
+            index = 0
+        if index > self.size:
+            return
         next = self.left.next
         while next and index > 0:
             next = next.next
@@ -60,7 +53,11 @@ class MyLinkedList:
             node.next, node.prev = next, prev
             next.prev = node
             prev.next = node
+            self.size += 1
+
     def deleteAtIndex(self, index: int) -> None:
+        if index < 0 or index >= self.size:
+            return
         node = self.left.next
         while node and index > 0:
             node = node.next
@@ -68,6 +65,7 @@ class MyLinkedList:
         if node and node != self.right and index == 0:
             node.prev.next = node.next
             node.next.prev = node.prev
+            self.size -= 1
 
 def main():
     obj = MyLinkedList()
@@ -77,6 +75,12 @@ def main():
     assert obj.get(1) == 2
     obj.deleteAtIndex(1)
     assert obj.get(1) == 3
+    obj.addAtIndex(3, 4)
+    assert obj.get(3) == -1
+    obj.addAtIndex(-1, 5)
+    assert obj.get(0) == 5
+    obj.deleteAtIndex(0)
+    assert obj.get(0) == 1
 
 if __name__ == "__main__":
     main()

--- a/audits/leetcode/0707_design_linked_list.sifr
+++ b/audits/leetcode/0707_design_linked_list.sifr
@@ -1,55 +1,86 @@
 # LeetCode 707: Design Linked List
 
+class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+
+def getAt(node: ListNode | None, index: int) -> int:
+    if node is None:
+        return -1
+    if index == 0:
+        return node.val
+    return getAt(node.next, index - 1)
+
+
+def appendTail(own mut node: ListNode | None, val: int) -> ListNode | None:
+    if node is None:
+        return ListNode(val, None)
+    node.next = appendTail(node.next, val)
+    return node
+
+
+def insertAt(own mut node: ListNode | None, index: int, val: int) -> ListNode | None:
+    if index <= 0:
+        return ListNode(val, node)
+    if node is None:
+        return None
+    node.next = insertAt(node.next, index - 1, val)
+    return node
+
+
+def deleteAt(own mut node: ListNode | None, index: int) -> ListNode | None:
+    if node is None:
+        return None
+    if index == 0:
+        return node.next
+    node.next = deleteAt(node.next, index - 1)
+    return node
+
+
 class MyLinkedList:
-    values: list[int]
+    head: ListNode | None
+    size: int
 
     def __init__(self):
-        self.values = []
+        self.head = None
+        self.size = 0
 
     def get(self, index: int) -> int:
-        if index < 0 or index >= len(self.values):
+        if index < 0 or index >= self.size:
             return -1
-        i = 0
-        for value in self.values:
-            if i == index:
-                return value
-            i += 1
-        return -1
+        return getAt(self.head, index)
 
     def addAtHead(self, val: int) -> None:
-        self.values = [val] + self.values
+        head: ListNode | None = self.head
+        self.head = insertAt(head, 0, val)
+        self.size = self.size + 1
 
     def addAtTail(self, val: int) -> None:
-        self.values.append(val)
+        head: ListNode | None = self.head
+        self.head = appendTail(head, val)
+        self.size = self.size + 1
 
     def addAtIndex(self, index: int, val: int) -> None:
         idx = index
         if idx < 0:
             idx = 0
-        if idx > len(self.values):
+        if idx > self.size:
             return
-
-        left: list[int] = []
-        right: list[int] = []
-        i = 0
-        for value in self.values:
-            if i < idx:
-                left.append(value)
-            else:
-                right.append(value)
-            i += 1
-        self.values = left + [val] + right
+        head: ListNode | None = self.head
+        self.head = insertAt(head, idx, val)
+        self.size = self.size + 1
 
     def deleteAtIndex(self, index: int) -> None:
-        if index < 0 or index >= len(self.values):
+        if index < 0 or index >= self.size:
             return
-        next_values: list[int] = []
-        i = 0
-        for value in self.values:
-            if i != index:
-                next_values.append(value)
-            i += 1
-        self.values = next_values
+        head: ListNode | None = self.head
+        self.head = deleteAt(head, index)
+        self.size = self.size - 1
 
 
 def main():
@@ -60,3 +91,9 @@ def main():
     assert obj.get(1) == 2
     obj.deleteAtIndex(1)
     assert obj.get(1) == 3
+    obj.addAtIndex(3, 4)
+    assert obj.get(3) == -1
+    obj.addAtIndex(-1, 5)
+    assert obj.get(0) == 5
+    obj.deleteAtIndex(0)
+    assert obj.get(0) == 1

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -903,9 +903,10 @@ Local gate:
 
 ## WS4 0147 Insertion Sort List Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0147-insertion-sort-list`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1627`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1627`
 
 ### Scope
 
@@ -943,6 +944,56 @@ Targeted validation:
 - `python3 audits/leetcode/0147_insertion_sort_list.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0147_insertion_sort_list.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0147_insertion_sort_list.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0707 Linked List Design Rewrite
+
+Status: validated locally
+Branch: `ws4-0707-linked-list-design`
+
+### Scope
+
+Rewrite the design-linked-list fixture to use linked-list storage rather than an array-backed public model:
+
+- `audits/leetcode/0707_design_linked_list.py`
+- `audits/leetcode/0707_design_linked_list.sifr`
+
+### Changes
+
+- Replaced the Sifr `list[int]` storage with a singly owned `ListNode` chain plus explicit `size`.
+- Implemented `get`, `addAtHead`, `addAtTail`, `addAtIndex`, and `deleteAtIndex` through recursive chain helpers.
+- Aligned the Python fixture with LeetCode index semantics by tracking `size`, rejecting `index > size`, and treating negative insert indexes as head insertion.
+- Added assertions for out-of-range insert, negative-index head insertion, and delete-at-head behavior.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0707_design_linked_list` | 108 | 64 | 44 | 82/62 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0707_design_linked_list` | 113 | 50 | 63 | 86/99 |
+
+The raw line diff increases slightly because the Sifr fixture now carries explicit node helpers and size bookkeeping. This wave closes the structural rewrite criterion: operations use a linked node chain instead of array slicing, concatenation, or filtering.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0707_design_linked_list.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0707_design_linked_list.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0707_design_linked_list.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 - `cargo fmt --check` PASS
 - `git diff --check` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -954,8 +954,9 @@ Local gate:
 
 ## WS4 0707 Linked List Design Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0707-linked-list-design`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1628`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -281,6 +281,18 @@
       "similarity_ratio": 0.3615819209039548
     },
     {
+      "stem": "0707_design_linked_list",
+      "py_relpath": "audits/leetcode/0707_design_linked_list.py",
+      "sifr_relpath": "audits/leetcode/0707_design_linked_list.sifr",
+      "py_lines": 86,
+      "sifr_lines": 99,
+      "changed_py_lines": 50,
+      "changed_sifr_lines": 63,
+      "changed_total_lines": 113,
+      "length_delta": 13,
+      "similarity_ratio": 0.3891891891891892
+    },
+    {
       "stem": "0286_walls_and_gates",
       "py_relpath": "audits/leetcode/0286_walls_and_gates.py",
       "sifr_relpath": "audits/leetcode/0286_walls_and_gates.sifr",
@@ -303,18 +315,6 @@
       "changed_total_lines": 109,
       "length_delta": 39,
       "similarity_ratio": 0.32298136645962733
-    },
-    {
-      "stem": "0707_design_linked_list",
-      "py_relpath": "audits/leetcode/0707_design_linked_list.py",
-      "sifr_relpath": "audits/leetcode/0707_design_linked_list.sifr",
-      "py_lines": 82,
-      "sifr_lines": 62,
-      "changed_py_lines": 64,
-      "changed_sifr_lines": 44,
-      "changed_total_lines": 108,
-      "length_delta": 20,
-      "similarity_ratio": 0.25
     },
     {
       "stem": "0019_remove_nth_node_from_end_of_list",


### PR DESCRIPTION
## Summary
- Replace the Sifr array-backed linked-list design with a singly owned `ListNode` chain and explicit `size`.
- Implement `get`, `addAtHead`, `addAtTail`, `addAtIndex`, and `deleteAtIndex` through recursive chain helpers.
- Align the Python fixture with LeetCode index semantics and add boundary assertions.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- Raw diff increases slightly (`changed_total=108` to `113`) because Sifr now carries node helpers and size bookkeeping; structurally, operations no longer use array slicing, concatenation, or filtering.

## Validation
- `python3 audits/leetcode/0707_design_linked_list.py`
- `cargo run -q -p sifr -- check audits/leetcode/0707_design_linked_list.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0707_design_linked_list.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`