### PR TITLE
Refactor project import discovery through ModuleResolver

### DIFF
--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -9,7 +9,7 @@ use crate::diagnostics::{run_codegen_with_boundary, CompileError, CompilePhase};
 use crate::frontend::{parse_source, FrontendCompiled, FrontendDiagnosticStyle};
 use crate::project::{
     collect_project_hir_modules, compile_frontend_modules, emit_project_frontend_diagnostics,
-    parse_import_closure_modules, DiscoveryDiagnosticStyle, ProjectLowering,
+    parse_import_closure_modules, DiscoveryDiagnosticStyle, ModuleResolver, ProjectLowering,
 };
 use crate::stdlib::{compile_stdlib, StdlibCompiled};
 use sifr_codegen::generate_rust_with_stdlib;
@@ -156,8 +156,9 @@ impl RootedEntrypointPlan {
                     }]);
                 };
                 let root_modules = BTreeSet::from([main_module_name]);
+                let resolver = ModuleResolver::entry_parent(project_dir);
                 let parsed_modules = parse_import_closure_modules(
-                    project_dir,
+                    &resolver,
                     &root_modules,
                     DiscoveryDiagnosticStyle::ModuleName,
                 )?;

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -41,7 +41,7 @@ pub(crate) use frontend::FrontendDiagnosticStyle;
 pub(crate) use project::{
     assemble_project_main_rs, collect_project_hir_modules, compile_frontend_modules,
     compute_module_compile_order, discover_test_root_modules, parse_import_closure_modules,
-    DiscoveryDiagnosticStyle,
+    DiscoveryDiagnosticStyle, ModuleResolver,
 };
 #[cfg(test)]
 pub(crate) use stdlib::compile_stdlib;

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -4,6 +4,62 @@ use sifr_python_parser::parse_module;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ModuleOrigin {
+    EntryParent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResolvedModule {
+    pub(crate) module_name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) origin: ModuleOrigin,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResolutionError {
+    pub(crate) module_name: String,
+    pub(crate) tried_paths: Vec<PathBuf>,
+    pub(crate) matches: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ModuleResolver {
+    entry_parent: PathBuf,
+}
+
+impl ModuleResolver {
+    pub(crate) fn entry_parent(entry_parent: impl Into<PathBuf>) -> Self {
+        Self {
+            entry_parent: entry_parent.into(),
+        }
+    }
+
+    pub(crate) fn module_source_path(&self, module_name: &str) -> PathBuf {
+        self.entry_parent.join(format!("{module_name}.sifr"))
+    }
+
+    pub(crate) fn resolve_if_exists(&self, module_name: &str) -> Option<ResolvedModule> {
+        let path = self.module_source_path(module_name);
+        path.is_file().then(|| ResolvedModule {
+            module_name: module_name.to_string(),
+            path,
+            origin: ModuleOrigin::EntryParent,
+        })
+    }
+
+    pub(crate) fn resolve(&self, module_name: &str) -> Result<ResolvedModule, ResolutionError> {
+        self.resolve_if_exists(module_name).ok_or_else(|| {
+            let path = self.module_source_path(module_name);
+            ResolutionError {
+                module_name: module_name.to_string(),
+                tried_paths: vec![path],
+                matches: Vec::new(),
+            }
+        })
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DiscoveryDiagnosticStyle {
     ModuleName,
@@ -37,10 +93,6 @@ pub(crate) fn discover_test_root_modules(test_dir: &Path) -> BTreeMap<String, Pa
         }
     }
     test_files_by_module
-}
-
-fn module_source_path(project_dir: &Path, module_name: &str) -> PathBuf {
-    project_dir.join(format!("{module_name}.sifr"))
 }
 
 fn discovery_label(
@@ -80,7 +132,7 @@ fn collect_import_closure_module_dependencies(stmts: &[Stmt]) -> BTreeSet<String
 }
 
 pub(crate) fn parse_import_closure_modules(
-    project_dir: &Path,
+    resolver: &ModuleResolver,
     root_modules: &BTreeSet<String>,
     diagnostic_style: DiscoveryDiagnosticStyle,
 ) -> Result<HashMap<String, Vec<Stmt>>, Vec<CompileError>> {
@@ -93,7 +145,14 @@ pub(crate) fn parse_import_closure_modules(
             continue;
         }
 
-        let path = module_source_path(project_dir, &module_name);
+        let path = match resolver.resolve(&module_name) {
+            Ok(resolved) => resolved.path,
+            Err(error) => error
+                .tried_paths
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| resolver.module_source_path(&module_name)),
+        };
         let source = std::fs::read_to_string(&path).map_err(|e| {
             vec![CompileError {
                 message: format!("failed to read '{}': {}", path.display(), e),
@@ -128,7 +187,7 @@ pub(crate) fn parse_import_closure_modules(
             if parsed_names.contains(dependency.as_str()) {
                 continue;
             }
-            if module_source_path(project_dir, &dependency).is_file() {
+            if resolver.resolve_if_exists(&dependency).is_some() {
                 pending.insert(dependency);
             }
         }

--- a/crates/sifr_driver/src/project/mod.rs
+++ b/crates/sifr_driver/src/project/mod.rs
@@ -7,6 +7,7 @@ mod frontend;
 pub(crate) use assembly::{assemble_project_main_rs, ordered_non_main_module_names};
 pub(crate) use discovery::{
     discover_test_root_modules, parse_import_closure_modules, DiscoveryDiagnosticStyle,
+    ModuleResolver,
 };
 pub(crate) use frontend::{
     collect_project_hir_modules, compile_frontend_modules, emit_project_frontend_diagnostics,

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -5,7 +5,7 @@ use crate::diagnostics::{
 use crate::frontend::{lower_frontend_module, FrontendDiagnosticStyle};
 use crate::project::{
     collect_project_hir_modules, discover_test_root_modules, parse_import_closure_modules,
-    DiscoveryDiagnosticStyle,
+    DiscoveryDiagnosticStyle, ModuleResolver,
 };
 use crate::stdlib::compile_stdlib;
 use sifr_codegen::{generate_rust_multi_with_metadata, generate_rust_test};
@@ -45,8 +45,9 @@ pub(crate) fn build_test_runner_project(
     test_files_by_module: &BTreeMap<String, PathBuf>,
 ) -> Result<GeneratedTestRunnerProject, Vec<CompileError>> {
     let test_roots: BTreeSet<String> = test_files_by_module.keys().cloned().collect();
+    let resolver = ModuleResolver::entry_parent(test_dir);
     let parsed_modules =
-        parse_import_closure_modules(test_dir, &test_roots, DiscoveryDiagnosticStyle::FilePath)?;
+        parse_import_closure_modules(&resolver, &test_roots, DiscoveryDiagnosticStyle::FilePath)?;
     let mut support_modules: HashMap<String, Vec<Stmt>> = HashMap::new();
     let mut test_modules: HashMap<String, Vec<Stmt>> = HashMap::new();
     for (module_name, suite) in parsed_modules {

--- a/crates/sifr_driver/src/tests/discovery_and_workspace.rs
+++ b/crates/sifr_driver/src/tests/discovery_and_workspace.rs
@@ -1,6 +1,6 @@
 use crate::{
     create_invocation_workspace, discover_test_root_modules, parse_import_closure_modules,
-    DiscoveryDiagnosticStyle,
+    DiscoveryDiagnosticStyle, ModuleResolver,
 };
 use std::collections::BTreeSet;
 
@@ -80,11 +80,15 @@ fn test_project_and_test_discovery_share_import_closure_membership() {
 
     let project_roots = BTreeSet::from(["main".to_string()]);
     let test_roots = BTreeSet::from(["test_parity".to_string()]);
-    let project_modules =
-        parse_import_closure_modules(&dir, &project_roots, DiscoveryDiagnosticStyle::ModuleName)
-            .expect("project closure discovery should succeed");
+    let resolver = ModuleResolver::entry_parent(&dir);
+    let project_modules = parse_import_closure_modules(
+        &resolver,
+        &project_roots,
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .expect("project closure discovery should succeed");
     let test_modules =
-        parse_import_closure_modules(&dir, &test_roots, DiscoveryDiagnosticStyle::ModuleName)
+        parse_import_closure_modules(&resolver, &test_roots, DiscoveryDiagnosticStyle::ModuleName)
             .expect("test closure discovery should succeed");
 
     let project_support: BTreeSet<String> = project_modules
@@ -139,13 +143,17 @@ fn test_project_and_test_discovery_parity_reports_reachable_parse_errors() {
 
     let project_roots = BTreeSet::from(["main".to_string()]);
     let test_roots = BTreeSet::from(["test_parity".to_string()]);
+    let resolver = ModuleResolver::entry_parent(&dir);
 
-    let project_errors =
-        parse_import_closure_modules(&dir, &project_roots, DiscoveryDiagnosticStyle::ModuleName)
-            .err()
-            .expect("project closure should fail on reachable parse error");
+    let project_errors = parse_import_closure_modules(
+        &resolver,
+        &project_roots,
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .err()
+    .expect("project closure should fail on reachable parse error");
     let test_errors =
-        parse_import_closure_modules(&dir, &test_roots, DiscoveryDiagnosticStyle::ModuleName)
+        parse_import_closure_modules(&resolver, &test_roots, DiscoveryDiagnosticStyle::ModuleName)
             .err()
             .expect("test closure should fail on reachable parse error");
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -9,7 +9,7 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 
 - [x] WS0 workspace discovery and config validation
 - [ ] WS1 workspace-aware compilation mode
-- [ ] WS2 module resolver refactor with no behavior change
+- [x] WS2 module resolver refactor with no behavior change
 - [ ] WS3 workspace source resolution and diagnostics
 - [ ] WS4 build/run/check/emit wiring and cache correctness
 - [ ] WS5 verification-suite fixtures, design note, and LeetCode pilot
@@ -17,10 +17,10 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 
 ## WS0 Workspace Discovery And Config Validation
 
-Status: implemented_pending_pr
+Status: merged
 Branch: ad-hoc/sifr-workspace-ws0
 PR: https://github.com/yaseralnajjar/sifr/pull/1639
-Merged: tbd
+Merged: 2026-04-25
 
 ### Planned Scope
 
@@ -39,8 +39,8 @@ Merged: tbd
 
 ## WS1 Workspace-Aware Compilation Mode
 
-Status: not_started
-Branch: tbd
+Status: implemented_pending_pr
+Branch: ad-hoc/sifr-workspace-ws2
 PR: tbd
 Merged: tbd
 
@@ -73,10 +73,10 @@ Merged: tbd
 
 ### Validation Evidence
 
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace -- -D warnings`
-- [ ] `cargo test -p sifr_driver discovery -- --nocapture` or equivalent targeted selector
-- [ ] Test-runner targeted selector proving no discovery-scope change
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --workspace -- -D warnings`
+- [x] `cargo test -p sifr_driver discovery -- --nocapture`
+- [x] `cargo test -p sifr_driver test_runner -- --nocapture`
 
 ## WS3 Workspace Source Resolution And Diagnostics
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -41,7 +41,7 @@ Merged: 2026-04-25
 
 Status: implemented_pending_pr
 Branch: ad-hoc/sifr-workspace-ws2
-PR: tbd
+PR: https://github.com/yaseralnajjar/sifr/pull/1640
 Merged: tbd
 
 ### Planned Scope


### PR DESCRIPTION
## Summary
- introduce `ModuleResolver`, `ResolvedModule`, `ModuleOrigin`, and `ResolutionError`
- keep the resolver configured to entry-parent-only resolution for this no-op wave
- thread the resolver through project import closure discovery and the test runner
- preserve existing missing-file and parse diagnostic behavior
- record WS2 validation evidence in the phase execution checklist

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_driver discovery -- --nocapture`
- `cargo test -p sifr_driver test_runner -- --nocapture`
- `cargo clippy --workspace -- -D warnings`