### PR TITLE
Remove owned-crate Clippy allowances

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -122,7 +122,7 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
         used_intrinsic_modules: emitter.used_stdlib_modules,
         required_crates: {
             let mut crates = emitter.intrinsic_registry_crates;
-            if emitter.runtime_needs.needs_bigint || import_needs.runtime.numeric.needs_bigint {
+            if emitter.runtime_needs.bigint() || import_needs.runtime.numeric.needs_bigint {
                 crates.insert("num-bigint".to_string());
                 crates.insert("num-traits".to_string());
             }

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -809,7 +809,7 @@ impl RustEmitter {
             &arg_exprs,
             is_deque_data_field,
         )?;
-        let lowered_expr = self.unwrap_compiler_verified_nonempty_pop_result(
+        let lowered_expr = Self::unwrap_compiler_verified_nonempty_pop_result(
             object_ty,
             method,
             args,
@@ -830,9 +830,7 @@ impl RustEmitter {
         Some(lowered_expr)
     }
 
-    #[allow(clippy::unused_self)]
     fn unwrap_compiler_verified_nonempty_pop_result(
-        &self,
         object_ty: &Type,
         method: &str,
         args: &[HirExpr],
@@ -1254,7 +1252,7 @@ impl RustEmitter {
                     &arg_exprs,
                     self.is_deque_data_field(object),
                 ) {
-                    return Some(self.unwrap_compiler_verified_nonempty_pop_result(
+                    return Some(Self::unwrap_compiler_verified_nonempty_pop_result(
                         &effective_object_ty,
                         method,
                         args,
@@ -1279,7 +1277,7 @@ impl RustEmitter {
                         }
                     }
                 }
-                Some(self.unwrap_compiler_verified_nonempty_pop_result(
+                Some(Self::unwrap_compiler_verified_nonempty_pop_result(
                     object.ty(),
                     method,
                     args,
@@ -1984,13 +1982,13 @@ impl RustEmitter {
                 | "file_read_bytes"
                 | "file_write_bytes"
         ) {
-            self.runtime_needs.needs_file_handles = true;
+            self.runtime_needs.require(crate::RuntimeNeed::FileHandles);
         }
         if func == "builtin_open" {
             self.used_stdlib_modules.insert("io".to_string());
         }
         if matches!(func, "set_global_level" | "get_global_level") {
-            self.runtime_needs.needs_logging_state = true;
+            self.runtime_needs.require(crate::RuntimeNeed::LoggingState);
         }
         if matches!(
             func,
@@ -1999,7 +1997,8 @@ impl RustEmitter {
                 | "random_module_state_gauss_next"
                 | "random_module_set_state"
         ) {
-            self.runtime_needs.needs_random_module_state = true;
+            self.runtime_needs
+                .require(crate::RuntimeNeed::RandomModuleState);
         }
 
         if let Some(required_crate) = lowered.required_crate {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -330,11 +330,11 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     }
 
     // Compute broad feature needs first, then refine imports structurally from preamble IR.
-    let needs_file_handles = emitter.runtime_needs.needs_file_handles || stdlib_needs_file_handles;
+    let needs_file_handles = emitter.runtime_needs.file_handles() || stdlib_needs_file_handles;
     let needs_logging = emitter.used_stdlib_modules.contains("sifr.logging")
         || emitter.used_stdlib_modules.contains("_sifr.logging")
-        || emitter.runtime_needs.needs_logging_state;
-    let needs_random_module_state = emitter.runtime_needs.needs_random_module_state;
+        || emitter.runtime_needs.logging_state();
+    let needs_random_module_state = emitter.runtime_needs.random_module_state();
 
     // Emit built-in error class struct definitions for referenced error types.
     let referenced_error_classes = collect_referenced_builtin_error_classes(
@@ -1066,13 +1066,43 @@ struct CollectionNeeds {
     needs_vecdeque: bool,
 }
 
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Default)]
 struct RuntimeNeeds {
-    needs_file_handles: bool,
-    needs_logging_state: bool,
-    needs_random_module_state: bool,
-    needs_bigint: bool,
+    flags: HashSet<RuntimeNeed>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RuntimeNeed {
+    FileHandles,
+    LoggingState,
+    RandomModuleState,
+    BigInt,
+}
+
+impl RuntimeNeeds {
+    fn require(&mut self, need: RuntimeNeed) {
+        self.flags.insert(need);
+    }
+
+    fn contains(&self, need: RuntimeNeed) -> bool {
+        self.flags.contains(&need)
+    }
+
+    fn file_handles(&self) -> bool {
+        self.contains(RuntimeNeed::FileHandles)
+    }
+
+    fn logging_state(&self) -> bool {
+        self.contains(RuntimeNeed::LoggingState)
+    }
+
+    fn random_module_state(&self) -> bool {
+        self.contains(RuntimeNeed::RandomModuleState)
+    }
+
+    fn bigint(&self) -> bool {
+        self.contains(RuntimeNeed::BigInt)
+    }
 }
 
 #[derive(Default)]
@@ -1175,7 +1205,7 @@ impl RustEmitter {
     fn emit_module(&mut self, module: &HirModule, module_public: bool, test_mode: bool) {
         // Pre-scan: detect bigint usage
         if module_uses_bigint(module) {
-            self.runtime_needs.needs_bigint = true;
+            self.runtime_needs.require(RuntimeNeed::BigInt);
         }
 
         self.prescan_module_metadata(module);

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -752,12 +752,14 @@ pub(crate) fn try_lower_simple_stmt_with_ctx_and_bindings(
             else_body,
             ..
         } => try_lower_simple_for_stmt(
-            target,
-            target_ty,
-            iter,
-            body,
-            else_body.as_deref(),
-            in_loop_with_else,
+            SimpleForStmtParts {
+                target,
+                target_ty,
+                iter,
+                body,
+                else_body: else_body.as_deref(),
+                in_loop_with_else,
+            },
             bindings,
             ctx,
         ),
@@ -2217,29 +2219,33 @@ fn try_lower_simple_while_stmt(
     }])
 }
 
-#[allow(clippy::too_many_arguments)]
-fn try_lower_simple_for_stmt(
-    target: &str,
-    target_ty: &Type,
-    iter: &HirExpr,
-    body: &[HirStmt],
-    else_body: Option<&[HirStmt]>,
+#[derive(Clone, Copy)]
+struct SimpleForStmtParts<'a> {
+    target: &'a str,
+    target_ty: &'a Type,
+    iter: &'a HirExpr,
+    body: &'a [HirStmt],
+    else_body: Option<&'a [HirStmt]>,
     in_loop_with_else: bool,
+}
+
+fn try_lower_simple_for_stmt(
+    parts: SimpleForStmtParts<'_>,
     bindings: SimpleStmtBindings<'_>,
     ctx: SimpleStmtLoweringCtx<'_>,
 ) -> Option<Vec<RustStmt>> {
-    if target.contains(',') {
+    if parts.target.contains(',') {
         return None;
     }
 
-    if let Some(else_body) = else_body {
+    if let Some(else_body) = parts.else_body {
         return try_lower_loop_else_stmts(
             RustStmt::For {
-                var: target.to_string(),
-                iter: try_lower_simple_for_iter_expr(iter, target_ty)?,
+                var: parts.target.to_string(),
+                iter: try_lower_simple_for_iter_expr(parts.iter, parts.target_ty)?,
                 // Breaks in the loop body should mark this loop's `_broke`.
                 body: try_lower_simple_stmt_block(
-                    body,
+                    parts.body,
                     true,
                     bindings.mutated_vars,
                     bindings.borrowed_params,
@@ -2247,18 +2253,18 @@ fn try_lower_simple_for_stmt(
                 )?,
             },
             else_body,
-            in_loop_with_else,
+            parts.in_loop_with_else,
             bindings,
             ctx,
         );
     }
 
     Some(vec![RustStmt::For {
-        var: target.to_string(),
-        iter: try_lower_simple_for_iter_expr(iter, target_ty)?,
+        var: parts.target.to_string(),
+        iter: try_lower_simple_for_iter_expr(parts.iter, parts.target_ty)?,
         // Entering a nested for without else resets loop-else break marker context.
         body: try_lower_simple_stmt_block(
-            body,
+            parts.body,
             false,
             bindings.mutated_vars,
             bindings.borrowed_params,

--- a/crates/sifr_hir/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_hir/src/lower/aug_assign_lowering.rs
@@ -300,7 +300,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
         ctx.error(format!("undefined variable: '{name}'"));
         return None;
     };
-    if var_info.is_parameter_binding() && !var_info.is_mutable_binding {
+    if var_info.is_parameter_binding() && !var_info.is_mutable_binding() {
         ctx.error(format!(
             "cannot reassign immutable parameter `{name}`: add `mut` to the parameter declaration"
         ));

--- a/crates/sifr_hir/src/lower/binding_mutability.rs
+++ b/crates/sifr_hir/src/lower/binding_mutability.rs
@@ -8,7 +8,7 @@ pub(super) fn ensure_mutable_parameter_binding(
     if ctx
         .scope
         .lookup(name)
-        .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding)
+        .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding())
     {
         ctx.error(format!(
             "cannot {operation} immutable parameter `{name}`: add `mut` to the parameter declaration"

--- a/crates/sifr_hir/src/lower/mutating_methods.rs
+++ b/crates/sifr_hir/src/lower/mutating_methods.rs
@@ -16,7 +16,7 @@ pub(super) fn reject_immutable_parameter_method_mutation(
         if ctx
             .scope
             .lookup(name)
-            .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding)
+            .is_some_and(|info| info.is_parameter_binding() && !info.is_mutable_binding())
         {
             ctx.error(format!(
                 "cannot mutate through immutable parameter `{name}`: add `mut` to the parameter declaration"

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -171,7 +171,7 @@ pub(super) fn lower_stmt(
         Stmt::AnnAssign(ann) => lower_ann_assign(ann, ctx),
         Stmt::Assign(assign) => lower_assign(assign, ctx),
         Stmt::AugAssign(aug) => lower_aug_assign(aug, ctx),
-        Stmt::Return(ret) => lower_return(ret, func_type, ctx),
+        Stmt::Return(ret) => Some(lower_return(ret, func_type, ctx)),
         Stmt::Expr(expr_stmt) => {
             // Check if this is a yield expression used as a statement
             if let Expr::Yield(yield_expr) = expr_stmt.value.as_ref() {
@@ -1534,7 +1534,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
             ctx.error(format!("undefined variable: '{name}'"));
             return None;
         };
-        if info.is_parameter_binding() && !info.is_mutable_binding {
+        if info.is_parameter_binding() && !info.is_mutable_binding() {
             ctx.error(format!(
                 "cannot reassign immutable parameter `{name}`: add `mut` to the parameter declaration"
             ));
@@ -1600,19 +1600,18 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
     lower_aug_assign_impl(aug, ctx)
 }
 
-#[allow(clippy::unnecessary_wraps)]
 pub(super) fn lower_return(
     ret: &StmtReturn,
     func_type: &FunctionType,
     ctx: &mut LowerCtx,
-) -> Option<HirStmt> {
+) -> HirStmt {
     let value = if let Some(val) = &ret.value {
         let Some(expr) = lower_expr(val, ctx) else {
             // Keep control-flow shape intact after expression diagnostics so
             // return-completeness analysis does not emit a cascade error.
-            return Some(HirStmt::Return {
+            return HirStmt::Return {
                 value: Some(HirExpr::NoneLiteral),
-            });
+            };
         };
         let expr_ty = expr.ty().clone();
 
@@ -1631,12 +1630,12 @@ pub(super) fn lower_return(
         if let Type::Result(ref ok_ty, _) = *func_type.return_type {
             if expr_ty.is_assignable_to(ok_ty) && !matches!(expr_ty, Type::Result(_, _)) {
                 // Wrap in Ok()
-                return Some(HirStmt::Return {
+                return HirStmt::Return {
                     value: Some(HirExpr::OkWrap {
                         ty: func_type.return_type.as_ref().clone(),
                         value: Box::new(expr),
                     }),
-                });
+                };
             }
         }
 
@@ -1653,12 +1652,12 @@ pub(super) fn lower_return(
             // If function returns Result[(), E], wrap in Ok(())
             if let Type::Result(ref ok_ty, _) = *func_type.return_type {
                 if **ok_ty == Type::None {
-                    return Some(HirStmt::Return {
+                    return HirStmt::Return {
                         value: Some(HirExpr::OkWrap {
                             ty: func_type.return_type.as_ref().clone(),
                             value: Box::new(HirExpr::NoneLiteral),
                         }),
-                    });
+                    };
                 }
             }
             ctx.error(format!(
@@ -1669,7 +1668,7 @@ pub(super) fn lower_return(
         None
     };
 
-    Some(HirStmt::Return { value })
+    HirStmt::Return { value }
 }
 
 pub(super) fn lower_if(

--- a/crates/sifr_hir/src/lower/tuple_unpack.rs
+++ b/crates/sifr_hir/src/lower/tuple_unpack.rs
@@ -100,7 +100,7 @@ pub(super) fn lower_tuple_unpack_assign(
                         ctx.error(format!("undefined variable: '{name}'"));
                         return None;
                     };
-                    if info.is_parameter_binding() && !info.is_mutable_binding {
+                    if info.is_parameter_binding() && !info.is_mutable_binding() {
                         ctx.error(format!(
                             "cannot reassign immutable parameter `{name}`: add `mut` to the parameter declaration"
                         ));

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -12,8 +12,19 @@ pub enum BindingKind {
     Parameter,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingMutability {
+    Mutable,
+    Immutable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingTypeSource {
+    Explicit,
+    Inferred,
+}
+
 /// Tracks variable state for ownership and narrowing.
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct VarInfo {
     /// The declared type (from annotation or inference).
@@ -25,11 +36,11 @@ pub struct VarInfo {
     /// Whether the variable is currently mutably borrowed.
     pub is_mut_borrowed: bool,
     /// Whether the binding itself is mutable.
-    pub is_mutable_binding: bool,
+    pub mutability: BindingMutability,
     /// Whether this binding originated from a function parameter.
     pub binding_kind: BindingKind,
     /// Whether the binding type was provided explicitly (annotation/parameter).
-    pub has_explicit_type: bool,
+    pub type_source: BindingTypeSource,
 }
 
 impl VarInfo {
@@ -42,8 +53,13 @@ impl VarInfo {
         matches!(self.binding_kind, BindingKind::Parameter)
     }
 
+    pub fn is_mutable_binding(&self) -> bool {
+        matches!(self.mutability, BindingMutability::Mutable)
+    }
+
     pub fn is_inferred_local_binding(&self) -> bool {
-        matches!(self.binding_kind, BindingKind::Local) && !self.has_explicit_type
+        matches!(self.binding_kind, BindingKind::Local)
+            && matches!(self.type_source, BindingTypeSource::Inferred)
     }
 }
 
@@ -125,6 +141,16 @@ impl Scope {
         has_explicit_type: bool,
     ) {
         if let Some(frame) = self.frames.last_mut() {
+            let mutability = if is_mutable_binding {
+                BindingMutability::Mutable
+            } else {
+                BindingMutability::Immutable
+            };
+            let type_source = if has_explicit_type {
+                BindingTypeSource::Explicit
+            } else {
+                BindingTypeSource::Inferred
+            };
             frame.insert(
                 name,
                 VarInfo {
@@ -132,9 +158,9 @@ impl Scope {
                     narrowed_type: None,
                     is_moved: false,
                     is_mut_borrowed: false,
-                    is_mutable_binding,
+                    mutability,
                     binding_kind,
-                    has_explicit_type,
+                    type_source,
                 },
             );
         }
@@ -260,7 +286,7 @@ impl Scope {
 
     /// Check whether an existing binding is mutable.
     pub fn is_mutable_binding(&self, name: &str) -> Option<bool> {
-        self.lookup(name).map(|info| info.is_mutable_binding)
+        self.lookup(name).map(VarInfo::is_mutable_binding)
     }
 
     // --- Moved state snapshot support ---


### PR DESCRIPTION
## Summary
- remove all `#[allow(clippy::...)]` attributes from the owned compiler crates
- replace boolean-heavy structs with typed state/grouping instead of suppressing `struct_excessive_bools`
- simplify return and method helper signatures instead of suppressing `unnecessary_wraps`, `unused_self`, and `too_many_arguments`

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`
- `rg -n "#\\!?\\[allow\\(clippy::" crates/sifr crates/sifr_hir crates/sifr_codegen crates/sifr_driver crates/sifr_type_system -g '*.rs'` returns no matches