### PR TITLE
[codex] Rewrite LeetCode 0023 with heap-backed ListNode model

### DIFF
--- a/audits/leetcode/0023_merge_k_sorted_lists.py
+++ b/audits/leetcode/0023_merge_k_sorted_lists.py
@@ -26,26 +26,7 @@ def list_node_to_string(node: ListNode | None) -> str:
     return "->".join(parts) if parts else "None"
 
 
-class Node:
-    def __init__(
-        self,
-        val: int = 0,
-        next: 'Node | None' = None,
-        random: 'Node | None' = None,
-        left: 'Node | None' = None,
-        right: 'Node | None' = None,
-        neighbors: list['Node'] | None = None,
-        key: int = -1,
-    ):
-        self.val = val
-        self.next = next
-        self.random = random
-        self.left = left
-        self.right = right
-        self.neighbors = [] if neighbors is None else neighbors
-        self.key = key
-
-def mergeKLists(lists: list[ListNode]) -> ListNode:
+def mergeKLists(lists: list[ListNode | None]) -> ListNode | None:
     if not lists or len(lists) == 0:
         return None
 

--- a/audits/leetcode/0023_merge_k_sorted_lists.sifr
+++ b/audits/leetcode/0023_merge_k_sorted_lists.sifr
@@ -1,17 +1,78 @@
-# LeetCode 23: Merge K Sorted Lists (residual Sifr-safe canonical form)
+# LeetCode 23: Merge K Sorted Lists
+from sifr.heapq import heappush, heappop
 
-def mergeKLists(lists: list[list[int]]) -> list[int]:
-    merged: list[int] = []
-    for row in lists:
-        for value in row:
-            merged.append(value)
-    merged.sort()
-    return merged
+class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+
+def nodeVal(node: ListNode | None) -> int:
+    if node is None:
+        return 0
+    return node.val
+
+
+def nodeNext(node: ListNode | None) -> ListNode | None:
+    if node is None:
+        return None
+    return node.next
+
+
+def hasNode(node: ListNode | None) -> bool:
+    return node is not None
+
+
+def appendTail(own mut node: ListNode | None, val: int) -> ListNode | None:
+    if node is None:
+        return ListNode(val, None)
+    node.next = appendTail(node.next, val)
+    return node
+
+
+def buildListNode(values: list[int]) -> ListNode | None:
+    result: ListNode | None = None
+    for value in values:
+        result = appendTail(result, value)
+    return result
+
+
+def listNodeToString(own node: ListNode | None) -> str:
+    if node is None:
+        return "None"
+    parts: list[str] = []
+    cur: ListNode | None = node
+    while hasNode(cur):
+        parts.append(str(nodeVal(cur)))
+        cur = nodeNext(cur)
+    return "->".join(parts)
+
+
+def mergeKLists(lists: list[ListNode | None]) -> ListNode | None:
+    heap: list[int] = []
+    for node in lists:
+        cur: ListNode | None = node
+        while hasNode(cur):
+            heappush(heap, nodeVal(cur))
+            cur = nodeNext(cur)
+
+    result: ListNode | None = None
+    while len(heap) > 0:
+        value: int | None = heappop(heap)
+        if value is not None:
+            result = appendTail(result, value)
+    return result
 
 
 def main():
-    lists: list[list[int]] = [[1, 4, 5], [1, 3, 4], [2, 6]]
-    expected0: list[int] = [1, 1, 2, 3, 4, 4, 5, 6]
-    expected1: list[int] = []
-    assert mergeKLists(lists) == expected0
-    assert mergeKLists([]) == expected1
+    lists: list[ListNode | None] = [
+        buildListNode([1, 4, 5]),
+        buildListNode([1, 3, 4]),
+        buildListNode([2, 6]),
+    ]
+    assert listNodeToString(mergeKLists(lists)) == "1->1->2->3->4->4->5->6"
+    empty: list[ListNode | None] = []
+    assert mergeKLists(empty) == None

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -954,9 +954,10 @@ Local gate:
 
 ## WS4 0707 Linked List Design Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0707-linked-list-design`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1628`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1628`
 
 ### Scope
 
@@ -995,6 +996,55 @@ Targeted validation:
 - `python3 audits/leetcode/0707_design_linked_list.py` PASS
 - `cargo run -q -p sifr -- check audits/leetcode/0707_design_linked_list.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0707_design_linked_list.sifr` PASS
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0023 Merge K Sorted Lists Rewrite
+
+Status: validated locally
+Branch: `ws4-0023-merge-k-lists-heap`
+
+### Scope
+
+Rewrite the merge-k-sorted-lists fixture to use the `ListNode` public model and heap-backed ordering:
+
+- `audits/leetcode/0023_merge_k_sorted_lists.py`
+- `audits/leetcode/0023_merge_k_sorted_lists.sifr`
+
+### Changes
+
+- Replaced the Sifr `list[list[int]]` public model with `ListNode` helpers and `list[ListNode | None]` input.
+- Used `sifr.heapq.heappush` / `heappop` to collect node values in sorted order instead of calling `merged.sort()`.
+- Rebuilt the result as a `ListNode` chain and removed unused Python catch-all `Node` helper baggage.
+
+### Pair Scan Movement
+
+Previous stats from `origin/main` scan artifact:
+
+| Fixture | Previous changed_total | Previous changed_py | Previous changed_sifr | Previous lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0023_merge_k_sorted_lists` | 101 | 88 | 13 | 92/17 |
+
+Regenerated artifact: `verification/leetcode/leetcode_pair_diff_scan_20260424.json`
+
+| Fixture | Current changed_total | Current changed_py | Current changed_sifr | Current lines py/sifr |
+| --- | ---: | ---: | ---: | --- |
+| `0023_merge_k_sorted_lists` | 117 | 56 | 61 | 73/78 |
+
+The raw line diff increases because the Sifr fixture now includes the linked-list helper surface. This wave closes the public-model criterion and removes the full-array `sort()` workaround by using heap ordering.
+
+### Validation
+
+Targeted validation:
+
+- `python3 audits/leetcode/0023_merge_k_sorted_lists.py` PASS
+- `cargo run -q -p sifr -- check audits/leetcode/0023_merge_k_sorted_lists.sifr` PASS
+- `cargo run -q -p sifr -- run audits/leetcode/0023_merge_k_sorted_lists.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
 - `cargo fmt --check` PASS
 - `git diff --check` PASS

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -1006,8 +1006,9 @@ Local gate:
 
 ## WS4 0023 Merge K Sorted Lists Rewrite
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0023-merge-k-lists-heap`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1629`
 
 ### Scope
 

--- a/verification/leetcode/leetcode_pair_diff_scan_20260424.json
+++ b/verification/leetcode/leetcode_pair_diff_scan_20260424.json
@@ -257,6 +257,18 @@
       "similarity_ratio": 0.25316455696202533
     },
     {
+      "stem": "0023_merge_k_sorted_lists",
+      "py_relpath": "audits/leetcode/0023_merge_k_sorted_lists.py",
+      "sifr_relpath": "audits/leetcode/0023_merge_k_sorted_lists.sifr",
+      "py_lines": 73,
+      "sifr_lines": 78,
+      "changed_py_lines": 56,
+      "changed_sifr_lines": 61,
+      "changed_total_lines": 117,
+      "length_delta": 5,
+      "similarity_ratio": 0.2251655629139073
+    },
+    {
       "stem": "0673_number_of_longest_increasing_subsequence",
       "py_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.py",
       "sifr_relpath": "audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr",
@@ -387,18 +399,6 @@
       "changed_total_lines": 104,
       "length_delta": 32,
       "similarity_ratio": 0.35
-    },
-    {
-      "stem": "0023_merge_k_sorted_lists",
-      "py_relpath": "audits/leetcode/0023_merge_k_sorted_lists.py",
-      "sifr_relpath": "audits/leetcode/0023_merge_k_sorted_lists.sifr",
-      "py_lines": 92,
-      "sifr_lines": 17,
-      "changed_py_lines": 88,
-      "changed_sifr_lines": 13,
-      "changed_total_lines": 101,
-      "length_delta": 75,
-      "similarity_ratio": 0.07339449541284404
     },
     {
       "stem": "0203_remove_linked_list_elements",


### PR DESCRIPTION
## Summary
- Replace the Sifr `list[list[int]]` public model with `ListNode` helpers and `list[ListNode | None]` input.
- Use `sifr.heapq.heappush` / `heappop` for ordering instead of `merged.sort()`.
- Return a `ListNode` chain and remove unused Python helper baggage.

## Pair scan
- Regenerated `verification/leetcode/leetcode_pair_diff_scan_20260424.json`.
- Raw diff increases (`changed_total=101` to `117`) because Sifr now includes linked-list helper surface; structurally, this closes the public-model debt and removes the full-array sort workaround.

## Validation
- `python3 audits/leetcode/0023_merge_k_sorted_lists.py`
- `cargo run -q -p sifr -- check audits/leetcode/0023_merge_k_sorted_lists.sifr`
- `cargo run -q -p sifr -- run audits/leetcode/0023_merge_k_sorted_lists.sifr`
- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80`
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`