### PR TITLE
Close WS6 fallback remediation tracker

### DIFF
--- a/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
+++ b/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
@@ -1,10 +1,10 @@
 # LeetCode WS6 Silent-Fallback Remediation
 
-Status: in_review
+Status: closed
 Owner: ad_hoc_leetcode_divergence_closure_followup
 Source phase: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
 Source PR: `https://github.com/yaseralnajjar/sifr/pull/1632`
-Remediation PR: `https://github.com/yaseralnajjar/sifr/pull/1635`
+Merged remediation PR: `https://github.com/yaseralnajjar/sifr/pull/1635`
 Created: 2026-04-25
 
 ## Progress
@@ -19,6 +19,7 @@ Created: 2026-04-25
 - Fixed codegen for constant-index projection of non-Copy fields from optional tuples by cloning the projected field when the tuple is accessed through `Option.as_ref()`.
 - Added `crates/sifr/tests/e2e/pass/optional_tuple_string_projection.sifr`.
 - Full corpus rerun artifact: `verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json` with `208 PASS`, `203 NO_ORACLE`, and no `CHECK_ERROR`, `RUN_ERROR`, or `TIMEOUT`.
+- Merged as PR `https://github.com/yaseralnajjar/sifr/pull/1635`.
 
 ## Problem
 


### PR DESCRIPTION
## Summary
- mark the WS6 silent-fallback remediation tracker closed after merged PR #1635
- preserve the merged remediation PR link in the issue document

## Validation
- `cargo fmt --check`
- `git diff --check`