### PR TITLE
Resolve workspace modules from source roots

### DIFF
--- a/crates/sifr_driver/src/diagnostics.rs
+++ b/crates/sifr_driver/src/diagnostics.rs
@@ -112,6 +112,18 @@ impl CompileError {
                 return Some("SIFR-WORKSPACE-0004");
             }
         }
+        if message.starts_with("could not resolve import ") {
+            return Some("SIFR-WORKSPACE-0101");
+        }
+        if message.starts_with("module ") && message.contains(" is ambiguous in workspace ") {
+            return Some("SIFR-WORKSPACE-0102");
+        }
+        if message.starts_with("module ")
+            && message.contains(" resolves to file ")
+            && message.contains("package directories are not supported in this phase")
+        {
+            return Some("SIFR-WORKSPACE-0103");
+        }
         None
     }
 

--- a/crates/sifr_driver/src/project/assembly.rs
+++ b/crates/sifr_driver/src/project/assembly.rs
@@ -1,3 +1,4 @@
+use super::rust_module_layout::top_level_module_declarations;
 use std::collections::HashMap;
 
 pub(crate) fn ordered_non_main_module_names(
@@ -18,9 +19,9 @@ pub(crate) fn assemble_project_main_rs(
 ) -> String {
     let mut main_rs = String::new();
     let ordered_non_main = ordered_non_main_module_names(compile_order, rust_files);
-    for module_name in &ordered_non_main {
+    for module_name in top_level_module_declarations(&ordered_non_main) {
         main_rs.push_str("mod ");
-        main_rs.push_str(module_name);
+        main_rs.push_str(&module_name);
         main_rs.push_str(";\n");
     }
     if !ordered_non_main.is_empty() && rust_files.contains_key("main") {

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{CompileError, CompilePhase};
+use crate::workspace::WorkspaceRoot;
 use sifr_python_ast::Stmt;
 use sifr_python_parser::parse_module;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -7,6 +8,7 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ModuleOrigin {
     EntryParent,
+    WorkspaceSource { source_root: PathBuf },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -21,42 +23,207 @@ pub(crate) struct ResolutionError {
     pub(crate) module_name: String,
     pub(crate) tried_paths: Vec<PathBuf>,
     pub(crate) matches: Vec<PathBuf>,
+    kind: ResolutionFailureKind,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ModuleResolver {
     entry_parent: PathBuf,
+    workspace: Option<WorkspaceModuleSources>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WorkspaceModuleSources {
+    workspace_root: PathBuf,
+    source_roots: Vec<PathBuf>,
 }
 
 impl ModuleResolver {
     pub(crate) fn entry_parent(entry_parent: impl Into<PathBuf>) -> Self {
         Self {
             entry_parent: entry_parent.into(),
+            workspace: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_workspace(
+        entry_parent: impl Into<PathBuf>,
+        workspace: WorkspaceRoot,
+    ) -> Self {
+        Self {
+            entry_parent: entry_parent.into(),
+            workspace: Some(WorkspaceModuleSources {
+                workspace_root: workspace.dir,
+                source_roots: workspace.config.source_roots,
+            }),
         }
     }
 
     pub(crate) fn module_source_path(&self, module_name: &str) -> PathBuf {
-        self.entry_parent.join(format!("{module_name}.sifr"))
+        self.entry_parent
+            .join(module_name_to_relative_path(module_name))
     }
 
-    pub(crate) fn resolve_if_exists(&self, module_name: &str) -> Option<ResolvedModule> {
-        let path = self.module_source_path(module_name);
-        path.is_file().then(|| ResolvedModule {
-            module_name: module_name.to_string(),
-            path,
-            origin: ModuleOrigin::EntryParent,
-        })
+    pub(crate) fn has_workspace(&self) -> bool {
+        self.workspace.is_some()
     }
 
     pub(crate) fn resolve(&self, module_name: &str) -> Result<ResolvedModule, ResolutionError> {
-        self.resolve_if_exists(module_name).ok_or_else(|| {
-            let path = self.module_source_path(module_name);
-            ResolutionError {
+        let entry_path = self.module_source_path(module_name);
+        if entry_path.is_file() {
+            let resolved = ResolvedModule {
                 module_name: module_name.to_string(),
-                tried_paths: vec![path],
+                path: entry_path,
+                origin: ModuleOrigin::EntryParent,
+            };
+            self.reject_namespace_file_collision(&resolved)?;
+            return Ok(resolved);
+        }
+
+        let Some(workspace) = &self.workspace else {
+            return Err(ResolutionError {
+                module_name: module_name.to_string(),
+                tried_paths: vec![entry_path],
                 matches: Vec::new(),
+                kind: ResolutionFailureKind::Unresolved,
+            });
+        };
+
+        let relative_path = module_name_to_relative_path(module_name);
+        let mut tried_paths = vec![entry_path];
+        let mut matches = Vec::new();
+        for source_root in &workspace.source_roots {
+            let candidate = workspace
+                .workspace_root
+                .join(source_root)
+                .join(&relative_path);
+            tried_paths.push(candidate.clone());
+            if candidate.is_file() && !matches.contains(&candidate) {
+                matches.push(candidate);
             }
+        }
+
+        if matches.len() > 1 {
+            return Err(ResolutionError {
+                module_name: module_name.to_string(),
+                tried_paths,
+                matches,
+                kind: ResolutionFailureKind::Ambiguous,
+            });
+        }
+
+        if let Some(path) = matches.into_iter().next() {
+            let source_root = workspace
+                .source_roots
+                .iter()
+                .find(|source_root| path.starts_with(workspace.workspace_root.join(source_root)))
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from("."));
+            let resolved = ResolvedModule {
+                module_name: module_name.to_string(),
+                path,
+                origin: ModuleOrigin::WorkspaceSource { source_root },
+            };
+            self.reject_namespace_file_collision(&resolved)?;
+            return Ok(resolved);
+        }
+
+        Err(ResolutionError {
+            module_name: module_name.to_string(),
+            tried_paths,
+            matches: Vec::new(),
+            kind: ResolutionFailureKind::Unresolved,
         })
+    }
+
+    fn reject_namespace_file_collision(
+        &self,
+        resolved: &ResolvedModule,
+    ) -> Result<(), ResolutionError> {
+        let Some((parent_name, parent_path)) = self.parent_module_file(&resolved.module_name)
+        else {
+            return Ok(());
+        };
+        Err(ResolutionError {
+            module_name: resolved.module_name.clone(),
+            tried_paths: vec![resolved.path.clone(), parent_path],
+            matches: Vec::new(),
+            kind: ResolutionFailureKind::NamespaceFileCollision { parent_name },
+        })
+    }
+
+    fn parent_module_file(&self, module_name: &str) -> Option<(String, PathBuf)> {
+        let parts: Vec<&str> = module_name.split('.').collect();
+        if parts.len() < 2 {
+            return None;
+        }
+        for end in 1..parts.len() {
+            let parent_name = parts[..end].join(".");
+            for candidate in self.candidate_paths(&parent_name) {
+                if candidate.is_file() {
+                    return Some((parent_name, candidate));
+                }
+            }
+        }
+        None
+    }
+
+    fn candidate_paths(&self, module_name: &str) -> Vec<PathBuf> {
+        let relative_path = module_name_to_relative_path(module_name);
+        let mut candidates = vec![self.entry_parent.join(&relative_path)];
+        if let Some(workspace) = &self.workspace {
+            candidates.extend(workspace.source_roots.iter().map(|source_root| {
+                workspace
+                    .workspace_root
+                    .join(source_root)
+                    .join(&relative_path)
+            }));
+        }
+        candidates
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ResolutionFailureKind {
+    Unresolved,
+    Ambiguous,
+    NamespaceFileCollision { parent_name: String },
+}
+
+impl ResolutionError {
+    fn to_compile_error(&self, resolver: &ModuleResolver) -> CompileError {
+        match &self.kind {
+            ResolutionFailureKind::Unresolved => CompileError {
+                message: unresolved_import_message(&self.module_name, &self.tried_paths),
+                phase: CompilePhase::Build,
+            },
+            ResolutionFailureKind::Ambiguous => CompileError {
+                message: ambiguous_import_message(&self.module_name, resolver, &self.matches),
+                phase: CompilePhase::Build,
+            },
+            ResolutionFailureKind::NamespaceFileCollision { parent_name } => {
+                let resolved_path = self
+                    .tried_paths
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| resolver.module_source_path(&self.module_name));
+                let parent_path = self
+                    .tried_paths
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| resolver.module_source_path(parent_name));
+                CompileError {
+                    message: namespace_collision_message(
+                        &self.module_name,
+                        &resolved_path,
+                        parent_name,
+                        &parent_path,
+                    ),
+                    phase: CompilePhase::Build,
+                }
+            }
+        }
     }
 }
 
@@ -93,6 +260,69 @@ pub(crate) fn discover_test_root_modules(test_dir: &Path) -> BTreeMap<String, Pa
         }
     }
     test_files_by_module
+}
+
+fn module_name_to_relative_path(module_name: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for component in module_name.split('.') {
+        path.push(component);
+    }
+    path.set_extension("sifr");
+    path
+}
+
+fn unresolved_import_message(module_name: &str, tried_paths: &[PathBuf]) -> String {
+    let entry_path = tried_paths
+        .first()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
+    let workspace_paths: Vec<String> = tried_paths
+        .iter()
+        .skip(1)
+        .map(|path| format!("'{}'", path.display()))
+        .collect();
+    if workspace_paths.is_empty() {
+        return format!(
+            "could not resolve import '{module_name}'; tried entry-relative '{entry_path}'"
+        );
+    }
+    format!(
+        "could not resolve import '{module_name}'; tried entry-relative '{entry_path}' and workspace-relative {}",
+        workspace_paths.join(", ")
+    )
+}
+
+fn ambiguous_import_message(
+    module_name: &str,
+    resolver: &ModuleResolver,
+    matches: &[PathBuf],
+) -> String {
+    let workspace_root = resolver
+        .workspace
+        .as_ref()
+        .map(|workspace| workspace.workspace_root.display().to_string())
+        .unwrap_or_default();
+    let match_paths: Vec<String> = matches
+        .iter()
+        .map(|path| format!("'{}'", path.display()))
+        .collect();
+    format!(
+        "module '{module_name}' is ambiguous in workspace '{workspace_root}': matches {}; reorder [source].roots or rename one module to disambiguate",
+        match_paths.join(" and ")
+    )
+}
+
+fn namespace_collision_message(
+    module_name: &str,
+    path: &Path,
+    parent_name: &str,
+    parent_path: &Path,
+) -> String {
+    format!(
+        "module '{module_name}' resolves to file '{}' but parent name '{parent_name}' is also a module file '{}'; package directories are not supported in this phase",
+        path.display(),
+        parent_path.display()
+    )
 }
 
 fn discovery_label(
@@ -147,6 +377,9 @@ pub(crate) fn parse_import_closure_modules(
 
         let path = match resolver.resolve(&module_name) {
             Ok(resolved) => resolved.path,
+            Err(error) if resolver.has_workspace() => {
+                return Err(vec![error.to_compile_error(resolver)]);
+            }
             Err(error) => error
                 .tried_paths
                 .into_iter()
@@ -187,8 +420,14 @@ pub(crate) fn parse_import_closure_modules(
             if parsed_names.contains(dependency.as_str()) {
                 continue;
             }
-            if resolver.resolve_if_exists(&dependency).is_some() {
-                pending.insert(dependency);
+            match resolver.resolve(&dependency) {
+                Ok(_) => {
+                    pending.insert(dependency);
+                }
+                Err(error) if resolver.has_workspace() => {
+                    return Err(vec![error.to_compile_error(resolver)]);
+                }
+                Err(_) => {}
             }
         }
         parsed_modules.insert(module_name, suite);

--- a/crates/sifr_driver/src/project/mod.rs
+++ b/crates/sifr_driver/src/project/mod.rs
@@ -3,6 +3,7 @@ mod compile_order;
 mod discovery;
 mod exports;
 mod frontend;
+mod rust_module_layout;
 
 pub(crate) use assembly::{assemble_project_main_rs, ordered_non_main_module_names};
 pub(crate) use discovery::{

--- a/crates/sifr_driver/src/project/rust_module_layout.rs
+++ b/crates/sifr_driver/src/project/rust_module_layout.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct NamespaceModuleFile {
+    pub(crate) path: PathBuf,
+    pub(crate) declarations: Vec<String>,
+}
+
+#[allow(dead_code)]
+pub(crate) fn rust_module_file_path(module_id: &str) -> PathBuf {
+    let mut path = PathBuf::new();
+    for component in module_id.split('.') {
+        path.push(component);
+    }
+    path.set_extension("rs");
+    path
+}
+
+pub(crate) fn top_level_module_declarations(module_ids: &[String]) -> Vec<String> {
+    module_ids
+        .iter()
+        .filter_map(|module_id| module_id.split('.').next())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+#[allow(dead_code)]
+pub(crate) fn namespace_module_files(module_ids: &[String]) -> Vec<NamespaceModuleFile> {
+    let mut namespace_children: std::collections::BTreeMap<String, BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+    for module_id in module_ids {
+        let parts: Vec<&str> = module_id.split('.').collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        for depth in 1..parts.len() {
+            let namespace = parts[..depth].join(".");
+            namespace_children
+                .entry(namespace)
+                .or_default()
+                .insert(parts[depth].to_string());
+        }
+    }
+
+    namespace_children
+        .into_iter()
+        .map(|(namespace, children)| {
+            let mut path = PathBuf::new();
+            for component in namespace.split('.') {
+                path.push(component);
+            }
+            path.push("mod.rs");
+            NamespaceModuleFile {
+                path,
+                declarations: children.into_iter().collect(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dotted_module_id_maps_to_nested_rust_file() {
+        assert_eq!(
+            rust_module_file_path("helpers.list_node"),
+            PathBuf::from("helpers").join("list_node.rs")
+        );
+    }
+
+    #[test]
+    fn test_top_level_declarations_deduplicate_dotted_namespaces() {
+        let module_ids = vec![
+            "helpers.list_node".to_string(),
+            "helpers.tree_node".to_string(),
+            "math".to_string(),
+        ];
+
+        assert_eq!(
+            top_level_module_declarations(&module_ids),
+            vec!["helpers".to_string(), "math".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_namespace_files_declare_direct_children() {
+        let module_ids = vec![
+            "helpers.list_node".to_string(),
+            "helpers.nested.value".to_string(),
+        ];
+
+        let namespace_files = namespace_module_files(&module_ids);
+
+        assert_eq!(
+            namespace_files,
+            vec![
+                NamespaceModuleFile {
+                    path: PathBuf::from("helpers").join("mod.rs"),
+                    declarations: vec!["list_node".to_string(), "nested".to_string()],
+                },
+                NamespaceModuleFile {
+                    path: PathBuf::from("helpers").join("nested").join("mod.rs"),
+                    declarations: vec!["value".to_string()],
+                },
+            ]
+        );
+    }
+}

--- a/crates/sifr_driver/src/tests/diagnostics.rs
+++ b/crates/sifr_driver/src/tests/diagnostics.rs
@@ -37,6 +37,37 @@ fn test_compile_errors_to_diagnostics_preserves_order() {
 }
 
 #[test]
+fn test_workspace_resolution_errors_have_stable_codes_and_urls() {
+    let cases = [
+        (
+            "could not resolve import 'helper'; tried entry-relative '/tmp/helper.sifr' and workspace-relative '/tmp/lib/helper.sifr'",
+            "SIFR-WORKSPACE-0101",
+        ),
+        (
+            "module 'helper' is ambiguous in workspace '/tmp/ws': matches '/tmp/a/helper.sifr' and '/tmp/b/helper.sifr'; reorder [source].roots or rename one module to disambiguate",
+            "SIFR-WORKSPACE-0102",
+        ),
+        (
+            "module 'helpers.list_node' resolves to file '/tmp/ws/lib/helpers/list_node.sifr' but parent name 'helpers' is also a module file '/tmp/ws/lib/helpers.sifr'; package directories are not supported in this phase",
+            "SIFR-WORKSPACE-0103",
+        ),
+    ];
+
+    for (message, code) in cases {
+        let diagnostic = CompileError {
+            message: message.to_string(),
+            phase: CompilePhase::Build,
+        }
+        .to_diagnostic();
+        assert_eq!(diagnostic.code, code);
+        assert_eq!(
+            diagnostic.url,
+            format!("https://sifr.dev/docs/errors/{code}")
+        );
+    }
+}
+
+#[test]
 fn test_apply_diagnostic_recovery_limits_summarizes_similar_diagnostics() {
     let mut diagnostics = Vec::new();
     for idx in 0..8 {

--- a/crates/sifr_driver/src/tests/discovery_and_workspace.rs
+++ b/crates/sifr_driver/src/tests/discovery_and_workspace.rs
@@ -1,8 +1,9 @@
 use crate::{
     create_invocation_workspace, discover_test_root_modules, parse_import_closure_modules,
-    DiscoveryDiagnosticStyle, ModuleResolver,
+    DiscoveryDiagnosticStyle, ModuleResolver, SifrWorkspaceConfig, WorkspaceRoot,
 };
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
 #[test]
 fn test_create_invocation_workspace_returns_unique_paths() {
@@ -161,6 +162,246 @@ fn test_project_and_test_discovery_parity_reports_reachable_parse_errors() {
         .iter()
         .any(|e| e.message.contains("[helper]")));
     assert!(test_errors.iter().any(|e| e.message.contains("[helper]")));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+fn workspace_resolver(
+    entry_parent: &std::path::Path,
+    workspace_root: &std::path::Path,
+    source_roots: Vec<&str>,
+) -> ModuleResolver {
+    ModuleResolver::with_workspace(
+        entry_parent,
+        WorkspaceRoot {
+            dir: workspace_root.to_path_buf(),
+            config: SifrWorkspaceConfig {
+                source_roots: source_roots.into_iter().map(PathBuf::from).collect(),
+                package_name: None,
+            },
+        },
+    )
+}
+
+#[test]
+fn test_workspace_resolver_prefers_entry_parent_over_workspace_sources() {
+    let unique = format!(
+        "sifr_workspace_sibling_wins_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    let source_dir = dir.join("lib");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(&source_dir).expect("source dir should be created");
+    std::fs::write(entry_dir.join("main.sifr"), "from helper import value\n")
+        .expect("main should be written");
+    std::fs::write(entry_dir.join("helper.sifr"), "ENTRY: int = 1\n")
+        .expect("entry helper should be written");
+    std::fs::write(source_dir.join("helper.sifr"), "WORKSPACE: int = 2\n")
+        .expect("workspace helper should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib"]);
+    let resolved = resolver
+        .resolve("helper")
+        .expect("entry helper should resolve first");
+
+    assert_eq!(resolved.path, entry_dir.join("helper.sifr"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_workspace_resolver_finds_declared_source_roots_and_dotted_paths() {
+    let unique = format!(
+        "sifr_workspace_dotted_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    let helper_dir = dir.join("lib/helpers");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(&helper_dir).expect("helper dir should be created");
+    std::fs::write(
+        entry_dir.join("main.sifr"),
+        "from helpers.list_node import ListNode\n",
+    )
+    .expect("main should be written");
+    std::fs::write(
+        helper_dir.join("list_node.sifr"),
+        "class ListNode:\n    pass\n",
+    )
+    .expect("helper should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib"]);
+    let resolved = resolver
+        .resolve("helpers.list_node")
+        .expect("dotted helper should resolve");
+
+    assert_eq!(resolved.path, helper_dir.join("list_node.sifr"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_workspace_resolver_reports_ambiguous_source_roots() {
+    let unique = format!(
+        "sifr_workspace_ambiguous_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(dir.join("lib_a")).expect("lib_a should be created");
+    std::fs::create_dir_all(dir.join("lib_b")).expect("lib_b should be created");
+    std::fs::write(entry_dir.join("main.sifr"), "from helper import value\n")
+        .expect("main should be written");
+    std::fs::write(
+        dir.join("lib_a/helper.sifr"),
+        "def value() -> int:\n    return 1\n",
+    )
+    .expect("lib_a helper should be written");
+    std::fs::write(
+        dir.join("lib_b/helper.sifr"),
+        "def value() -> int:\n    return 2\n",
+    )
+    .expect("lib_b helper should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib_a", "lib_b"]);
+    let errors = parse_import_closure_modules(
+        &resolver,
+        &BTreeSet::from(["main".to_string()]),
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .expect_err("ambiguous workspace helper should fail");
+
+    assert!(errors[0].message.contains("module 'helper' is ambiguous"));
+    assert!(errors[0].message.contains("lib_a/helper.sifr"));
+    assert!(errors[0].message.contains("lib_b/helper.sifr"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_workspace_resolver_reports_unresolved_tried_paths() {
+    let unique = format!(
+        "sifr_workspace_unresolved_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(dir.join("lib")).expect("lib should be created");
+    std::fs::write(entry_dir.join("main.sifr"), "from missing import value\n")
+        .expect("main should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib", "."]);
+    let errors = parse_import_closure_modules(
+        &resolver,
+        &BTreeSet::from(["main".to_string()]),
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .expect_err("missing workspace helper should fail");
+
+    assert!(errors[0]
+        .message
+        .contains("could not resolve import 'missing'"));
+    assert!(errors[0].message.contains("cases/missing.sifr"));
+    assert!(errors[0].message.contains("lib/missing.sifr"));
+    assert!(errors[0].message.contains("missing.sifr"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_workspace_resolver_keeps_stdlib_imports_out_of_filesystem_resolution() {
+    let unique = format!(
+        "sifr_workspace_stdlib_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(dir.join("lib")).expect("lib should be created");
+    std::fs::write(
+        entry_dir.join("main.sifr"),
+        "from sifr.statistics import mean\nfrom _sifr.core import panic\nfrom typing import List\n",
+    )
+    .expect("main should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib"]);
+    let parsed = parse_import_closure_modules(
+        &resolver,
+        &BTreeSet::from(["main".to_string()]),
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .expect("stdlib imports should not require workspace files");
+
+    assert_eq!(parsed.len(), 1);
+    assert!(parsed.contains_key("main"));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_workspace_resolver_rejects_namespace_file_collision() {
+    let unique = format!(
+        "sifr_workspace_namespace_collision_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let dir = std::env::temp_dir().join(unique);
+    let entry_dir = dir.join("cases");
+    std::fs::create_dir_all(&entry_dir).expect("entry dir should be created");
+    std::fs::create_dir_all(dir.join("lib/helpers")).expect("helper dir should be created");
+    std::fs::write(
+        entry_dir.join("main.sifr"),
+        "from helpers.list_node import ListNode\n",
+    )
+    .expect("main should be written");
+    std::fs::write(dir.join("lib/helpers.sifr"), "VALUE: int = 1\n")
+        .expect("parent helper should be written");
+    std::fs::write(
+        dir.join("lib/helpers/list_node.sifr"),
+        "class ListNode:\n    pass\n",
+    )
+    .expect("dotted helper should be written");
+
+    let resolver = workspace_resolver(&entry_dir, &dir, vec!["lib"]);
+    let errors = parse_import_closure_modules(
+        &resolver,
+        &BTreeSet::from(["main".to_string()]),
+        DiscoveryDiagnosticStyle::ModuleName,
+    )
+    .expect_err("namespace collision should fail");
+
+    assert!(errors[0]
+        .message
+        .contains("package directories are not supported"));
+    assert!(errors[0].message.contains("parent name 'helpers'"));
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/sifr_driver/src/tests/project_graph.rs
+++ b/crates/sifr_driver/src/tests/project_graph.rs
@@ -334,6 +334,22 @@ fn test_assemble_project_main_rs_is_deterministic_against_hashmap_order() {
 }
 
 #[test]
+fn test_assemble_project_main_rs_declares_dotted_modules_by_top_level_namespace() {
+    let compile_order = vec!["helpers.list_node".to_string(), "main".to_string()];
+
+    let mut rust_files = HashMap::new();
+    rust_files.insert("main".to_string(), "fn main() {}\n".to_string());
+    rust_files.insert(
+        "helpers.list_node".to_string(),
+        "pub struct ListNode;\n".to_string(),
+    );
+
+    let main_rs = assemble_project_main_rs(&compile_order, &rust_files);
+
+    assert_eq!(main_rs, "mod helpers;\n\nfn main() {}\n");
+}
+
+#[test]
 fn test_collect_project_modules_reports_unknown_module_in_non_main() {
     let mut parsed_modules = HashMap::new();
     parsed_modules.insert(

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -10,7 +10,7 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 - [x] WS0 workspace discovery and config validation
 - [ ] WS1 workspace-aware compilation mode
 - [x] WS2 module resolver refactor with no behavior change
-- [ ] WS3 workspace source resolution and diagnostics
+- [x] WS3 workspace source resolution and diagnostics
 - [ ] WS4 build/run/check/emit wiring and cache correctness
 - [ ] WS5 verification-suite fixtures, design note, and LeetCode pilot
 - [ ] WS6 final gate, review, and closure
@@ -59,8 +59,8 @@ Merged: tbd
 
 ## WS2 Module Resolver Refactor With No Behavior Change
 
-Status: not_started
-Branch: tbd
+Status: implemented_pending_pr
+Branch: ad-hoc/sifr-workspace-ws3
 PR: tbd
 Merged: tbd
 
@@ -95,11 +95,11 @@ Merged: tbd
 
 ### Validation Evidence
 
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace -- -D warnings`
-- [ ] `cargo test -p sifr_driver workspace -- --nocapture` or equivalent targeted selector
-- [ ] `cargo test -p sifr_driver discovery -- --nocapture` or equivalent targeted selector
-- [ ] Snapshot evidence for diagnostic codes and URLs
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --workspace -- -D warnings`
+- [x] `cargo test -p sifr_driver workspace -- --nocapture`
+- [x] `cargo test -p sifr_driver discovery -- --nocapture`
+- [x] Diagnostic code and URL unit coverage for `SIFR-WORKSPACE-0101`, `SIFR-WORKSPACE-0102`, and `SIFR-WORKSPACE-0103`
 
 ## WS4 Build/Run/Check/Emit Wiring And Cache Correctness
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -61,7 +61,7 @@ Merged: tbd
 
 Status: implemented_pending_pr
 Branch: ad-hoc/sifr-workspace-ws3
-PR: tbd
+PR: https://github.com/yaseralnajjar/sifr/pull/1641
 Merged: tbd
 
 ### Planned Scope


### PR DESCRIPTION
## Summary
- extend `ModuleResolver` with optional workspace source roots while keeping entry-parent precedence
- resolve dotted module names to nested `.sifr` paths
- report deterministic unresolved, ambiguous, and namespace/file-collision workspace diagnostics
- add a shared Rust module layout helper and use it for top-level `main.rs` declarations
- cover sibling-wins, source roots, dotted paths, ambiguity, unresolved imports, stdlib exclusions, namespace collisions, and diagnostic codes

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_driver workspace -- --nocapture`
- `cargo test -p sifr_driver discovery -- --nocapture`
- `cargo test -p sifr_driver diagnostics::test_workspace_resolution_errors_have_stable_codes_and_urls -- --nocapture`
- `cargo clippy --workspace -- -D warnings`

## Notes
- Full CLI verification snapshots are deferred to WS5 with the project verification-suite fixtures.