### PR TITLE
Remediate WS6 silent fallback helpers

### DIFF
--- a/audits/leetcode/0084_largest_rectangle_in_histogram.sifr
+++ b/audits/leetcode/0084_largest_rectangle_in_histogram.sifr
@@ -1,21 +1,5 @@
 # LeetCode 84: Largest Rectangle In Histogram
 
-def pairIndex(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[0]
-    if value is None:
-        return 0
-    return value
-
-def pairHeight(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[1]
-    if value is None:
-        return 0
-    return value
-
 def largestRectangleArea(heights: list[int]) -> int:
     maxArea = 0
     stack = []  # pair: (index, height)
@@ -24,8 +8,8 @@ def largestRectangleArea(heights: list[int]) -> int:
         start = i
         while stack and stack[-1][1] > h:
             pair = stack.pop()
-            index = pairIndex(pair)
-            height = pairHeight(pair)
+            index = pair[0]
+            height = pair[1]
             maxArea = max(maxArea, height * (i - index))
             start = index
         stack.append((start, h))

--- a/audits/leetcode/0332_reconstruct_itinerary.sifr
+++ b/audits/leetcode/0332_reconstruct_itinerary.sifr
@@ -1,20 +1,13 @@
 # LeetCode 332: Reconstruct Itinerary
 
-def unwrapStr(own value: str | None) -> str:
-    if value is None:
-        return ""
-    return value
-
 def findItinerary(tickets: list[tuple[str, str]]) -> list[str]:
     ordered: list[tuple[str, str]] = tickets[:]
     ordered.sort()
 
     adj: dict[str, list[str]] = {}
     for ticket in ordered:
-        src = unwrapStr(ticket[0])
-        dst = unwrapStr(ticket[1])
-        if src == "" or dst == "":
-            continue
+        src = ticket[0]
+        dst = ticket[1]
         values = adj.get(src, [])
         values.append(dst)
         adj[src] = values
@@ -22,18 +15,14 @@ def findItinerary(tickets: list[tuple[str, str]]) -> list[str]:
     route: list[str] = []
     stack: list[str] = ['JFK']
     while stack:
-        src = unwrapStr(stack.pop())
-        if src == "":
-            continue
+        src = stack.pop()
         values = adj.get(src, [])
         if len(values) == 0:
             route.append(src)
             continue
         stack.append(str(src))
-        next_stop = unwrapStr(values[0])
+        next_stop = values[0]
         adj[src] = values[1:]
-        if next_stop == "":
-            continue
         stack.append(str(next_stop))
 
     route.reverse()

--- a/audits/leetcode/0735_asteroid_collision.sifr
+++ b/audits/leetcode/0735_asteroid_collision.sifr
@@ -1,17 +1,12 @@
 # LeetCode 735: Asteroid Collision
 
-def unwrapInt(value: int | None) -> int:
-    if value is None:
-        return 0
-    return value
-
 def asteroidCollision(asteroids: list[int]) -> list[int]:
     stack: list[int] = []
 
     for a in asteroids:
         alive = True
         while alive and a < 0 and len(stack) > 0:
-            top_val = unwrapInt(stack.pop())
+            top_val = stack.pop()
 
             if top_val < 0:
                 stack.append(top_val)

--- a/audits/leetcode/0739_daily_temperatures.sifr
+++ b/audits/leetcode/0739_daily_temperatures.sifr
@@ -1,21 +1,5 @@
 # LeetCode 739: Daily Temperatures
 
-def pairTemp(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[0]
-    if value is None:
-        return 0
-    return value
-
-def pairIndex(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[1]
-    if value is None:
-        return 0
-    return value
-
 def dailyTemperatures(temperatures: list[int]) -> list[int]:
     res = [0] * len(temperatures)
     stack = []  # pair: [temp, index]
@@ -23,7 +7,7 @@ def dailyTemperatures(temperatures: list[int]) -> list[int]:
     for i, t in enumerate(temperatures):
         while stack and t > stack[-1][0]:
             pair = stack.pop()
-            stackInd = pairIndex(pair)
+            stackInd = pair[1]
             res[stackInd] = i - stackInd
         stack.append((t, i))
     return res

--- a/audits/leetcode/0838_push_dominoes.sifr
+++ b/audits/leetcode/0838_push_dominoes.sifr
@@ -1,44 +1,26 @@
 # LeetCode 838: Push Dominoes
 
-def pairIndex(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[0]
-    if value is None:
-        return 0
-    return value
-
-def pairDirection(pair: tuple[int, int] | None) -> int:
-    if pair is None:
-        return 0
-    value = pair[1]
-    if value is None:
-        return 0
-    return value
-
 def pushDominoes(dominoes: str) -> str:
     dom = list(dominoes)
-    q: list[tuple[int, int]] = []
+    q: list[tuple[int, str]] = []
     for i, d in enumerate(dom):
-        if d == 'L':
-            q.append((i, -1))
-        elif d == 'R':
-            q.append((i, 1))
+        if d != '.':
+            q.append((i, d))
     
     while len(q) > 0:
         pair0 = q.pop(0)
-        i = pairIndex(pair0)
-        d = pairDirection(pair0)
+        i = pair0[0]
+        d = pair0[1]
 
-        if d == -1 and i > 0 and dom[i - 1] == '.':
-            q.append((i - 1, -1))
+        if d == 'L' and i > 0 and dom[i - 1] == '.':
+            q.append((i - 1, 'L'))
             dom[i - 1] = 'L'
-        elif d == 1:
+        elif d == 'R':
             if i + 1 < len(dom) and dom[i + 1] == '.':
                 if i + 2 < len(dom) and dom[i + 2] == 'L':
                     _ = q.pop(0)
                 else:
-                    q.append((i + 1, 1))
+                    q.append((i + 1, 'R'))
                     dom[i + 1] = 'R'
 
     return ''.join(dom)

--- a/audits/leetcode/0895_maximum_frequency_stack.sifr
+++ b/audits/leetcode/0895_maximum_frequency_stack.sifr
@@ -1,10 +1,5 @@
 # LeetCode 895: Maximum Frequency Stack
 
-def unwrapInt(value: int | None) -> int:
-    if value is None:
-        return 0
-    return value
-
 class FreqStack:
     cnt: dict[int, int]
     maxCnt: int
@@ -31,7 +26,7 @@ class FreqStack:
         if len(stack) == 0:
             return 0
 
-        res = unwrapInt(stack.pop())
+        res = stack.pop()
         stack_len = len(stack)
         self.stacks[self.maxCnt] = stack
 

--- a/audits/leetcode/1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero.sifr
+++ b/audits/leetcode/1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero.sifr
@@ -1,29 +1,12 @@
 # LeetCode 1466: Reorder Routes To Make All Paths Lead To The City Zero
 
-def tupleFirst(edge: tuple[int, int]) -> int:
-    value = edge[0]
-    if value is None:
-        return 0
-    return value
-
-def tupleSecond(edge: tuple[int, int]) -> int:
-    value = edge[1]
-    if value is None:
-        return 0
-    return value
-
-def unwrapInt(value: int | None) -> int:
-    if value is None:
-        return -1
-    return value
-
 def minReorder(n: int, connections: list[tuple[int, int]]) -> int:
     edges: set[tuple[int, int]] = set()
     neighbors: dict[int, list[int]] = {}
 
     for edge in connections:
-        a = tupleFirst(edge)
-        b = tupleSecond(edge)
+        a = edge[0]
+        b = edge[1]
         edges.add((a, b))
         if a in neighbors:
             neighbors[a].append(b)
@@ -39,9 +22,7 @@ def minReorder(n: int, connections: list[tuple[int, int]]) -> int:
     stack: list[int] = [0]
 
     while stack:
-        city = unwrapInt(stack.pop())
-        if city < 0:
-            continue
+        city = stack.pop()
         city_neighbors = neighbors.get(city, [])
         for neighbor in city_neighbors:
             if neighbor in visit:

--- a/crates/sifr/tests/e2e/pass/optional_tuple_string_projection.sifr
+++ b/crates/sifr/tests/e2e/pass/optional_tuple_string_projection.sifr
@@ -1,0 +1,6 @@
+def main():
+    values: list[tuple[int, str]] = [(1, "L")]
+    while values:
+        item = values.pop(0)
+        direction: str = item[1]
+        assert direction == "L"

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1082,10 +1082,24 @@ impl RustEmitter {
                 ) {
                     return Ok(None);
                 }
-                let Some(inner_expr) = build_inner_index(crate::RustExpr::Ident("__v".to_string()))
+                let Some(mut inner_expr) =
+                    build_inner_index(crate::RustExpr::Ident("__v".to_string()))
                 else {
                     return Ok(None);
                 };
+                if let (Type::Tuple(elements), HirExpr::IntLiteral(raw_idx)) = (inner_ty, index) {
+                    if let Ok(idx) = usize::try_from(*raw_idx) {
+                        if let Some(element_ty) = elements.get(idx) {
+                            if !crate::helpers::is_copy_type_for_codegen(element_ty) {
+                                inner_expr = crate::RustExpr::MethodCall {
+                                    receiver: Box::new(inner_expr),
+                                    method: "clone".to_string(),
+                                    args: vec![],
+                                };
+                            }
+                        }
+                    }
+                }
                 let projection_method = if matches!(inner_ty, Type::Tuple(_)) {
                     "map"
                 } else {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -4177,9 +4177,16 @@ impl RustEmitter {
 fn supports_nonempty_pop_narrowing_type_for_codegen(object_ty: &Type) -> bool {
     match crate::resolve_alias_type_for_plain_call(object_ty) {
         Type::List(_) => true,
-        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
+        Type::Class { name, .. } => is_deque_class_name_for_codegen(name),
         _ => false,
     }
+}
+
+fn is_deque_class_name_for_codegen(name: &str) -> bool {
+    name == "deque"
+        || name
+            .rsplit_once('.')
+            .is_some_and(|(_, tail)| tail == "deque")
 }
 
 fn is_narrowable_pop_call_for_codegen(method: &str, args: &[HirExpr]) -> bool {

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -76,9 +76,16 @@ fn canonical_plain_call_name_for_ir(func: &str) -> &str {
 fn supports_nonempty_pop_narrowing_type_for_ir(object_ty: &Type) -> bool {
     match crate::resolve_alias_type_for_plain_call(object_ty) {
         Type::List(_) => true,
-        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
+        Type::Class { name, .. } => is_deque_class_name_for_ir(name),
         _ => false,
     }
+}
+
+fn is_deque_class_name_for_ir(name: &str) -> bool {
+    name == "deque"
+        || name
+            .rsplit_once('.')
+            .is_some_and(|(_, tail)| tail == "deque")
 }
 
 fn is_narrowable_pop_call_for_ir(method: &str, args: &[HirExpr]) -> bool {

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -29,7 +29,9 @@ use super::method_call_args::{
     validate_dict_update_arg, validate_list_extend_arg, validate_set_iterable_arg,
 };
 use super::min_max_validation::validate_variadic_min_max_operands;
-use super::mutating_methods::reject_immutable_parameter_method_mutation;
+use super::mutating_methods::{
+    invalidate_collection_flow_facts_for_method, reject_immutable_parameter_method_mutation,
+};
 use super::nonempty_method_narrowing::refine_nonempty_method_return_type;
 use super::numeric_sentinels::{
     float_sentinel_expr, float_sentinel_kind_from_call, lower_sentinel_expr_for_name_domain,
@@ -2548,6 +2550,7 @@ pub(super) fn lower_method_call(
         &resolve_method_type(&object_ty, &method_name, &args, ctx)?,
         ctx,
     );
+    invalidate_collection_flow_facts_for_method(ctx, &object, &object_ty, &method_name);
     if matches!(object_ty.resolve_alias(), Type::Str) && method_name == "encode" {
         let mut intrinsic_args = vec![object];
         let intrinsic_name = if args.is_empty() {

--- a/crates/sifr_hir/src/lower/mutating_methods.rs
+++ b/crates/sifr_hir/src/lower/mutating_methods.rs
@@ -25,7 +25,6 @@ pub(super) fn reject_immutable_parameter_method_mutation(
         }
     }
 
-    invalidate_collection_flow_facts_for_method(ctx, object, object_ty, method);
     false
 }
 

--- a/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
+++ b/crates/sifr_hir/src/lower/nonempty_method_narrowing.rs
@@ -52,7 +52,7 @@ fn sequence_guard_name_from_hir_expr(expr: &HirExpr) -> Option<String> {
 fn supports_nonempty_pop_narrowing_on_type(object_ty: &Type) -> bool {
     match object_ty.resolve_alias() {
         Type::List(_) => true,
-        Type::Class { name, .. } => name == "deque" || name.ends_with(".deque"),
+        Type::Class { name, .. } => is_deque_class_name(name),
         _ => false,
     }
 }
@@ -60,7 +60,7 @@ fn supports_nonempty_pop_narrowing_on_type(object_ty: &Type) -> bool {
 fn nonempty_pop_element_type(object_ty: &Type) -> Option<Type> {
     match object_ty.resolve_alias() {
         Type::List(elem) => Some(*elem.clone()),
-        Type::Class { name, fields, .. } if name == "deque" || name.ends_with(".deque") => {
+        Type::Class { name, fields, .. } if is_deque_class_name(name) => {
             fields.iter().find_map(|(field_name, field_ty)| {
                 if field_name != "_data" {
                     return None;
@@ -73,6 +73,13 @@ fn nonempty_pop_element_type(object_ty: &Type) -> Option<Type> {
         }
         _ => None,
     }
+}
+
+fn is_deque_class_name(name: &str) -> bool {
+    name == "deque"
+        || name
+            .rsplit_once('.')
+            .is_some_and(|(_, tail)| tail == "deque")
 }
 
 fn is_narrowable_pop_call(method_name: &str, args: &[HirExpr]) -> bool {

--- a/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
+++ b/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
@@ -1,10 +1,24 @@
 # LeetCode WS6 Silent-Fallback Remediation
 
-Status: ready_to_implement
+Status: in_review
 Owner: ad_hoc_leetcode_divergence_closure_followup
 Source phase: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
 Source PR: `https://github.com/yaseralnajjar/sifr/pull/1632`
+Remediation PR: `https://github.com/yaseralnajjar/sifr/pull/1635`
 Created: 2026-04-25
+
+## Progress
+
+2026-04-25 code remediation:
+
+- Removed silent tuple-projection fallback helpers from `0084_largest_rectangle_in_histogram`.
+- Removed silent tuple-projection fallback helpers from `0739_daily_temperatures`.
+- Restored `0838_push_dominoes` to canonical `tuple[int, str]` queue entries using `'L'` / `'R'`.
+- Removed silent stack/tuple fallback helpers from `0332_reconstruct_itinerary`, `0735_asteroid_collision`, `0895_maximum_frequency_stack`, and `1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero`.
+- Fixed HIR non-empty pop narrowing invalidation order so the `pop` result can use the pre-call non-empty proof while the sequence facts are still invalidated for later statements.
+- Fixed codegen for constant-index projection of non-Copy fields from optional tuples by cloning the projected field when the tuple is accessed through `Option.as_ref()`.
+- Added `crates/sifr/tests/e2e/pass/optional_tuple_string_projection.sifr`.
+- Full corpus rerun artifact: `verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json` with `208 PASS`, `203 NO_ORACLE`, and no `CHECK_ERROR`, `RUN_ERROR`, or `TIMEOUT`.
 
 ## Problem
 
@@ -59,10 +73,12 @@ Use one of these approaches instead:
 1. Add a proof-gated non-empty pop narrowing rule.
    - Covers stack/queue patterns in `0084`, `0232`, `0735`, `0739`, `0838`, `0895`, `1046`, and `1466`.
    - Must invalidate on intervening collection mutation, rebinding, or calls that can alias-mutate the collection.
+   - Partially closed for direct non-empty guarded `pop` / `pop(0)` sites in `0084`, `0332`, `0735`, `0739`, `0838`, `0895`, and `1466`; `0232`, `1046`, `0103`, `0513`, and `1609` still need valid-operation precondition, post-pop length decrement, or snapshot-length queue proofs.
 
 2. Add fixed tuple constant-index projection narrowing.
    - Covers tuple stack/queue patterns in `0084`, `0739`, `0838`, and `1466`.
    - Constant in-range tuple projection should produce the declared element type; dynamic tuple indexes can remain optional.
+   - Partially closed for `0084`, `0332`, `0739`, `0838`, and `1466`.
 
 3. Close recursive node field projection gaps.
    - Covers `0103`, `0513`, and `1609`.
@@ -70,7 +86,7 @@ Use one of these approaches instead:
 
 4. Restore `0838_push_dominoes` to a canonical direction representation if compiler support allows it.
    - Prefer `tuple[int, str]` with `'L'` / `'R'` over encoded `-1` / `1`.
-   - If current string tuple codegen cannot safely move/project the value, track that as part of the tuple projection work.
+   - Closed by the 2026-04-25 codegen and fixture remediation.
 
 5. Reassess `0023_merge_k_sorted_lists`.
    - Current fixture restores the `ListNode` public model and heap ordering, but it heaps values and recursively appends the result chain.

--- a/verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json
+++ b/verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json
@@ -1,0 +1,16068 @@
+{
+  "command_prefix": [
+    "./target/release/sifr"
+  ],
+  "manifest": "verification/leetcode/full_corpus_manifest_20260402_live.json",
+  "output": "verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json",
+  "phase": 31,
+  "results": [
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0001_two_sum",
+      "id": "0001",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0001_two_sum.sifr"
+          ],
+          "duration_ms": 526,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0001_two_sum.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2e2abf919893d2b9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2e2abf919893d2b9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0002_add_two_numbers",
+      "id": "0002",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0002_add_two_numbers.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0002_add_two_numbers.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=476527b5d33e3d76 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/476527b5d33e3d76",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0003_longest_substring_without_repeating_characters",
+      "id": "0003",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "hash_map",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0003_longest_substring_without_repeating_characters.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0003_longest_substring_without_repeating_characters.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f9b7f2f22eda7f1e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f9b7f2f22eda7f1e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0004_median_of_two_sorted_arrays",
+      "id": "0004",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0004_median_of_two_sorted_arrays.sifr"
+          ],
+          "duration_ms": 133,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0004_median_of_two_sorted_arrays.sifr"
+          ],
+          "duration_ms": 236,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=be80a56892ff11ec cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/be80a56892ff11ec",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0005_longest_palindromic_substring",
+      "id": "0005",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0005_longest_palindromic_substring.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0005_longest_palindromic_substring.sifr"
+          ],
+          "duration_ms": 212,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0f497c85ddb48006 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0f497c85ddb48006",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0006_zigzag_conversion",
+      "id": "0006",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0006_zigzag_conversion.sifr"
+          ],
+          "duration_ms": 156,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0006_zigzag_conversion.sifr"
+          ],
+          "duration_ms": 212,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ab2eeb0fe818d10c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ab2eeb0fe818d10c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0007_reverse_integer",
+      "id": "0007",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "math",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0007_reverse_integer.sifr"
+          ],
+          "duration_ms": 147,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0007_reverse_integer.sifr"
+          ],
+          "duration_ms": 242,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b7fa117ccff5bb82 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b7fa117ccff5bb82",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0009_palindrome_number",
+      "id": "0009",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "math",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0009_palindrome_number.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0009_palindrome_number.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0eed5c269005c722 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0eed5c269005c722",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0010_regular_expression_matching",
+      "id": "0010",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0010_regular_expression_matching.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0010_regular_expression_matching.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=773c4b44ee16f7a8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/773c4b44ee16f7a8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0011_container_with_most_water",
+      "id": "0011",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0011_container_with_most_water.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0011_container_with_most_water.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=1d008d4fb028df2d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1d008d4fb028df2d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0012_integer_to_roman",
+      "id": "0012",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0012_integer_to_roman.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0012_integer_to_roman.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d9ba2ad2efe9a264 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d9ba2ad2efe9a264",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0013_roman_to_integer",
+      "id": "0013",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0013_roman_to_integer.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0013_roman_to_integer.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=692fc3369ded29e8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/692fc3369ded29e8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0014_longest_common_prefix",
+      "id": "0014",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0014_longest_common_prefix.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0014_longest_common_prefix.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=62ccdd9b52507e0e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/62ccdd9b52507e0e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0014_longest_common_prefix_v2",
+      "id": "0014",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0014_longest_common_prefix_v2.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0014_longest_common_prefix_v2.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=62ccdd9b52507e0e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/62ccdd9b52507e0e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0015_3sum",
+      "id": "0015",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "two_pointers_sliding_window",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0015_3sum.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0015_3sum.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b5a242145a113bde cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b5a242145a113bde",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0016_3sum_closest",
+      "id": "0016",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0016_3sum_closest.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0016_3sum_closest.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e07787deacac5e53 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e07787deacac5e53",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0017_letter_combinations_of_a_phone_number",
+      "id": "0017",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "backtracking",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0017_letter_combinations_of_a_phone_number.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0017_letter_combinations_of_a_phone_number.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d0456e3c5cf74845 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d0456e3c5cf74845",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0018_4sum",
+      "id": "0018",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0018_4sum.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0018_4sum.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d606892c3c831eab cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d606892c3c831eab",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0019_remove_nth_node_from_end_of_list",
+      "id": "0019",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0019_remove_nth_node_from_end_of_list.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0019_remove_nth_node_from_end_of_list.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=404fa081063022f2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/404fa081063022f2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0020_valid_parentheses",
+      "id": "0020",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0020_valid_parentheses.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0020_valid_parentheses.sifr"
+          ],
+          "duration_ms": 721,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9e276c6ac64ddbe0 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9e276c6ac64ddbe0 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0021_merge_two_sorted_lists",
+      "id": "0021",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0021_merge_two_sorted_lists.sifr"
+          ],
+          "duration_ms": 142,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0021_merge_two_sorted_lists.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6aac0c837e878f3e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6aac0c837e878f3e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0022_generate_parentheses",
+      "id": "0022",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0022_generate_parentheses.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0022_generate_parentheses.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=353c23c1d332be57 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/353c23c1d332be57",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0023_merge_k_sorted_lists",
+      "id": "0023",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0023_merge_k_sorted_lists.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0023_merge_k_sorted_lists.sifr"
+          ],
+          "duration_ms": 738,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3db26de83feddffa cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3db26de83feddffa miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0024_swap_nodes_in_pairs",
+      "id": "0024",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0024_swap_nodes_in_pairs.sifr"
+          ],
+          "duration_ms": 136,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0024_swap_nodes_in_pairs.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b63552dde00dc153 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b63552dde00dc153",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0025_reverse_nodes_in_k_group",
+      "id": "0025",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0025_reverse_nodes_in_k_group.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0025_reverse_nodes_in_k_group.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b6dbef95b61a571c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b6dbef95b61a571c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0026_remove_duplicates_from_sorted_array",
+      "id": "0026",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0026_remove_duplicates_from_sorted_array.sifr"
+          ],
+          "duration_ms": 139,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0026_remove_duplicates_from_sorted_array.sifr"
+          ],
+          "duration_ms": 278,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=35bca41f7253aa76 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/35bca41f7253aa76",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0027_remove_element",
+      "id": "0027",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0027_remove_element.sifr"
+          ],
+          "duration_ms": 160,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0027_remove_element.sifr"
+          ],
+          "duration_ms": 283,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2d456503c011f3c7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2d456503c011f3c7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0028_find_the_index_of_the_first_occurrence_in_a_string",
+      "id": "0028",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0028_find_the_index_of_the_first_occurrence_in_a_string.sifr"
+          ],
+          "duration_ms": 131,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0028_find_the_index_of_the_first_occurrence_in_a_string.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f92dae5231840e0d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f92dae5231840e0d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0033_search_in_rotated_sorted_array",
+      "id": "0033",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0033_search_in_rotated_sorted_array.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0033_search_in_rotated_sorted_array.sifr"
+          ],
+          "duration_ms": 279,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=57c99d258be60616 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/57c99d258be60616",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0034_find_first_and_last_position_of_element_in_sorted_array",
+      "id": "0034",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0034_find_first_and_last_position_of_element_in_sorted_array.sifr"
+          ],
+          "duration_ms": 196,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0034_find_first_and_last_position_of_element_in_sorted_array.sifr"
+          ],
+          "duration_ms": 213,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d4252dceb94aea22 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d4252dceb94aea22",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0035_search_insert_position",
+      "id": "0035",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0035_search_insert_position.sifr"
+          ],
+          "duration_ms": 128,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0035_search_insert_position.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a3603977ba64e607 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a3603977ba64e607",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0036_valid_sudoku",
+      "id": "0036",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0036_valid_sudoku.sifr"
+          ],
+          "duration_ms": 129,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0036_valid_sudoku.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9b522546d20c280c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9b522546d20c280c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0039_combination_sum",
+      "id": "0039",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "backtracking",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0039_combination_sum.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0039_combination_sum.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f4a7952037258cde cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f4a7952037258cde",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0040_combination_sum_ii",
+      "id": "0040",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0040_combination_sum_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0040_combination_sum_ii.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4366ed8a6a3b8c95 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4366ed8a6a3b8c95",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0041_first_missing_positive",
+      "id": "0041",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0041_first_missing_positive.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0041_first_missing_positive.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=2132974cfbb193fe cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2132974cfbb193fe",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "hard",
+      "failure_stage": null,
+      "fixture_slug": "0042_trapping_rain_water",
+      "id": "0042",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "two_pointers_sliding_window",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0042_trapping_rain_water.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0042_trapping_rain_water.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bae3d3ad0946f60c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bae3d3ad0946f60c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0043_multiply_strings",
+      "id": "0043",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0043_multiply_strings.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0043_multiply_strings.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=c324c90eee00e2cc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c324c90eee00e2cc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0044_wildcard_matching",
+      "id": "0044",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0044_wildcard_matching.sifr"
+          ],
+          "duration_ms": 128,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0044_wildcard_matching.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=89899d9a0c0659af cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/89899d9a0c0659af",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0045_jump_game_ii",
+      "id": "0045",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0045_jump_game_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0045_jump_game_ii.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=dacd440dca42e699 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dacd440dca42e699",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0045_jump_game_ii_v2",
+      "id": "0045",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0045_jump_game_ii_v2.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0045_jump_game_ii_v2.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ccf879dfc141c971 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ccf879dfc141c971",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0046_permutations",
+      "id": "0046",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0046_permutations.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0046_permutations.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=139a8ddb781a6257 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/139a8ddb781a6257",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0047_permutations_ii",
+      "id": "0047",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0047_permutations_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0047_permutations_ii.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=34322182a0e89c24 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/34322182a0e89c24",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0048_rotate_image",
+      "id": "0048",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0048_rotate_image.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0048_rotate_image.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6379e28c548ce09e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6379e28c548ce09e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0049_group_anagrams",
+      "id": "0049",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0049_group_anagrams.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0049_group_anagrams.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=71ef672fc58242d3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/71ef672fc58242d3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0050_powx_n",
+      "id": "0050",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "math",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0050_powx_n.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0050_powx_n.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=34701068ef069f80 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/34701068ef069f80",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0051_n_queens",
+      "id": "0051",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0051_n_queens.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0051_n_queens.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0c4b40bc20c207ab cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0c4b40bc20c207ab",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "hard",
+      "failure_stage": null,
+      "fixture_slug": "0052_n_queens_ii",
+      "id": "0052",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "backtracking",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0052_n_queens_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0052_n_queens_ii.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=18479ad1f09d0929 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/18479ad1f09d0929",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0053_maximum_subarray",
+      "id": "0053",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0053_maximum_subarray.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0053_maximum_subarray.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f2a488bb185e8f26 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f2a488bb185e8f26",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0053_maximum_subarray_v2",
+      "id": "0053",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0053_maximum_subarray_v2.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0053_maximum_subarray_v2.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bae2f438eddd6b64 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bae2f438eddd6b64",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0054_spiral_matrix",
+      "id": "0054",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0054_spiral_matrix.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0054_spiral_matrix.sifr"
+          ],
+          "duration_ms": 198,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=570b3ae679831625 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/570b3ae679831625",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0055_jump_game",
+      "id": "0055",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0055_jump_game.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0055_jump_game.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f564a8d1cc8b3c61 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f564a8d1cc8b3c61",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0055_jump_game_v2",
+      "id": "0055",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0055_jump_game_v2.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0055_jump_game_v2.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=70678e6aa58eb8c5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/70678e6aa58eb8c5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0056_merge_intervals",
+      "id": "0056",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0056_merge_intervals.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0056_merge_intervals.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a0002e57cc502d41 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a0002e57cc502d41",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0057_insert_interval",
+      "id": "0057",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0057_insert_interval.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0057_insert_interval.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a19666d2aef2ac99 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a19666d2aef2ac99",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0058_length_of_last_word",
+      "id": "0058",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0058_length_of_last_word.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0058_length_of_last_word.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=15b334f65a512975 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/15b334f65a512975",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0058_length_of_last_word_v2",
+      "id": "0058",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0058_length_of_last_word_v2.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0058_length_of_last_word_v2.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5e5eb040b2aa6ac7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5e5eb040b2aa6ac7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0061_rotate_list",
+      "id": "0061",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0061_rotate_list.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0061_rotate_list.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=07a1b1690b45a561 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/07a1b1690b45a561",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0062_unique_paths",
+      "id": "0062",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0062_unique_paths.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0062_unique_paths.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=39c4933d32579806 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/39c4933d32579806",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0063_unique_paths_ii",
+      "id": "0063",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0063_unique_paths_ii.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0063_unique_paths_ii.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=129694004f925f18 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/129694004f925f18",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0064_minimum_path_sum",
+      "id": "0064",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0064_minimum_path_sum.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0064_minimum_path_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e4f9a22df9cc545d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e4f9a22df9cc545d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0066_plus_one",
+      "id": "0066",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0066_plus_one.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0066_plus_one.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=256e64eb86207566 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/256e64eb86207566",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0067_add_binary",
+      "id": "0067",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0067_add_binary.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0067_add_binary.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c37f6638db56eeac cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c37f6638db56eeac",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0068_text_justification",
+      "id": "0068",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0068_text_justification.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0068_text_justification.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=201dde66bf350030 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/201dde66bf350030",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0069_sqrtx",
+      "id": "0069",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "math",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0069_sqrtx.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0069_sqrtx.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=466981a5de7fab85 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/466981a5de7fab85",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0070_climbing_stairs",
+      "id": "0070",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0070_climbing_stairs.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0070_climbing_stairs.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d4e6c13260b32f7e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d4e6c13260b32f7e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0071_simplify_path",
+      "id": "0071",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0071_simplify_path.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0071_simplify_path.sifr"
+          ],
+          "duration_ms": 733,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4b7ec36daa3f2473 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4b7ec36daa3f2473 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0072_edit_distance",
+      "id": "0072",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0072_edit_distance.sifr"
+          ],
+          "duration_ms": 140,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0072_edit_distance.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cf9ea7476c192d4d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cf9ea7476c192d4d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0073_set_matrix_zeroes",
+      "id": "0073",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0073_set_matrix_zeroes.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0073_set_matrix_zeroes.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=032c45670c072649 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/032c45670c072649",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0074_search_a_2d_matrix",
+      "id": "0074",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0074_search_a_2d_matrix.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0074_search_a_2d_matrix.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6a7bb021a3b73dea cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6a7bb021a3b73dea",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0075_sort_colors",
+      "id": "0075",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0075_sort_colors.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0075_sort_colors.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ff3b0649ccdac1d4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ff3b0649ccdac1d4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0076_minimum_window_substring",
+      "id": "0076",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0076_minimum_window_substring.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0076_minimum_window_substring.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d3f91b37ffe8c051 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d3f91b37ffe8c051",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0077_combinations",
+      "id": "0077",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0077_combinations.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0077_combinations.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f160e3880ddcc0f3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f160e3880ddcc0f3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0078_subsets",
+      "id": "0078",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "backtracking",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0078_subsets.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0078_subsets.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=468aa3de4ca628d7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/468aa3de4ca628d7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0079_word_search",
+      "id": "0079",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0079_word_search.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0079_word_search.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=44202bba671cf33e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/44202bba671cf33e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0080_remove_duplicates_from_sorted_array_ii",
+      "id": "0080",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0080_remove_duplicates_from_sorted_array_ii.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0080_remove_duplicates_from_sorted_array_ii.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f8727463899b3dd9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f8727463899b3dd9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0081_search_in_rotated_sorted_array_ii",
+      "id": "0081",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0081_search_in_rotated_sorted_array_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0081_search_in_rotated_sorted_array_ii.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fb495ea603be9fdc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fb495ea603be9fdc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0083_remove_duplicates_from_sorted_list",
+      "id": "0083",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0083_remove_duplicates_from_sorted_list.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0083_remove_duplicates_from_sorted_list.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b53f99ae3c9b4770 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b53f99ae3c9b4770",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0084_largest_rectangle_in_histogram",
+      "id": "0084",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0084_largest_rectangle_in_histogram.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0084_largest_rectangle_in_histogram.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=341582e60149a445 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/341582e60149a445",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0086_partition_list",
+      "id": "0086",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0086_partition_list.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0086_partition_list.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=684ccb5e2dc351eb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/684ccb5e2dc351eb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0088_merge_sorted_array",
+      "id": "0088",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0088_merge_sorted_array.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0088_merge_sorted_array.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=33f1dba13f57da0e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/33f1dba13f57da0e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0090_subsets_ii",
+      "id": "0090",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "backtracking",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0090_subsets_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0090_subsets_ii.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=671ab63f80d929b9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/671ab63f80d929b9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0091_decode_ways",
+      "id": "0091",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0091_decode_ways.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\nunreachable statement at block index 5 was ignored\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0091_decode_ways.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\nunreachable statement at block index 5 was ignored\n[sifr-artifact-cache] namespace=run key=1be17e7cb85dd21a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1be17e7cb85dd21a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0092_reverse_linked_list_ii",
+      "id": "0092",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0092_reverse_linked_list_ii.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0092_reverse_linked_list_ii.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9eea07a8d30d0b53 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9eea07a8d30d0b53",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0094_binary_tree_inorder_traversal",
+      "id": "0094",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0094_binary_tree_inorder_traversal.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0094_binary_tree_inorder_traversal.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a16258bee0704a23 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a16258bee0704a23",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0097_interleaving_string",
+      "id": "0097",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0097_interleaving_string.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0097_interleaving_string.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d4add541f4e52d23 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d4add541f4e52d23",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0098_validate_binary_search_tree",
+      "id": "0098",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0098_validate_binary_search_tree.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0098_validate_binary_search_tree.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c6f071a4dd9a9599 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c6f071a4dd9a9599",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0100_same_tree",
+      "id": "0100",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "trees",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0100_same_tree.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0100_same_tree.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b261f088305497a7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b261f088305497a7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0101_symmetric_tree",
+      "id": "0101",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0101_symmetric_tree.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0101_symmetric_tree.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ce71db3add748c53 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ce71db3add748c53",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0102_binary_tree_level_order_traversal",
+      "id": "0102",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "trees",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0102_binary_tree_level_order_traversal.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0102_binary_tree_level_order_traversal.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=813e2bb223eb4b84 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/813e2bb223eb4b84",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0103_binary_tree_zigzag_level_order_traversal",
+      "id": "0103",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0103_binary_tree_zigzag_level_order_traversal.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0103_binary_tree_zigzag_level_order_traversal.sifr"
+          ],
+          "duration_ms": 745,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d34e0bda6e86f250 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d34e0bda6e86f250 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0104_maximum_depth_of_binary_tree",
+      "id": "0104",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0104_maximum_depth_of_binary_tree.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0104_maximum_depth_of_binary_tree.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5b991f91c1f3707a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5b991f91c1f3707a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0105_construct_binary_tree_from_preorder_and_inorder_traversal",
+      "id": "0105",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0105_construct_binary_tree_from_preorder_and_inorder_traversal.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0105_construct_binary_tree_from_preorder_and_inorder_traversal.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=439afc30e5964047 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/439afc30e5964047",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0106_construct_binary_tree_from_inorder_and_postorder_traversal",
+      "id": "0106",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0106_construct_binary_tree_from_inorder_and_postorder_traversal.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0106_construct_binary_tree_from_inorder_and_postorder_traversal.sifr"
+          ],
+          "duration_ms": 234,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c15f6fe8db8639f8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c15f6fe8db8639f8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0108_convert_sorted_array_to_binary_search_tree",
+      "id": "0108",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0108_convert_sorted_array_to_binary_search_tree.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0108_convert_sorted_array_to_binary_search_tree.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6593bf019e7303e7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6593bf019e7303e7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0110_balanced_binary_tree",
+      "id": "0110",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "trees",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0110_balanced_binary_tree.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0110_balanced_binary_tree.sifr"
+          ],
+          "duration_ms": 234,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=16849dc265989117 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/16849dc265989117",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0112_path_sum",
+      "id": "0112",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0112_path_sum.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0112_path_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cc460e3b8228f9be cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cc460e3b8228f9be",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0115_distinct_subsequences",
+      "id": "0115",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0115_distinct_subsequences.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0115_distinct_subsequences.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cd5032a72e3e4225 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cd5032a72e3e4225",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0118_pascals_triangle",
+      "id": "0118",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0118_pascals_triangle.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0118_pascals_triangle.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e112160f8fe45f87 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e112160f8fe45f87",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0119_pascal_triangle_ii",
+      "id": "0119",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0119_pascal_triangle_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0119_pascal_triangle_ii.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=17fc320b4a41b128 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/17fc320b4a41b128",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0120_triangle",
+      "id": "0120",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0120_triangle.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0120_triangle.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a3823cacb5caf036 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a3823cacb5caf036",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0121_best_time_to_buy_and_sell_stock",
+      "id": "0121",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0121_best_time_to_buy_and_sell_stock.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0121_best_time_to_buy_and_sell_stock.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0318955a4a566d8a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0318955a4a566d8a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0121_best_time_to_buy_and_sell_stock_v2",
+      "id": "0121",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0121_best_time_to_buy_and_sell_stock_v2.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0121_best_time_to_buy_and_sell_stock_v2.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7a4ee72542b2627f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7a4ee72542b2627f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0122_best_time_to_buy_and_sell_stock_ii",
+      "id": "0122",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0122_best_time_to_buy_and_sell_stock_ii.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0122_best_time_to_buy_and_sell_stock_ii.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=25d4c3f3d8bcce99 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/25d4c3f3d8bcce99",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0124_binary_tree_maximum_path_sum",
+      "id": "0124",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0124_binary_tree_maximum_path_sum.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0124_binary_tree_maximum_path_sum.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=eefcce65e4ceea85 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/eefcce65e4ceea85",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0125_valid_palindrome",
+      "id": "0125",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0125_valid_palindrome.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0125_valid_palindrome.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1f0f5a6252e560d9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1f0f5a6252e560d9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "hard",
+      "failure_stage": null,
+      "fixture_slug": "0127_word_ladder",
+      "id": "0127",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "graphs",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0127_word_ladder.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0127_word_ladder.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=89aa1650400b34e4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/89aa1650400b34e4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0128_longest_consecutive_sequence",
+      "id": "0128",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0128_longest_consecutive_sequence.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0128_longest_consecutive_sequence.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d45a456e47632fcc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d45a456e47632fcc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0130_surrounded_regions",
+      "id": "0130",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0130_surrounded_regions.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0130_surrounded_regions.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=59d5d4f39f258b8e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/59d5d4f39f258b8e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0131_palindrome_partitioning",
+      "id": "0131",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0131_palindrome_partitioning.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0131_palindrome_partitioning.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ee02a536cdd7463b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ee02a536cdd7463b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0133_clone_graph",
+      "id": "0133",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0133_clone_graph.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0133_clone_graph.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=28a4adcf6e5f8444 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/28a4adcf6e5f8444",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0134_gas_station",
+      "id": "0134",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0134_gas_station.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0134_gas_station.sifr"
+          ],
+          "duration_ms": 196,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=650a7ff89dada564 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/650a7ff89dada564",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0134_gas_station_v2",
+      "id": "0134",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0134_gas_station_v2.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0134_gas_station_v2.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b776a05174090b32 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b776a05174090b32",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0135_candy",
+      "id": "0135",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0135_candy.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0135_candy.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ff7b02bfc01da61d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ff7b02bfc01da61d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0136_single_number",
+      "id": "0136",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0136_single_number.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0136_single_number.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bf6babb1df17c2dd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bf6babb1df17c2dd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0138_copy_list_with_random_pointer",
+      "id": "0138",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0138_copy_list_with_random_pointer.sifr"
+          ],
+          "duration_ms": 115,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0138_copy_list_with_random_pointer.sifr"
+          ],
+          "duration_ms": 196,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=350dd1b6bff523ef cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/350dd1b6bff523ef",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0139_word_break",
+      "id": "0139",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0139_word_break.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0139_word_break.sifr"
+          ],
+          "duration_ms": 196,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7bfbf770dd6feb04 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7bfbf770dd6feb04",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0141_linked_list_cycle",
+      "id": "0141",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0141_linked_list_cycle.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0141_linked_list_cycle.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6df7d0b008ed78df cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6df7d0b008ed78df",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0143_reorder_list",
+      "id": "0143",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0143_reorder_list.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0143_reorder_list.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bb7050db4ef6aa83 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bb7050db4ef6aa83",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0144_binary_tree_preorder_traversal",
+      "id": "0144",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0144_binary_tree_preorder_traversal.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0144_binary_tree_preorder_traversal.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7044cca603abf6a7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7044cca603abf6a7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0145_binary_tree_postorder_traversal",
+      "id": "0145",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0145_binary_tree_postorder_traversal.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0145_binary_tree_postorder_traversal.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=abdc8e40eb7ca151 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/abdc8e40eb7ca151",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0146_lru_cache",
+      "id": "0146",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0146_lru_cache.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0146_lru_cache.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=eba7973ac5f2cdc6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/eba7973ac5f2cdc6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0147_insertion_sort_list",
+      "id": "0147",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0147_insertion_sort_list.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0147_insertion_sort_list.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=48f1887b2023dfb3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/48f1887b2023dfb3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0148_sort_list",
+      "id": "0148",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0148_sort_list.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0148_sort_list.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=44d773bc3076d5f5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/44d773bc3076d5f5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0149_max_points_on_a_line",
+      "id": "0149",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0149_max_points_on_a_line.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0149_max_points_on_a_line.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=53e89746aab4c428 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/53e89746aab4c428",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0150_evaluate_reverse_polish_notation",
+      "id": "0150",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0150_evaluate_reverse_polish_notation.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0150_evaluate_reverse_polish_notation.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=9d4335edb6cdd96b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9d4335edb6cdd96b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0151_reverse_words_in_a_string",
+      "id": "0151",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0151_reverse_words_in_a_string.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0151_reverse_words_in_a_string.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9228157167a6e471 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9228157167a6e471",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0152_maximum_product_subarray",
+      "id": "0152",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0152_maximum_product_subarray.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0152_maximum_product_subarray.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=c6e5f3b6ef632d1f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c6e5f3b6ef632d1f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0152_maximum_product_subarray_v2",
+      "id": "0152",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0152_maximum_product_subarray_v2.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0152_maximum_product_subarray_v2.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=e1f34273dd5135a0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e1f34273dd5135a0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0153_find_minimum_in_rotated_sorted_array",
+      "id": "0153",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0153_find_minimum_in_rotated_sorted_array.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0153_find_minimum_in_rotated_sorted_array.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0703f99add896659 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0703f99add896659",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0155_min_stack",
+      "id": "0155",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0155_min_stack.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0155_min_stack.sifr"
+          ],
+          "duration_ms": 658,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a71b135335f7a662 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a71b135335f7a662 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0160_intersection_of_two_linked_lists",
+      "id": "0160",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0160_intersection_of_two_linked_lists.sifr"
+          ],
+          "duration_ms": 141,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0160_intersection_of_two_linked_lists.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1138795b1e8cd987 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1138795b1e8cd987",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0162_find_peak_element",
+      "id": "0162",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0162_find_peak_element.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0162_find_peak_element.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=292040a6341a2365 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/292040a6341a2365",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0167_two_sum_ii_input_array_is_sorted",
+      "id": "0167",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0167_two_sum_ii_input_array_is_sorted.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0167_two_sum_ii_input_array_is_sorted.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7529cc6d0a6a8f4b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7529cc6d0a6a8f4b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0168_excel_sheet_column_title",
+      "id": "0168",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0168_excel_sheet_column_title.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0168_excel_sheet_column_title.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c69da2d6800c16e0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c69da2d6800c16e0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0169_majority_element",
+      "id": "0169",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0169_majority_element.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0169_majority_element.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=333ef03febd4ee71 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/333ef03febd4ee71",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0169_majority_element_v2",
+      "id": "0169",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0169_majority_element_v2.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0169_majority_element_v2.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7bf175cf3be13823 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7bf175cf3be13823",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0179_largest_number",
+      "id": "0179",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0179_largest_number.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0179_largest_number.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=056a846d29dd04fa cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/056a846d29dd04fa",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0187_repeated_dna_sequences",
+      "id": "0187",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0187_repeated_dna_sequences.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0187_repeated_dna_sequences.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4785ac0d9262ed1d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4785ac0d9262ed1d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0189_rotate_array",
+      "id": "0189",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0189_rotate_array.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0189_rotate_array.sifr"
+          ],
+          "duration_ms": 637,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3e10b87deddc4327 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3e10b87deddc4327 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0190_reverse_bits",
+      "id": "0190",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0190_reverse_bits.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0190_reverse_bits.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\n[sifr-artifact-cache] namespace=run key=041268b74a19ce80 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/041268b74a19ce80",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0191_number_of_1_bits",
+      "id": "0191",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0191_number_of_1_bits.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0191_number_of_1_bits.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=598c90db832b5a38 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/598c90db832b5a38",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0198_house_robber",
+      "id": "0198",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0198_house_robber.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0198_house_robber.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=79446ca9063098b5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/79446ca9063098b5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0198_house_robber_v2",
+      "id": "0198",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0198_house_robber_v2.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0198_house_robber_v2.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6d606b7d5be46d86 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6d606b7d5be46d86",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0199_binary_tree_right_side_view",
+      "id": "0199",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0199_binary_tree_right_side_view.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0199_binary_tree_right_side_view.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=39dac7dbba64ff12 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/39dac7dbba64ff12",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0200_number_of_islands",
+      "id": "0200",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0200_number_of_islands.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0200_number_of_islands.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=677b7e25103936e3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/677b7e25103936e3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0201_bitwise_and_of_numbers_range",
+      "id": "0201",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0201_bitwise_and_of_numbers_range.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0201_bitwise_and_of_numbers_range.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\n[sifr-artifact-cache] namespace=run key=fa37aeecb4a2396f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fa37aeecb4a2396f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0202_happy_number",
+      "id": "0202",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0202_happy_number.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0202_happy_number.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ae0453bde66c69b6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ae0453bde66c69b6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0203_remove_linked_list_elements",
+      "id": "0203",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0203_remove_linked_list_elements.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0203_remove_linked_list_elements.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=63d1d8684993c398 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/63d1d8684993c398",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0205_isomorphic_strings",
+      "id": "0205",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0205_isomorphic_strings.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0205_isomorphic_strings.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5611bfdac1e5c2b3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5611bfdac1e5c2b3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0206_reverse_linked_list",
+      "id": "0206",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0206_reverse_linked_list.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0206_reverse_linked_list.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0ed266929808d9a7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0ed266929808d9a7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0207_course_schedule",
+      "id": "0207",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "graphs",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0207_course_schedule.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0207_course_schedule.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4a93a58b43750ec2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4a93a58b43750ec2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0208_implement_trie_prefix_tree",
+      "id": "0208",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0208_implement_trie_prefix_tree.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0208_implement_trie_prefix_tree.sifr"
+          ],
+          "duration_ms": 213,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=16aee46848551f5c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/16aee46848551f5c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0209_minimum_size_subarray_sum",
+      "id": "0209",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "two_pointers_sliding_window",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0209_minimum_size_subarray_sum.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0209_minimum_size_subarray_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fed40e9ec3a7541f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fed40e9ec3a7541f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0210_course_schedule_ii",
+      "id": "0210",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0210_course_schedule_ii.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0210_course_schedule_ii.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=41d96eedd8d18494 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/41d96eedd8d18494",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0211_design_add_and_search_words_data_structure",
+      "id": "0211",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0211_design_add_and_search_words_data_structure.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0211_design_add_and_search_words_data_structure.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=24d0f3568ecbf4e0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/24d0f3568ecbf4e0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0212_word_search_ii",
+      "id": "0212",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0212_word_search_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0212_word_search_ii.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=740260f5db2db639 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/740260f5db2db639",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0213_house_robber_ii",
+      "id": "0213",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0213_house_robber_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0213_house_robber_ii.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f5638587f426e839 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f5638587f426e839",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0215_kth_largest_element_in_an_array",
+      "id": "0215",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "heap_priority_queue",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0215_kth_largest_element_in_an_array.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0215_kth_largest_element_in_an_array.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=acc19203c4c63810 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/acc19203c4c63810",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0217_contains_duplicate",
+      "id": "0217",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "hash_map",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0217_contains_duplicate.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0217_contains_duplicate.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c7526fc2a7a2a04b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c7526fc2a7a2a04b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0219_contains_duplicate_ii",
+      "id": "0219",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0219_contains_duplicate_ii.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0219_contains_duplicate_ii.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=441f6166840a94ba cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/441f6166840a94ba",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0221_maximal_square",
+      "id": "0221",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0221_maximal_square.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0221_maximal_square.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=dcb3e6d4736ba9ef cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dcb3e6d4736ba9ef",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0225_implement_stack_using_queues",
+      "id": "0225",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0225_implement_stack_using_queues.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0225_implement_stack_using_queues.sifr"
+          ],
+          "duration_ms": 647,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=270a5e51858d7cf1 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/270a5e51858d7cf1 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0226_invert_binary_tree",
+      "id": "0226",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "trees",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0226_invert_binary_tree.sifr"
+          ],
+          "duration_ms": 138,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0226_invert_binary_tree.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3d3c97451cd8a053 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3d3c97451cd8a053",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0230_kth_smallest_element_in_a_bst",
+      "id": "0230",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0230_kth_smallest_element_in_a_bst.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0230_kth_smallest_element_in_a_bst.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1cb26baa00687987 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1cb26baa00687987",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0231_power_of_two",
+      "id": "0231",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0231_power_of_two.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0231_power_of_two.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=75499c2f8c476146 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/75499c2f8c476146",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0232_implement_queue_using_stacks",
+      "id": "0232",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0232_implement_queue_using_stacks.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0232_implement_queue_using_stacks.sifr"
+          ],
+          "duration_ms": 666,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4b1e2ea242a80d3f cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4b1e2ea242a80d3f miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0234_palindrome_linked_list",
+      "id": "0234",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0234_palindrome_linked_list.sifr"
+          ],
+          "duration_ms": 130,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0234_palindrome_linked_list.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c70f96099674aba6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c70f96099674aba6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0235_lowest_common_ancestor_of_a_binary_search_tree",
+      "id": "0235",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "trees",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0235_lowest_common_ancestor_of_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0235_lowest_common_ancestor_of_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=73d032217c83002d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/73d032217c83002d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0236_lowest_common_ancestor_of_a_binary_tree",
+      "id": "0236",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0236_lowest_common_ancestor_of_a_binary_tree.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0236_lowest_common_ancestor_of_a_binary_tree.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ede3c987aa1b40c8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ede3c987aa1b40c8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0238_product_of_array_except_self",
+      "id": "0238",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0238_product_of_array_except_self.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0238_product_of_array_except_self.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=f93c78c245c90792 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f93c78c245c90792",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0238_product_of_array_except_self_v2",
+      "id": "0238",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0238_product_of_array_except_self_v2.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0238_product_of_array_except_self_v2.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=b879165159ea77db cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b879165159ea77db",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0239_sliding_window_maximum",
+      "id": "0239",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0239_sliding_window_maximum.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0239_sliding_window_maximum.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=04a96e27abc73a78 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/04a96e27abc73a78",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0241_different_ways_to_add_parentheses",
+      "id": "0241",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0241_different_ways_to_add_parentheses.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0241_different_ways_to_add_parentheses.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=093b726401a38616 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/093b726401a38616",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0242_valid_anagram",
+      "id": "0242",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "hash_map",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0242_valid_anagram.sifr"
+          ],
+          "duration_ms": 131,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0242_valid_anagram.sifr"
+          ],
+          "duration_ms": 238,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f7c6c3d261ccae33 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f7c6c3d261ccae33",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0252_meeting_rooms",
+      "id": "0252",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0252_meeting_rooms.sifr"
+          ],
+          "duration_ms": 132,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0252_meeting_rooms.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=86303d0b8bc28fcc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/86303d0b8bc28fcc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0253_meeting_rooms",
+      "id": "0253",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0253_meeting_rooms.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0253_meeting_rooms.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1bb60dbde49403f9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1bb60dbde49403f9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0253_meeting_rooms_ii",
+      "id": "0253",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0253_meeting_rooms_ii.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0253_meeting_rooms_ii.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e3af931077f62508 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e3af931077f62508",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0261_graph_valid_tree",
+      "id": "0261",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0261_graph_valid_tree.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0261_graph_valid_tree.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=75cc8e7ccfc6ebb2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/75cc8e7ccfc6ebb2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0263_ugly_number",
+      "id": "0263",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0263_ugly_number.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0263_ugly_number.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cbe34dc4933f0fbd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cbe34dc4933f0fbd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0268_missing_number",
+      "id": "0268",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0268_missing_number.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0268_missing_number.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3f0097a6b38c0f2a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3f0097a6b38c0f2a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0269_alien_dictionary",
+      "id": "0269",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0269_alien_dictionary.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0269_alien_dictionary.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3a6192e839520615 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3a6192e839520615",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0271_encode_and_decode_strings",
+      "id": "0271",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0271_encode_and_decode_strings.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0271_encode_and_decode_strings.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=df01467189582b7d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/df01467189582b7d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0274_H_index",
+      "id": "0274",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0274_H_index.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0274_H_index.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1dcce223f419e38a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1dcce223f419e38a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0278_first_bad_version",
+      "id": "0278",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0278_first_bad_version.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0278_first_bad_version.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=04bb795961b1c13c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/04bb795961b1c13c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0280_wiggle_sort",
+      "id": "0280",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0280_wiggle_sort.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0280_wiggle_sort.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=79d7ef3a3984e52b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/79d7ef3a3984e52b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0283_move_zeroes",
+      "id": "0283",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0283_move_zeroes.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0283_move_zeroes.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=704dcc8e33389101 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/704dcc8e33389101",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0286_walls_and_gates",
+      "id": "0286",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0286_walls_and_gates.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0286_walls_and_gates.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=673370730d4d2f43 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/673370730d4d2f43",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0287_find_the_duplicate_number",
+      "id": "0287",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0287_find_the_duplicate_number.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0287_find_the_duplicate_number.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c88be4d83a749256 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c88be4d83a749256",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0290_word_pattern",
+      "id": "0290",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0290_word_pattern.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0290_word_pattern.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=712cbf92e48ebec1 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/712cbf92e48ebec1",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "hard",
+      "failure_stage": null,
+      "fixture_slug": "0295_find_median_from_data_stream",
+      "id": "0295",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "heap_priority_queue",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0295_find_median_from_data_stream.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0295_find_median_from_data_stream.sifr"
+          ],
+          "duration_ms": 689,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c49e8d8faa8a3405 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c49e8d8faa8a3405 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0297_serialize_and_deserialize_binary_tree",
+      "id": "0297",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0297_serialize_and_deserialize_binary_tree.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0297_serialize_and_deserialize_binary_tree.sifr"
+          ],
+          "duration_ms": 788,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=c45da4957eb05662 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c45da4957eb05662 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0300_longest_increasing_subsequence",
+      "id": "0300",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0300_longest_increasing_subsequence.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0300_longest_increasing_subsequence.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5fc3c58d78083bd4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5fc3c58d78083bd4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0300_longest_increasing_subsequence_v2",
+      "id": "0300",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0300_longest_increasing_subsequence_v2.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0300_longest_increasing_subsequence_v2.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=003f71fe210b13c2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/003f71fe210b13c2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0303_range_sum_query_immutable",
+      "id": "0303",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0303_range_sum_query_immutable.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0303_range_sum_query_immutable.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ab6de16e886a1fbf cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ab6de16e886a1fbf",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0304_range_sum_query_2d_immutable",
+      "id": "0304",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0304_range_sum_query_2d_immutable.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0304_range_sum_query_2d_immutable.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c29256424b2ebe07 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c29256424b2ebe07",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0309_best_time_to_buy_and_sell_stock_with_cooldown",
+      "id": "0309",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0309_best_time_to_buy_and_sell_stock_with_cooldown.sifr"
+          ],
+          "duration_ms": 150,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0309_best_time_to_buy_and_sell_stock_with_cooldown.sifr"
+          ],
+          "duration_ms": 289,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6737c6020b8230b6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6737c6020b8230b6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0312_burst_balloons",
+      "id": "0312",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0312_burst_balloons.sifr"
+          ],
+          "duration_ms": 162,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0312_burst_balloons.sifr"
+          ],
+          "duration_ms": 224,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=1391f16ba343c76a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1391f16ba343c76a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0322_coin_change",
+      "id": "0322",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0322_coin_change.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0322_coin_change.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=693456f3e3222211 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/693456f3e3222211",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0323_number_of_connected_components_in_an_undirected_graph",
+      "id": "0323",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0323_number_of_connected_components_in_an_undirected_graph.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0323_number_of_connected_components_in_an_undirected_graph.sifr"
+          ],
+          "duration_ms": 221,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c0dde12f6f301fe7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c0dde12f6f301fe7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0329_longest_increasing_path_in_a_matrix",
+      "id": "0329",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0329_longest_increasing_path_in_a_matrix.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0329_longest_increasing_path_in_a_matrix.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=21e8e52e2d685223 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/21e8e52e2d685223",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0332_reconstruct_itinerary",
+      "id": "0332",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0332_reconstruct_itinerary.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0332_reconstruct_itinerary.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=615bdf981f8d5feb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/615bdf981f8d5feb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0334_increasing_triplet_subsequence",
+      "id": "0334",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0334_increasing_triplet_subsequence.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0334_increasing_triplet_subsequence.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0c25437a7ba6e39c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0c25437a7ba6e39c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0338_counting_bits",
+      "id": "0338",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0338_counting_bits.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0338_counting_bits.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1810a69dcbb6eb36 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1810a69dcbb6eb36",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0344_reverse_string",
+      "id": "0344",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0344_reverse_string.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0344_reverse_string.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3db5b781a45e2f26 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3db5b781a45e2f26",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0347_top_k_frequent_elements",
+      "id": "0347",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0347_top_k_frequent_elements.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0347_top_k_frequent_elements.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7563cf8601eccb8e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7563cf8601eccb8e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0349_intersection_of_two_arrays",
+      "id": "0349",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0349_intersection_of_two_arrays.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0349_intersection_of_two_arrays.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=8bd7983681f67a47 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8bd7983681f67a47",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0350_intersection_of_two_arrays_ii",
+      "id": "0350",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0350_intersection_of_two_arrays_ii.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0350_intersection_of_two_arrays_ii.sifr"
+          ],
+          "duration_ms": 213,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a638c9243f51282b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a638c9243f51282b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0355_design_twitter",
+      "id": "0355",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0355_design_twitter.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0355_design_twitter.sifr"
+          ],
+          "duration_ms": 227,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2f44bc12ce15a3d3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2f44bc12ce15a3d3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0367_valid_perfect_square",
+      "id": "0367",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0367_valid_perfect_square.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0367_valid_perfect_square.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=e2ae0f0a52f20da3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e2ae0f0a52f20da3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0371_sum_of_two_integers",
+      "id": "0371",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0371_sum_of_two_integers.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0371_sum_of_two_integers.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=3456f68757f17fb8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3456f68757f17fb8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0374_guess_number_higher_or_lower",
+      "id": "0374",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0374_guess_number_higher_or_lower.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0374_guess_number_higher_or_lower.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c5511a7ea4207ddf cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c5511a7ea4207ddf",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0377_combination_sum_iv",
+      "id": "0377",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0377_combination_sum_iv.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0377_combination_sum_iv.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\n[sifr-artifact-cache] namespace=run key=bb7edd5a24a1e8ae cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bb7edd5a24a1e8ae",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0380_insert_delete_getrandom_o1",
+      "id": "0380",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0380_insert_delete_getrandom_o1.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0380_insert_delete_getrandom_o1.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=575c457187a830ee cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/575c457187a830ee",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0383_ransom_note",
+      "id": "0383",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0383_ransom_note.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0383_ransom_note.sifr"
+          ],
+          "duration_ms": 214,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1a38400aba5b4fb4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1a38400aba5b4fb4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0392_is_subsequence",
+      "id": "0392",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0392_is_subsequence.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0392_is_subsequence.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fdfd25daff5fae6b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fdfd25daff5fae6b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0394_decode_string",
+      "id": "0394",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0394_decode_string.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0394_decode_string.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7c203062b13c67f3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7c203062b13c67f3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0402_remove_k_digits",
+      "id": "0402",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0402_remove_k_digits.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0402_remove_k_digits.sifr"
+          ],
+          "duration_ms": 712,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2f3af7aeaf32bd3c cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2f3af7aeaf32bd3c miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0410_split_array_largest_sum",
+      "id": "0410",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0410_split_array_largest_sum.sifr"
+          ],
+          "duration_ms": 141,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0410_split_array_largest_sum.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3869d511db01d988 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3869d511db01d988",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0416_partition_equal_subset_sum",
+      "id": "0416",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0416_partition_equal_subset_sum.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0416_partition_equal_subset_sum.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fad99b1bbbca3a52 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fad99b1bbbca3a52",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0417_pacific_atlantic_water_flow",
+      "id": "0417",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0417_pacific_atlantic_water_flow.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0417_pacific_atlantic_water_flow.sifr"
+          ],
+          "duration_ms": 737,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e77603960d97d80c cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e77603960d97d80c miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0424_longest_repeating_character_replacement",
+      "id": "0424",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "two_pointers_sliding_window",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0424_longest_repeating_character_replacement.sifr"
+          ],
+          "duration_ms": 136,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0424_longest_repeating_character_replacement.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ca13391bd5409e72 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ca13391bd5409e72",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0435_non_overlapping_intervals",
+      "id": "0435",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0435_non_overlapping_intervals.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0435_non_overlapping_intervals.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bcb0068f7ef3afaa cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bcb0068f7ef3afaa",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0438_find_all_anagrams_in_a_string",
+      "id": "0438",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0438_find_all_anagrams_in_a_string.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0438_find_all_anagrams_in_a_string.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=8e56bab6f2aa79fa cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8e56bab6f2aa79fa",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0441_arranging_coins",
+      "id": "0441",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0441_arranging_coins.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0441_arranging_coins.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4afcf55c0b9035ee cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4afcf55c0b9035ee",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0442_find_all_duplicates_in_an_array",
+      "id": "0442",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0442_find_all_duplicates_in_an_array.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0442_find_all_duplicates_in_an_array.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9671874a45809db0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9671874a45809db0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0448_find_all_numbers_disappeared_in_an_array",
+      "id": "0448",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0448_find_all_numbers_disappeared_in_an_array.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0448_find_all_numbers_disappeared_in_an_array.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=dd5735f2b9d0b311 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dd5735f2b9d0b311",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0450_delete_node_in_a_bst",
+      "id": "0450",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0450_delete_node_in_a_bst.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0450_delete_node_in_a_bst.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0c71bd40416dc8b4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0c71bd40416dc8b4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0452_minimum_number_of_arrows_to_burst_balloons",
+      "id": "0452",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0452_minimum_number_of_arrows_to_burst_balloons.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0452_minimum_number_of_arrows_to_burst_balloons.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7b89db95a727e9f6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7b89db95a727e9f6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0456_132_pattern",
+      "id": "0456",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0456_132_pattern.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0456_132_pattern.sifr"
+          ],
+          "duration_ms": 671,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=16a30b4dcb1e77e2 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/16a30b4dcb1e77e2 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0459_repeated_substring_pattern",
+      "id": "0459",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0459_repeated_substring_pattern.sifr"
+          ],
+          "duration_ms": 131,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0459_repeated_substring_pattern.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2e5b74ca9c9fdb27 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2e5b74ca9c9fdb27",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0463_island_perimeter",
+      "id": "0463",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0463_island_perimeter.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0463_island_perimeter.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=65261f8a91f411bc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/65261f8a91f411bc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0473_matchsticks_to_square",
+      "id": "0473",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0473_matchsticks_to_square.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0473_matchsticks_to_square.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a4524b52c92d87aa cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a4524b52c92d87aa",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0474_ones_and_zeroes",
+      "id": "0474",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0474_ones_and_zeroes.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0474_ones_and_zeroes.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4eec7722bdefdeb5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4eec7722bdefdeb5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0494_target_sum",
+      "id": "0494",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0494_target_sum.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0494_target_sum.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a77cbf62340471b4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a77cbf62340471b4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0496_next_greater_element_i",
+      "id": "0496",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0496_next_greater_element_i.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0496_next_greater_element_i.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=73b6aab9fb70cadb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/73b6aab9fb70cadb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "hard",
+      "failure_stage": null,
+      "fixture_slug": "0502_ipo",
+      "id": "0502",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "heap_priority_queue",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0502_ipo.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0502_ipo.sifr"
+          ],
+          "duration_ms": 707,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=560cc301aca99fc0 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/560cc301aca99fc0 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0509_fibonacci_number",
+      "id": "0509",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0509_fibonacci_number.sifr"
+          ],
+          "duration_ms": 137,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0509_fibonacci_number.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a7fa2bc8183d565f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a7fa2bc8183d565f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0513_find_bottom_left_tree_value",
+      "id": "0513",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0513_find_bottom_left_tree_value.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0513_find_bottom_left_tree_value.sifr"
+          ],
+          "duration_ms": 702,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ff1ce4072c684429 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ff1ce4072c684429 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0516_longest_palindromic_subsequence",
+      "id": "0516",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0516_longest_palindromic_subsequence.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0516_longest_palindromic_subsequence.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e1c9886c8acca950 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e1c9886c8acca950",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0518_coin_change_ii",
+      "id": "0518",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0518_coin_change_ii.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\nunreachable statement at block index 5 was ignored\nunreachable statement at block index 6 was ignored\nunreachable statement at block index 7 was ignored\nunreachable statement at block index 8 was ignored\nunreachable statement at block index 9 was ignored\nunreachable statement at block index 10 was ignored\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0518_coin_change_ii.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "unreachable statement at block index 3 was ignored\nunreachable statement at block index 4 was ignored\nunreachable statement at block index 5 was ignored\nunreachable statement at block index 6 was ignored\nunreachable statement at block index 7 was ignored\nunreachable statement at block index 8 was ignored\nunreachable statement at block index 9 was ignored\nunreachable statement at block index 10 was ignored\n[sifr-artifact-cache] namespace=run key=f61c085b39d0e0a5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f61c085b39d0e0a5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0523_continuous_subarray_sum",
+      "id": "0523",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "hash_map",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0523_continuous_subarray_sum.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0523_continuous_subarray_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=36a3cfc862b14836 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/36a3cfc862b14836",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0525_contiguous_array",
+      "id": "0525",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0525_contiguous_array.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0525_contiguous_array.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=8eaab65ab0d435e4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8eaab65ab0d435e4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0535_encode_and_decode_tinyurl",
+      "id": "0535",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0535_encode_and_decode_tinyurl.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0535_encode_and_decode_tinyurl.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=dbc3c070d6626d93 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dbc3c070d6626d93",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0540_single_element_in_a_sorted_array",
+      "id": "0540",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0540_single_element_in_a_sorted_array.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0540_single_element_in_a_sorted_array.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a028f0aefed0b6fc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a028f0aefed0b6fc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0543_diameter_of_binary_tree",
+      "id": "0543",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0543_diameter_of_binary_tree.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0543_diameter_of_binary_tree.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9d466af387abd5e3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9d466af387abd5e3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0554_brick_wall",
+      "id": "0554",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0554_brick_wall.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0554_brick_wall.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=deaac62fdb6040b5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/deaac62fdb6040b5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0560_subarray_sum_equals_k",
+      "id": "0560",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "hash_map",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0560_subarray_sum_equals_k.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0560_subarray_sum_equals_k.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=faf953e743fcaa95 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/faf953e743fcaa95",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0567_permutation_in_string",
+      "id": "0567",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0567_permutation_in_string.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0567_permutation_in_string.sifr"
+          ],
+          "duration_ms": 211,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b2cdd9c7ee3f875f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b2cdd9c7ee3f875f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0572_subtree_of_another_tree",
+      "id": "0572",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0572_subtree_of_another_tree.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0572_subtree_of_another_tree.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=eeb4e228effc7dba cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/eeb4e228effc7dba",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0605_can_place_flowers",
+      "id": "0605",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0605_can_place_flowers.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0605_can_place_flowers.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f793501f8935d1c8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f793501f8935d1c8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0605_can_place_flowers_v2",
+      "id": "0605",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0605_can_place_flowers_v2.sifr"
+          ],
+          "duration_ms": 129,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0605_can_place_flowers_v2.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fcf132d0e9c410b0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fcf132d0e9c410b0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0606_construct_string_from_binary_tree",
+      "id": "0606",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0606_construct_string_from_binary_tree.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0606_construct_string_from_binary_tree.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b800913d3d67316f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b800913d3d67316f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0617_merge_two_binary_trees",
+      "id": "0617",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0617_merge_two_binary_trees.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0617_merge_two_binary_trees.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=824b12efa3c93018 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/824b12efa3c93018",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0621_task_scheduler",
+      "id": "0621",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0621_task_scheduler.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0621_task_scheduler.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=3235da99fcc1c710 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3235da99fcc1c710",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0622_design_circular_queue",
+      "id": "0622",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0622_design_circular_queue.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0622_design_circular_queue.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a46a5adb0c09b902 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a46a5adb0c09b902",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0647_palindromic_substrings",
+      "id": "0647",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0647_palindromic_substrings.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0647_palindromic_substrings.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ec8f904b2df66d0c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ec8f904b2df66d0c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0658_find_k_closest_elements",
+      "id": "0658",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0658_find_k_closest_elements.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0658_find_k_closest_elements.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7aaf54d41727f8c3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7aaf54d41727f8c3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0662_maximum_width_of_binary_tree",
+      "id": "0662",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0662_maximum_width_of_binary_tree.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0662_maximum_width_of_binary_tree.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c856def9b339529c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c856def9b339529c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0665_non_decreasing_array",
+      "id": "0665",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0665_non_decreasing_array.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0665_non_decreasing_array.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=47258ed08bcc8d6a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/47258ed08bcc8d6a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0669_trim_a_binary_search_tree",
+      "id": "0669",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0669_trim_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0669_trim_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=25bb0bff7cf85d22 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/25bb0bff7cf85d22",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0673_number_of_longest_increasing_subsequence",
+      "id": "0673",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0673_number_of_longest_increasing_subsequence.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ec758072e3e9652c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ec758072e3e9652c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0678_valid_parenthesis_string",
+      "id": "0678",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0678_valid_parenthesis_string.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0678_valid_parenthesis_string.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=84eabb9fc187d0c8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/84eabb9fc187d0c8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0680_valid_palindrome_ii",
+      "id": "0680",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0680_valid_palindrome_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0680_valid_palindrome_ii.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=47627fd0dd469c1a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/47627fd0dd469c1a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0682_baseball_game",
+      "id": "0682",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0682_baseball_game.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0682_baseball_game.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=fe62a959e7dc7581 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fe62a959e7dc7581",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0684_redundant_connection",
+      "id": "0684",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "graphs",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0684_redundant_connection.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0684_redundant_connection.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a9efd9c05a9a7861 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a9efd9c05a9a7861",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0695_max_area_of_island",
+      "id": "0695",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0695_max_area_of_island.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0695_max_area_of_island.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=23b20b2fdbcf6409 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/23b20b2fdbcf6409",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0698_partition_to_k_equal_sum_subsets",
+      "id": "0698",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0698_partition_to_k_equal_sum_subsets.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0698_partition_to_k_equal_sum_subsets.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7796c2936707761f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7796c2936707761f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0701_insert_into_a_binary_search_tree",
+      "id": "0701",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0701_insert_into_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0701_insert_into_a_binary_search_tree.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=35c5cefe7533e113 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/35c5cefe7533e113",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0703_kth_largest_element_in_a_stream",
+      "id": "0703",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "heap_priority_queue",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0703_kth_largest_element_in_a_stream.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0703_kth_largest_element_in_a_stream.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9bcf54428ee3dd30 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9bcf54428ee3dd30",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0704_binary_search",
+      "id": "0704",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0704_binary_search.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0704_binary_search.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c91d0b0563a1f3c8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c91d0b0563a1f3c8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0704_binary_search_v2",
+      "id": "0704",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0704_binary_search_v2.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0704_binary_search_v2.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=dbd90854954d1f74 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dbd90854954d1f74",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0705_design_hashset",
+      "id": "0705",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0705_design_hashset.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0705_design_hashset.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3f439a84c89d9eba cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3f439a84c89d9eba",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0706_design_hashmap",
+      "id": "0706",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0706_design_hashmap.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0706_design_hashmap.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0f7a41af3b8636d9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0f7a41af3b8636d9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0707_design_linked_list",
+      "id": "0707",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0707_design_linked_list.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0707_design_linked_list.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3b3e29884563295a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3b3e29884563295a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0721_accounts_merge",
+      "id": "0721",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0721_accounts_merge.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0721_accounts_merge.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e62d8abd65f0623e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e62d8abd65f0623e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0724_find_pivot_index",
+      "id": "0724",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0724_find_pivot_index.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0724_find_pivot_index.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f33ef2efb082bfdb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f33ef2efb082bfdb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0729_my_calendar_i",
+      "id": "0729",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0729_my_calendar_i.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0729_my_calendar_i.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d0d35641327fee82 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d0d35641327fee82",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0735_asteroid_collision",
+      "id": "0735",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0735_asteroid_collision.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0735_asteroid_collision.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f4a2a5d4baf25dad cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f4a2a5d4baf25dad",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0739_daily_temperatures",
+      "id": "0739",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0739_daily_temperatures.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0739_daily_temperatures.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=48b49596aac611d8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/48b49596aac611d8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0740_delete_and_earn",
+      "id": "0740",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0740_delete_and_earn.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0740_delete_and_earn.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=984f9a87ad3eda33 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/984f9a87ad3eda33",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0743_network_delay_time",
+      "id": "0743",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "graphs",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0743_network_delay_time.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0743_network_delay_time.sifr"
+          ],
+          "duration_ms": 775,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=67c14320ecb37fed cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/67c14320ecb37fed miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0745_prefix_and_suffix_search",
+      "id": "0745",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0745_prefix_and_suffix_search.sifr"
+          ],
+          "duration_ms": 143,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0745_prefix_and_suffix_search.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bf8c05cb6b38b6e8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bf8c05cb6b38b6e8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0746_min_cost_climbing_stairs",
+      "id": "0746",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0746_min_cost_climbing_stairs.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0746_min_cost_climbing_stairs.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=173265a328296c25 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/173265a328296c25",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0752_open_the_lock",
+      "id": "0752",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0752_open_the_lock.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0752_open_the_lock.sifr"
+          ],
+          "duration_ms": 6635,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=926cc91246104c31 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/926cc91246104c31 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0763_partition_labels",
+      "id": "0763",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0763_partition_labels.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0763_partition_labels.sifr"
+          ],
+          "duration_ms": 198,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=49ada699071e874e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/49ada699071e874e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0767_reorganize_string",
+      "id": "0767",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0767_reorganize_string.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0767_reorganize_string.sifr"
+          ],
+          "duration_ms": 213,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=502fbd27351b61cd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/502fbd27351b61cd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0778_swim_in_rising_water",
+      "id": "0778",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0778_swim_in_rising_water.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0778_swim_in_rising_water.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=715c62379acb40bc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/715c62379acb40bc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0783_minimum_distance_between_bst_nodes",
+      "id": "0783",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0783_minimum_distance_between_bst_nodes.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0783_minimum_distance_between_bst_nodes.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a270092b95da8dfc cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a270092b95da8dfc",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0785_is_graph_bipartite",
+      "id": "0785",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0785_is_graph_bipartite.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0785_is_graph_bipartite.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ed9025d9472035bd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ed9025d9472035bd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0787_cheapest_flights_within_k_stops",
+      "id": "0787",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0787_cheapest_flights_within_k_stops.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0787_cheapest_flights_within_k_stops.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=70303313c31c2687 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/70303313c31c2687",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0791_custom_sort_string",
+      "id": "0791",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0791_custom_sort_string.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0791_custom_sort_string.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d2a24bfb25a73838 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d2a24bfb25a73838",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0802_find_eventual_safe_states",
+      "id": "0802",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0802_find_eventual_safe_states.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0802_find_eventual_safe_states.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b102702a7a33aeb1 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b102702a7a33aeb1",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0838_push_dominoes",
+      "id": "0838",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0838_push_dominoes.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0838_push_dominoes.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=8323eb7368bcb27e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8323eb7368bcb27e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0846_hand_of_straights",
+      "id": "0846",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0846_hand_of_straights.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0846_hand_of_straights.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9912897d951a9744 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9912897d951a9744",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0853_car_fleet",
+      "id": "0853",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0853_car_fleet.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0853_car_fleet.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ef32d8bfef6bc568 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ef32d8bfef6bc568",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0862_shortest_subarray_with_sum_at_least_k",
+      "id": "0862",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0862_shortest_subarray_with_sum_at_least_k.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0862_shortest_subarray_with_sum_at_least_k.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9354f1cfd8a379a0 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9354f1cfd8a379a0",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0875_koko_eating_bananas",
+      "id": "0875",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0875_koko_eating_bananas.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0875_koko_eating_bananas.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=74b2353538d41df7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/74b2353538d41df7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0876_middle_of_the_linked_list",
+      "id": "0876",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0876_middle_of_the_linked_list.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0876_middle_of_the_linked_list.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ec75f6715c48c8e6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ec75f6715c48c8e6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0881_boats_to_save_people",
+      "id": "0881",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0881_boats_to_save_people.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0881_boats_to_save_people.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=402a683ac3da155c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/402a683ac3da155c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0894_all_possible_full_binary_trees",
+      "id": "0894",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0894_all_possible_full_binary_trees.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0894_all_possible_full_binary_trees.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5c9fcfba74c0b7c6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5c9fcfba74c0b7c6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0895_maximum_frequency_stack",
+      "id": "0895",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0895_maximum_frequency_stack.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0895_maximum_frequency_stack.sifr"
+          ],
+          "duration_ms": 228,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7cf9b0977b2cbf84 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7cf9b0977b2cbf84",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0896_monotonic_array",
+      "id": "0896",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0896_monotonic_array.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0896_monotonic_array.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ebc75185eedda37b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ebc75185eedda37b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0901_online_stock_span",
+      "id": "0901",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0901_online_stock_span.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0901_online_stock_span.sifr"
+          ],
+          "duration_ms": 666,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7f572042cb1a3b6a cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7f572042cb1a3b6a miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0904_fruit_into_baskets",
+      "id": "0904",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0904_fruit_into_baskets.sifr"
+          ],
+          "duration_ms": 134,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0904_fruit_into_baskets.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=20a8e4496a90cc42 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/20a8e4496a90cc42",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0909_snakes_and_ladders",
+      "id": "0909",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0909_snakes_and_ladders.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0909_snakes_and_ladders.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=6d771d9bb8f83742 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6d771d9bb8f83742",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0912_sort_an_array",
+      "id": "0912",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0912_sort_an_array.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0912_sort_an_array.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=58df66f4c7544550 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/58df66f4c7544550",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0918_maximum_sum_circular_subarray",
+      "id": "0918",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0918_maximum_sum_circular_subarray.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0918_maximum_sum_circular_subarray.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f29f6ea676a0d0c3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f29f6ea676a0d0c3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0929_unique_email_addresses",
+      "id": "0929",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0929_unique_email_addresses.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0929_unique_email_addresses.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=50c19e53286337c9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/50c19e53286337c9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0930_binary_subarrays_with_sum",
+      "id": "0930",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0930_binary_subarrays_with_sum.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0930_binary_subarrays_with_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=265ae64350c1f300 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/265ae64350c1f300",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0931_minimum_falling_path_sum",
+      "id": "0931",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0931_minimum_falling_path_sum.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0931_minimum_falling_path_sum.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3d1c8f3c59c602b3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3d1c8f3c59c602b3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0946_validate_stack_sequences",
+      "id": "0946",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0946_validate_stack_sequences.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0946_validate_stack_sequences.sifr"
+          ],
+          "duration_ms": 671,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ab8fbf93989cce33 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ab8fbf93989cce33 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0948_bag_of_tokens",
+      "id": "0948",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0948_bag_of_tokens.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0948_bag_of_tokens.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a8173398056e920c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a8173398056e920c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0953_verifying_an_alien_dictionary",
+      "id": "0953",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0953_verifying_an_alien_dictionary.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0953_verifying_an_alien_dictionary.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2fc6487b68970606 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2fc6487b68970606",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0973_k_closest_points_to_origin",
+      "id": "0973",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0973_k_closest_points_to_origin.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0973_k_closest_points_to_origin.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=479db7e61b0cffb3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/479db7e61b0cffb3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0977_squares_of_a_sorted_array",
+      "id": "0977",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0977_squares_of_a_sorted_array.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0977_squares_of_a_sorted_array.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=12b51289b8144e50 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/12b51289b8144e50",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0978_longest_turbulent_subarray",
+      "id": "0978",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0978_longest_turbulent_subarray.sifr"
+          ],
+          "duration_ms": 128,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0978_longest_turbulent_subarray.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=76822cb1ec912c54 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/76822cb1ec912c54",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0981_time_based_key_value_store",
+      "id": "0981",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0981_time_based_key_value_store.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0981_time_based_key_value_store.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=71f866dfa4b31505 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/71f866dfa4b31505",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "0994_rotting_oranges",
+      "id": "0994",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0994_rotting_oranges.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0994_rotting_oranges.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b528451d32e8a267 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b528451d32e8a267",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "0997_find_the_town_judge",
+      "id": "0997",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "graphs",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/0997_find_the_town_judge.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/0997_find_the_town_judge.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cf2aebd346e026f5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cf2aebd346e026f5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1011_capacity_to_ship_packages_within_d_days",
+      "id": "1011",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1011_capacity_to_ship_packages_within_d_days.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1011_capacity_to_ship_packages_within_d_days.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=42214e0d416b515b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/42214e0d416b515b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1020_number_of_enclaves",
+      "id": "1020",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1020_number_of_enclaves.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1020_number_of_enclaves.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b7da09716dfd1b4c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b7da09716dfd1b4c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1029_two_city_scheduling",
+      "id": "1029",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1029_two_city_scheduling.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1029_two_city_scheduling.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7d643726bc43dc81 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7d643726bc43dc81",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "1046_last_stone_weight",
+      "id": "1046",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "heap_priority_queue",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1046_last_stone_weight.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1046_last_stone_weight.sifr"
+          ],
+          "duration_ms": 674,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=c3f7434726d78142 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/c3f7434726d78142 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1049_last_stone_weight_ii",
+      "id": "1049",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1049_last_stone_weight_ii.sifr"
+          ],
+          "duration_ms": 137,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1049_last_stone_weight_ii.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=16e058e4fcbba092 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/16e058e4fcbba092",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1074_number_of_submatrices_that_sum_to_target",
+      "id": "1074",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1074_number_of_submatrices_that_sum_to_target.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1074_number_of_submatrices_that_sum_to_target.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=562c919f17b9f840 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/562c919f17b9f840",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1091_shortest_path_in_binary_matrix",
+      "id": "1091",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1091_shortest_path_in_binary_matrix.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1091_shortest_path_in_binary_matrix.sifr"
+          ],
+          "duration_ms": 197,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9575576aa10cee55 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9575576aa10cee55",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1137_n_th_tribonacci_number",
+      "id": "1137",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1137_n_th_tribonacci_number.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1137_n_th_tribonacci_number.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=cdeaaa00c34c2ff9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/cdeaaa00c34c2ff9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1143_longest_common_subsequence",
+      "id": "1143",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "dp",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1143_longest_common_subsequence.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1143_longest_common_subsequence.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4f66a9f97dcd4d22 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4f66a9f97dcd4d22",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1189_maximum_number_of_balloons",
+      "id": "1189",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1189_maximum_number_of_balloons.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1189_maximum_number_of_balloons.sifr"
+          ],
+          "duration_ms": 219,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a01ed8a1e6105b93 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a01ed8a1e6105b93",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1203_sort_items_by_groups_respecting_dependencies",
+      "id": "1203",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1203_sort_items_by_groups_respecting_dependencies.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1203_sort_items_by_groups_respecting_dependencies.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4eef5fa50ab6f948 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4eef5fa50ab6f948",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1209_remove_all_adjacent_duplicates_in_string_ii",
+      "id": "1209",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1209_remove_all_adjacent_duplicates_in_string_ii.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1209_remove_all_adjacent_duplicates_in_string_ii.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6d2426bd83a8fd01 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6d2426bd83a8fd01",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1220_count_vowels_permutation",
+      "id": "1220",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1220_count_vowels_permutation.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1220_count_vowels_permutation.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=e3c25717f03a2580 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e3c25717f03a2580",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1239_maximum_length_of_a_concatenated_string_with_unique_characters",
+      "id": "1239",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1239_maximum_length_of_a_concatenated_string_with_unique_characters.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1239_maximum_length_of_a_concatenated_string_with_unique_characters.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\n[sifr-artifact-cache] namespace=run key=261d88c95b1b458c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/261d88c95b1b458c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1254_number_of_closed_islands",
+      "id": "1254",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1254_number_of_closed_islands.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1254_number_of_closed_islands.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=53068d1ef6ad6442 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/53068d1ef6ad6442",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1260_shift_2d_grid",
+      "id": "1260",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1260_shift_2d_grid.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1260_shift_2d_grid.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=317196a4ee5042e1 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/317196a4ee5042e1",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1288_remove_covered_intervals",
+      "id": "1288",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1288_remove_covered_intervals.sifr"
+          ],
+          "duration_ms": 128,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1288_remove_covered_intervals.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=87bbfb7a5854911d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/87bbfb7a5854911d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "1299_replace_elements_with_greatest_element_on_right_side",
+      "id": "1299",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1299_replace_elements_with_greatest_element_on_right_side.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1299_replace_elements_with_greatest_element_on_right_side.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bdbbd6aea47d5b58 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bdbbd6aea47d5b58",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1343_number_of_sub_arrays_of_size_k_and_average_greater_than_or_equal_to_threshold",
+      "id": "1343",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1343_number_of_sub_arrays_of_size_k_and_average_greater_than_or_equal_to_threshold.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1343_number_of_sub_arrays_of_size_k_and_average_greater_than_or_equal_to_threshold.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=ab53fa07d837b1ec cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ab53fa07d837b1ec",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1345_jump_game_iv",
+      "id": "1345",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1345_jump_game_iv.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1345_jump_game_iv.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=27a60eb8be63c50a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/27a60eb8be63c50a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1383_maximum_performance_of_a_team",
+      "id": "1383",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1383_maximum_performance_of_a_team.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1383_maximum_performance_of_a_team.sifr"
+          ],
+          "duration_ms": 737,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=8a7f6a1b32000236 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8a7f6a1b32000236 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1396_design_underground_system",
+      "id": "1396",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1396_design_underground_system.sifr"
+          ],
+          "duration_ms": 134,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1396_design_underground_system.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=959835cba40c3af2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/959835cba40c3af2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1397_find_all_good_strings",
+      "id": "1397",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1397_find_all_good_strings.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1397_find_all_good_strings.sifr"
+          ],
+          "duration_ms": 198,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=2084f506108238cd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2084f506108238cd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1423_maximum_points_you_can_obtain_from_cards",
+      "id": "1423",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1423_maximum_points_you_can_obtain_from_cards.sifr"
+          ],
+          "duration_ms": 140,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1423_maximum_points_you_can_obtain_from_cards.sifr"
+          ],
+          "duration_ms": 274,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=71300e6ea173388c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/71300e6ea173388c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1448_count_good_nodes_in_binary_tree",
+      "id": "1448",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1448_count_good_nodes_in_binary_tree.sifr"
+          ],
+          "duration_ms": 132,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1448_count_good_nodes_in_binary_tree.sifr"
+          ],
+          "duration_ms": 231,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=a3ce1794ce47f4d8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/a3ce1794ce47f4d8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1456_maximum_number_of_vowels_in_a_substring_of_given_length",
+      "id": "1456",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "two_pointers_sliding_window",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1456_maximum_number_of_vowels_in_a_substring_of_given_length.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1456_maximum_number_of_vowels_in_a_substring_of_given_length.sifr"
+          ],
+          "duration_ms": 227,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=589514be59e30105 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/589514be59e30105",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1461_check_if_a_string_contains_all_binary_codes_of_size_k",
+      "id": "1461",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1461_check_if_a_string_contains_all_binary_codes_of_size_k.sifr"
+          ],
+          "duration_ms": 133,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int exponentiation (**) with non-constant exponent may overflow i64 at runtime; consider using bigint\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1461_check_if_a_string_contains_all_binary_codes_of_size_k.sifr"
+          ],
+          "duration_ms": 225,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int exponentiation (**) with non-constant exponent may overflow i64 at runtime; consider using bigint\n[sifr-artifact-cache] namespace=run key=6cc9ab8804d49ea6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6cc9ab8804d49ea6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1462_course_schedule_iv",
+      "id": "1462",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1462_course_schedule_iv.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1462_course_schedule_iv.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2e80ef505e960902 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2e80ef505e960902",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1464_maximum_product_of_two_elements_in_an_array",
+      "id": "1464",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1464_maximum_product_of_two_elements_in_an_array.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1464_maximum_product_of_two_elements_in_an_array.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=e61953e3e5ac5466 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e61953e3e5ac5466",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero",
+      "id": "1466",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1466_reorder_routes_to_make_all_paths_lead_to_the_city_zero.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9968c8596bdfc66c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9968c8596bdfc66c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1472_design_browser_history",
+      "id": "1472",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1472_design_browser_history.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1472_design_browser_history.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5caaa2ab33ad1be7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5caaa2ab33ad1be7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1475_final_prices_with_a_special_discount_in_a_shop",
+      "id": "1475",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1475_final_prices_with_a_special_discount_in_a_shop.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1475_final_prices_with_a_special_discount_in_a_shop.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f957368b0f177b09 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f957368b0f177b09",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1481_least_number_of_unique_integers_after_k_removals",
+      "id": "1481",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1481_least_number_of_unique_integers_after_k_removals.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1481_least_number_of_unique_integers_after_k_removals.sifr"
+          ],
+          "duration_ms": 212,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=051c590202094f83 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/051c590202094f83",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1489_find_critical_and_pseudo_critical_edges_in_minimum_spanning_tree",
+      "id": "1489",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1489_find_critical_and_pseudo_critical_edges_in_minimum_spanning_tree.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1489_find_critical_and_pseudo_critical_edges_in_minimum_spanning_tree.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=221762c13eff9977 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/221762c13eff9977",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1498_number_of_subsequences_that_satisfy_the_given_sum_condition",
+      "id": "1498",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1498_number_of_subsequences_that_satisfy_the_given_sum_condition.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1498_number_of_subsequences_that_satisfy_the_given_sum_condition.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\n[sifr-artifact-cache] namespace=run key=138bafbc2de46a43 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/138bafbc2de46a43",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1514_path_with_maximum_probability",
+      "id": "1514",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1514_path_with_maximum_probability.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1514_path_with_maximum_probability.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=dc75e94b9e75ff04 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/dc75e94b9e75ff04",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1523_count_odd_numbers_in_an_interval_range",
+      "id": "1523",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1523_count_odd_numbers_in_an_interval_range.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1523_count_odd_numbers_in_an_interval_range.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b2a4d511cdb1253b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b2a4d511cdb1253b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1572_matrix_diagonal_sum",
+      "id": "1572",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1572_matrix_diagonal_sum.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1572_matrix_diagonal_sum.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3d058d299fa8ac32 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3d058d299fa8ac32",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1582_special_positions_in_a_binary_matrix",
+      "id": "1582",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1582_special_positions_in_a_binary_matrix.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1582_special_positions_in_a_binary_matrix.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=745335fd57492edb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/745335fd57492edb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1584_min_cost_to_connect_all_points",
+      "id": "1584",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1584_min_cost_to_connect_all_points.sifr"
+          ],
+          "duration_ms": 129,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1584_min_cost_to_connect_all_points.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f805a462a87b8ea6 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f805a462a87b8ea6",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1603_design_parking_system",
+      "id": "1603",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1603_design_parking_system.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1603_design_parking_system.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f84c23e14bb6ce4d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f84c23e14bb6ce4d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1609_even_odd_tree",
+      "id": "1609",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1609_even_odd_tree.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1609_even_odd_tree.sifr"
+          ],
+          "duration_ms": 704,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2568032ffcf45ede cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2568032ffcf45ede miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1631_path_with_minimum_effort",
+      "id": "1631",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1631_path_with_minimum_effort.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1631_path_with_minimum_effort.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=1cbc2f533de393d9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1cbc2f533de393d9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1642_furthest_building_you_can_reach",
+      "id": "1642",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1642_furthest_building_you_can_reach.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1642_furthest_building_you_can_reach.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=08db1cbc77173b7b cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/08db1cbc77173b7b",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1658_minimum_operations_to_reduce_x_to_zero",
+      "id": "1658",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1658_minimum_operations_to_reduce_x_to_zero.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1658_minimum_operations_to_reduce_x_to_zero.sifr"
+          ],
+          "duration_ms": 210,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ad41e43a6d05ca8e cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ad41e43a6d05ca8e",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1669_merge_in_between_linked_lists",
+      "id": "1669",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1669_merge_in_between_linked_lists.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1669_merge_in_between_linked_lists.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b3e470a181765525 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b3e470a181765525",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1700_number_of_students_unable_to_eat_lunch",
+      "id": "1700",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1700_number_of_students_unable_to_eat_lunch.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1700_number_of_students_unable_to_eat_lunch.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5d9b56536b7aab58 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5d9b56536b7aab58",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1721_swapping_nodes_in_a_linked_list",
+      "id": "1721",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1721_swapping_nodes_in_a_linked_list.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1721_swapping_nodes_in_a_linked_list.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=70abe7c27a222eea cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/70abe7c27a222eea",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1750_minimum_length_of_string_after_deleting_similar_ends",
+      "id": "1750",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1750_minimum_length_of_string_after_deleting_similar_ends.sifr"
+          ],
+          "duration_ms": 129,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1750_minimum_length_of_string_after_deleting_similar_ends.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=4d702bb705c59393 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/4d702bb705c59393",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "1768_merge_strings_alternately",
+      "id": "1768",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1768_merge_strings_alternately.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1768_merge_strings_alternately.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ccdc096377f9dd97 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ccdc096377f9dd97",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "1768_merge_strings_alternately_v2",
+      "id": "1768",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "strings",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1768_merge_strings_alternately_v2.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1768_merge_strings_alternately_v2.sifr"
+          ],
+          "duration_ms": 209,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=6bef82ba9b49e97d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/6bef82ba9b49e97d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1800_maximum_ascending_subarray_sum",
+      "id": "1800",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1800_maximum_ascending_subarray_sum.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1800_maximum_ascending_subarray_sum.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3726ea91d8436ba1 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3726ea91d8436ba1",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1822_sign_of_the_product_of_an_array",
+      "id": "1822",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1822_sign_of_the_product_of_an_array.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1822_sign_of_the_product_of_an_array.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=df763db52eca8dc5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/df763db52eca8dc5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1834_single_threaded_cpu",
+      "id": "1834",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1834_single_threaded_cpu.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1834_single_threaded_cpu.sifr"
+          ],
+          "duration_ms": 213,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9b0b9abdf5e64e2f cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9b0b9abdf5e64e2f",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1838_frequency_of_the_most_frequent_element",
+      "id": "1838",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1838_frequency_of_the_most_frequent_element.sifr"
+          ],
+          "duration_ms": 130,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1838_frequency_of_the_most_frequent_element.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=1d8d4081295045c4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1d8d4081295045c4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1845_seat_reservation_manager",
+      "id": "1845",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1845_seat_reservation_manager.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1845_seat_reservation_manager.sifr"
+          ],
+          "duration_ms": 708,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=1eb742e689fd16a3 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/1eb742e689fd16a3 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1849_splitting_a_string_into_descending_consecutive_values",
+      "id": "1849",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1849_splitting_a_string_into_descending_consecutive_values.sifr"
+          ],
+          "duration_ms": 138,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1849_splitting_a_string_into_descending_consecutive_values.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=430cfc907b86a111 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/430cfc907b86a111",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1851_minimum_interval_to_include_each_query",
+      "id": "1851",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1851_minimum_interval_to_include_each_query.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1851_minimum_interval_to_include_each_query.sifr"
+          ],
+          "duration_ms": 198,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=9bcb03fb8581ea5c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/9bcb03fb8581ea5c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1888_minimum_number_of_flips_to_make_the_binary_string_alternating",
+      "id": "1888",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1888_minimum_number_of_flips_to_make_the_binary_string_alternating.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1888_minimum_number_of_flips_to_make_the_binary_string_alternating.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=044512693d082efa cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/044512693d082efa",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1899_merge_triplets_to_form_target_triplet",
+      "id": "1899",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1899_merge_triplets_to_form_target_triplet.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1899_merge_triplets_to_form_target_triplet.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=f77cd358dea129e7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/f77cd358dea129e7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1905_count_sub_islands",
+      "id": "1905",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1905_count_sub_islands.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1905_count_sub_islands.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=291921f7c7bb8391 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/291921f7c7bb8391",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1929_concatenation_of_array",
+      "id": "1929",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1929_concatenation_of_array.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1929_concatenation_of_array.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0013bab9c6d22fb4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0013bab9c6d22fb4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1929_concatenation_of_array_v2",
+      "id": "1929",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1929_concatenation_of_array_v2.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1929_concatenation_of_array_v2.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=bedb7e0ea54cf646 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/bedb7e0ea54cf646",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1930_unique_length_3_palindromic_subsequences",
+      "id": "1930",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1930_unique_length_3_palindromic_subsequences.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1930_unique_length_3_palindromic_subsequences.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b5585fadf0f04518 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b5585fadf0f04518",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1958_check_if_move_is_legal",
+      "id": "1958",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1958_check_if_move_is_legal.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1958_check_if_move_is_legal.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=aa3965e013348bb3 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/aa3965e013348bb3",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1963_minimum_number_of_swaps_to_make_the_string_balanced",
+      "id": "1963",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1963_minimum_number_of_swaps_to_make_the_string_balanced.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1963_minimum_number_of_swaps_to_make_the_string_balanced.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=fa4bc805deaf3ebd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/fa4bc805deaf3ebd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1968_array_with_elements_not_equal_to_average_of_neighbors",
+      "id": "1968",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1968_array_with_elements_not_equal_to_average_of_neighbors.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1968_array_with_elements_not_equal_to_average_of_neighbors.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2c36c4b693988bd8 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2c36c4b693988bd8",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1980_find_unique_binary_string",
+      "id": "1980",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1980_find_unique_binary_string.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1980_find_unique_binary_string.sifr"
+          ],
+          "duration_ms": 198,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=5455346847d1cd7a cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5455346847d1cd7a",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1984_minimum_difference_between_highest_and_lowest_of_k_scores",
+      "id": "1984",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1984_minimum_difference_between_highest_and_lowest_of_k_scores.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1984_minimum_difference_between_highest_and_lowest_of_k_scores.sifr"
+          ],
+          "duration_ms": 207,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ba4dabeb434019e4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ba4dabeb434019e4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "1985_find_the_kth_largest_integer_in_the_array",
+      "id": "1985",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/1985_find_the_kth_largest_integer_in_the_array.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/1985_find_the_kth_largest_integer_in_the_array.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=3f213735120579b9 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/3f213735120579b9",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2001_number_of_pairs_of_interchangeable_rectangles",
+      "id": "2001",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2001_number_of_pairs_of_interchangeable_rectangles.sifr"
+          ],
+          "duration_ms": 117,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2001_number_of_pairs_of_interchangeable_rectangles.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=e1724867f385f4dd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/e1724867f385f4dd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2002_maximum_product_of_the_length_of_two_palindromic_subsequences",
+      "id": "2002",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2002_maximum_product_of_the_length_of_two_palindromic_subsequences.sifr"
+          ],
+          "duration_ms": 122,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2002_maximum_product_of_the_length_of_two_palindromic_subsequences.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int left shift (<<) with non-constant shift amount may overflow i64 at runtime; consider using bigint\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=5249095abf9f6353 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/5249095abf9f6353",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2013_detect_squares",
+      "id": "2013",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2013_detect_squares.sifr"
+          ],
+          "duration_ms": 120,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2013_detect_squares.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=573b372d62260ead cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/573b372d62260ead",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2017_grid_game",
+      "id": "2017",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2017_grid_game.sifr"
+          ],
+          "duration_ms": 118,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2017_grid_game.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=791e6e4bcd9e1182 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/791e6e4bcd9e1182",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2092_find_all_people_with_secret",
+      "id": "2092",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2092_find_all_people_with_secret.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2092_find_all_people_with_secret.sifr"
+          ],
+          "duration_ms": 833,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0b45c1b0d96d7bf6 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0b45c1b0d96d7bf6 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2101_detonate_the_maximum_bombs",
+      "id": "2101",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2101_detonate_the_maximum_bombs.sifr"
+          ],
+          "duration_ms": 126,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2101_detonate_the_maximum_bombs.sifr"
+          ],
+          "duration_ms": 722,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nwarning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=2d6c363cc3a4e227 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2d6c363cc3a4e227 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2130_maximum_twin_sum_of_a_linked_list",
+      "id": "2130",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2130_maximum_twin_sum_of_a_linked_list.sifr"
+          ],
+          "duration_ms": 141,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2130_maximum_twin_sum_of_a_linked_list.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=8faa297eb76cd91d cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/8faa297eb76cd91d",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2215_find_the_difference_of_two_arrays",
+      "id": "2215",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2215_find_the_difference_of_two_arrays.sifr"
+          ],
+          "duration_ms": 149,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2215_find_the_difference_of_two_arrays.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7e87761368ff4545 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7e87761368ff4545",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "easy",
+      "failure_stage": null,
+      "fixture_slug": "2235_add_two_integers",
+      "id": "2235",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "math",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2235_add_two_integers.sifr"
+          ],
+          "duration_ms": 124,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2235_add_two_integers.sifr"
+          ],
+          "duration_ms": 204,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=7787112eeefbce2c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/7787112eeefbce2c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2300_successful_pairs_of_spells_and_potions",
+      "id": "2300",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2300_successful_pairs_of_spells_and_potions.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2300_successful_pairs_of_spells_and_potions.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=114971b0a74ff606 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/114971b0a74ff606",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2306_naming_a_company",
+      "id": "2306",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2306_naming_a_company.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2306_naming_a_company.sifr"
+          ],
+          "duration_ms": 202,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=65ed309758b702b4 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/65ed309758b702b4",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2348_number_of_zero_filled_subarrays",
+      "id": "2348",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2348_number_of_zero_filled_subarrays.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2348_number_of_zero_filled_subarrays.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=de4c92dcd355f05c cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/de4c92dcd355f05c",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2390_removing_stars_from_a_string",
+      "id": "2390",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2390_removing_stars_from_a_string.sifr"
+          ],
+          "duration_ms": 119,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2390_removing_stars_from_a_string.sifr"
+          ],
+          "duration_ms": 687,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d321b9d0344b8dc1 cache_hit=false workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d321b9d0344b8dc1 miss_reason=not_found",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2402_meeting_rooms_iii",
+      "id": "2402",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2402_meeting_rooms_iii.sifr"
+          ],
+          "duration_ms": 139,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2402_meeting_rooms_iii.sifr"
+          ],
+          "duration_ms": 206,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=212ca1e96b903ada cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/212ca1e96b903ada",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2405_optimal_partition_of_string",
+      "id": "2405",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2405_optimal_partition_of_string.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2405_optimal_partition_of_string.sifr"
+          ],
+          "duration_ms": 199,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=b09ed7999696dfd2 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/b09ed7999696dfd2",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2482_difference_between_ones_and_zeros_in_row_and_column",
+      "id": "2482",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2482_difference_between_ones_and_zeros_in_row_and_column.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2482_difference_between_ones_and_zeros_in_row_and_column.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=2b8f1319a9f47fbd cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/2b8f1319a9f47fbd",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2483_minimum_penalty_for_a_shop",
+      "id": "2483",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2483_minimum_penalty_for_a_shop.sifr"
+          ],
+          "duration_ms": 125,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2483_minimum_penalty_for_a_shop.sifr"
+          ],
+          "duration_ms": 208,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d043d8beeaac9784 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d043d8beeaac9784",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2554_maximum_number_of_integers_to_choose_from_a_range_i",
+      "id": "2554",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2554_maximum_number_of_integers_to_choose_from_a_range_i.sifr"
+          ],
+          "duration_ms": 203,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=0b5cb97a1797acc5 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/0b5cb97a1797acc5",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2616_minimize_the_maximum_difference_of_pairs",
+      "id": "2616",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2616_minimize_the_maximum_difference_of_pairs.sifr"
+          ],
+          "duration_ms": 123,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2616_minimize_the_maximum_difference_of_pairs.sifr"
+          ],
+          "duration_ms": 228,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=426fef163a6f4cc7 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/426fef163a6f4cc7",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2709_greatest_common_divisor_traversal",
+      "id": "2709",
+      "oracle_mode": "no_oracle",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2709_greatest_common_divisor_traversal.sifr"
+          ],
+          "duration_ms": 127,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\nno errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2709_greatest_common_divisor_traversal.sifr"
+          ],
+          "duration_ms": 205,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "warning: int multiplication with non-constant operands may overflow i64 at runtime; consider using bigint for large values\n[sifr-artifact-cache] namespace=run key=d44553d0156bfbdb cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d44553d0156bfbdb",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "NO_ORACLE",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2864_maximum_odd_binary_number",
+      "id": "2864",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2864_maximum_odd_binary_number.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2864_maximum_odd_binary_number.sifr"
+          ],
+          "duration_ms": 200,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=ab988431cedebd66 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/ab988431cedebd66",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    },
+    {
+      "difficulty": "medium",
+      "failure_stage": null,
+      "fixture_slug": "2971_find_polygon_with_the_largest_perimeter",
+      "id": "2971",
+      "oracle_mode": "embedded_asserts",
+      "primary_topic": "arrays",
+      "scope_classification": "in_scope",
+      "stages": [
+        {
+          "command": [
+            "./target/release/sifr",
+            "check",
+            "audits/leetcode/2971_find_polygon_with_the_largest_perimeter.sifr"
+          ],
+          "duration_ms": 121,
+          "returncode": 0,
+          "stage": "check",
+          "stderr": "no errors found",
+          "stdout": "",
+          "timed_out": false
+        },
+        {
+          "command": [
+            "./target/release/sifr",
+            "run",
+            "audits/leetcode/2971_find_polygon_with_the_largest_perimeter.sifr"
+          ],
+          "duration_ms": 201,
+          "returncode": 0,
+          "stage": "run",
+          "stderr": "[sifr-artifact-cache] namespace=run key=d7c2ae9d6dd3c446 cache_hit=true workspace=/var/folders/lq/l19_y_rn76b8vprfvdjn9zch0000gn/T/sifr_generated_artifact_cache/run/d7c2ae9d6dd3c446",
+          "stdout": "",
+          "timed_out": false
+        }
+      ],
+      "status": "PASS",
+      "timeout_seconds": 20
+    }
+  ],
+  "summary": {
+    "case_count": 411,
+    "difficulty_counts": {
+      "easy": 21,
+      "hard": 5,
+      "medium": 385
+    },
+    "scope_counts": {
+      "blocked_feature": 0,
+      "in_scope": 411,
+      "out_of_scope_external_dep": 0
+    },
+    "status_counts": {
+      "NO_ORACLE": 203,
+      "PASS": 208
+    },
+    "topic_counts": {
+      "arrays": 363,
+      "backtracking": 5,
+      "dp": 6,
+      "graphs": 5,
+      "hash_map": 5,
+      "heap_priority_queue": 5,
+      "math": 5,
+      "strings": 7,
+      "trees": 5,
+      "two_pointers_sliding_window": 5
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fix HIR non-empty pop narrowing so call return types use the pre-call non-empty proof before mutation invalidation
- fix optional tuple string projection codegen by cloning non-Copy tuple fields projected through `Option.as_ref()`
- remove silent fallback helpers from seven LeetCode fixtures and restore `0838` to canonical `tuple[int, str]` directions
- add an e2e regression and refreshed full-corpus LeetCode result artifact

## Validation
- `cargo fmt --check`
- `git diff --check`
- targeted `check`/`run` for `0084`, `0332`, `0735`, `0739`, `0838`, `0895`, `1466`, and `optional_tuple_string_projection`
- `cargo test -p sifr_hir guarded_list_pop -- --nocapture`
- `cargo test -p sifr_hir guarded_zero_index_list_pop -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`
- full LeetCode corpus rerun: 411 cases, 208 PASS, 203 NO_ORACLE, no CHECK_ERROR/RUN_ERROR/TIMEOUT