### PR TITLE
Fix Sifr workspace closure review blockers

### DIFF
--- a/crates/sifr_driver/src/project/mod.rs
+++ b/crates/sifr_driver/src/project/mod.rs
@@ -14,7 +14,9 @@ pub(crate) use frontend::{
     collect_project_hir_modules, compile_frontend_modules, emit_project_frontend_diagnostics,
     ProjectLowering,
 };
-pub(crate) use rust_module_layout::{namespace_module_files, rust_module_file_path};
+pub(crate) use rust_module_layout::{
+    namespace_module_files, rust_module_file_path, top_level_module_declarations,
+};
 
 #[cfg(test)]
 pub(crate) use compile_order::compute_module_compile_order;

--- a/crates/sifr_driver/src/test_runner/artifacts.rs
+++ b/crates/sifr_driver/src/test_runner/artifacts.rs
@@ -1,4 +1,5 @@
 use crate::build::generate_dependency_cargo_toml;
+use crate::project::top_level_module_declarations;
 use std::collections::HashSet;
 
 pub(crate) fn compose_test_runner_lib(
@@ -6,9 +7,9 @@ pub(crate) fn compose_test_runner_lib(
     all_rust_code: &str,
 ) -> String {
     let mut test_lib = String::from("#![cfg(test)]\n\n");
-    for module_name in support_module_names {
+    for module_name in top_level_module_declarations(support_module_names) {
         test_lib.push_str("mod ");
-        test_lib.push_str(module_name);
+        test_lib.push_str(&module_name);
         test_lib.push_str(";\n");
     }
     if !support_module_names.is_empty() {

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -2,6 +2,7 @@ use super::artifacts::{compose_test_runner_lib, generate_test_runner_cargo_toml}
 use super::orchestrator::GeneratedTestRunnerProject;
 use crate::build::{prepare_cached_artifact, ArtifactCacheReport, PreparedArtifactCache};
 use crate::diagnostics::{write_stderr, write_stderr_line, CompileError, CompilePhase};
+use crate::project::{namespace_module_files, rust_module_file_path};
 use std::path::Path;
 
 pub(crate) struct TestRunnerExecutionOutcome {
@@ -52,15 +53,59 @@ pub(crate) fn execute_test_runner_project(
 
         for module_name in &generated_project.support_module_names {
             if let Some(code) = generated_project.support_rust_files.get(module_name) {
-                std::fs::write(src_dir.join(format!("{module_name}.rs")), code).map_err(
-                    |error| {
+                let module_path = rust_module_file_path(module_name);
+                let output_path = src_dir.join(&module_path);
+                if let Some(parent) = output_path.parent() {
+                    std::fs::create_dir_all(parent).map_err(|error| {
                         vec![CompileError {
-                            message: format!("failed to write {module_name}.rs: {error}"),
+                            message: format!(
+                                "failed to create test support module directory '{}': {error}",
+                                parent.display()
+                            ),
                             phase: CompilePhase::Build,
                         }]
-                    },
-                )?;
+                    })?;
+                }
+                std::fs::write(&output_path, code).map_err(|error| {
+                    vec![CompileError {
+                        message: format!(
+                            "failed to write test support module '{}': {error}",
+                            output_path.display()
+                        ),
+                        phase: CompilePhase::Build,
+                    }]
+                })?;
             }
+        }
+
+        for namespace_file in namespace_module_files(&generated_project.support_module_names) {
+            let output_path = src_dir.join(&namespace_file.path);
+            if let Some(parent) = output_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|error| {
+                    vec![CompileError {
+                        message: format!(
+                            "failed to create test support namespace directory '{}': {error}",
+                            parent.display()
+                        ),
+                        phase: CompilePhase::Build,
+                    }]
+                })?;
+            }
+            let mut contents = String::new();
+            for declaration in namespace_file.declarations {
+                contents.push_str("pub mod ");
+                contents.push_str(&declaration);
+                contents.push_str(";\n");
+            }
+            std::fs::write(&output_path, contents).map_err(|error| {
+                vec![CompileError {
+                    message: format!(
+                        "failed to write test support namespace '{}': {error}",
+                        output_path.display()
+                    ),
+                    phase: CompilePhase::Build,
+                }]
+            })?;
         }
 
         std::fs::write(src_dir.join("lib.rs"), &test_lib).map_err(|error| {

--- a/crates/sifr_driver/src/tests/project_graph.rs
+++ b/crates/sifr_driver/src/tests/project_graph.rs
@@ -330,7 +330,7 @@ fn test_assemble_project_main_rs_is_deterministic_against_hashmap_order() {
     let main_a = assemble_project_main_rs(&compile_order, &rust_files_a);
     let main_b = assemble_project_main_rs(&compile_order, &rust_files_b);
     assert_eq!(main_a, main_b);
-    assert_eq!(main_a, "mod provider;\nmod consumer;\n\nfn main() {}\n");
+    assert_eq!(main_a, "mod consumer;\nmod provider;\n\nfn main() {}\n");
 }
 
 #[test]

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -47,6 +47,44 @@ def test_import_parity():
 }
 
 #[test]
+fn test_run_tests_resolves_dotted_local_support_modules() {
+    let unique = format!(
+        "sifr_test_dotted_import_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos()
+    );
+    let test_dir = std::env::temp_dir().join(unique);
+    std::fs::create_dir_all(test_dir.join("helpers")).expect("test helper dir should be created");
+
+    std::fs::write(
+        test_dir.join("helpers").join("list_node.sifr"),
+        r#"
+def value() -> int:
+    return 41
+"#,
+    )
+    .expect("dotted helper module should be written");
+    std::fs::write(
+        test_dir.join("test_dotted_imports.sifr"),
+        r#"
+from helpers.list_node import value
+
+def test_dotted_import():
+    assert value() == 41
+"#,
+    )
+    .expect("test module should be written");
+
+    let result = run_tests(&test_dir).expect("test runner should compile dotted support modules");
+    assert!(result, "sifr test run should succeed");
+
+    let _ = std::fs::remove_dir_all(&test_dir);
+}
+
+#[test]
 fn test_run_tests_reuses_cached_workspace_for_unchanged_project() {
     let unique = format!(
         "sifr_test_cache_reuse_{}_{}",
@@ -358,5 +396,23 @@ fn test_compose_test_runner_lib_is_test_scoped() {
     let lib_source = compose_test_runner_lib(&support_modules, all_rust_code);
     assert!(lib_source.starts_with("#![cfg(test)]"));
     assert!(lib_source.contains("mod helper;"));
+    assert!(lib_source.contains("#[test]\nfn smoke() {}"));
+}
+
+#[test]
+fn test_compose_test_runner_lib_declares_dotted_modules_by_namespace() {
+    let support_modules = vec![
+        "helpers.list_node".to_string(),
+        "helpers.tree_node".to_string(),
+        "math".to_string(),
+    ];
+    let all_rust_code = "#[test]\nfn smoke() {}\n";
+
+    let lib_source = compose_test_runner_lib(&support_modules, all_rust_code);
+
+    assert!(lib_source.starts_with("#![cfg(test)]"));
+    assert!(lib_source.contains("mod helpers;\n"));
+    assert!(lib_source.contains("mod math;\n"));
+    assert!(!lib_source.contains("mod helpers.list_node;"));
     assert!(lib_source.contains("#[test]\nfn smoke() {}"));
 }

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -186,6 +186,12 @@ Merged: 2026-04-25
 - [x] `scripts/run_all_tests.sh`; report `target/validation_lane_reports/pr.latest.json`, wall time 96.82s, hardening `variants = 28`, `failures = 0`, `blocking_failures = 0`.
 - [x] `cargo build --release -p sifr`
 - [x] `python3 scripts/run_phase31_leetcode.py --manifest verification/leetcode/full_corpus_manifest_20260402_live.json --output verification/leetcode/full_corpus_current_results_20260425_workspace_closure.json --timeout-seconds 30 --no-build-release-if-missing`; summary `case_count = 411`, `PASS = 208`, `NO_ORACLE = 203`, no `CHECK_ERROR`, `RUN_ERROR`, or `TIMEOUT`.
+- [x] Post-pass-5 blocker fix validation: `cargo test -p sifr_driver --lib`; 97 passed, 0 failed.
+- [x] Post-pass-5 blocker fix validation: `cargo test -p sifr_driver test_run_tests_resolves_dotted_local_support_modules -- --nocapture`.
+- [x] Post-pass-5 blocker fix validation: `cargo fmt --check`.
+- [x] Post-pass-5 blocker fix validation: `cargo clippy --workspace -- -D warnings`.
+- [x] Post-pass-5 blocker fix validation: `scripts/run_all_tests.sh --profile quick`; report `target/validation_lane_reports/quick.latest.json`, wall time 87.03s, 0 failures, includes `cargo test -p sifr_driver --lib`.
+- [x] Post-pass-5 blocker fix validation: `scripts/run_all_tests.sh`; report `target/validation_lane_reports/pr.latest.json`, wall time 108.06s, hardening `variants = 28`, `failures = 0`, `blocking_failures = 0`, includes `cargo test -p sifr_driver --lib`.
 
 ## External Reviews
 
@@ -193,5 +199,6 @@ Merged: 2026-04-25
 - historical pass 2: `reviews/sifr-workspace-pyproject-import-resolution-2026-04-25-review-pass2.md` returned NOT READY; blockers were dotted Rust module materialization and incompatible flat e2e fixture placement.
 - historical pass 3: `reviews/sifr-workspace-pyproject-import-resolution-2026-04-25-review-pass3.md` returned READY for the old pyproject-targeted plan. A fresh review is required after switching this phase to native `sifr.toml`.
 - pass 4: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass4.md` returned READY with no blocking findings for the native `sifr.toml` plan.
-- pass 5: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md` returned READY post-merge with no blocking findings; observations are forward-looking follow-up hygiene.
-- pass 6: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass6.md` returned READY with no blockers and explicitly closed the review loop with no further rounds needed.
+- pass 5: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md` superseded the earlier pass-5 draft and returned NOT READY; blockers were the stale `sifr_driver` deterministic assembly test, the missing `sifr_driver` lib-test gate in `scripts/run_all_tests.sh`, and missing dotted support-module materialization in the test runner.
+- pass 6: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass6.md` reviewed the earlier pass-5 READY draft before the corrected NOT READY pass-5 artifact landed; treat it as superseded by pass 5 and the follow-up blocker-fix work.
+- pass 7: `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass7.md` returned READY; B1, B2, and B3 from the corrected pass-5 review are resolved and no further blocker-fix review rounds are required.

--- a/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md
+++ b/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md
@@ -1,99 +1,143 @@
-# External Review (pass 5): Sifr Workspace Resolution Via `sifr.toml`
+# External Review (pass 5): Sifr Workspace Resolution Via `sifr.toml` (closure)
 
-Reviewer: external review pass
+Verdict: NOT READY
+
+Reviewer: external review pass 5 (post-merge closure audit)
 Review date: 2026-04-25
 Inputs reviewed:
 
-- `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md` (source issue, status open)
-- `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md` (phase plan, status closed)
-- `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md` (execution checklist, status closed, all WS0-WS6 merged)
-- `internal_docs/roadmap.md` (Phase 31.6 row, status `closed`)
-- `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass4.md` (READY)
-- Spot checks against the merged tree:
-  - `crates/sifr_driver/src/workspace/{mod.rs,tests.rs}`
-  - `crates/sifr_driver/src/project/{discovery.rs,rust_module_layout.rs,assembly.rs}`
-  - `crates/sifr_driver/src/diagnostics.rs` (`SIFR-WORKSPACE-XXXX` mapping)
-  - `crates/sifr_driver/src/build/entrypoint.rs` (workspace-aware cache tests)
-  - `crates/sifr_driver/src/tests/project_build_check.rs` (`test_cached_project_invalidates_when_workspace_helper_changes`)
-  - `crates/sifr/tests/verification/project/` (six fixtures including the four workspace cases)
-  - `sifr.toml` at repo root, `audits/leetcode/helpers/list_node.sifr`, `audits/leetcode/0021_merge_two_sorted_lists.sifr`
-  - `verification/leetcode/leetcode_pair_diff_scan_20260425.json`, `verification/leetcode/full_corpus_current_results_20260425_workspace_pilot.json`, `verification/leetcode/full_corpus_current_results_20260425_workspace_closure.json`
+- `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md` (phase plan, status: closed)
+- `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md` (execution checklist, status: closed)
+- `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass4.md` (pre-merge READY)
+- Local `main` at `b60ff461` representing merged PRs [#1639–#1645](https://github.com/yaseralnajjar/sifr/pulls)
+- Spot checks against `crates/sifr/src/main.rs`, `crates/sifr_driver/src/workspace/`, `crates/sifr_driver/src/project/`, `crates/sifr_driver/src/build/`, `crates/sifr_driver/src/test_runner/`, `crates/sifr_driver/src/tests/`, `crates/sifr/tests/verification/project/`, `verification/suites/manifest.json`, `audits/leetcode/`, `internal_docs/sifr_workspace_design.md`, `internal_docs/architecture.md`, `internal_docs/roadmap.md`, `verification/leetcode/`, `scripts/run_all_tests.sh`
+- Local validation re-run: `cargo build --release -p sifr`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test -p sifr_driver workspace`, `cargo test -p sifr_driver --lib`, `cargo run -p sifr -- {check,run,emit} audits/leetcode/0021_merge_two_sorted_lists.sifr`
 
-This is a post-merge confirmation review. Pass 4 returned READY; the phase landed on 2026-04-25 across PRs #1639-#1645 and the roadmap row is `closed`. The review below verifies that the merged tree honors the design and that pass-4 nonblockers were either resolved before merge or carried forward as intentional follow-ups. Structure: 1) blocking findings, 2) post-merge confirmations, 3) nonblocking observations carried forward, 4) verdict.
+Note: a prior pass-5 artifact existed at this path that returned READY. This pass-5 supersedes it after running the full `sifr_driver` lib test suite, which the previous pass-5 did not. Findings below are reproducible on `main` at b60ff461.
 
 ---
 
 ## 1. Blocking Findings
 
-None.
+### B1. `sifr_driver` lib test deterministically fails on merged main
 
-The pass-2 blockers (B1 dotted-module materialization, B2 verification-suite fixture placement) are resolved in the merged tree. The native `sifr.toml` target is internally consistent across the source issue, phase plan, execution checklist, and roadmap. No regression of pass-3 or pass-4 contract claims was observed.
+[crates/sifr_driver/src/tests/project_graph.rs:312-334](crates/sifr_driver/src/tests/project_graph.rs:312) — `test_assemble_project_main_rs_is_deterministic_against_hashmap_order` deterministically fails on `main` at b60ff461:
 
----
+```
+left:  "mod consumer;\nmod provider;\n\nfn main() {}\n"
+right: "mod provider;\nmod consumer;\n\nfn main() {}\n"
+panicked at crates/sifr_driver/src/tests/project_graph.rs:333:5
+test result: FAILED. 94 passed; 1 failed; 0 ignored
+```
 
-## 2. Post-Merge Confirmations
+Root cause: WS3 (commit `b30d511d`, "Resolve workspace modules from source roots") changed [crates/sifr_driver/src/project/assembly.rs:16-34](crates/sifr_driver/src/project/assembly.rs:16) to declare top-level Rust modules through [`top_level_module_declarations`](crates/sifr_driver/src/project/rust_module_layout.rs:19-27), which orders names through a `BTreeSet` (alphabetic). The pre-existing assertion at line 333 still expects the legacy `compile_order` order (`provider, consumer`). The same diff added a sibling `test_assemble_project_main_rs_declares_dotted_modules_by_top_level_namespace` test but did not update the failing one.
 
-### Implementation matches the design
+Beyond the broken assertion, this test was the primary regression sentinel for "main.rs declarations are deterministic against HashMap order" — leaving the wrong expectation removes that protection until it is fixed.
 
-- Workspace discovery module exists at `crates/sifr_driver/src/workspace/` with `mod.rs` and `tests.rs`, split per pass-2 and WS6 maintainability guardrail. `mod.rs` is 182 lines and `tests.rs` is 238 lines.
-- `crates/sifr_driver/src/project/rust_module_layout.rs` exists at the path fixed by the phase plan (pass-4 N6).
-- `ModuleResolver` and `ResolvedModule` live in `crates/sifr_driver/src/project/discovery.rs` and consume the workspace context per WS2 / WS3 design.
-- Diagnostic codes `SIFR-WORKSPACE-0001` through `0004` (parse/config) and `0101` through `0103` (resolution) are emitted from `crates/sifr_driver/src/diagnostics.rs:96-128` with the documented `https://sifr.dev/docs/errors/<CODE>` URL form.
-- Cache-key regression for workspace helper content lives at `crates/sifr_driver/src/tests/project_build_check.rs:146` (`test_cached_project_invalidates_when_workspace_helper_changes`), and adjacent tests in `crates/sifr_driver/src/build/entrypoint.rs:436,476` cover the cache-reuse and cache-invalidation pair required by WS4.
-- Pass-4 N8 nested-ancestor test exists: `crates/sifr_driver/src/workspace/tests.rs:227` — `test_closer_valid_manifest_ignores_farther_malformed_manifest`.
-- Pass-4 N1 decision (accept and silently ignore unknown top-level tables and unknown nested keys) is locked in by `test_unknown_tables_and_keys_are_ignored` at `crates/sifr_driver/src/workspace/tests.rs:147`.
+### B2. Local validation gate does not exercise `sifr_driver` library tests, masking B1
 
-### Verification fixtures and pilot are in place
+[scripts/run_all_tests.sh:99-100](scripts/run_all_tests.sh:99) runs only `cargo test -p sifr -- --skip test_e2e_pass`. `cargo test -p sifr` does not execute the `sifr_driver` crate's library tests. The execution checklist's WS6 row at [line 181](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:181) ran `cargo test -p sifr_driver workspace -- --nocapture`, which substring-filters by `workspace` and silently excludes `tests::project_graph::*`. As a result, the WS6 evidence rows that claim "0 failures" ([execution lines 185-186](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:185)) do not actually exercise the bulk of `sifr_driver`'s lib tests.
 
-- `crates/sifr/tests/verification/project/` contains `workspace_dotted_helper_run`, `workspace_ambiguous_import`, `workspace_malformed_manifest`, and `workspace_unresolved_import` matching the WS5 case list.
-- Repo-root `sifr.toml` declares `[source].roots = ["audits/leetcode", "."]` per the locked pilot configuration.
-- `audits/leetcode/helpers/list_node.sifr` exists with the canonical `ListNode` model plus `nodeVal`, `nodeNext`, `hasNode`, `makeListNode`, and `listNodeToString` helpers.
-- `audits/leetcode/0021_merge_two_sorted_lists.sifr` imports `from helpers.list_node import ...` (one matching import line).
-- Pair scan `verification/leetcode/leetcode_pair_diff_scan_20260425.json` and the workspace-pilot/closure full corpus runs are both present, matching the execution checklist evidence (`PASS = 208`, `NO_ORACLE = 203`, no `CHECK_ERROR`/`RUN_ERROR`/`TIMEOUT`).
+This is the validation gap that allowed B1 to ship green. Closing the phase requires either widening `run_all_tests.sh` to run `cargo test -p sifr_driver` (or `cargo test --workspace`) and re-running the WS6 evidence row, or otherwise wiring `sifr_driver` lib tests into the merge-gate; otherwise the same class of regression will recur.
 
-### Pass-4 nonblockers — disposition
+### B3. Unimplemented WS4 scope: test-runner Rust materialization does not use the dotted module layout helper
 
-- N1 (unknown tables/keys policy): resolved. Phase plan line 78 codifies "accepted and ignored in this slice" and `test_unknown_tables_and_keys_are_ignored` enforces it.
-- N2 (source issue lacks codes/URLs): resolved by the pointer line at source issue line 139 routing canonical diagnostic codes to the phase plan WS3 contract.
-- N3 (synthetic vs. pilot fixture tree mismatch): resolved by the explanatory line at source issue line 176.
-- N4 (`sifr test` deferral missing from source issue Non-Goals): resolved by source issue line 52.
-- N5 (stale "Review status" line on the phase plan): resolved by phase plan line 7 referencing pass-4 READY plus the WS6 local-gate date.
-- N6 (layout helper home reaffirmed in WS4 scope): resolved. Phase plan WS4 scope cites `crates/sifr_driver/src/project/rust_module_layout.rs` directly.
-- N7 (per-wave validation selectors firmness): resolved as a per-PR sanity check; the execution checklist now records the exact selectors that ran (e.g., `cargo test -p sifr_driver workspace -- --nocapture`, `cargo test -p sifr_driver discovery -- --nocapture`, `cargo test -p sifr_driver project_build_check -- --nocapture`).
-- N8 (named nested-ancestor test): resolved (see confirmation above).
+WS4 scope ([phase plan line 310](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md:310)) and WS3 affected-files list ([lines 152-153](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md:152)) explicitly require:
 
-All eight pass-4 nonblockers are closed before merge or carried forward as expected.
+> `crates/sifr_driver/src/test_runner/artifacts.rs` and `crates/sifr_driver/src/test_runner/execution.rs`: use the same module layout helper for support modules that contain dotted IDs
+
+Neither file was updated:
+
+- [crates/sifr_driver/src/test_runner/artifacts.rs:9-13](crates/sifr_driver/src/test_runner/artifacts.rs:9) emits `mod {module_name};` directly for each `support_module_names` entry. For a dotted ID like `helpers.list_node` this writes `mod helpers.list_node;` — invalid Rust.
+- [crates/sifr_driver/src/test_runner/execution.rs:53-64](crates/sifr_driver/src/test_runner/execution.rs:53) writes each support module to `src_dir.join(format!("{module_name}.rs"))`, which for the same dotted ID produces a literal `helpers.list_node.rs` flat file rather than `helpers/list_node.rs` plus `helpers/mod.rs`.
+
+This is a real (not theoretical) regression because [crates/sifr_driver/src/project/discovery.rs:62-65](crates/sifr_driver/src/project/discovery.rs:62) and [discovery.rs:264-271](crates/sifr_driver/src/project/discovery.rs:264) now convert dots to nested paths even for the entry-parent-only resolver used by [test_runner/orchestrator.rs:48](crates/sifr_driver/src/test_runner/orchestrator.rs:48). Pre-WS3, `helpers.list_node` mapped to a non-existent flat `helpers.list_node.sifr` file and never reached the support-module list; post-WS3, a test directory containing `test_*.sifr` that imports `from helpers.list_node import …` plus a sibling `helpers/list_node.sifr` will resolve through the orchestrator and break the test runner. No existing test exercises that scenario, which is why CI did not flag it, but the scope item is explicit and the bug latent.
+
+This must either be implemented (using `top_level_module_declarations` / `namespace_module_files` / `rust_module_file_path`) or the phase plan must be amended to remove the scope and the test-runner orchestrator must reject dotted support module IDs with a clear diagnostic until support lands. The current "neither" state contradicts the merged plan.
 
 ---
 
-## 3. Nonblocking Observations Carried Forward
+## 2. Non-blocking Notes
 
-These are post-merge observations for follow-up phases. They do not affect the closure of Phase 31.6.
+### N1. WS4 cache-regression coverage is one of three required cases
 
-### O1. Workspace diagnostic codes are derived by message-prefix matching
+WS4 acceptance criteria ([phase plan lines 313-318](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md:313)) call out three cache regression assertions:
 
-`crates/sifr_driver/src/diagnostics.rs:96-128` maps `CompileError` instances to `SIFR-WORKSPACE-XXXX` codes by `message.starts_with(...)` and `message.contains(...)` against the user-facing wording. This works today because every workspace error site emits the exact prefix the mapper looks for, and the unit tests in `crates/sifr_driver/src/tests/diagnostics.rs` lock the mapping. The fragility: a future copy edit to a diagnostic message string can silently drop the workspace code and fall through to the generic `SIFR-BUILD-0001`, with no compile-time signal. A future hardening phase should consider attaching the diagnostic code at the `CompileError` construction site (e.g., a `code: Option<&'static str>` field on `CompileError`) so the mapping is structural rather than textual. Not a regression; the locked tests catch the current strings.
+1. dotted helper content change → cache key changes
+2. inert source-root reorder → cache key unchanged
+3. shadowing source-root reorder → cache key changes
 
-### O2. `[package].name` in repo-root `sifr.toml` differs from the pilot example in the phase plan
+Only (1) is implemented at [crates/sifr_driver/src/tests/project_build_check.rs:145-170](crates/sifr_driver/src/tests/project_build_check.rs:145) (`test_cached_project_invalidates_when_workspace_helper_changes`). (2) and (3) have no test. The current cache-key implementation at [crates/sifr_driver/src/build/materialize.rs:144-168](crates/sifr_driver/src/build/materialize.rs:144) is content-keyed (over `support_modules` BTreeMap, `main_rs`, Cargo.toml, stdlib set, crates set), so the desired behavior is plausibly satisfied — but no regression sentinel exists, which is what the acceptance criterion was protecting.
 
-`sifr.toml:2` sets `name = "sifr-workspace"`, while the phase plan "Target Configuration For This Slice" (lines 64) uses `name = "leetcode-fixtures"` as the example. This is fine — `package.name` has no semantic effect in this slice — but the design note `internal_docs/sifr_workspace_design.md` (and any future doc snapshots) should make clear that the actual repo-root manifest uses `sifr-workspace`, so future readers do not file a doc-vs-state mismatch. Pure hygiene; not a regression.
+### N2. Verification-suite diagnostic coverage is incomplete for SIFR-WORKSPACE-0002/0003/0004
 
-### O3. `sifr test` workspace-awareness remains the largest open follow-up
+WS3 acceptance ([phase plan line 290](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md:290)):
 
-Both the source issue (line 52) and the phase plan (line 348) explicitly defer `sifr test` workspace-awareness to a later frontend-mode-parity follow-up. The execution checklist does not yet point to a created issue for that follow-up. Once a follow-up issue is filed, the source issue's "Non-Goals" line and `internal_docs/sifr_workspace_design.md` should backfill the issue link so the deferral is traceable. Not blocking; tracking improvement.
+> Verification-suite diagnostic snapshots cover every new user-facing diagnostic in `human`, `json`, and `compact` formats, including diagnostic code and URL.
 
-### O4. Reserved Cargo-inspired tables are accepted-and-ignored without a forward-compat warning
+The merged project suite covers SIFR-WORKSPACE-0001 ([workspace_malformed_manifest](crates/sifr/tests/verification/project/workspace_malformed_manifest)), 0101 ([workspace_unresolved_import](crates/sifr/tests/verification/project/workspace_unresolved_import)), and 0102 ([workspace_ambiguous_import](crates/sifr/tests/verification/project/workspace_ambiguous_import)). 0103 has unit coverage but no project-suite fixture. 0002 (`escapes the workspace root via '..'`), 0003 (`is not a directory under the workspace root`), and 0004 (`must be a relative non-empty path under the workspace root`) have unit-message coverage in [crates/sifr_driver/src/workspace/tests.rs:162-190](crates/sifr_driver/src/workspace/tests.rs:162) but no verification-suite snapshot in any of human/json/compact.
 
-Per the WS0 policy, unknown top-level tables (`[workspace]`, `[[bin]]`, `[dependencies]`, `[profile.dev]`) are accepted and silently ignored. This is the right call for this slice. As soon as a dedicated package-management phase begins, these tables will start to take effect, and users who copied the "Proposed native shape" example from phase plan lines 99-122 into their own `sifr.toml` may see behavior change without warning. Consider, in the package-management phase entry criteria, an explicit migration note plus a one-cycle deprecation/info diagnostic when reserved tables are first encountered with non-trivial content. Not blocking; forward-looking.
+The unit test [crates/sifr_driver/src/tests/diagnostics.rs:39-68](crates/sifr_driver/src/tests/diagnostics.rs:39) (`test_workspace_resolution_errors_have_stable_codes_and_urls`) only exercises 0101, 0102, 0103 through `to_diagnostic`. The 0001-series codes are derived only by the prefix-dispatch in [crates/sifr_driver/src/diagnostics.rs:96-128](crates/sifr_driver/src/diagnostics.rs:96) and are not unit-tested for code+URL.
 
-### O5. The execution checklist's historical reviews list is informative but has no link to pass-5
+### N3. Workspace diagnostic codes are derived by string-prefix matching on the message
 
-`issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:190-195` lists historical pass 1 through pass 4. Add a pass-5 line once this artifact is filed, so the execution checklist and the reviews directory stay in sync. Pure bookkeeping.
+[crates/sifr_driver/src/diagnostics.rs:96-128](crates/sifr_driver/src/diagnostics.rs:96) recovers each `SIFR-WORKSPACE-XXXX` code by prefix-matching on `CompileError.message`. If the human-readable wording at [workspace/mod.rs:160-179](crates/sifr_driver/src/workspace/mod.rs:160) or [project/discovery.rs:273-325](crates/sifr_driver/src/project/discovery.rs:273) changes — even a casing or punctuation tweak — the diagnostic silently downgrades to `SIFR-BUILD-0001` and the URL drops to `https://sifr.dev/docs/errors/SIFR-BUILD-0001`. A more durable model would attach the code at the construction site (e.g., a `code` field on `CompileError` or a typed enum). Not blocking because the current strings are tested for one example each via the workspace 0101/0102/0103 unit, but the 0001-0004 series and any rewording of those messages have no guard.
+
+### N4. CLI human-format label for workspace errors is `error:`, not `build error:`
+
+`SIFR-WORKSPACE-XXXX` codes carry `CompilePhase::Build`, but [crates/sifr/src/main.rs:371-386](crates/sifr/src/main.rs:371) selects the label by `code.starts_with("SIFR-PARSE-")` etc. and falls through to severity-based `error` for `SIFR-WORKSPACE-*`. Cosmetic, but inconsistent with sibling diagnostic categories.
+
+### N5. Unresolved-import diagnostic includes literal `./` when source root is `.`
+
+[crates/sifr/tests/verification/project/workspace_unresolved_import/baselines/check-human.stderr.txt:1](crates/sifr/tests/verification/project/workspace_unresolved_import/baselines/check-human.stderr.txt:1) shows `…/workspace_unresolved_import/./missing/helper.sifr` because [workspace/mod.rs:145-149](crates/sifr_driver/src/workspace/mod.rs:145) normalizes empty source roots to `PathBuf::from(".")` and the resolver then `join`s that. Functionally correct and deterministic, but visually noisy. A `Path::components` clean-up before display would tidy this up.
+
+### N6. Dead branch in `unresolved_import_message`
+
+[crates/sifr_driver/src/project/discovery.rs:283-286](crates/sifr_driver/src/project/discovery.rs:283) handles the case where `workspace_paths.is_empty()`. `to_compile_error` is only invoked from the `resolver.has_workspace()` arms in `parse_import_closure_modules` (lines 379, 426), and a workspace always carries at least one source root (defaults to `["."]`), so this branch is unreachable. Either delete it or make the call sites consistent.
+
+### N7. WS6 reduced-scope test selector hides the broader `sifr_driver` failure surface
+
+The execution checklist row [line 181](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:181) `cargo test -p sifr_driver workspace -- --nocapture` filters by name substring — narrower than `cargo test -p sifr_driver`. Combined with B2, no merge-gate evidence row actually proves the full `sifr_driver` lib tests pass. Pair the broadened gate from B2 with a re-run of the full checklist before re-closing.
+
+### N8. Architecture doc bullet still describes `[dependencies]` as live behavior
+
+[internal_docs/architecture.md:592](internal_docs/architecture.md:592) keeps a legacy bullet ``**sifr.toml`:** project manifest with `[dependencies]` section specifying version ranges (semver)``. This phase explicitly defers `[dependencies]` semantics ([sifr_workspace_design.md:30-36](internal_docs/sifr_workspace_design.md:30)). Either drop the bullet or amend it to "reserved" so a reader doesn't expect dependency resolution to work today. Cosmetic.
+
+---
+
+## 3. Validation Reviewed
+
+Run locally on `main` at `b60ff461`:
+
+| Check | Result |
+| --- | --- |
+| `cargo build --release -p sifr` | pass (15.7s) |
+| `cargo fmt --check` | pass |
+| `cargo clippy --workspace -- -D warnings` | pass |
+| `cargo test -p sifr_driver workspace` | 30 passed |
+| `cargo test -p sifr_driver --lib` | **FAIL — 1 failure (B1)** |
+| `cargo run -p sifr -- check audits/leetcode/0021_merge_two_sorted_lists.sifr` | "no errors found" |
+| `cargo run -p sifr -- run audits/leetcode/0021_merge_two_sorted_lists.sifr` | exit 0, cache hit |
+| `cargo run -p sifr -- emit audits/leetcode/0021_merge_two_sorted_lists.sifr` | nested `// src/helpers/list_node.rs` emitted, only `mod helpers;` at top level |
+
+Closure-artifact spot checks:
+
+- [verification/leetcode/full_corpus_current_results_20260425_workspace_closure.json](verification/leetcode/full_corpus_current_results_20260425_workspace_closure.json) summary matches checklist line 188: `case_count=411`, `PASS=208`, `NO_ORACLE=203`, no `CHECK_ERROR`/`RUN_ERROR`/`TIMEOUT`.
+- [verification/leetcode/leetcode_pair_diff_scan_20260425.json](verification/leetcode/leetcode_pair_diff_scan_20260425.json) shows the 0021 pilot at `sifr_lines=9`, matching checklist line 147.
+- [audits/leetcode/helpers/list_node.sifr](audits/leetcode/helpers/list_node.sifr) and migrated [audits/leetcode/0021_merge_two_sorted_lists.sifr](audits/leetcode/0021_merge_two_sorted_lists.sifr) are in place; root [sifr.toml](sifr.toml) declares `roots = ["audits/leetcode", "."]`.
+- Verification fixtures [workspace_dotted_helper_run](crates/sifr/tests/verification/project/workspace_dotted_helper_run), [workspace_ambiguous_import](crates/sifr/tests/verification/project/workspace_ambiguous_import), [workspace_malformed_manifest](crates/sifr/tests/verification/project/workspace_malformed_manifest), [workspace_unresolved_import](crates/sifr/tests/verification/project/workspace_unresolved_import) exist and are registered in [verification/suites/manifest.json](verification/suites/manifest.json).
+- [internal_docs/roadmap.md:56](internal_docs/roadmap.md:56) row 31.6 status is `closed`.
 
 ---
 
 ## 4. Verdict
 
-READY (post-merge confirmation).
+NOT READY.
 
-Phase 31.6 is closed across the source issue, phase plan, execution checklist, and roadmap. The merged tree implements the native `sifr.toml` workspace concept, dotted module materialization, deterministic diagnostics with stable codes/URLs, cache invalidation for workspace helpers, verification-suite coverage, and the LeetCode helper pilot exactly as designed. All pass-4 nonblockers are resolved or recorded. No blocking findings; the observations in section 3 are forward-looking improvements for follow-up phases and do not require reopening Phase 31.6.
+Three blockers must be resolved before re-closing:
+
+- B1: fix the failing `sifr_driver` lib test by updating the assertion to the alphabetic top-level-namespace order (the preferred direction; reverting `assemble_project_main_rs` to compile_order would re-open the dotted-namespace dedupe behavior that WS3 deliberately introduced).
+- B2: extend `scripts/run_all_tests.sh` (and the WS6 evidence row) to actually run `cargo test -p sifr_driver` (or `cargo test --workspace`), so this class of regression is caught locally next time.
+- B3: implement the test-runner dotted module materialization called out in WS3/WS4, or formally amend the plan and add a hard diagnostic for dotted support modules until support lands.
+
+Non-blocking notes N1–N8 should be tracked but do not gate closure.

--- a/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass7.md
+++ b/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass7.md
@@ -1,0 +1,92 @@
+# External Review (pass 7): Sifr Workspace Resolution Via `sifr.toml` (post-pass-5 blocker fixes)
+
+Verdict: READY
+
+Reviewer: external review pass 7 (post-pass-5 blocker-fix audit)
+Review date: 2026-04-25
+Branch reviewed: `ad-hoc/sifr-workspace-pass5-fixes`
+Base: `main` at `9a8a6f84` (post `Record Sifr workspace closure review rounds (#1646)`)
+Inputs reviewed:
+
+- `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md` (the corrected pass-5 NOT READY artifact, authoritative)
+- `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass6.md` (treated as superseded — reviewed an earlier READY pass-5 draft)
+- `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md` and `…-execution.md`
+- Working-tree diff against `main` for: `crates/sifr_driver/src/project/mod.rs`, `crates/sifr_driver/src/test_runner/{artifacts.rs,execution.rs}`, `crates/sifr_driver/src/tests/{project_graph.rs,test_runner.rs}`, `scripts/run_all_tests.sh`, the execution checklist, the pass-5 review file
+- Spot checks against `crates/sifr_driver/src/project/rust_module_layout.rs` (helpers wired into the test runner)
+- Local validation re-run: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test -p sifr_driver --lib`, `cargo test -p sifr_driver test_run_tests_resolves_dotted_local_support_modules -- --nocapture`
+
+Scope of this review: confirm whether B1, B2, and B3 from the corrected pass-5 review are fixed on the working branch, and sanity-check the execution-checklist additions and the supersedence note for pass 6. Per the user's instructions, only the review artifact was written; no source or doc files were modified.
+
+---
+
+## 1. Blocking Findings
+
+None. B1, B2, and B3 from pass 5 are all resolved on this branch.
+
+---
+
+## 2. Verification of pass-5 blockers
+
+### B1 — Resolved
+
+[crates/sifr_driver/src/tests/project_graph.rs:333](crates/sifr_driver/src/tests/project_graph.rs:333) now asserts `"mod consumer;\nmod provider;\n\nfn main() {}\n"` (alphabetic top-level-namespace order), matching the WS3 `top_level_module_declarations` behavior at [crates/sifr_driver/src/project/rust_module_layout.rs:19-27](crates/sifr_driver/src/project/rust_module_layout.rs:19). The sibling test `test_assemble_project_main_rs_declares_dotted_modules_by_top_level_namespace` at [project_graph.rs:336-350](crates/sifr_driver/src/tests/project_graph.rs:336) is still in place and continues to guard the dotted-namespace dedupe behavior. Pass 5's "preferred direction" (update the assertion rather than revert assembly) was followed.
+
+Verified by running `cargo test -p sifr_driver --lib`: 97 passed, 0 failed (was 94 passed / 1 failed at b60ff461).
+
+### B2 — Resolved
+
+[scripts/run_all_tests.sh:102-103](scripts/run_all_tests.sh:102) now adds:
+
+```
+echo "Running sifr_driver library tests"
+cargo test -p sifr_driver --lib
+```
+
+That is the exact gate pass 5 prescribed (`cargo test -p sifr_driver`, narrowed safely to `--lib` since integration-test wiring isn't present for this crate). With B1 fixed and this gate in place, the same regression class — a stale assembly assertion — would now fail the local lane on the next iteration.
+
+The execution checklist at [issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:189-192](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:189) records direct `cargo test -p sifr_driver --lib` evidence (97 passed, 0 failed) plus quick and full `run_all_tests.sh` runs that explicitly note the `cargo test -p sifr_driver --lib` step is included. This also addresses pass-5 N7 (the substring-filter `cargo test -p sifr_driver workspace` evidence row no longer stands alone).
+
+### B3 — Resolved
+
+The test-runner Rust materialization now uses the same module-layout helpers WS3/WS4 prescribed:
+
+- [crates/sifr_driver/src/test_runner/artifacts.rs:10-14](crates/sifr_driver/src/test_runner/artifacts.rs:10) emits top-level `mod` declarations through `top_level_module_declarations`, dropping invalid `mod helpers.list_node;` lines for dotted IDs.
+- [crates/sifr_driver/src/test_runner/execution.rs:54-79](crates/sifr_driver/src/test_runner/execution.rs:54) writes each support module file via `rust_module_file_path`, so `helpers.list_node` lands at `src/helpers/list_node.rs` (creating parents as needed) instead of the literal `helpers.list_node.rs` flat file.
+- [crates/sifr_driver/src/test_runner/execution.rs:81-109](crates/sifr_driver/src/test_runner/execution.rs:81) writes the per-namespace `mod.rs` files via `namespace_module_files`, declaring each direct child as `pub mod <child>;`, mirroring the project-build assembly path.
+- [crates/sifr_driver/src/project/mod.rs:17-19](crates/sifr_driver/src/project/mod.rs:17) re-exports `top_level_module_declarations` alongside `namespace_module_files` and `rust_module_file_path`, keeping the helper surface unified.
+
+Coverage:
+
+- Unit-level: [crates/sifr_driver/src/tests/test_runner.rs:402-418](crates/sifr_driver/src/tests/test_runner.rs:402) (`test_compose_test_runner_lib_declares_dotted_modules_by_namespace`) confirms the lib emits `mod helpers;` once and never `mod helpers.list_node;` for a mixed `["helpers.list_node", "helpers.tree_node", "math"]` set.
+- End-to-end: [crates/sifr_driver/src/tests/test_runner.rs:49-85](crates/sifr_driver/src/tests/test_runner.rs:49) (`test_run_tests_resolves_dotted_local_support_modules`) is the exact pass-5 scenario — a `helpers/list_node.sifr` import from a sibling `test_*.sifr` — and it passes locally (`cargo test -p sifr_driver test_run_tests_resolves_dotted_local_support_modules -- --nocapture` → 1 passed). Without the materialization fix this test would have hit either an invalid-Rust `mod helpers.list_node;` error or a missing-file error.
+
+Implementation aligns with pass-5's preferred resolution direction (use the helper rather than reject dotted support IDs); the plan does not need amendment.
+
+---
+
+## 3. Local validation re-run
+
+Run on the working branch:
+
+| Check | Result |
+| --- | --- |
+| `cargo fmt --check` | pass |
+| `cargo clippy --workspace -- -D warnings` | pass |
+| `cargo test -p sifr_driver --lib` | 97 passed, 0 failed |
+| `cargo test -p sifr_driver test_run_tests_resolves_dotted_local_support_modules -- --nocapture` | 1 passed |
+
+I did not re-run the full `scripts/run_all_tests.sh` lane during this pass; the execution checklist records both `--profile quick` (87.03s, 0 failures) and full (108.06s, 0 failures, 28 hardening variants) runs at [execution lines 191-192](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:191), and the lane scripts on the branch include the new `cargo test -p sifr_driver --lib` step.
+
+---
+
+## 4. Other observations
+
+- **Pass-5 review file**: the working tree replaces the old READY pass-5 with the corrected NOT READY pass-5 in place. That matches the user's framing that the corrected pass 5 is authoritative. The execution checklist `External Reviews` section ([execution lines 202-203](issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md:202)) now correctly documents the pass-5 supersedence and explicitly marks pass 6 as superseded because it reviewed the earlier READY draft. Both updates are accurate and non-controversial.
+- **Pass-5 non-blocking notes N1–N6, N8**: out of scope for this audit and not addressed on this branch (they were never blockers). They remain valid follow-up hygiene items: N1 (missing two of three WS4 cache regression assertions), N2 (verification-suite coverage gaps for SIFR-WORKSPACE-0002/0003/0004), N3 (string-prefix diagnostic-code recovery), N4 (`error:` vs `build error:` label), N5 (literal `./` in unresolved-import message), N6 (dead branch in `unresolved_import_message`), N8 (architecture-doc bullet still describes `[dependencies]` as live). None gate closure; track in a hygiene follow-up.
+- **Latent shadow on test-runner src layout (informational, not blocking)**: if both a bare `helpers` and a dotted `helpers.list_node` ever appear in `support_module_names`, `execution.rs` would emit both `src/helpers.rs` (from `rust_module_file_path("helpers")`) and `src/helpers/mod.rs` (from `namespace_module_files`), which `rustc` rejects with a same-named-module ambiguity. This mirrors the equivalent risk on the project-assembly path and is not a regression introduced by this fix; leaving the note here for the hygiene tracker.
+
+---
+
+## 5. Verdict
+
+READY. B1, B2, and B3 from the corrected pass-5 review are resolved on `ad-hoc/sifr-workspace-pass5-fixes`. No further review rounds are required to land the post-pass-5 blocker-fix work; the non-blocking pass-5 notes (N1–N6, N8) should be tracked as follow-up hygiene rather than re-reviewed here.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -99,6 +99,9 @@ python3 "${SCRIPT_DIR}/check_sifr_driver_maintainability_guardrails.py"
 echo "Running unit tests and non-pass e2e tests (cargo test -p sifr -- --skip test_e2e_pass)"
 cargo test -p sifr -- --skip test_e2e_pass
 
+echo "Running sifr_driver library tests"
+cargo test -p sifr_driver --lib
+
 if [[ -n "${CONTRACT_SUITES}" ]]; then
   echo "Running validation contract matrix suites"
   CONTRACT_ARGS=()


### PR DESCRIPTION
## Summary
- Fix the stale `sifr_driver` deterministic assembly expectation after WS3 switched top-level Rust module declarations to namespace-sorted order.
- Add `cargo test -p sifr_driver --lib` to `scripts/run_all_tests.sh` so the local gate covers driver library tests.
- Materialize dotted `sifr test` support modules through the shared Rust module layout helpers, including namespace `mod.rs` files.
- Record the corrected pass-5 NOT READY review, superseded pass-6 note, and pass-7 READY confirmation.

## Validation
- `cargo test -p sifr_driver --lib`
- `cargo test -p sifr_driver test_run_tests_resolves_dotted_local_support_modules -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`
- `scripts/run_all_tests.sh`
- External review pass 7: READY, B1-B3 resolved, no further blocker-fix rounds required.