### PR TITLE
Wire workspace modules through project builds

### DIFF
--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -8,7 +8,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build, build_cached_project, build_cached_single_file,
-    build_project, check, check_project, compile, compile_errors_to_diagnostics,
+    build_project, check, check_project, compile, compile_errors_to_diagnostics, emit_project,
     find_workspace_root, run_tests, CachedBinaryArtifact, CompileError, CompilePhase,
     CompileResult, CompilerDiagnostic, Severity,
 };
@@ -573,17 +573,12 @@ fn emit_entrypoint(file: &Path) -> CompileResult {
         Ok(mode) => mode,
         Err(errors) => return CompileResult::Errors { errors },
     };
-    let source = read_source(file);
     match mode {
-        CompilationMode::Project => {
-            let errors = check_project(file);
-            if errors.is_empty() {
-                compile(&source)
-            } else {
-                CompileResult::Errors { errors }
-            }
+        CompilationMode::Project => emit_project(file),
+        CompilationMode::SingleFile => {
+            let source = read_source(file);
+            compile(&source)
         }
-        CompilationMode::SingleFile => compile(&source),
     }
 }
 

--- a/crates/sifr_driver/src/build/api.rs
+++ b/crates/sifr_driver/src/build/api.rs
@@ -1,8 +1,9 @@
 use crate::build::{
     build_cached_project_binary, build_cached_single_file_binary, build_rooted_entrypoint_binary,
-    resolve_project_entrypoint_plan, CachedBinaryArtifact, RootedEntrypoint,
+    emit_project_entrypoint, resolve_project_entrypoint_plan, CachedBinaryArtifact,
+    RootedEntrypoint,
 };
-use crate::diagnostics::CompileError;
+use crate::diagnostics::{CompileError, CompileResult};
 use std::path::{Path, PathBuf};
 
 pub fn build_project(main_file: &Path, output_dir: &Path) -> Result<PathBuf, Vec<CompileError>> {
@@ -17,6 +18,10 @@ pub fn check_project(main_file: &Path) -> Vec<CompileError> {
         }
         Err(errors) => errors,
     }
+}
+
+pub fn emit_project(main_file: &Path) -> CompileResult {
+    emit_project_entrypoint(main_file)
 }
 
 pub fn build(source: &str, output_dir: &Path) -> Result<PathBuf, Vec<CompileError>> {

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -5,13 +5,14 @@ use super::project_codegen::{
     generated_project_binary_project, generated_single_file_binary_project, GeneratedBinaryProject,
 };
 use super::ArtifactCacheReport;
-use crate::diagnostics::{run_codegen_with_boundary, CompileError, CompilePhase};
+use crate::diagnostics::{run_codegen_with_boundary, CompileError, CompilePhase, CompileResult};
 use crate::frontend::{parse_source, FrontendCompiled, FrontendDiagnosticStyle};
 use crate::project::{
     collect_project_hir_modules, compile_frontend_modules, emit_project_frontend_diagnostics,
     parse_import_closure_modules, DiscoveryDiagnosticStyle, ModuleResolver, ProjectLowering,
 };
 use crate::stdlib::{compile_stdlib, StdlibCompiled};
+use crate::workspace::find_workspace_root;
 use sifr_codegen::generate_rust_with_stdlib;
 use sifr_hir::LoweringResult;
 use std::collections::{BTreeSet, HashMap};
@@ -73,6 +74,20 @@ pub(crate) fn resolve_project_entrypoint_plan(
     main_file: &Path,
 ) -> Result<RootedEntrypointPlan, Vec<CompileError>> {
     RootedEntrypointPlan::from_entrypoint(&RootedEntrypoint::Project { main_file })
+}
+
+pub(crate) fn emit_project_entrypoint(main_file: &Path) -> CompileResult {
+    let plan = match resolve_project_entrypoint_plan(main_file) {
+        Ok(plan) => plan,
+        Err(errors) => return CompileResult::Errors { errors },
+    };
+    plan.emit_frontend_diagnostics();
+    match plan.into_generated_binary_project() {
+        Ok(generated_project) => CompileResult::Success {
+            rust_source: generated_project.emit_source_listing(),
+        },
+        Err(errors) => CompileResult::Errors { errors },
+    }
 }
 
 pub(crate) fn build_rooted_entrypoint_binary(
@@ -155,13 +170,23 @@ impl RootedEntrypointPlan {
                         phase: CompilePhase::Build,
                     }]);
                 };
-                let root_modules = BTreeSet::from([main_module_name]);
-                let resolver = ModuleResolver::entry_parent(project_dir);
-                let parsed_modules = parse_import_closure_modules(
+                let root_modules = BTreeSet::from([main_module_name.clone()]);
+                let resolver = match find_workspace_root(main_file)? {
+                    Some(workspace_root) => {
+                        ModuleResolver::with_workspace(project_dir, workspace_root)
+                    }
+                    None => ModuleResolver::entry_parent(project_dir),
+                };
+                let mut parsed_modules = parse_import_closure_modules(
                     &resolver,
                     &root_modules,
                     DiscoveryDiagnosticStyle::ModuleName,
                 )?;
+                if main_module_name != "main" {
+                    if let Some(entry_suite) = parsed_modules.remove(&main_module_name) {
+                        parsed_modules.insert("main".to_string(), entry_suite);
+                    }
+                }
                 let project_lowering =
                     collect_project_hir_modules(&parsed_modules, stdlib.defs.clone())?;
                 (RootedEntrypointShape::Project, project_lowering)

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -2,6 +2,7 @@ use super::cargo_manifest::generate_dependency_cargo_toml;
 use super::project_codegen::GeneratedBinaryProject;
 use super::{prepare_cached_artifact, CachedArtifactEntry, PreparedArtifactCache};
 use crate::diagnostics::{CompileError, CompilePhase};
+use crate::project::{namespace_module_files, rust_module_file_path};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -82,9 +83,29 @@ fn materialize_binary_project_at_path(
         "main.rs",
     )?;
 
+    let support_module_names: Vec<String> =
+        generated_project.support_modules.keys().cloned().collect();
+    for namespace_file in namespace_module_files(&support_module_names) {
+        let mut contents = String::new();
+        for module_name in &namespace_file.declarations {
+            contents.push_str("pub mod ");
+            contents.push_str(module_name);
+            contents.push_str(";\n");
+        }
+        write_project_file(
+            &src_dir.join(&namespace_file.path),
+            contents,
+            &namespace_file.path.display().to_string(),
+        )?;
+    }
+
     for (module_name, code) in generated_project.support_modules {
-        let file_name = format!("{module_name}.rs");
-        write_project_file(&src_dir.join(&file_name), code, &file_name)?;
+        let file_name = rust_module_file_path(&module_name);
+        write_project_file(
+            &src_dir.join(&file_name),
+            code,
+            &file_name.display().to_string(),
+        )?;
     }
 
     let output = Command::new("cargo")
@@ -105,6 +126,10 @@ fn write_project_file(
     contents: impl AsRef<[u8]>,
     label: &str,
 ) -> Result<(), Vec<CompileError>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| vec![build_error(format!("failed to create {label}: {error}"))])?;
+    }
     std::fs::write(path, contents)
         .map_err(|error| vec![build_error(format!("failed to write {label}: {error}"))])
 }

--- a/crates/sifr_driver/src/build/mod.rs
+++ b/crates/sifr_driver/src/build/mod.rs
@@ -7,6 +7,7 @@ mod workspace;
 
 pub use api::{
     build, build_cached_project, build_cached_single_file, build_project, check_project,
+    emit_project,
 };
 pub use entrypoint::CachedBinaryArtifact;
 
@@ -14,7 +15,7 @@ pub(crate) use cargo_manifest::generate_dependency_cargo_toml;
 pub(crate) use entrypoint::{
     build_cached_project_binary, build_cached_single_file_binary, build_rooted_entrypoint_binary,
     compile_single_file_entrypoint_with_metadata, compile_single_file_frontend,
-    resolve_project_entrypoint_plan, RootedEntrypoint,
+    emit_project_entrypoint, resolve_project_entrypoint_plan, RootedEntrypoint,
 };
 pub(crate) use workspace::{
     prepare_cached_artifact, ArtifactCacheReport, CachedArtifactEntry, PreparedArtifactCache,

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -1,5 +1,7 @@
 use crate::diagnostics::{run_codegen_with_boundary, CompileError};
-use crate::project::{assemble_project_main_rs, ordered_non_main_module_names, ProjectLowering};
+use crate::project::{
+    assemble_project_main_rs, ordered_non_main_module_names, rust_module_file_path, ProjectLowering,
+};
 use sifr_codegen::{generate_rust_multi_with_metadata, StdlibCode};
 use sifr_hir::HirModule;
 use std::collections::{BTreeMap, HashSet};
@@ -9,6 +11,27 @@ pub(super) struct GeneratedBinaryProject {
     pub(super) support_modules: BTreeMap<String, String>,
     pub(super) used_stdlib_modules: HashSet<String>,
     pub(super) required_crates: HashSet<String>,
+}
+
+impl GeneratedBinaryProject {
+    pub(super) fn emit_source_listing(&self) -> String {
+        let mut listing = String::new();
+        listing.push_str("// src/main.rs\n");
+        listing.push_str(&self.main_rs);
+        if !self.main_rs.ends_with('\n') {
+            listing.push('\n');
+        }
+        for (module_name, code) in &self.support_modules {
+            listing.push_str("\n// src/");
+            listing.push_str(&rust_module_file_path(module_name).display().to_string());
+            listing.push('\n');
+            listing.push_str(code);
+            if !code.ends_with('\n') {
+                listing.push('\n');
+            }
+        }
+        listing
+    }
 }
 
 pub(super) fn generated_single_file_binary_project(

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -17,7 +17,7 @@ mod workspace;
 
 pub use build::{
     build, build_cached_project, build_cached_single_file, build_project, check_project,
-    CachedBinaryArtifact,
+    emit_project, CachedBinaryArtifact,
 };
 pub use diagnostics::{
     apply_diagnostic_recovery_limits, compile_errors_to_diagnostics, CompileError, CompilePhase,

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -46,7 +46,6 @@ impl ModuleResolver {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn with_workspace(
         entry_parent: impl Into<PathBuf>,
         workspace: WorkspaceRoot,

--- a/crates/sifr_driver/src/project/mod.rs
+++ b/crates/sifr_driver/src/project/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use frontend::{
     collect_project_hir_modules, compile_frontend_modules, emit_project_frontend_diagnostics,
     ProjectLowering,
 };
+pub(crate) use rust_module_layout::{namespace_module_files, rust_module_file_path};
 
 #[cfg(test)]
 pub(crate) use compile_order::compute_module_compile_order;

--- a/crates/sifr_driver/src/project/rust_module_layout.rs
+++ b/crates/sifr_driver/src/project/rust_module_layout.rs
@@ -2,13 +2,11 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) struct NamespaceModuleFile {
     pub(crate) path: PathBuf,
     pub(crate) declarations: Vec<String>,
 }
 
-#[allow(dead_code)]
 pub(crate) fn rust_module_file_path(module_id: &str) -> PathBuf {
     let mut path = PathBuf::new();
     for component in module_id.split('.') {
@@ -28,7 +26,6 @@ pub(crate) fn top_level_module_declarations(module_ids: &[String]) -> Vec<String
         .collect()
 }
 
-#[allow(dead_code)]
 pub(crate) fn namespace_module_files(module_ids: &[String]) -> Vec<NamespaceModuleFile> {
     let mut namespace_children: std::collections::BTreeMap<String, BTreeSet<String>> =
         std::collections::BTreeMap::new();

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -1,4 +1,4 @@
-use crate::{build_project, check_project};
+use crate::{build_cached_project, build_project, check_project, emit_project, CompileResult};
 use std::path::PathBuf;
 
 fn mktemp_dir(name: &str) -> PathBuf {
@@ -46,6 +46,127 @@ def area(radius: float) -> float:
     );
 
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_check_project_resolves_workspace_source_import_for_non_main_entry() {
+    let dir = mktemp_dir("workspace_check_non_main");
+    std::fs::create_dir_all(dir.join("cases")).expect("cases dir should be created");
+    std::fs::create_dir_all(dir.join("lib")).expect("lib dir should be created");
+    std::fs::write(dir.join("sifr.toml"), "[source]\nroots = [\"lib\"]\n")
+        .expect("manifest should be written");
+    std::fs::write(
+        dir.join("cases/app.sifr"),
+        "from helper import value\n\ndef main():\n    print(value())\n",
+    )
+    .expect("entry should be written");
+    std::fs::write(
+        dir.join("lib/helper.sifr"),
+        "def value() -> int:\n    return 42\n",
+    )
+    .expect("helper should be written");
+
+    let errors = check_project(&dir.join("cases/app.sifr"));
+
+    assert!(
+        errors.is_empty(),
+        "workspace check should succeed: {errors:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_build_project_materializes_dotted_workspace_modules() {
+    let dir = mktemp_dir("workspace_dotted_build");
+    let main_file = dir.join("cases/app.sifr");
+    let build_out = dir.join("build_out");
+    std::fs::create_dir_all(dir.join("cases")).expect("cases dir should be created");
+    std::fs::create_dir_all(dir.join("lib/helpers")).expect("helpers dir should be created");
+    std::fs::write(dir.join("sifr.toml"), "[source]\nroots = [\"lib\"]\n")
+        .expect("manifest should be written");
+    std::fs::write(
+        &main_file,
+        "from helpers.value import answer\n\ndef main():\n    print(answer())\n",
+    )
+    .expect("entry should be written");
+    std::fs::write(
+        dir.join("lib/helpers/value.sifr"),
+        "def answer() -> int:\n    return 42\n",
+    )
+    .expect("helper should be written");
+
+    let binary = build_project(&main_file, &build_out)
+        .expect("workspace dotted project should build successfully");
+
+    assert!(binary.exists());
+    let src_dir = build_out.join("sifr_output/src");
+    let main_rs = std::fs::read_to_string(src_dir.join("main.rs")).expect("main.rs should exist");
+    let helpers_mod =
+        std::fs::read_to_string(src_dir.join("helpers/mod.rs")).expect("helpers mod should exist");
+    assert!(main_rs.contains("mod helpers;"));
+    assert_eq!(helpers_mod, "pub mod value;\n");
+    assert!(src_dir.join("helpers/value.rs").is_file());
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_emit_project_includes_workspace_support_modules() {
+    let dir = mktemp_dir("workspace_emit");
+    let main_file = dir.join("cases/app.sifr");
+    std::fs::create_dir_all(dir.join("cases")).expect("cases dir should be created");
+    std::fs::create_dir_all(dir.join("lib/helpers")).expect("helpers dir should be created");
+    std::fs::write(dir.join("sifr.toml"), "[source]\nroots = [\"lib\"]\n")
+        .expect("manifest should be written");
+    std::fs::write(
+        &main_file,
+        "from helpers.value import answer\n\ndef main():\n    print(answer())\n",
+    )
+    .expect("entry should be written");
+    std::fs::write(
+        dir.join("lib/helpers/value.sifr"),
+        "def answer() -> int:\n    return 7\n",
+    )
+    .expect("helper should be written");
+
+    let emitted = emit_project(&main_file);
+
+    let CompileResult::Success { rust_source } = emitted else {
+        panic!("workspace project emit should succeed");
+    };
+    assert!(rust_source.contains("// src/main.rs"));
+    assert!(rust_source.contains("mod helpers;"));
+    assert!(rust_source.contains("// src/helpers/value.rs"));
+
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn test_cached_project_invalidates_when_workspace_helper_changes() {
+    let dir = mktemp_dir("workspace_cache_invalidation");
+    let main_file = dir.join("cases/app.sifr");
+    let helper_file = dir.join("lib/helpers/value.sifr");
+    std::fs::create_dir_all(dir.join("cases")).expect("cases dir should be created");
+    std::fs::create_dir_all(dir.join("lib/helpers")).expect("helpers dir should be created");
+    std::fs::write(dir.join("sifr.toml"), "[source]\nroots = [\"lib\"]\n")
+        .expect("manifest should be written");
+    std::fs::write(
+        &main_file,
+        "from helpers.value import answer\n\ndef main():\n    print(answer())\n",
+    )
+    .expect("entry should be written");
+    std::fs::write(&helper_file, "def answer() -> int:\n    return 10\n")
+        .expect("helper should be written");
+
+    let first = build_cached_project(&main_file).expect("first workspace build should succeed");
+    std::fs::write(&helper_file, "def answer() -> int:\n    return 11\n")
+        .expect("helper should be updated");
+    let second = build_cached_project(&main_file).expect("second workspace build should succeed");
+
+    assert_ne!(first.cache_report().key(), second.cache_report().key());
+
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
@@ -215,8 +336,8 @@ fn test_build_project_includes_reachable_support_module_stdlib_crates_in_manifes
     .expect("main should be written");
     std::fs::write(
         dir.join("helper.sifr"),
-        "from sifr.tomllib import loads\n\n\
-def render() -> str:\n    try:\n        parsed: str = loads(\"name = \\\"phase-five\\\"\\nvalue = 5\")\n        return parsed\n    except TOMLDecodeError as e:\n        return e.message\n",
+        "from sifr.tomllib import TomlValue, loads\n\n\
+def render() -> str:\n    try:\n        parsed: TomlValue = loads(\"name = \\\"phase-five\\\"\\nvalue = 5\")\n        return \"ok\"\n    except TOMLDecodeError as e:\n        return e.message\n",
     )
     .expect("helper should be written");
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -11,7 +11,7 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 - [x] WS1 workspace-aware compilation mode
 - [x] WS2 module resolver refactor with no behavior change
 - [x] WS3 workspace source resolution and diagnostics
-- [ ] WS4 build/run/check/emit wiring and cache correctness
+- [x] WS4 build/run/check/emit wiring and cache correctness
 - [ ] WS5 verification-suite fixtures, design note, and LeetCode pilot
 - [ ] WS6 final gate, review, and closure
 
@@ -103,8 +103,8 @@ Merged: 2026-04-25
 
 ## WS4 Build/Run/Check/Emit Wiring And Cache Correctness
 
-Status: not_started
-Branch: tbd
+Status: implemented_pending_pr
+Branch: ad-hoc/sifr-workspace-ws4
 PR: tbd
 Merged: tbd
 
@@ -117,10 +117,10 @@ Merged: tbd
 
 ### Validation Evidence
 
-- [ ] `cargo fmt --check`
-- [ ] `cargo clippy --workspace -- -D warnings`
-- [ ] `cargo test -p sifr_driver project_build_check -- --nocapture` or equivalent targeted selector
-- [ ] Cache-key regression proving dotted helper content invalidates cached runs
+- [x] `cargo fmt --check`
+- [x] `cargo clippy --workspace -- -D warnings`
+- [x] `cargo test -p sifr_driver project_build_check -- --nocapture`
+- [x] Cache-key regression covered by `test_cached_project_invalidates_when_workspace_helper_changes`.
 
 ## WS5 Verification-Suite Fixtures, Design Note, And LeetCode Pilot
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -105,7 +105,7 @@ Merged: 2026-04-25
 
 Status: implemented_pending_pr
 Branch: ad-hoc/sifr-workspace-ws4
-PR: tbd
+PR: https://github.com/yaseralnajjar/sifr/pull/1643
 Merged: tbd
 
 ### Planned Scope


### PR DESCRIPTION
## Summary
- discover and pass workspace context inside driver project entrypoint planning
- support non-`main.sifr` workspace entries by lowering the selected entry as generated `main`
- make `check`, `build`, cached `run`, and project `emit` share the workspace resolver
- materialize dotted support modules as nested Rust module trees with generated `mod.rs` namespace files
- add workspace build/check/emit/cache regressions for dotted helpers

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_driver project_build_check -- --nocapture`
- `cargo test -p sifr_driver build::entrypoint -- --nocapture`
- `cargo test -p sifr -- resolve_compilation_mode -- --nocapture`
- `cargo clippy --workspace -- -D warnings`