### PR TITLE
[codex] Track LeetCode 0148 owned merge sort blocker

### DIFF
--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -1057,8 +1057,9 @@ Local gate:
 
 ## WS4 0148 Merge Sort Blocker Tracking
 
-Status: validated locally
+Status: opened PR
 Branch: `ws4-0148-blocker-note`
+PR: `https://github.com/yaseralnajjar/sifr/pull/1630`
 
 ### Scope
 

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -1006,9 +1006,10 @@ Local gate:
 
 ## WS4 0023 Merge K Sorted Lists Rewrite
 
-Status: opened PR
+Status: merged
 Branch: `ws4-0023-merge-k-lists-heap`
 PR: `https://github.com/yaseralnajjar/sifr/pull/1629`
+Merged: `https://github.com/yaseralnajjar/sifr/pull/1629`
 
 ### Scope
 
@@ -1047,6 +1048,34 @@ Targeted validation:
 - `cargo run -q -p sifr -- check audits/leetcode/0023_merge_k_sorted_lists.sifr` PASS
 - `cargo run -q -p sifr -- run audits/leetcode/0023_merge_k_sorted_lists.sifr` PASS
 - `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_20260424.json --top 80` PASS
+- `cargo fmt --check` PASS
+- `git diff --check` PASS
+
+Local gate:
+
+- `scripts/run_all_tests.sh --profile quick` PASS
+
+## WS4 0148 Merge Sort Blocker Tracking
+
+Status: validated locally
+Branch: `ws4-0148-blocker-note`
+
+### Scope
+
+Track the remaining canonical linked-list merge sort blocker:
+
+- `issues/leetcode-0148-owned-merge-sort-blocker-2026-04-24.md`
+
+### Decision
+
+`0148_sort_list` remains the only WS4 rewrite item not safely closed in this phase. Direct owned-node insertion sort is expressible (`0147`), and single-chain rewiring is expressible (`0206`, `0024`, `0707`), but the canonical `0148` merge requires moving one of two owned list heads across sibling branches. The checker currently reports moved-value errors for both optional and non-optional two-list merge helper shapes.
+
+The fixture must not be replaced by another drain/sort/rebuild workaround. It is now separately tracked as an owned two-list merge/cursor capability gap.
+
+### Validation
+
+Docs/tracking validation:
+
 - `cargo fmt --check` PASS
 - `git diff --check` PASS
 

--- a/issues/leetcode-0148-owned-merge-sort-blocker-2026-04-24.md
+++ b/issues/leetcode-0148-owned-merge-sort-blocker-2026-04-24.md
@@ -1,0 +1,59 @@
+# LeetCode 0148 Owned Merge Sort Blocker
+
+Status: open
+Owner: ad_hoc_leetcode_divergence_closure
+Source phase: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
+Tracked from: WS4 canonical rewrite debt
+
+## Fixture
+
+- `audits/leetcode/0148_sort_list.sifr`
+
+## Required Canonical Shape
+
+`0148_sort_list` should be a linked-list merge sort over `ListNode` chains:
+
+- preserve the `ListNode | None -> ListNode | None` public model,
+- split the owned chain into two subchains,
+- recursively sort both halves,
+- merge sorted chains by moving/relinking owned nodes,
+- avoid draining to `list[int]`, calling `sorted`, or rebuilding from a sorted array.
+
+## Current Blocker
+
+The Sifr checker currently rejects the two-list owned merge helper needed by the canonical rewrite. A minimized shape is:
+
+```python
+def mergeNodes(own mut left: ListNode, own mut right: ListNode) -> ListNode:
+    if left.val <= right.val:
+        left_next: ListNode | None = left.next
+        if left_next is None:
+            left.next = right
+            return left
+        left.next = mergeNodes(left_next, right)
+        return left
+
+    right_next: ListNode | None = right.next
+    if right_next is None:
+        right.next = left
+        return right
+    right.next = mergeNodes(left, right_next)
+    return right
+```
+
+`cargo run -q -p sifr -- check audits/leetcode/0148_sort_list.sifr` reports moved-value errors for `left` / `right` when both owned nodes can be moved in sibling branches. Rewriting the helper to use optional parameters, early returns, or branch-local value reads still leaves the same ownership false positives.
+
+## Closure Rule
+
+Do not replace this with another drain/sort/rebuild workaround. Close this issue only when either:
+
+- owned two-list merge can be expressed and compiled safely, or
+- an approved helper/stdlib abstraction provides the same ownership transfer semantics without interior mutability or shared mutable aliases.
+
+## Validation Needed When Fixed
+
+- `python3 audits/leetcode/0148_sort_list.py`
+- `cargo run -q -p sifr -- check audits/leetcode/0148_sort_list.sifr`
+- `cargo run -q -p sifr -- run audits/leetcode/0148_sort_list.sifr`
+- `python3 scripts/scan_leetcode_pair_diffs.py --output verification/leetcode/leetcode_pair_diff_scan_<YYYYMMDD>.json --top 80`
+- `scripts/run_all_tests.sh --profile quick`


### PR DESCRIPTION
## Summary
- Add a dedicated issue note for the remaining `0148_sort_list` canonical merge-sort blocker.
- Record that single-chain owned rewrites are working, but two-list owned merge still hits moved-value false positives.
- Mark the blocker as a capability gap rather than replacing it with another drain/sort/rebuild workaround.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`