### PR TITLE
Activate workspace compilation mode

### DIFF
--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -8,8 +8,9 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build, build_cached_project, build_cached_single_file,
-    build_project, check, check_project, compile, compile_errors_to_diagnostics, run_tests,
-    CachedBinaryArtifact, CompileError, CompilePhase, CompileResult, CompilerDiagnostic, Severity,
+    build_project, check, check_project, compile, compile_errors_to_diagnostics,
+    find_workspace_root, run_tests, CachedBinaryArtifact, CompileError, CompilePhase,
+    CompileResult, CompilerDiagnostic, Severity,
 };
 use sifr_python_ast::Stmt;
 use sifr_python_parser::parse_module;
@@ -103,14 +104,18 @@ fn run_cli(cli: Cli) -> i32 {
     }
 }
 
-fn resolve_compilation_mode(file: &Path) -> CompilationMode {
+fn resolve_compilation_mode(file: &Path) -> Result<CompilationMode, Vec<CompileError>> {
+    if find_workspace_root(file)?.is_some() {
+        return Ok(CompilationMode::Project);
+    }
+
     let is_project_entry =
         file.file_stem().is_some_and(|stem| stem == "main") && has_local_project_imports(file);
 
     if is_project_entry {
-        CompilationMode::Project
+        Ok(CompilationMode::Project)
     } else {
-        CompilationMode::SingleFile
+        Ok(CompilationMode::SingleFile)
     }
 }
 
@@ -533,7 +538,7 @@ fn cmd_emit(file: &Path, diagnostic_format: DiagnosticFormat) -> i32 {
 }
 
 fn compile_entrypoint(file: &Path, output: &Path) -> Result<PathBuf, Vec<CompileError>> {
-    match resolve_compilation_mode(file) {
+    match resolve_compilation_mode(file)? {
         CompilationMode::Project => build_project(file, output),
         CompilationMode::SingleFile => {
             let source = read_source(file);
@@ -543,7 +548,7 @@ fn compile_entrypoint(file: &Path, output: &Path) -> Result<PathBuf, Vec<Compile
 }
 
 fn build_run_artifact(file: &Path) -> Result<CachedBinaryArtifact, Vec<CompileError>> {
-    match resolve_compilation_mode(file) {
+    match resolve_compilation_mode(file)? {
         CompilationMode::Project => build_cached_project(file),
         CompilationMode::SingleFile => {
             let source = read_source(file);
@@ -554,8 +559,9 @@ fn build_run_artifact(file: &Path) -> Result<CachedBinaryArtifact, Vec<CompileEr
 
 fn check_entrypoint(file: &Path) -> Vec<CompileError> {
     match resolve_compilation_mode(file) {
-        CompilationMode::Project => check_project(file),
-        CompilationMode::SingleFile => {
+        Err(errors) => errors,
+        Ok(CompilationMode::Project) => check_project(file),
+        Ok(CompilationMode::SingleFile) => {
             let source = read_source(file);
             check(&source)
         }
@@ -563,8 +569,22 @@ fn check_entrypoint(file: &Path) -> Vec<CompileError> {
 }
 
 fn emit_entrypoint(file: &Path) -> CompileResult {
+    let mode = match resolve_compilation_mode(file) {
+        Ok(mode) => mode,
+        Err(errors) => return CompileResult::Errors { errors },
+    };
     let source = read_source(file);
-    compile(&source)
+    match mode {
+        CompilationMode::Project => {
+            let errors = check_project(file);
+            if errors.is_empty() {
+                compile(&source)
+            } else {
+                CompileResult::Errors { errors }
+            }
+        }
+        CompilationMode::SingleFile => compile(&source),
+    }
 }
 
 #[cfg(test)]
@@ -583,6 +603,10 @@ mod tests {
         let dir = std::env::temp_dir().join(unique);
         std::fs::create_dir_all(&dir).expect("temp dir should be created");
         dir
+    }
+
+    fn resolved_mode(file: &Path) -> CompilationMode {
+        resolve_compilation_mode(file).expect("compilation mode should resolve")
     }
 
     struct TestProject {
@@ -638,7 +662,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::Project);
+        assert_eq!(resolved_mode(&main), CompilationMode::Project);
     }
 
     #[test]
@@ -655,7 +679,49 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&app), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&app), CompilationMode::SingleFile);
+    }
+
+    #[test]
+    fn test_resolve_compilation_mode_project_for_non_main_entry_in_workspace() {
+        let project = TestProject::new("workspace_non_main");
+        project.write(
+            "sifr.toml",
+            "[source]\nroots = [\"src\"]\n",
+            "manifest should be written",
+        );
+        project.write(
+            "src/helper.sifr",
+            "VALUE: int = 1\n",
+            "helper should be written",
+        );
+        let app = project.write(
+            "src/app.sifr",
+            "from helper import VALUE\n\ndef main():\n    print(VALUE)\n",
+            "app file should be written",
+        );
+
+        assert_eq!(resolved_mode(&app), CompilationMode::Project);
+    }
+
+    #[test]
+    fn test_resolve_compilation_mode_reports_malformed_workspace_manifest() {
+        let project = TestProject::new("workspace_malformed");
+        project.write(
+            "sifr.toml",
+            "[source\nroots = [\".\"]\n",
+            "manifest should be written",
+        );
+        let app = project.write(
+            "app.sifr",
+            "def main():\n    pass\n",
+            "app should be written",
+        );
+
+        let errors = resolve_compilation_mode(&app)
+            .expect_err("malformed manifest should prevent single-file fallback");
+
+        assert!(errors[0].message.contains("could not parse sifr.toml"));
     }
 
     #[test]
@@ -672,7 +738,7 @@ mod tests {
             "scratch file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -689,7 +755,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -701,7 +767,7 @@ mod tests {
             "main file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -718,7 +784,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -731,7 +797,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -748,7 +814,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -765,7 +831,7 @@ mod tests {
             "typing file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -782,7 +848,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -799,7 +865,7 @@ mod tests {
             "enum file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -816,7 +882,7 @@ mod tests {
             "pkg init should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -833,7 +899,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::Project);
+        assert_eq!(resolved_mode(&main), CompilationMode::Project);
     }
 
     #[test]
@@ -845,7 +911,7 @@ mod tests {
             "main file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -862,7 +928,7 @@ mod tests {
             "helper file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]
@@ -874,7 +940,7 @@ mod tests {
             "main file should be written",
         );
 
-        assert_eq!(resolve_compilation_mode(&main), CompilationMode::SingleFile);
+        assert_eq!(resolved_mode(&main), CompilationMode::SingleFile);
     }
 
     #[test]

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -41,7 +41,7 @@ Merged: 2026-04-25
 
 Status: implemented_pending_pr
 Branch: ad-hoc/sifr-workspace-ws1
-PR: tbd
+PR: https://github.com/yaseralnajjar/sifr/pull/1642
 Merged: tbd
 
 ### Planned Scope

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -8,7 +8,7 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 ## Wave Checklist
 
 - [x] WS0 workspace discovery and config validation
-- [ ] WS1 workspace-aware compilation mode
+- [x] WS1 workspace-aware compilation mode
 - [x] WS2 module resolver refactor with no behavior change
 - [x] WS3 workspace source resolution and diagnostics
 - [ ] WS4 build/run/check/emit wiring and cache correctness
@@ -40,8 +40,8 @@ Merged: 2026-04-25
 ## WS1 Workspace-Aware Compilation Mode
 
 Status: implemented_pending_pr
-Branch: ad-hoc/sifr-workspace-ws2
-PR: https://github.com/yaseralnajjar/sifr/pull/1640
+Branch: ad-hoc/sifr-workspace-ws1
+PR: tbd
 Merged: tbd
 
 ### Planned Scope
@@ -52,17 +52,17 @@ Merged: tbd
 
 ### Validation Evidence
 
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace -- -D warnings`
-- [ ] `cargo test -p sifr -- resolve_compilation_mode -- --nocapture` or equivalent targeted selector
-- [ ] CLI malformed-workspace diagnostic check recorded in PR notes
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --workspace -- -D warnings`
+- [x] `cargo test -p sifr -- resolve_compilation_mode -- --nocapture`
+- [x] CLI malformed-workspace diagnostic path covered by `test_resolve_compilation_mode_reports_malformed_workspace_manifest`.
 
 ## WS2 Module Resolver Refactor With No Behavior Change
 
-Status: implemented_pending_pr
-Branch: ad-hoc/sifr-workspace-ws3
-PR: https://github.com/yaseralnajjar/sifr/pull/1641
-Merged: tbd
+Status: merged
+Branch: ad-hoc/sifr-workspace-ws2
+PR: https://github.com/yaseralnajjar/sifr/pull/1640
+Merged: 2026-04-25
 
 ### Planned Scope
 
@@ -80,10 +80,10 @@ Merged: tbd
 
 ## WS3 Workspace Source Resolution And Diagnostics
 
-Status: not_started
-Branch: tbd
-PR: tbd
-Merged: tbd
+Status: merged
+Branch: ad-hoc/sifr-workspace-ws3
+PR: https://github.com/yaseralnajjar/sifr/pull/1641
+Merged: 2026-04-25
 
 ### Planned Scope
 


### PR DESCRIPTION
## Summary
- make CLI compilation-mode resolution return workspace discovery diagnostics
- enter project mode for any entry inside a discovered `sifr.toml` workspace
- preserve legacy non-workspace `main.sifr` sibling-import behavior
- prevent malformed workspace config from silently falling back to single-file mode
- record WS1 validation evidence and fix merged WS2/WS3 checklist status

## Validation
- `cargo fmt --check`
- `cargo test -p sifr -- resolve_compilation_mode -- --nocapture`
- `cargo clippy --workspace -- -D warnings`