### PR TITLE
Update GitHub references for sifr-lang move

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 rust-version = "1.75"
-homepage = "https://github.com/yaseralnajjar/sifr"
-documentation = "https://github.com/yaseralnajjar/sifr"
-repository = "https://github.com/yaseralnajjar/sifr"
+homepage = "https://github.com/sifr-lang/sifr"
+documentation = "https://github.com/sifr-lang/sifr"
+repository = "https://github.com/sifr-lang/sifr"
 authors = ["Yaser Al-Najjar"]
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ def main():
 ### Build the compiler
 
 ```bash
-git clone https://github.com/yaseralnajjar/sifr.git
+git clone https://github.com/sifr-lang/sifr.git
 cd sifr
 cargo build --release
 ```
@@ -122,7 +122,7 @@ For stable command-mode behavior and edge-case guarantees, see the [CLI Command 
 Want to see how a Sifr program travels from source text to a native binary?
 The interactive pipeline visualizer walks through every compiler step with a live `factorial` example at each stage.
 
-**[▶ Open the Compiler Pipeline Visualizer](https://htmlpreview.github.io/?https://github.com/yaseralnajjar/sifr/blob/main/internal_docs/compiler_pipeline.html)**
+**[▶ Open the Compiler Pipeline Visualizer](https://htmlpreview.github.io/?https://github.com/sifr-lang/sifr/blob/main/internal_docs/compiler_pipeline.html)**
 
 ## License
 

--- a/internal_docs/phases/23_project_graph_and_isolation_correctness.md
+++ b/internal_docs/phases/23_project_graph_and_isolation_correctness.md
@@ -53,11 +53,11 @@ Make project and test compilation graph-correct, deterministic, and isolated per
   - Graph/discovery/isolation regressions are automatically caught before merge.
 
 ## Execution Progress
-- 2026-03-06: `milestone_23_1` completed (PR [#863](https://github.com/yaseralnajjar/sifr/pull/863)).
-- 2026-03-06: `milestone_23_2` completed (PR [#865](https://github.com/yaseralnajjar/sifr/pull/865)).
-- 2026-03-06: `milestone_23_3` completed (PR [#867](https://github.com/yaseralnajjar/sifr/pull/867)).
-- 2026-03-06: `milestone_23_4` completed (PR [#869](https://github.com/yaseralnajjar/sifr/pull/869)).
-- 2026-03-06: `milestone_23_5` completed (PR [#871](https://github.com/yaseralnajjar/sifr/pull/871)).
+- 2026-03-06: `milestone_23_1` completed (PR [#863](https://github.com/sifr-lang/sifr/pull/863)).
+- 2026-03-06: `milestone_23_2` completed (PR [#865](https://github.com/sifr-lang/sifr/pull/865)).
+- 2026-03-06: `milestone_23_3` completed (PR [#867](https://github.com/sifr-lang/sifr/pull/867)).
+- 2026-03-06: `milestone_23_4` completed (PR [#869](https://github.com/sifr-lang/sifr/pull/869)).
+- 2026-03-06: `milestone_23_5` completed (PR [#871](https://github.com/sifr-lang/sifr/pull/871)).
 
 ## Quality Contract
 - Entry criteria: Phase 22 is completed and frontend mode parity contract is in place.

--- a/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
+++ b/issues/ad-hoc-leetcode-divergence-closure-2026-04-24-execution.md
@@ -18,8 +18,8 @@ Phase plan: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
 
 Status: merged
 Branch: `ws0-leetcode-corpus-noise-normalization`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1609`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1609`
+PR: `https://github.com/sifr-lang/sifr/pull/1609`
+Merged: `https://github.com/sifr-lang/sifr/pull/1609`
 
 ### Scope
 
@@ -85,8 +85,8 @@ Local gate:
 
 Status: merged
 Branch: `ws5-architecture-boundary-classification`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1631`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1631`
+PR: `https://github.com/sifr-lang/sifr/pull/1631`
+Merged: `https://github.com/sifr-lang/sifr/pull/1631`
 
 ### Scope
 
@@ -116,8 +116,8 @@ Local gate:
 
 Status: merged
 Branch: `ws6-final-leetcode-closure`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1632`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1632`
+PR: `https://github.com/sifr-lang/sifr/pull/1632`
+Merged: `https://github.com/sifr-lang/sifr/pull/1632`
 
 ### Scope
 
@@ -221,8 +221,8 @@ Follow-up issue:
 
 Status: merged
 Branch: `ws1-narrowing-invalidation-design`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1610`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1610`
+PR: `https://github.com/sifr-lang/sifr/pull/1610`
+Merged: `https://github.com/sifr-lang/sifr/pull/1610`
 
 ### Scope
 
@@ -267,8 +267,8 @@ Local gate:
 
 Status: merged
 Branch: `ws2-s1-heap-stdlib`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1611`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1611`
+PR: `https://github.com/sifr-lang/sifr/pull/1611`
+Merged: `https://github.com/sifr-lang/sifr/pull/1611`
 
 ### Scope
 
@@ -316,8 +316,8 @@ Local gate:
 
 Status: merged
 Branch: `ws2-s2-dsu-stdlib`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1612`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1612`
+PR: `https://github.com/sifr-lang/sifr/pull/1612`
+Merged: `https://github.com/sifr-lang/sifr/pull/1612`
 
 ### Scope
 
@@ -378,8 +378,8 @@ Known unrelated validation note:
 
 Status: merged
 Branch: `ws2-s3-deque-consumption`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1613`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1613`
+PR: `https://github.com/sifr-lang/sifr/pull/1613`
+Merged: `https://github.com/sifr-lang/sifr/pull/1613`
 
 ### Scope
 
@@ -434,8 +434,8 @@ Local gate:
 
 Status: merged
 Branch: `ws2-s4-char-predicate-consumption`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1614`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1614`
+PR: `https://github.com/sifr-lang/sifr/pull/1614`
+Merged: `https://github.com/sifr-lang/sifr/pull/1614`
 
 ### Scope
 
@@ -481,8 +481,8 @@ Local gate:
 
 Status: merged
 Branch: `ws2-s5-int-parse-consumption`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1615`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1615`
+PR: `https://github.com/sifr-lang/sifr/pull/1615`
+Merged: `https://github.com/sifr-lang/sifr/pull/1615`
 
 ### Scope
 
@@ -528,8 +528,8 @@ Local gate:
 
 Status: merged; corrected by `move-trie-to-leetcode-helper`
 Branch: `ws2-s6-trie-decision`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1616`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1616`
+PR: `https://github.com/sifr-lang/sifr/pull/1616`
+Merged: `https://github.com/sifr-lang/sifr/pull/1616`
 
 ### Scope
 
@@ -581,8 +581,8 @@ Local gate:
 
 Status: merged
 Branch: `ws3-b1-fixture-helper-convention`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1617`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1617`
+PR: `https://github.com/sifr-lang/sifr/pull/1617`
+Merged: `https://github.com/sifr-lang/sifr/pull/1617`
 
 ### Scope
 
@@ -632,8 +632,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0211-trie-wildcard-rewrite`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1618`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1618`
+PR: `https://github.com/sifr-lang/sifr/pull/1618`
+Merged: `https://github.com/sifr-lang/sifr/pull/1618`
 
 ### Scope
 
@@ -680,8 +680,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0212-trie-board-search`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1619`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1619`
+PR: `https://github.com/sifr-lang/sifr/pull/1619`
+Merged: `https://github.com/sifr-lang/sifr/pull/1619`
 
 ### Scope
 
@@ -728,8 +728,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0146-recency-design`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1620`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1620`
+PR: `https://github.com/sifr-lang/sifr/pull/1620`
+Merged: `https://github.com/sifr-lang/sifr/pull/1620`
 
 ### Scope
 
@@ -756,8 +756,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0706-hashmap-storage-design`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1621`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1621`
+PR: `https://github.com/sifr-lang/sifr/pull/1621`
+Merged: `https://github.com/sifr-lang/sifr/pull/1621`
 
 ### Scope
 
@@ -784,8 +784,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0706-hashmap-rewrite`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1622`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1622`
+PR: `https://github.com/sifr-lang/sifr/pull/1622`
+Merged: `https://github.com/sifr-lang/sifr/pull/1622`
 
 ### Scope
 
@@ -833,8 +833,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0146-lru-rewrite`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1623`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1623`
+PR: `https://github.com/sifr-lang/sifr/pull/1623`
+Merged: `https://github.com/sifr-lang/sifr/pull/1623`
 
 ### Scope
 
@@ -882,8 +882,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0004-binary-median`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1624`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1624`
+PR: `https://github.com/sifr-lang/sifr/pull/1624`
+Merged: `https://github.com/sifr-lang/sifr/pull/1624`
 
 ### Scope
 
@@ -934,8 +934,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0206-reverse-linked-list`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1625`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1625`
+PR: `https://github.com/sifr-lang/sifr/pull/1625`
+Merged: `https://github.com/sifr-lang/sifr/pull/1625`
 
 ### Scope
 
@@ -985,8 +985,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0024-swap-pairs`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1626`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1626`
+PR: `https://github.com/sifr-lang/sifr/pull/1626`
+Merged: `https://github.com/sifr-lang/sifr/pull/1626`
 
 ### Scope
 
@@ -1036,8 +1036,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0147-insertion-sort-list`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1627`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1627`
+PR: `https://github.com/sifr-lang/sifr/pull/1627`
+Merged: `https://github.com/sifr-lang/sifr/pull/1627`
 
 ### Scope
 
@@ -1087,8 +1087,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0707-linked-list-design`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1628`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1628`
+PR: `https://github.com/sifr-lang/sifr/pull/1628`
+Merged: `https://github.com/sifr-lang/sifr/pull/1628`
 
 ### Scope
 
@@ -1139,8 +1139,8 @@ Local gate:
 
 Status: merged
 Branch: `ws4-0023-merge-k-lists-heap`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1629`
-Merged: `https://github.com/yaseralnajjar/sifr/pull/1629`
+PR: `https://github.com/sifr-lang/sifr/pull/1629`
+Merged: `https://github.com/sifr-lang/sifr/pull/1629`
 
 ### Scope
 
@@ -1190,7 +1190,7 @@ Local gate:
 
 Status: opened PR
 Branch: `ws4-0148-blocker-note`
-PR: `https://github.com/yaseralnajjar/sifr/pull/1630`
+PR: `https://github.com/sifr-lang/sifr/pull/1630`
 
 ### Scope
 

--- a/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
+++ b/issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md
@@ -19,7 +19,7 @@ Source issue: `issues/sifr-workspace-sifr-toml-import-resolution-2026-04-25.md`
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws0
-PR: https://github.com/yaseralnajjar/sifr/pull/1639
+PR: https://github.com/sifr-lang/sifr/pull/1639
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -41,7 +41,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws1
-PR: https://github.com/yaseralnajjar/sifr/pull/1642
+PR: https://github.com/sifr-lang/sifr/pull/1642
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -61,7 +61,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws2
-PR: https://github.com/yaseralnajjar/sifr/pull/1640
+PR: https://github.com/sifr-lang/sifr/pull/1640
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -82,7 +82,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws3
-PR: https://github.com/yaseralnajjar/sifr/pull/1641
+PR: https://github.com/sifr-lang/sifr/pull/1641
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -105,7 +105,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws4
-PR: https://github.com/yaseralnajjar/sifr/pull/1643
+PR: https://github.com/sifr-lang/sifr/pull/1643
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -126,7 +126,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws5
-PR: https://github.com/yaseralnajjar/sifr/pull/1644
+PR: https://github.com/sifr-lang/sifr/pull/1644
 Merged: 2026-04-25
 
 ### Planned Scope
@@ -151,7 +151,7 @@ Merged: 2026-04-25
 
 Status: merged
 Branch: ad-hoc/sifr-workspace-ws6
-PR: https://github.com/yaseralnajjar/sifr/pull/1645
+PR: https://github.com/sifr-lang/sifr/pull/1645
 Merged: 2026-04-25
 
 ### Planned Scope

--- a/issues/archive/ad-hoc-canonical-iteration-model-and-lazy-parity-closure-execution.md
+++ b/issues/archive/ad-hoc-canonical-iteration-model-and-lazy-parity-closure-execution.md
@@ -80,7 +80,7 @@ Contract lock for wave progression:
 ### wave_psp_iter_fix_0: Contract Freeze and Governance Lock
 - Status: completed (implementation merged; completion and production-grade review passes approved)
 - Implementation PR:
-  - `#1339` (merged): https://github.com/yaseralnajjar/sifr/pull/1339
+  - `#1339` (merged): https://github.com/sifr-lang/sifr/pull/1339
 - Scope:
   - freeze canonical iteration semantics and permanent divergences
   - update architecture and governance docs before implementation waves begin
@@ -271,8 +271,8 @@ Contract lock for wave progression:
 ### wave_psp_iter_fix_6: `sifr.itertools` and Iterator-Returning Stdlib Closure
 - Status: completed (implementation + local validation complete; completion and production-grade reviews approved)
 - Implementation PRs:
-  - `#1357` (merged): https://github.com/yaseralnajjar/sifr/pull/1357
-  - `#1358` (merged): https://github.com/yaseralnajjar/sifr/pull/1358
+  - `#1357` (merged): https://github.com/sifr-lang/sifr/pull/1357
+  - `#1358` (merged): https://github.com/sifr-lang/sifr/pull/1358
 - Scope:
   - rewrite iterable signatures and buffering semantics where required
   - align iterator-returning stdlib APIs with builtin iterator consumers
@@ -491,7 +491,7 @@ Contract lock for wave progression:
   - `lib/sifr/itertools.sifr` (`count` root-cause remediation: replace unsupported unbounded `yield` loop with bounded-prefix delegation to `count_from`)
   - `verification/stdlib/wave_psp_iter_fix_6_cpython_traceability.md` (expanded mapping and intentional-diff boundary record)
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1373` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1373` (merged)
 - Validation:
   - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_itertools.sifr` -> PASS
   - `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/cpython_itertools_subset.sifr` -> PASS

--- a/issues/archive/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05-execution.md
+++ b/issues/archive/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05-execution.md
@@ -78,8 +78,8 @@ Owning phase: `issues/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05.
 - observed deltas vs wave-2 steady state (`wave1_after_patch5`):
   - `0567_permutation_in_string`: FAIL (`E0308`) -> PASS
 - PR:
-  - draft: https://github.com/yaseralnajjar/sifr/pull/1575
-  - merged: https://github.com/yaseralnajjar/sifr/pull/1575 (`2026-04-06`, squash)
+  - draft: https://github.com/sifr-lang/sifr/pull/1575
+  - merged: https://github.com/sifr-lang/sifr/pull/1575 (`2026-04-06`, squash)
 
 ### 2026-04-05 wave-4 (ws1 type-contract patchset D)
 - scope:

--- a/issues/archive/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05.md
+++ b/issues/archive/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05.md
@@ -161,7 +161,7 @@ Phase exit gate:
 - Updated taxonomy JSON (new dated artifact)
 - Final closure report linking compiler changes and adaptation patches
 - Closure report artifact: `issues/codegen-runtime-build-gap-closure-report-2026-04-06.md`
-- Closure PR: https://github.com/yaseralnajjar/sifr/pull/1575 (merged `2026-04-06`)
+- Closure PR: https://github.com/sifr-lang/sifr/pull/1575 (merged `2026-04-06`)
 
 ## Ready-to-implement Checklist
 - [x] Create execution issue for this phase and track wave status.

--- a/issues/archive/ad-hoc-demo-closure-and-compiler-correctness-execution.md
+++ b/issues/archive/ad-hoc-demo-closure-and-compiler-correctness-execution.md
@@ -58,7 +58,7 @@ Owning phase: `issues/ad-hoc-demo-closure-and-compiler-correctness.md`
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `cargo test -p sifr_codegen test_generate_rust_iterator_return_consumes_local_list_binding -- --nocapture`
   - `cargo test -p sifr_codegen test_generate_rust_iterator_return_consumes_owned_param_binding -- --nocapture`
@@ -84,7 +84,7 @@ status: completed
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `cargo test -p sifr_codegen test_generate_rust_open_uses_canonical_filehandle_constructor -- --nocapture`
   - `target/debug/sifr run demos/advanced_class_libraries/main.sifr`
@@ -97,7 +97,7 @@ status: completed
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `target/debug/sifr run demos/mut_sort/main.sifr`
 - Notes:
@@ -108,7 +108,7 @@ status: completed
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `cargo test -p sifr_codegen test_generate_rust_generator_clones_borrowed_params_into_owned_locals_before_calls -- --nocapture`
   - `cargo test -p sifr_codegen test_generate_rust_defaultdict_int_augassign_uses_entry_default -- --nocapture`
@@ -122,7 +122,7 @@ status: completed
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `cargo test -p sifr_codegen test_generate_rust_recursive_constructor_argument_wraps_optional_box_field -- --nocapture`
   - `target/debug/sifr run demos/nested_recursive_helpers/main.sifr`
@@ -135,7 +135,7 @@ status: completed
 
 status: completed
 
-- PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+- PR: `https://github.com/sifr-lang/sifr/pull/1435`
 - Validation:
   - `cargo test -p sifr_codegen test_generate_rust_tuple_field_assignment_emits_mutable_self_receiver -- --nocapture`
   - `target/debug/sifr run demos/tuple_assignment/main.sifr`
@@ -152,5 +152,5 @@ status: completed
   - `demos/mut_sort/main.sifr` was confirmed as a canonical demo adaptation to `own mut`, not a compiler bug.
   - `demos/recursive_records/main.sifr` retained the compiler-side recursive constructor fix, but its final call-site shape was also normalized to explicit option-typed locals to avoid repeated temporary ownership moves.
 - Merged PR links:
-- `https://github.com/yaseralnajjar/sifr/pull/1435`
+- `https://github.com/sifr-lang/sifr/pull/1435`
 - final implementation review: `tmp/claude_phase_final_impl_review.md` (`no actionable findings`)

--- a/issues/archive/ad-hoc-demo-closure-and-compiler-correctness.md
+++ b/issues/archive/ad-hoc-demo-closure-and-compiler-correctness.md
@@ -4,7 +4,7 @@ Status: complete (documented 2026-03-28, closed after implementation review)
 Context: corrective follow-up phase inserted after the latest `demos/` reliability sweep and after the Phase 31 algorithmic compatibility carry-forward plan was reviewed for language-rot risk
 Execution readiness: implementation-ready in dependency order; compiler root causes must be fixed before any broad demo sweep is treated as closed
 Execution ledger: `issues/ad-hoc-demo-closure-and-compiler-correctness-execution.md`
-Merged PR: `https://github.com/yaseralnajjar/sifr/pull/1435`
+Merged PR: `https://github.com/sifr-lang/sifr/pull/1435`
 
 ## Objective
 

--- a/issues/archive/ad-hoc-entrypoint-compilation-unification-and-dependency-metadata-closure-execution.md
+++ b/issues/archive/ad-hoc-entrypoint-compilation-unification-and-dependency-metadata-closure-execution.md
@@ -33,7 +33,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_adhoc_1: Canonical Rooted Entrypoint Compilation Plan
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1082
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1082
 - Implementation target:
   - add one rooted-entrypoint driver plan abstraction
   - route both single-file and project build orchestration through it
@@ -51,7 +51,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_adhoc_2: Multi-Module Dependency Metadata Aggregation
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1083
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1083
 - Implementation target:
   - return aggregate `used_stdlib_modules` and `required_crates` from multi-module codegen
   - thread aggregated metadata through rooted project build planning and test support-module codegen
@@ -70,7 +70,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_adhoc_3: Canonical Manifest Generation Path
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1084
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1084
 - Implementation target:
   - move Cargo.toml generation into the one shared rooted-entrypoint materialization path
   - drive both single-file and project manifests from aggregated compiler metadata
@@ -89,7 +89,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_adhoc_4: CLI Contract Preservation and Regression Hardening
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1085
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1085
 - Implementation target:
   - add explicit CLI tests for single-file isolation after the rooted-entrypoint refactor
   - prove non-main entrypoints still bypass project mode
@@ -108,7 +108,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_adhoc_5: Dependency Closure Regression Matrix
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1086
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1086
 - Implementation target:
   - add regression coverage for reachable support-module stdlib dependencies and unreachable sibling exclusion
   - prove non-main intrinsic-required crates remain included only through reachable closure
@@ -144,7 +144,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
   - positive path: `cargo test -p sifr_driver rooted_entrypoint -- --nocapture` -> passed (`11 passed, 0 failed`) after removing the dead-store rooted-entrypoint helper plumbing
   - local gate: `scripts/run_all_tests.sh --profile quick` -> passed (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`)
 - Follow-up PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1087 (merged 2026-03-10)
+  - https://github.com/sifr-lang/sifr/pull/1087 (merged 2026-03-10)
 
 ### review_pass_2
 - Reviewer artifact: `/Users/yaseralnajjar/work/sifr/codebase/reviews/adhoc-entrypoint-review-3.md`
@@ -156,4 +156,4 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 - Validation evidence:
   - reviewer explicitly approved the current `main` state as production-grade for the phase
 - Follow-up PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1088
+  - https://github.com/sifr-lang/sifr/pull/1088

--- a/issues/archive/ad-hoc-first-class-bytes-and-binary-surface-foundation-execution.md
+++ b/issues/archive/ad-hoc-first-class-bytes-and-binary-surface-foundation-execution.md
@@ -56,7 +56,7 @@ Required entry records:
 ### wave_psp_bytes_0: Architecture Lock
 - Status: completed
 - Implementation PR:
-  - `#1291` (merged): https://github.com/yaseralnajjar/sifr/pull/1291
+  - `#1291` (merged): https://github.com/sifr-lang/sifr/pull/1291
 - Scope:
   - lock first-class immutable `bytes` contract and text/binary boundary for this phase
   - classify permanent diffs (`bytearray`, `memoryview`, buffer protocol, implicit coercions, non-UTF-8 codecs)
@@ -77,7 +77,7 @@ Required entry records:
 ### wave_psp_bytes_1: Core `bytes` Type and Compiler Support
 - Status: completed
 - Implementation PR:
-  - `#1294`: https://github.com/yaseralnajjar/sifr/pull/1294
+  - `#1294`: https://github.com/sifr-lang/sifr/pull/1294
 - Scope:
   - add first-class `Type::Bytes` in type-system inference/checking/union ordering
   - lower bytes literals and `bytes()` constructor through HIR/lowering/codegen as immutable sequence values
@@ -96,7 +96,7 @@ Required entry records:
 ### wave_psp_bytes_2: Conversion Surfaces and Compatibility Migration
 - Status: completed
 - Implementation PR:
-  - `#1297` (merged): https://github.com/yaseralnajjar/sifr/pull/1297
+  - `#1297` (merged): https://github.com/sifr-lang/sifr/pull/1297
 - Scope:
   - lower `bytes(size)` to a typed `Result[bytes, ValueError]` intrinsic path
   - lower `bytes.from_ints(list[int])` and `bytes.from_hex(str)` as first-class bytes factory calls
@@ -122,7 +122,7 @@ Required entry records:
 ### wave_psp_bytes_3: Downstream Contract Adoption and Governance Closeout
 - Status: completed
 - Implementation PR:
-  - `#1301` (merged): https://github.com/yaseralnajjar/sifr/pull/1301
+  - `#1301` (merged): https://github.com/sifr-lang/sifr/pull/1301
 - Scope:
   - migrate current shipped `io` binary method boundaries to first-class `bytes` (`FileHandle.read_bytes` / `write_bytes`) while keeping internal intrinsic names stable
   - add explicit wave-3 pass/fail coverage proving downstream binary-carrier contract adoption (`bytes`) and compile-time rejection of stale `list[int]` payload assumptions
@@ -144,7 +144,7 @@ Required entry records:
 ### wave_psp_bytes_4: Raw-Byte Backend and Bytes/List Lowering Separation
 - Status: completed
 - Implementation PR:
-  - `#1311` (merged): https://github.com/yaseralnajjar/sifr/pull/1311
+  - `#1311` (merged): https://github.com/sifr-lang/sifr/pull/1311
 - Scope:
   - move `Type::Bytes` backend storage off widened integer vectors onto raw-byte storage
   - remove bytes-native dependence on generic list lowering where it preserves the widened-storage assumption
@@ -166,7 +166,7 @@ Required entry records:
 ### wave_psp_bytes_5: Successor-Phase and FFI Readiness Closeout
 - Status: completed
 - Implementation PR:
-  - `#1313` (merged): https://github.com/yaseralnajjar/sifr/pull/1313
+  - `#1313` (merged): https://github.com/sifr-lang/sifr/pull/1313
 - Scope:
   - refresh runtime/file-object successor planning to assume raw-byte-backed `bytes`
   - refresh RNG/crypto successor planning to assume raw-byte-backed `bytes`

--- a/issues/archive/ad-hoc-first-class-lazy-iterators-and-python-iterable-protocol-execution.md
+++ b/issues/archive/ad-hoc-first-class-lazy-iterators-and-python-iterable-protocol-execution.md
@@ -66,7 +66,7 @@ Required entry records:
   - wire typing helpers so iterator element extraction is protocol-based
   - update architecture/governance docs to replace eager-lazy waiver baseline
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1241` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1241` (merged)
 - Validation:
   - positive path: `cargo run -q -p sifr -- check demos/ad_hoc_iter_wave1_type_protocol_demo.sifr` -> `no errors found`
   - positive path: `cargo run -q -p sifr -- run demos/ad_hoc_iter_wave1_type_protocol_demo.sifr` -> `12`
@@ -76,7 +76,7 @@ Required entry records:
 ### wave_iter_2: Builtin Protocol Entry and `for` Lowering
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1242` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1242` (merged)
 - Validation:
   - positive path: `cargo test -p sifr_hir -- test_for_loop_lowers_through_iter_protocol_call` -> PASS
   - positive path: `cargo test -p sifr_hir -- test_iter_and_next_builtin_protocol_calls_lower` -> PASS
@@ -89,7 +89,7 @@ Required entry records:
 ### wave_iter_3: Generator Rewrite
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1243` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1243` (merged)
 - Validation:
   - positive path: `cargo test -p sifr_hir -- test_generator_function_infers_iterator_return_type --nocapture` -> PASS
   - positive path: `cargo test -p sifr_hir -- test_generator_expression_is_typed_as_iterator --nocapture` -> PASS
@@ -104,7 +104,7 @@ Required entry records:
 ### wave_iter_4: Core Builtin Lazy Parity
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1244` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1244` (merged)
 - Validation:
   - positive path: `cargo test -p sifr_hir -- test_reversed_enumerate_zip_are_typed_as_iterators --nocapture` -> PASS
   - positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/builtin_enumerate_zip.sifr` -> PASS
@@ -117,7 +117,7 @@ Required entry records:
 ### wave_iter_5: Initial `itertools` Lazy Subset
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1245` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1245` (merged)
 - Validation:
   - positive path: `cargo test -p sifr_codegen -- test_generate_rust_generator_conditional_yield_preserves_else_branch --nocapture` -> PASS
   - positive path: `cargo run -q -p sifr -- check demos/ad_hoc_iter_wave5_itertools_lazy_subset_demo.sifr` -> `no errors found`
@@ -135,7 +135,7 @@ Required entry records:
 ### wave_iter_6: Parity Closure, Demo, Governance
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1247` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1247` (merged)
 - Validation:
   - positive path: `cargo run -q -p sifr -- check demos/ad_hoc_iter_wave6_parity_closure_demo.sifr` -> `no errors found`
   - positive path: `cargo run -q -p sifr -- run demos/ad_hoc_iter_wave6_parity_closure_demo.sifr` -> `ad_hoc_iter_wave6_parity_closure_demo: ok`

--- a/issues/archive/ad-hoc-operator-truthiness-contract-closure-2026-04-07-execution.md
+++ b/issues/archive/ad-hoc-operator-truthiness-contract-closure-2026-04-07-execution.md
@@ -63,17 +63,17 @@ Owning phase doc: `issues/ad-hoc-operator-truthiness-contract-closure-2026-04-07
 - Wave WS1 (simple truthiness canonicalization)
   - Fixtures: `0007`, `0068`, `0416`, `0846`
   - Validation: targeted `check` + `run` all PASS
-  - PR: `https://github.com/yaseralnajjar/sifr/pull/1592` (merged)
+  - PR: `https://github.com/sifr-lang/sifr/pull/1592` (merged)
 
 - Wave WS2 (callable/return contract closure)
   - Fixtures: `0201`, `0371`, `1220`, `0931`, `0162`
   - Validation: targeted `check` + `run` all PASS
-  - PR: `https://github.com/yaseralnajjar/sifr/pull/1593` (merged)
+  - PR: `https://github.com/sifr-lang/sifr/pull/1593` (merged)
 
 - Wave WS3 (structural rewrite closure)
   - Fixtures: `0473`, `0735`, `0973`, `1514`, `0516`
   - Validation: targeted `check` + `run` all PASS
-  - PR: `https://github.com/yaseralnajjar/sifr/pull/1594` (merged)
+  - PR: `https://github.com/sifr-lang/sifr/pull/1594` (merged)
 
 - Wave WS4 (phase close validation/reporting)
   - Scoped confirmation artifact:

--- a/issues/archive/ad-hoc-operator-truthiness-contract-closure-2026-04-07.md
+++ b/issues/archive/ad-hoc-operator-truthiness-contract-closure-2026-04-07.md
@@ -22,9 +22,9 @@ Source taxonomy artifact: `verification/leetcode/full_corpus_failure_taxonomy_20
     - `destructuring_and_assignment_target_surface_gap`: `1 -> 1`
     - `python_stdlib_and_builtin_parity_gap`: `10 -> 10`
 - implementation PRs:
-  - `https://github.com/yaseralnajjar/sifr/pull/1592` (WS1)
-  - `https://github.com/yaseralnajjar/sifr/pull/1593` (WS2)
-  - `https://github.com/yaseralnajjar/sifr/pull/1594` (WS3)
+  - `https://github.com/sifr-lang/sifr/pull/1592` (WS1)
+  - `https://github.com/sifr-lang/sifr/pull/1593` (WS2)
+  - `https://github.com/sifr-lang/sifr/pull/1594` (WS3)
 
 ## Scope
 

--- a/issues/archive/ad-hoc-optional-none-and-narrowing-closure-execution.md
+++ b/issues/archive/ad-hoc-optional-none-and-narrowing-closure-execution.md
@@ -57,7 +57,7 @@ status: in progress
     - `cargo run -q -p sifr -- check audits/leetcode/0004_median_of_two_sorted_arrays.sifr` -> still failing (`int | None` ternary branches)
     - `cargo run -q -p sifr -- check audits/leetcode/0013_roman_to_integer.sifr` -> still failing (`int | None` dict index arithmetic)
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1444` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1444` (merged)
 - 2026-03-29 local iteration (wave-3 slice):
   - compiler changes:
     - `while` lowering now applies condition-based narrowing facts to the loop body before statement lowering
@@ -68,7 +68,7 @@ status: in progress
     - `cargo run -q -p sifr -- check audits/leetcode/0206_reverse_linked_list.sifr` -> attribute-access Optional noise removed; remaining boundary/ownership diagnostics persist
     - `cargo run -q -p sifr -- check audits/leetcode/0024_swap_nodes_in_pairs.sifr` -> attribute-access Optional noise removed; remaining boundary diagnostics persist
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1446` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1446` (merged)
 - 2026-03-29 local iteration (wave-4 slice):
   - compiler changes:
     - reassignment for inferred local bindings now supports Optional widening on `None` transitions (`T` <-> `T | None`) without widening explicitly annotated locals or parameters
@@ -81,7 +81,7 @@ status: in progress
     - `cargo run -q -p sifr -- check audits/leetcode/0206_reverse_linked_list.sifr` -> reassignment-flow type mismatches reduced (remaining signature/boundary diagnostics persist)
     - `cargo run -q -p sifr -- check audits/leetcode/0024_swap_nodes_in_pairs.sifr` -> reassignment-flow type mismatches reduced (remaining signature/boundary diagnostics persist)
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1460` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1460` (merged)
 - 2026-03-29 local iteration (wave-7 sequence-guard dominance slice):
   - compiler changes:
     - boolean short-circuit lowering now propagates sequence guards per operand:
@@ -114,7 +114,7 @@ status: in progress
       - `0290_word_pattern`: `CHECK_ERROR -> RUN_ERROR` (ownership move-use emitted after check-side Optional gate removal)
     - vs entry baseline: `PASS +16`, `CHECK_ERROR -18`, `RUN_ERROR +2`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1472` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1472` (merged)
 - 2026-03-29 local iteration (wave-8 tuple-unpack flow hygiene slice):
   - compiler changes:
     - tuple-unpack assignment now records len-alias facts from tuple RHS elements
@@ -138,7 +138,7 @@ status: in progress
     - vs wave-7: no status transitions (`PASS/CHECK_ERROR/RUN_ERROR` unchanged)
     - vs entry baseline: `PASS +16`, `CHECK_ERROR -18`, `RUN_ERROR +2`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1474` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1474` (merged)
 - 2026-03-29 local iteration (wave-8b run-stage ownership stabilization slice):
   - root cause:
     - wave-7 removed check-side Optional gates for `0205`/`0290`, exposing an existing codegen ownership bug where non-copy `Name` operands in subscript assignment were moved and then reused by generated Rust (`E0382`)
@@ -168,7 +168,7 @@ status: in progress
       - `0290_word_pattern`: `RUN_ERROR -> PASS`
     - vs entry baseline: `PASS +18`, `CHECK_ERROR -18`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1477` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1477` (merged)
 - Validation to record:
   - owning unit tests
   - non-LeetCode e2e regression(s)
@@ -278,7 +278,7 @@ status: in progress
   - closure note:
     - phase remains open; closeout criterion requiring Optional/None no longer be dominant unresolved family is not yet met on the latest rerun
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1463` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1463` (merged)
 - 2026-03-29 local iteration (wave-6 residual run-stability slice):
   - residual canonicalization inventory:
     - `0010_regular_expression_matching`
@@ -302,7 +302,7 @@ status: in progress
   - closure note:
     - phase remains open; Optional/None unresolved family size is reduced but still not closed by criterion
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1464` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1464` (merged)
 - 2026-03-29 local iteration (wave-9a residual canonicalization batch-1):
   - root cause:
     - selected fixtures depended on unstated non-empty/index-safety problem constraints and therefore failed Sifr Optional checks without explicit local proof
@@ -335,7 +335,7 @@ status: in progress
       - `0540_single_element_in_a_sorted_array`: `CHECK_ERROR -> PASS`
     - vs entry baseline: `PASS +22`, `CHECK_ERROR -22`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1480` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1480` (merged)
 - 2026-03-29 local iteration (wave-9b residual canonicalization batch-2):
   - root cause:
     - selected fixtures still encoded unstated index-seed assumptions (`nums[0]`, direct first-element reads) that are invalid under explicit Sifr Optional/index semantics and therefore remained `CHECK_ERROR`
@@ -368,7 +368,7 @@ status: in progress
       - `1800_maximum_ascending_subarray_sum`: `CHECK_ERROR -> PASS`
     - vs entry baseline: `PASS +26`, `CHECK_ERROR -26`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1482` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1482` (merged)
 - 2026-03-29 local iteration (wave-9c residual canonicalization batch-3):
   - root cause:
     - a residual DP/index fixture cluster still performed arithmetic and returns on indexed list reads typed as `int | None` without explicit local non-empty/index proof
@@ -401,7 +401,7 @@ status: in progress
       - `0135_candy`: `CHECK_ERROR -> PASS`
     - vs entry baseline: `PASS +30`, `CHECK_ERROR -30`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1484` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1484` (merged)
 - 2026-03-29 local iteration (wave-9d residual canonicalization batch-4):
   - root cause:
     - residual DP/sliding-window fixtures still performed arithmetic on Optional-contaminated indexed/helper-return paths (`int | None` in `+`/`-`) without explicit local proof
@@ -434,7 +434,7 @@ status: in progress
       - `1343_number_of_sub_arrays_of_size_k_and_average_greater_than_or_equal_to_threshold`: `CHECK_ERROR -> PASS`
     - vs entry baseline: `PASS +34`, `CHECK_ERROR -34`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1485` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1485` (merged)
 - 2026-03-29 local iteration (wave-9e mutability boundary canonicalization batch-5):
   - root cause:
     - a residual fixture cluster mutated list parameters without explicit `mut` boundary declarations; one fixture also used unsupported tuple-swap assignment syntax
@@ -466,7 +466,7 @@ status: in progress
       - `0448_find_all_numbers_disappeared_in_an_array`: `CHECK_ERROR -> PASS`
     - vs entry baseline: `PASS +38`, `CHECK_ERROR -38`, `RUN_ERROR ±0`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1486` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1486` (merged)
 - 2026-03-30 local iteration (wave-R1 run-stage panic-closure compiler slice):
   - root cause:
     - structured statement lowering had parity gaps between top-level and nested block paths, causing production panics for loop bodies that required:
@@ -672,7 +672,7 @@ status: in progress
     - remaining run-error set in probe cohort:
       - `0054`, `0071`, `0349`, `0459`, `0763`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1539` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1539` (merged)
 
 - 2026-03-30 local iteration (wave-R3c container/guard/slice stabilization slice):
   - root cause:
@@ -708,7 +708,7 @@ status: in progress
   - residual ownership after wave-R3c:
     - `0054`, `0763`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1541` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1541` (merged)
 
 - 2026-03-30 local iteration (wave-R3d final residual run-error closure slice):
   - root cause:
@@ -740,7 +740,7 @@ status: in progress
     - run-stage residuals from this lane: none
     - check-stage residuals requiring explicit Optional-safe author intent: `0054`, `0763`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1542` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1542` (merged)
 
 - 2026-03-30 local iteration (wave-R3e residual check-stage canonicalization slice):
   - root cause:
@@ -766,7 +766,7 @@ status: in progress
   - residual ownership after wave-R3e:
     - residual run/check ownership from this lane: none
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1548` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1548` (merged)
 
 - Validation to record:
   - post-wave full corpus rerun

--- a/issues/archive/ad-hoc-owned-crate-clippy-cleanup-execution.md
+++ b/issues/archive/ad-hoc-owned-crate-clippy-cleanup-execution.md
@@ -34,7 +34,7 @@ Notes:
 - Source inventory after edits no longer shows wildcard imports or `push_str(&format!(...))` in `sifr_hir`.
 - Targeted validation passed with `cargo clippy -p sifr_hir --message-format short -- -D warnings` and `cargo test -p sifr_hir --lib`.
 - Test-only explicit imports were fixed in `src/lower/expressions.rs` after the unit-test pass surfaced missing symbols.
-- PR: https://github.com/yaseralnajjar/sifr/pull/1099
+- PR: https://github.com/sifr-lang/sifr/pull/1099
 
 ## Part 2: `sifr_codegen`
 
@@ -58,7 +58,7 @@ Notes:
 - Targeted validation passed with `cargo clippy -p sifr_codegen --message-format short -- -D warnings`.
 - Smoke tests passed with `cargo test -p sifr_codegen simple_function_codegen --lib` and `cargo test -p sifr_codegen generate_rust_multi_exports_non_main_items --lib`.
 - Test-only explicit imports were fixed in `src/lib_codegen_tests.rs` after the targeted test run surfaced missing symbols.
-- PR: https://github.com/yaseralnajjar/sifr/pull/1099
+- PR: https://github.com/sifr-lang/sifr/pull/1099
 
 ## Part 3: residual owned crates
 
@@ -83,7 +83,7 @@ Notes:
 - CLI user-path validation passed with:
   - positive: `cargo run -q -p sifr -- check demos/milestone_enums_demo.sifr`
   - negative: `cargo run -q -p sifr -- check demos/milestone_generics_impl_demo.sifr` -> expected frontend type error
-- PR: https://github.com/yaseralnajjar/sifr/pull/1099
+- PR: https://github.com/sifr-lang/sifr/pull/1099
 
 ## Phase-wide Quality Gates
 

--- a/issues/archive/ad-hoc-ownership-aware-collection-lowering-and-clone-elision-execution.md
+++ b/issues/archive/ad-hoc-ownership-aware-collection-lowering-and-clone-elision-execution.md
@@ -102,7 +102,7 @@ Secondary review paths:
 
 ### wave_clone_0: Architecture Lock, Inventory, and Baseline
 - Status: completed
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1394 (merged)
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1394 (merged)
 - Scope:
   - capture the generated-code baseline and inventory all targeted clone-heavy patterns
   - lock one canonical ownership-aware planner design before broad edits
@@ -142,7 +142,7 @@ Secondary review paths:
 
 ### wave_clone_1: Iterator and Comprehension Ownership Correction
 - Status: completed
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1395 (merged)
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1395 (merged)
 - Scope:
   - implement the shared planner in `helpers.rs` or an equivalent focused support module
   - refactor iterator/comprehension lowering to derive decisions from planner output
@@ -191,7 +191,7 @@ Secondary review paths:
 
 ### wave_clone_2: Indexing, Safe Indexing, Slicing, and Star-Unpack Ownership Correction
 - Status: completed
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1398 (merged)
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1398 (merged)
 - Scope:
   - refactor indexing and safe-indexing extraction to use ownership-aware plans
   - remove `Copy`-element `.clone()` / `.cloned()` in targeted indexing paths
@@ -234,7 +234,7 @@ Secondary review paths:
 
 ### wave_clone_3: Generic Hardening, Regression Lock, and Closure
 - Status: completed
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1402 (merged)
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1402 (merged)
 - Scope:
   - harden `TypeVar`, `Any`, and union cases under the shared planner
   - ensure no unsound `.copied()` lowering is emitted for conservative types

--- a/issues/archive/ad-hoc-phase-focus4-root-cause-closure-2026-04-06-execution.md
+++ b/issues/archive/ad-hoc-phase-focus4-root-cause-closure-2026-04-06-execution.md
@@ -108,7 +108,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass5-wave-cd.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1577` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1577` (merged)
 
 - Wave E1 (adaptation): duplicate-solution canonicalization for RF-1 fixtures
   - Canonicalized to one top-level solution per module:
@@ -134,7 +134,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass6-wave-e1.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1580`
+    - `https://github.com/sifr-lang/sifr/pull/1580`
 
 - Wave B1 (compiler): failed-initializer binding seeding + exhaustive if/else branch binding propagation
   - Compiler changes:
@@ -162,7 +162,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass7-wave-b1.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1581`
+    - `https://github.com/sifr-lang/sifr/pull/1581`
 
 - Wave B2 (compiler): suppress return-completeness cascades from failed return expression lowering
   - Compiler changes:
@@ -183,7 +183,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass8-wave-b2.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1582`
+    - `https://github.com/sifr-lang/sifr/pull/1582`
 
 - Wave D2/E2 (adaptation): policy canonicalization for DS-4/DS-5 fixtures
   - Canonicalized tuple-swap/chained-assignment forms into simple assignment targets:
@@ -207,7 +207,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass9-wave-de2.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1583`
+    - `https://github.com/sifr-lang/sifr/pull/1583`
 
 - Wave D3/E3 (adaptation): list-shaped destructuring canonicalization for DS-1/DS-2 fixtures
   - Canonicalized list-based tuple destructuring and list unpacking forms into index-based extraction or tuple-shaped carriers in:
@@ -242,7 +242,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass10-wave-de3.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1584`
+    - `https://github.com/sifr-lang/sifr/pull/1584`
 
 - Wave A1/B3/E4 (compiler + adaptation): AU and RF-3 primary closure sweep
   - Compiler changes:
@@ -284,7 +284,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass11-wave-ab3e4.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1585`
+    - `https://github.com/sifr-lang/sifr/pull/1585`
 
 - Wave F1 (phase reporting closure): full-corpus rerun3 + taxonomy regeneration + delta report
   - Full-corpus rerun artifact:
@@ -312,7 +312,7 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass12-wave-f1.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1586` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1586` (merged)
 
 - Wave G1 (convergence closure): multi-workstream residual fixtures canonicalization + full-corpus rerun4
   - Canonicalized convergence fixtures:
@@ -355,4 +355,4 @@ outside focus-4 scope. Exclude them from focus-4 pass-rate calculations.
   - Reviewer logs:
     - `reviews/focus4-root-cause-closure-review-pass13-wave-g1.md`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1588` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1588` (merged)

--- a/issues/archive/ad-hoc-phase-leetcode-18-failure-root-cause-closure-2026-04-08-execution.md
+++ b/issues/archive/ad-hoc-phase-leetcode-18-failure-root-cause-closure-2026-04-08-execution.md
@@ -119,7 +119,7 @@ Phase exit validation:
     - targeted `sifr run` on `0049`, `0144`, `0145`, `0286`, `0705`, `0973`, `1137`
     - `cargo test -p sifr -- --skip test_e2e_pass`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1605` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1605` (merged)
 
 - Wave `WS3_canonical_adaptation_sweep`
   - Changes:
@@ -129,7 +129,7 @@ Phase exit validation:
     - targeted `sifr run` on `0018`, `0056`, `0230`, `0402`, `0442`, `0543`, `0673`, `0707`, `0721`, `1849`
     - `cargo test -p sifr -- --skip test_e2e_pass`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1606` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1606` (merged)
 
 - Wave `WS2_field_surface_and_optional_flow_core` + `WS4_closure_and_reclassification`
   - Changes:
@@ -142,4 +142,4 @@ Phase exit validation:
     - `scripts/run_all_tests.sh --profile quick`
     - `scripts/run_all_tests.sh`
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1607` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1607` (merged)

--- a/issues/archive/ad-hoc-phase-leetcode-18-failure-root-cause-closure-2026-04-08.md
+++ b/issues/archive/ad-hoc-phase-leetcode-18-failure-root-cause-closure-2026-04-08.md
@@ -24,9 +24,9 @@ Closure artifacts:
 
 Merged PR ledger:
 
-- `WS1_codegen_soundness_run_stage`: `https://github.com/yaseralnajjar/sifr/pull/1605`
-- `WS3_canonical_adaptation_sweep`: `https://github.com/yaseralnajjar/sifr/pull/1606`
-- `WS2_field_surface_and_optional_flow_core` + `WS4_closure_and_reclassification`: `https://github.com/yaseralnajjar/sifr/pull/1607`
+- `WS1_codegen_soundness_run_stage`: `https://github.com/sifr-lang/sifr/pull/1605`
+- `WS3_canonical_adaptation_sweep`: `https://github.com/sifr-lang/sifr/pull/1606`
+- `WS2_field_surface_and_optional_flow_core` + `WS4_closure_and_reclassification`: `https://github.com/sifr-lang/sifr/pull/1607`
 
 ## Scope Snapshot
 

--- a/issues/archive/ad-hoc-python-source-parity-extension-waiver-reduction-execution.md
+++ b/issues/archive/ad-hoc-python-source-parity-extension-waiver-reduction-execution.md
@@ -63,7 +63,7 @@ Required entry records:
 ### wave_psp_ext_1: Builtin Iterator Re-Closure
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1254` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1254` (merged)
 - Validation:
   - positive path: `cargo test -p sifr_hir -- test_map_is_typed_as_iterator --nocapture` -> PASS
   - negative path: `cargo test -p sifr_hir -- test_map_rejects_plain_list_annotation_without_materialization --nocapture` -> PASS
@@ -77,7 +77,7 @@ Required entry records:
 ### wave_psp_ext_2: `itertools` Lazy Surface Closure
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1256` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1256` (merged)
 - Validation:
   - positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_itertools_subset.sifr` -> PASS
   - positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/phase_psp_b2_iterators_functional_randomness.sifr` -> PASS
@@ -96,9 +96,9 @@ Required entry records:
 ### wave_psp_ext_3: Regex and Filesystem Iterator Surfaces
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1259` (merged)
-  - review closure PR (pass 1): `https://github.com/yaseralnajjar/sifr/pull/1260` (merged)
-  - review closure PR (pass 2): `https://github.com/yaseralnajjar/sifr/pull/1261` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1259` (merged)
+  - review closure PR (pass 1): `https://github.com/sifr-lang/sifr/pull/1260` (merged)
+  - review closure PR (pass 2): `https://github.com/sifr-lang/sifr/pull/1261` (merged)
 - Validation:
   - positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_glob_subset.sifr` -> PASS
   - positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_pathlib_subset.sifr` -> PASS
@@ -116,7 +116,7 @@ Required entry records:
 ### wave_psp_ext_4: Waiver Ledger Reduction and Exit Closure
 - Status: merged
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1262` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1262` (merged)
 - Validation:
   - governance/doc updates:
     - `verification/stdlib/milestone_psp_7_parity_governance_inventory.md`

--- a/issues/archive/ad-hoc-runtime-and-file-object-parity-expansion-execution.md
+++ b/issues/archive/ad-hoc-runtime-and-file-object-parity-expansion-execution.md
@@ -55,7 +55,7 @@ Required entry records:
 ### wave_psp_runtime_0: Architecture Lock
 - Status: completed (implementation merged; completion review pass approved)
 - Implementation PR:
-  - `#1317` (merged): https://github.com/yaseralnajjar/sifr/pull/1317
+  - `#1317` (merged): https://github.com/sifr-lang/sifr/pull/1317
 - Scope:
   - lock sealed stream hierarchy and lifecycle-cleanup model for this phase
   - lock explicit permanent divergences (`_pyio` full inheritance, async `Popen`, `dictConfig`/dynamic graphs, thread-order claims, `SpooledTemporaryFile`, string-eval `timeit`, timezone mutation helpers)
@@ -78,7 +78,7 @@ Required entry records:
 ### wave_psp_runtime_1: `io` and In-Memory Stream Hierarchy
 - Status: completed (implementation merged; completion and production-grade external review passes approved)
 - Implementation PR:
-  - `#1320` (merged): https://github.com/yaseralnajjar/sifr/pull/1320
+  - `#1320` (merged): https://github.com/sifr-lang/sifr/pull/1320
 - Scope:
   - add first-class in-memory stream wrappers (`StringIO`, `BytesIO`) with typed cursor/lifecycle APIs
   - add binary-handle entry `open_binary(...) -> Result[BinaryFileHandle, IOError]` while preserving `open(...)` compatibility
@@ -99,8 +99,8 @@ Required entry records:
 ### wave_psp_runtime_2: Tempfile and Archive Object Lifecycles
 - Status: completed (implementation merged; completion and production-grade review passes closed)
 - Implementation PR:
-  - `#1323` (merged): https://github.com/yaseralnajjar/sifr/pull/1323
-  - `#1325` (merged): https://github.com/yaseralnajjar/sifr/pull/1325
+  - `#1323` (merged): https://github.com/sifr-lang/sifr/pull/1323
+  - `#1325` (merged): https://github.com/sifr-lang/sifr/pull/1325
 - Scope:
   - add deterministic lifecycle wrappers (`NamedTemporaryFile`, `TemporaryDirectory`) with explicit `close()/cleanup()` result surfaces and best-effort scope-exit cleanup
   - extend `zipfile` with bytes-backed write/read helpers plus governance surfaces (`is_zipfile`, `ZIP_STORED`, `ZIP_DEFLATED`, `ZipInfo`, `ZipReadHandle`)
@@ -122,7 +122,7 @@ Required entry records:
 ### wave_psp_runtime_3: Logging, Clock, and Timer Object Expansion
 - Status: completed (implementation merged; completion and production-grade review passes approved)
 - Implementation PR:
-  - `#1327` (merged): https://github.com/yaseralnajjar/sifr/pull/1327
+  - `#1327` (merged): https://github.com/sifr-lang/sifr/pull/1327
 - Scope:
   - expand `sifr.logging` with deterministic handler family (`Handler`, `StreamHandler`, `FileHandler`, `NullHandler`) and logger wiring (`add_handler`, `set_stream_handler`, `set_null_handler`, `clear_handler`) under single-process deterministic governance
   - expand `sifr.time` with immutable `struct_time`, explicit `gmtime_struct/localtime_struct`, `mktime`, and stable timezone constants (`TIMEZONE`, `ALTZONE`, `DAYLIGHT`, `TZNAME`)
@@ -147,7 +147,7 @@ Required entry records:
 ### wave_psp_runtime_4: Synchronous Subprocess Boundary Cleanup and Governance Closure
 - Status: completed (implementation merged; completion and production-grade external review passes approved)
 - Implementation PR:
-  - `#1330` (merged): https://github.com/yaseralnajjar/sifr/pull/1330
+  - `#1330` (merged): https://github.com/sifr-lang/sifr/pull/1330
 - Scope:
   - expand `sifr.subprocess` with synchronous subprocess constants (`PIPE`, `STDOUT`, `DEVNULL`) and helper APIs (`check_call`, `check_output`)
   - keep deterministic sync `CompletedProcess` contract (`returncode`, `stdout`, `stderr`) while making non-zero exit behavior explicit through typed `IOError`

--- a/issues/archive/ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-execution.md
+++ b/issues/archive/ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-execution.md
@@ -41,7 +41,7 @@ Loop per wave: Plan -> Implement -> Validate -> Demo -> PR -> External completio
 - [x] Add negative fixture for `SystemRandom` state boundary.
 - [x] Run `cargo test -p sifr -- --skip test_e2e_pass`.
 - [x] Run full gate `$(pwd)/scripts/run_all_tests.sh`.
-- [x] Open PR, review, and merge for this wave (`https://github.com/yaseralnajjar/sifr/pull/1376`).
+- [x] Open PR, review, and merge for this wave (`https://github.com/sifr-lang/sifr/pull/1376`).
 
 ### `wave_psp_rng_2`
 - [x] Expand `hashlib` to bytes-native digest/object APIs (`digest`, `digest_bytes`, `update_bytes`, `new_bytes`).
@@ -110,9 +110,9 @@ Required entry records:
   - unit lane: `cargo test -p sifr -- --skip test_e2e_pass` -> PASS
   - wave gate: `$(pwd)/scripts/run_all_tests.sh` -> PASS (2026-03-21)
 - Merge evidence:
-  - implementation PR: `https://github.com/yaseralnajjar/sifr/pull/1376` (merged 2026-03-21)
+  - implementation PR: `https://github.com/sifr-lang/sifr/pull/1376` (merged 2026-03-21)
   - external review pass 1 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-review-pass-1.md`
-  - external review pass 1 fixes PR: `https://github.com/yaseralnajjar/sifr/pull/1377` (merged 2026-03-21)
+  - external review pass 1 fixes PR: `https://github.com/sifr-lang/sifr/pull/1377` (merged 2026-03-21)
   - external review pass 2 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-review-pass-2.md`
   - pass 2 validation result: reviewer output was stale (claimed wave 1 absent) and contradicted merged code/docs in PR `#1376`; no additional code fix was valid from that report
 
@@ -130,9 +130,9 @@ Required entry records:
   - unit/non-pass lane: `cargo test -p sifr -- --skip test_e2e_pass` -> PASS
   - wave gate: `$(pwd)/scripts/run_all_tests.sh` -> PASS (2026-03-21)
 - Merge evidence:
-  - implementation PR: `https://github.com/yaseralnajjar/sifr/pull/1379` (merged 2026-03-21)
+  - implementation PR: `https://github.com/sifr-lang/sifr/pull/1379` (merged 2026-03-21)
   - external review pass 1 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-wave-psp-rng-2-review-pass-1.md`
-  - external review pass 1 fixes PR: `https://github.com/yaseralnajjar/sifr/pull/1380` (merged 2026-03-21)
+  - external review pass 1 fixes PR: `https://github.com/sifr-lang/sifr/pull/1380` (merged 2026-03-21)
   - external review pass 2 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-wave-psp-rng-2-review-pass-2.md`
   - pass 2 validation result: reviewer marked wave as production-grade with no additional code changes required
 
@@ -150,9 +150,9 @@ Required entry records:
   - negative boundary: `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/phase_psp_struct_0_html_package_parser_unsupported.sifr` -> expected compile failure (PASS)
   - wave gate: `$(pwd)/scripts/run_all_tests.sh` -> PASS (2026-03-21)
 - Merge evidence:
-  - implementation PR: `https://github.com/yaseralnajjar/sifr/pull/1382` (merged 2026-03-21)
+  - implementation PR: `https://github.com/sifr-lang/sifr/pull/1382` (merged 2026-03-21)
   - external review pass 1 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-wave-psp-rng-3-review-pass-1.md`
-  - pass 1 status PR: `https://github.com/yaseralnajjar/sifr/pull/1383` (merged 2026-03-21)
+  - pass 1 status PR: `https://github.com/sifr-lang/sifr/pull/1383` (merged 2026-03-21)
   - pass 1 validation result: reviewer approved wave scope with no additional code changes required
   - external review pass 2 artifact: `reviews/phase-ad-hoc-stateful-rng-crypto-and-polish-parity-expansion-wave-psp-rng-3-review-pass-2.md`
   - pass 2 validation result: reviewer marked wave as production-grade with no additional code changes required

--- a/issues/archive/ad-hoc-structured-data-and-class-surface-parity-expansion-execution.md
+++ b/issues/archive/ad-hoc-structured-data-and-class-surface-parity-expansion-execution.md
@@ -55,8 +55,8 @@ Required entry records:
 ### wave_psp_struct_0: Architecture Lock
 - Status: completed
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1269` (merged)
-  - review closure PR (pass 1): `https://github.com/yaseralnajjar/sifr/pull/1270` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1269` (merged)
+  - review closure PR (pass 1): `https://github.com/sifr-lang/sifr/pull/1270` (merged)
 - Scope:
   - contract lock for `json`, `datetime`, `uuid`, `csv`, `argparse`, `collections`
   - permanent-diff classification and enforcement fixtures
@@ -76,8 +76,8 @@ Required entry records:
 ### wave_psp_struct_1: Parser and Serialization Surface Expansion
 - Status: completed
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1272` (merged)
-  - review closure PR (pass 1): `https://github.com/yaseralnajjar/sifr/pull/1273` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1272` (merged)
+  - review closure PR (pass 1): `https://github.com/sifr-lang/sifr/pull/1273` (merged)
 - Scope:
   - `json`: add `JSONEncoder`/`JSONDecoder` typed wrapper classes with file and handle load/dump helpers
   - `configparser`: add interpolation-aware `get(..., raw=...)`, `SectionProxy`, and ini write-back surface (`to_ini_string`, `write`)
@@ -93,7 +93,7 @@ Required entry records:
 ### wave_psp_struct_2: Collections and CLI Class-Surface Expansion
 - Status: completed
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1275` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1275` (merged)
 - Scope:
   - `collections`: add `Counter(iterable=...)` constructor parity alongside mapping input, and promote `defaultdict` to an explicit typed class surface (`ensure`, `set`, `has`, `pop`, `clear`, `keys`, `values`, `items`, `len`)
   - `argparse`: add bounded `subparsers`, `nargs` forms (`int`, `?`, `*`, `+`), typed coercion (`str`/`int`/`float`/`bool`) via `add_argument_typed`, and namespace list support (`set_list`/`get_list`)
@@ -107,8 +107,8 @@ Required entry records:
 ### wave_psp_struct_3: UUID and Datetime Expansion
 - Status: completed
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1278` (merged)
-  - review closure PR (pass 1): `https://github.com/yaseralnajjar/sifr/pull/1279` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1278` (merged)
+  - review closure PR (pass 1): `https://github.com/sifr-lang/sifr/pull/1279` (merged)
 - Scope:
   - `uuid`: add typed name-based generation (`uuid3`, `uuid5`) and exported namespace accessors (`NAMESPACE_DNS`, `NAMESPACE_URL`, `NAMESPACE_OID`, `NAMESPACE_X500`)
   - `datetime`: expand fixed-offset timezone surfaces (`UTC`, `utc`, `now(tz=...)`, `from_timestamp(..., tz=...)`, `datetime.astimezone(...)`) with explicit offset-aware ISO/timestamp behavior
@@ -122,8 +122,8 @@ Required entry records:
 ### wave_psp_struct_4: Text-Surface Polish and Governance Closure
 - Status: completed
 - Implementation PR:
-  - `https://github.com/yaseralnajjar/sifr/pull/1281` (merged)
-  - review closure PR (pass 1): `https://github.com/yaseralnajjar/sifr/pull/1282` (merged)
+  - `https://github.com/sifr-lang/sifr/pull/1281` (merged)
+  - review closure PR (pass 1): `https://github.com/sifr-lang/sifr/pull/1282` (merged)
 - Scope:
   - `textwrap`: expand `TextWrapper` adjacent option matrix with bounded deterministic fields (`expand_tabs`, `tabsize`, `replace_whitespace`, `drop_whitespace`, `break_on_hyphens`)
   - `html`: add top-level `escape(s, quote: bool = True)` polish while keeping package-level expansion (`html.parser`) explicitly unsupported

--- a/issues/archive/ad-hoc-surface-parity-and-api-cleanup-2026-04-07-execution.md
+++ b/issues/archive/ad-hoc-surface-parity-and-api-cleanup-2026-04-07-execution.md
@@ -107,7 +107,7 @@ Current scoped fixture total: `22`
   - Scope delta:
     - scoped fixtures no longer emit `min()/max() takes 1 or 2 arguments`; residual diagnostics are secondary non-WS1 blockers
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1596` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1596` (merged)
 
 - Wave WS2 (membership parity for `range` and compat mapping wrappers)
   - Compiler changes:
@@ -135,7 +135,7 @@ Current scoped fixture total: `22`
     - scoped fixtures no longer emit `range` membership diagnostics
     - compat mapping membership diagnostic (`__compat_defaultdict_list`) is removed
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1597` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1597` (merged)
 
 - Wave WS4 (empty-container specialization repair)
   - Compiler changes:
@@ -153,7 +153,7 @@ Current scoped fixture total: `22`
     - `0290_word_pattern` now passes; scoped dict-specialization drift is removed
     - `1345_jump_game_iv` still has residual non-WS4 blockers
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1598` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1598` (merged)
 
 - Wave WS3 (iterator consumer stabilization and tuple heap comparability)
   - Compiler changes:
@@ -183,7 +183,7 @@ Current scoped fixture total: `22`
     - `1834_single_threaded_cpu` no longer fails on iterator-consumer parity; residual issues are secondary (`mut` param and `heapq` optional/Any typing flow)
     - `1851_minimum_interval_to_include_each_query` no longer fails on tuple comparability; residual issue is optional arithmetic narrowing
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1599` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1599` (merged)
 
 - Wave WS5 + WS6 (codegen defect closure + canonical adaptation sweep)
   - Compiler/codegen closure:
@@ -199,10 +199,10 @@ Current scoped fixture total: `22`
     - `scripts/run_all_tests.sh --profile quick` pass
     - `scripts/run_all_tests.sh` (profile `pr`) pass
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1600` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1600` (merged)
 
 - Wave WS7 (documentation closure consistency)
   - Change:
     - parent phase doc updated with merged PR ledger section for WS1-WS6
   - PR:
-    - `https://github.com/yaseralnajjar/sifr/pull/1602` (merged)
+    - `https://github.com/sifr-lang/sifr/pull/1602` (merged)

--- a/issues/archive/ad-hoc-surface-parity-and-api-cleanup-2026-04-07.md
+++ b/issues/archive/ad-hoc-surface-parity-and-api-cleanup-2026-04-07.md
@@ -581,11 +581,11 @@ Reasoning:
 
 ## Wave/PR Ledger (Merged)
 
-- WS1: [#1596](https://github.com/yaseralnajjar/sifr/pull/1596)
-- WS2: [#1597](https://github.com/yaseralnajjar/sifr/pull/1597)
-- WS4: [#1598](https://github.com/yaseralnajjar/sifr/pull/1598)
-- WS3: [#1599](https://github.com/yaseralnajjar/sifr/pull/1599)
-- WS5 + WS6 + phase closure validation: [#1600](https://github.com/yaseralnajjar/sifr/pull/1600)
+- WS1: [#1596](https://github.com/sifr-lang/sifr/pull/1596)
+- WS2: [#1597](https://github.com/sifr-lang/sifr/pull/1597)
+- WS4: [#1598](https://github.com/sifr-lang/sifr/pull/1598)
+- WS3: [#1599](https://github.com/sifr-lang/sifr/pull/1599)
+- WS5 + WS6 + phase closure validation: [#1600](https://github.com/sifr-lang/sifr/pull/1600)
 
 ## Closure Validation (2026-04-07)
 

--- a/issues/archive/ad-hoc-test-strategy-and-validation-lane-redesign-execution.md
+++ b/issues/archive/ad-hoc-test-strategy-and-validation-lane-redesign-execution.md
@@ -54,7 +54,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_1: Lane Taxonomy and Policy Redesign
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1170
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1170
 - Implementation target:
   - define checked-in lane metadata for `quick`, `pr`, `nightly`, and `release`
   - make `quick` a true developer lane with representative e2e instead of broad hardening
@@ -76,7 +76,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_2: Declarative Validation Harness
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1172
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1172
 - Implementation target:
   - replace shell-matrix orchestration with one manifest-driven harness
   - keep top-level scripts as thin wrappers only
@@ -97,7 +97,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_3: Invariant Downshifting
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1175
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1175
 - Implementation target:
   - move diagnostic/lowering/codegen invariants into cheaper integration or unit coverage where possible
   - keep traceability from removed expensive checks to the new cheaper proof
@@ -117,7 +117,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_4: Artifact Reuse and Cache Boundary Redesign
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1178
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1178
 - Implementation target:
   - introduce reusable generated-program workspaces and repeat-run cache visibility
   - materially improve unchanged reruns for `run` and `test`
@@ -144,7 +144,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_5: Hardening Lane Refactor
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1180
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1180
 - Implementation target:
   - preserve broad hardening and determinism coverage while removing it from the default local loop
   - make lane placement explicit rather than script-local
@@ -168,7 +168,7 @@ Known architectural entry facts from the planning doc:
 
 ### milestone_test_6: Throughput and Resource Governance
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1183
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1183
 - Implementation target:
   - report lane timing, cache behavior, fixture/group skew, and memory-related guidance
   - make performance and resource regressions visible from local runs
@@ -203,7 +203,7 @@ Known architectural entry facts from the planning doc:
   - script validation: `scripts/check_e2e_report_determinism.sh` and `scripts/check_e2e_sequential_parallel_equivalence.sh` already exit with an explicit error when `signature` is empty, and the extraction regex only matches `[0-9a-f]+`, so reviewer finding 5 did not expose a real bug in the merged scripts
   - reviewer-artifact preservation: the external review output was recorded verbatim under `reviews/ad-hoc-test-strategy-and-validation-lane-redesign-review-pass-1a.md` for traceability even though no code delta followed from this pass
 - Follow-up PR:
-  - PR `#1185` (`https://github.com/yaseralnajjar/sifr/pull/1185`) records the reviewer artifact and the no-code-change disposition for this pass
+  - PR `#1185` (`https://github.com/sifr-lang/sifr/pull/1185`) records the reviewer artifact and the no-code-change disposition for this pass
 
 ### review_pass_2
 - Reviewer artifact: `reviews/ad-hoc-test-strategy-and-validation-lane-redesign-production-grade-review-pass-2a.md`
@@ -220,7 +220,7 @@ Known architectural entry facts from the planning doc:
   - positive path: `find target/validation_lane_reports -type f -newer /tmp/validation-lane-marker.G1cX7v | sort` -> only `quick.latest.{json,log,time}`, proving `run_all_tests.sh` no longer leaves behind per-run `lane.<profile>.*` capture files once the latest artifacts are written
   - rejected finding validation: `scripts/check_e2e_report_determinism.sh` and `scripts/check_e2e_sequential_parallel_equivalence.sh` only default `PROFILE` before argument parsing; the passed `--profile` value still wins, so the reported “always release” bug was not reproducible
 - Follow-up PR:
-  - PR `#1186` (`https://github.com/yaseralnajjar/sifr/pull/1186`) carries the accepted production-grade review fixes and records the reviewer artifact/disposition
+  - PR `#1186` (`https://github.com/sifr-lang/sifr/pull/1186`) carries the accepted production-grade review fixes and records the reviewer artifact/disposition
 
 ### review_pass_3
 - Reviewer artifact: `reviews/ad-hoc-test-strategy-and-validation-lane-redesign-review-pass-3a.md`
@@ -233,4 +233,4 @@ Known architectural entry facts from the planning doc:
   - disposition validation: the review’s only actionable-looking cache/temp-file concerns were already addressed in review pass 2 (`#1186`), and the remaining comments were enhancement suggestions rather than regressions in the merged phase work
   - closure basis: after three external passes, no unresolved critical or high-severity defects remain against the completed phase scope
 - Follow-up PR:
-  - PR `#1188` (`https://github.com/yaseralnajjar/sifr/pull/1188`) records the reviewer artifact and closes the phase status after the additional external review pass
+  - PR `#1188` (`https://github.com/sifr-lang/sifr/pull/1188`) records the reviewer artifact and closes the phase status after the additional external review pass

--- a/issues/archive/codegen-runtime-build-gap-closure-report-2026-04-06.md
+++ b/issues/archive/codegen-runtime-build-gap-closure-report-2026-04-06.md
@@ -27,4 +27,4 @@ Execution log: `issues/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05
 - `scripts/run_all_tests.sh --profile quick` -> PASS
 
 ## PR
-- Merged: https://github.com/yaseralnajjar/sifr/pull/1575
+- Merged: https://github.com/sifr-lang/sifr/pull/1575

--- a/issues/archive/optional-none-gap-38-root-cause-breakdown-2026-04-03.md
+++ b/issues/archive/optional-none-gap-38-root-cause-breakdown-2026-04-03.md
@@ -17,7 +17,7 @@
 - Post-fix sweep (closure to 27 pass / 11 fail): `verification/leetcode/optional_none_gap_38_full_diagnostics_20260403_post_1980_closure_to_27_pass.tsv`
 - Post-fix sweep (closure to 28 pass / 10 fail): `verification/leetcode/optional_none_gap_38_full_diagnostics_20260403_post_1980_closure_to_28_pass.tsv`
 - Post-fix sweep (final closure to 38 pass / 0 fail): `verification/leetcode/optional_none_gap_38_full_diagnostics_20260403_post_1980.tsv`
-- Phase closure PR (2026-04-03): `https://github.com/yaseralnajjar/sifr/pull/1573`
+- Phase closure PR (2026-04-03): `https://github.com/sifr-lang/sifr/pull/1573`
 
 ## Decision Summary
 - `compiler_fix`: `25`

--- a/issues/archive/phase15-baseline-reconciliation-execution.md
+++ b/issues/archive/phase15-baseline-reconciliation-execution.md
@@ -22,7 +22,7 @@ status: done (2026-03-03, PR #793)
 - [x] Tag each finding with owning future phase
 - [x] Run milestone quality checks
 - [x] Run full local suite (waived by user for docs-only phase scope)
-- [x] Open PR, review, and merge (https://github.com/yaseralnajjar/sifr/pull/793)
+- [x] Open PR, review, and merge (https://github.com/sifr-lang/sifr/pull/793)
 - [x] Mark part complete in phase doc and this checklist
 
 ## Part 2: milestone_15_2 Phase Contract Definition
@@ -34,7 +34,7 @@ status: done (2026-03-03, PR #794)
 - [x] Ensure every phase gate maps to at least one concrete validation command
 - [x] Run milestone quality checks
 - [x] Run full local suite (waived by user for docs-only phase scope)
-- [x] Open PR, review, and merge (https://github.com/yaseralnajjar/sifr/pull/794)
+- [x] Open PR, review, and merge (https://github.com/sifr-lang/sifr/pull/794)
 - [x] Mark part complete in phase doc and this checklist
 
 ## Part 3: milestone_15_3 Stakeholder Sign-off Snapshot
@@ -45,17 +45,17 @@ status: done (2026-03-03, PR #795)
 - [x] Update roadmap and phase status to reflect Phase 15 completion
 - [x] Run milestone quality checks
 - [x] Run full local suite (waived by user for docs-only phase scope)
-- [x] Open PR, review, and merge (https://github.com/yaseralnajjar/sifr/pull/795)
+- [x] Open PR, review, and merge (https://github.com/sifr-lang/sifr/pull/795)
 - [x] Mark phase complete in all planning docs
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/793 (merged)
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/794 (merged)
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/795 (merged)
+- Part 1: https://github.com/sifr-lang/sifr/pull/793 (merged)
+- Part 2: https://github.com/sifr-lang/sifr/pull/794 (merged)
+- Part 3: https://github.com/sifr-lang/sifr/pull/795 (merged)
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase15-review.md`
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/797 (merged)
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/797 (merged)
 - External review pass 2 output: `reviews/phase15-production-grade-review.md`
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/798 (merged)
-- Milestone coverage closure: https://github.com/yaseralnajjar/sifr/pull/799 (merged)
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/798 (merged)
+- Milestone coverage closure: https://github.com/sifr-lang/sifr/pull/799 (merged)

--- a/issues/archive/phase16-local-first-test-platform-execution.md
+++ b/issues/archive/phase16-local-first-test-platform-execution.md
@@ -76,12 +76,12 @@ Validation evidence:
 - Milestone demo: `cargo run -q -p sifr -- run demos/m16_3_ci_parity_smoke_hardening_demo.sifr` -> `m16_3 ci parity + smoke demo: ok`.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/806 (merged)
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/807 (merged)
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/808 (merged)
+- Part 1: https://github.com/sifr-lang/sifr/pull/806 (merged)
+- Part 2: https://github.com/sifr-lang/sifr/pull/807 (merged)
+- Part 3: https://github.com/sifr-lang/sifr/pull/808 (merged)
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase16-review.md`
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/810 (merged)
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/810 (merged)
 - External review pass 2 output: `reviews/phase16-production-grade-review.md`
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/811 (merged)
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/811 (merged)

--- a/issues/archive/phase17-import-and-externals-correctness-execution.md
+++ b/issues/archive/phase17-import-and-externals-correctness-execution.md
@@ -92,14 +92,14 @@ Validation evidence:
 - Full suite: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/813 (merged)
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/814 (merged)
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/815 (merged)
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/828 (merged)
+- Part 1: https://github.com/sifr-lang/sifr/pull/813 (merged)
+- Part 2: https://github.com/sifr-lang/sifr/pull/814 (merged)
+- Part 3: https://github.com/sifr-lang/sifr/pull/815 (merged)
+- Part 4: https://github.com/sifr-lang/sifr/pull/828 (merged)
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase17-review.md`
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/816 (merged)
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/816 (merged)
 - Triage outcome: reviewer findings were based on pre-merge code and were validated as already fixed by PRs #813, #814, and #815.
 - Validation commands used during triage:
   - `cargo test -q -p sifr_driver test_check_only_reports_frontend_phases`
@@ -107,7 +107,7 @@ Validation evidence:
   - `cargo test -q -p sifr_codegen test_generate_rust_test_emits_local_module_import_uses`
   - `cargo test -q -p sifr_codegen test_generate_rust_multi_exports_non_main_items`
 - External review pass 2 output: `reviews/phase17-production-grade-review.md`
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/817 (merged)
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/817 (merged)
 - Pass-2 triage outcome: production-grade review findings were also stale against current `origin/main` and validated as already fixed by PRs #813, #814, #815.
 - Validation commands used during pass-2 triage:
   - `cargo test -q -p sifr_driver test_check_only_reports_frontend_phases`
@@ -115,7 +115,7 @@ Validation evidence:
   - `cargo test -q -p sifr_codegen test_generate_rust_test_emits_local_module_import_uses`
   - `cargo test -q -p sifr_codegen test_generate_rust_multi_exports_non_main_items`
 - External review pass 3 output: `reviews/phase17-review-2.md`
-- Remediation PR (pass 3): https://github.com/yaseralnajjar/sifr/pull/824
+- Remediation PR (pass 3): https://github.com/sifr-lang/sifr/pull/824
 - Pass-3 remediation summary:
   - Scoped generated test-runner `lib.rs` to `cfg(test)` to eliminate non-test build unused-import/dead-code warnings without changing runtime behavior.
   - Added negative-path regression coverage for non-main unknown-module imports and cyclic/no-progress module lowering.
@@ -129,11 +129,11 @@ Validation evidence:
 - Additional verification command:
   - `cargo test -q -p sifr_driver test_compose_test_runner_lib_is_test_scoped`
 - External review pass 5 output: `reviews/phase17-review-3.md`
-- Remediation PR (pass 5): https://github.com/yaseralnajjar/sifr/pull/829
+- Remediation PR (pass 5): https://github.com/sifr-lang/sifr/pull/829
 - Pass-5 remediation summary:
   - Added explicit canonical import-form matrix table under milestone `17_4` to satisfy the quality-contract requirement for documented supported/unsupported/non-activating forms.
 - External review pass 6 output: `reviews/phase17-production-grade-review-3.md`
-- Remediation PR (pass 6): https://github.com/yaseralnajjar/sifr/pull/830
+- Remediation PR (pass 6): https://github.com/sifr-lang/sifr/pull/830
 - Pass-6 remediation summary:
   - Added explicit positive-path coverage for supported level-1 relative imports via `test_collect_project_modules_supports_single_level_relative_import`.
   - Updated milestone `17_4` demo to use supported relative form `from .helper import value`.

--- a/issues/archive/phase18-project-and-cli-semantics-execution.md
+++ b/issues/archive/phase18-project-and-cli-semantics-execution.md
@@ -95,21 +95,21 @@ Validation evidence:
 - Full suite: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/818 (merged)
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/819 (merged)
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/820 (merged)
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/831 (merged)
+- Part 1: https://github.com/sifr-lang/sifr/pull/818 (merged)
+- Part 2: https://github.com/sifr-lang/sifr/pull/819 (merged)
+- Part 3: https://github.com/sifr-lang/sifr/pull/820 (merged)
+- Part 4: https://github.com/sifr-lang/sifr/pull/831 (merged)
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase18-review.md`
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/821 (merged)
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/821 (merged)
 - Pass-1 triage + actions:
   - Added explicit resolver regression tests for `typing`, `enum`, and package-like `__init__.sifr` imports.
   - Expanded CLI contract docs to cover unsupported package-style auto-detect and parse/read fallback behavior.
 - Validation commands used for pass-1 remediation:
   - `cargo test -q -p sifr test_resolve_compilation_mode_`
 - External review pass 2 output: `reviews/phase18-production-grade-review.md`
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/822 (merged)
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/822 (merged)
 - Pass-2 triage + actions:
   - Added regression test for relative-import project-mode activation (`from .helper import ...` with sibling module).
   - Added regression test for run/build project-mode error consistency via shared `compile_entrypoint`.
@@ -118,7 +118,7 @@ Validation evidence:
   - `cargo test -q -p sifr test_resolve_compilation_mode_`
   - `cargo test -q -p sifr test_compile_entrypoint_error_consistency_for_project_mode`
 - External review pass 3 output: `reviews/phase18-review-2.md`
-- Remediation PR (pass 3): https://github.com/yaseralnajjar/sifr/pull/826
+- Remediation PR (pass 3): https://github.com/sifr-lang/sifr/pull/826
 - Pass-3 remediation summary:
   - Added resolver regression test for relative import without sibling module to enforce single-file fallback.
   - Added resolver regression tests proving local `typing.sifr`/`enum.sifr` files do not activate project mode for stdlib-like imports.
@@ -138,10 +138,10 @@ Validation evidence:
   - `cargo test -q -p sifr test_resolve_compilation_mode_`
   - `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh`
 - External review pass 5 output: `reviews/phase18-review-3.md`
-- Remediation PR (pass 5): https://github.com/yaseralnajjar/sifr/pull/832
+- Remediation PR (pass 5): https://github.com/sifr-lang/sifr/pull/832
 - Pass-5 triage outcome:
   - No new still-valid gaps; reviewer confirmed milestone `18_4` trigger-matrix coverage and phase-18 quality-contract coverage are complete.
 - External review pass 6 output: `reviews/phase18-production-grade-review-3.md`
-- Remediation PR (pass 6): https://github.com/yaseralnajjar/sifr/pull/833
+- Remediation PR (pass 6): https://github.com/sifr-lang/sifr/pull/833
 - Pass-6 triage outcome:
   - No concrete production-grade defects identified; phase remains production-ready for milestone `18_4`.

--- a/issues/archive/phase19-module-graph-safety-determinism-cache-execution.md
+++ b/issues/archive/phase19-module-graph-safety-determinism-cache-execution.md
@@ -68,18 +68,18 @@ Validation evidence:
 - Full suite: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/834
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/835
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/836
+- Part 1: https://github.com/sifr-lang/sifr/pull/834
+- Part 2: https://github.com/sifr-lang/sifr/pull/835
+- Part 3: https://github.com/sifr-lang/sifr/pull/836
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase19-review.md`
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/837
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/837
 - Pass-1 triage + actions:
   - Documented that module-graph local dependency extraction intentionally follows Phase 18 import-form semantics (including level-1 relative imports only, excluding unsupported deeper levels).
   - Documented that stdlib cache scope is process-local (`OnceLock`), clarifying deterministic behavior and lifetime.
 - External review pass 2 output: `reviews/phase19-production-grade-review.md`
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/838
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/838
 - Pass-2 triage outcome:
   - Reviewer confirmed production readiness for Phase 19 with no blocking defects.
   - No additional code changes required beyond pass-1 clarifications.

--- a/issues/archive/phase20-cleanup-fallback-removal-execution.md
+++ b/issues/archive/phase20-cleanup-fallback-removal-execution.md
@@ -2,7 +2,7 @@
 
 Status: completed (2026-03-05)
 Owner: fallback-cleanup execution loop
-Reference PR: https://github.com/yaseralnajjar/sifr/pull/845
+Reference PR: https://github.com/sifr-lang/sifr/pull/845
 
 Loop: Work -> Validate -> PR -> Review -> Merge
 
@@ -26,16 +26,16 @@ Validation evidence:
   - tuple `match` sequence on non-tuple subject -> `tuple pattern requires subject of tuple type...`
 
 ## PR Log
-- Main cleanup: https://github.com/yaseralnajjar/sifr/pull/845
+- Main cleanup: https://github.com/sifr-lang/sifr/pull/845
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase20-cleanup-review-2.md`
 - Pass-1 triage:
   - Applied reviewer observation to remove remaining tuple-sequence `match` fallback-to-`Any`.
   - Added regression tests for tuple-subject requirement and tuple-arity mismatch in match patterns.
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/846
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/846
 - External review pass 2 output: `reviews/phase20-cleanup-production-grade-review.md`
 - Pass-2 triage:
   - Reviewer confirmed production-grade readiness with no additional blocking defects.
   - No further compiler-code changes were required after validating pass-2 notes.
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/847
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/847

--- a/issues/archive/phase20-hir-decomposition-and-maintainability-hardening-execution.md
+++ b/issues/archive/phase20-hir-decomposition-and-maintainability-hardening-execution.md
@@ -107,18 +107,18 @@ Validation evidence:
 - Full suite: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (includes guardrail gate execution).
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/839
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/840
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/841
+- Part 1: https://github.com/sifr-lang/sifr/pull/839
+- Part 2: https://github.com/sifr-lang/sifr/pull/840
+- Part 3: https://github.com/sifr-lang/sifr/pull/841
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase20-review.md`
 - Pass-1 triage outcome:
   - Reviewer confirmed Phase 20 implementation quality and contract adherence with no blocking defects.
   - Verified CI/local enforcement path: `.github/workflows/local-first-validation.yml` runs `scripts/run_all_tests.sh`, which now executes `scripts/check_hir_maintainability_guardrails.py`.
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/842
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/842
 - External review pass 2 output: `reviews/phase20-production-grade-review.md`
 - Pass-2 triage outcome:
   - Reviewer confirmed phase-20 implementation is production-grade with no blocking defects.
   - No additional compiler-code changes were required after validating reviewer observations.
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/843
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/843

--- a/issues/archive/phase21-traversal-completeness-and-control-flow-correctness-execution.md
+++ b/issues/archive/phase21-traversal-completeness-and-control-flow-correctness-execution.md
@@ -101,11 +101,11 @@ Validation evidence:
 - Negative path: `cargo run -q -p sifr -- run demos/m21_3_yield_exception_path_coverage_demo/negative_cases/undefined_in_except_yield.sifr` -> exits `1` with `type error: undefined variable: 'missing_value'`.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/849
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/850
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/851
-- Review pass 1 remediation: https://github.com/yaseralnajjar/sifr/pull/852
-- Review pass 2 remediation: https://github.com/yaseralnajjar/sifr/pull/853
+- Part 1: https://github.com/sifr-lang/sifr/pull/849
+- Part 2: https://github.com/sifr-lang/sifr/pull/850
+- Part 3: https://github.com/sifr-lang/sifr/pull/851
+- Review pass 1 remediation: https://github.com/sifr-lang/sifr/pull/852
+- Review pass 2 remediation: https://github.com/sifr-lang/sifr/pull/853
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase21-review.md` (2026-03-05, approved; advisory notes only)

--- a/issues/archive/phase22-frontend-mode-parity-hardening-execution.md
+++ b/issues/archive/phase22-frontend-mode-parity-hardening-execution.md
@@ -136,10 +136,10 @@ Validation evidence:
   - `test` fails with exit `1` and expected frontend type error message on the same fixture family.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/856
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/857
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/858
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/859
+- Part 1: https://github.com/sifr-lang/sifr/pull/856
+- Part 2: https://github.com/sifr-lang/sifr/pull/857
+- Part 3: https://github.com/sifr-lang/sifr/pull/858
+- Part 4: https://github.com/sifr-lang/sifr/pull/859
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase22-review.md` (2026-03-06, approved)
@@ -147,10 +147,10 @@ Validation evidence:
   - Reviewer approved phase 22 implementation as complete across milestones 22.1-22.4.
   - No blocking defects were identified; no compiler-code remediation was required.
   - Non-blocking future considerations were recorded as advisory notes only.
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/860
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/860
 - External review pass 2 output: `reviews/phase22-production-grade-review.md` (2026-03-06, approved for production)
 - Pass-2 triage outcome:
   - Reviewer confirmed production-grade readiness with no blocking defects.
   - Applied the actionable recommendation by documenting `FrontendDiagnosticStyle` variants inline for long-term contract clarity.
   - Broader matrix-expansion suggestions were retained as future advisory work outside phase 22 scope.
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/861
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/861

--- a/issues/archive/phase23-project-graph-and-isolation-correctness-execution.md
+++ b/issues/archive/phase23-project-graph-and-isolation-correctness-execution.md
@@ -170,20 +170,20 @@ Validation evidence:
 - Negative path: matrix `reachable_parse_error_contract` row validates `check/build/run/test` failures for reachable parse errors.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/863
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/865
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/867
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/869
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/871
+- Part 1: https://github.com/sifr-lang/sifr/pull/863
+- Part 2: https://github.com/sifr-lang/sifr/pull/865
+- Part 3: https://github.com/sifr-lang/sifr/pull/867
+- Part 4: https://github.com/sifr-lang/sifr/pull/869
+- Part 5: https://github.com/sifr-lang/sifr/pull/871
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase23-review.md` (2026-03-06, approved)
 - Pass-1 triage outcome:
   - Reviewer approved phase 23 implementation as complete across milestones 23.1-23.5.
   - No blocking defects were identified; no compiler-code remediation was required.
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/873
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/873
 - External review pass 2 output: `reviews/phase23-production-grade-review.md` (2026-03-06, approved for production)
 - Pass-2 triage outcome:
   - Reviewer confirmed production-grade readiness with no blocking defects.
   - Applied actionable hardening: documented multi-level relative import exclusion in closure discovery and added retry-based workspace allocation for collision-proof temp isolation.
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/874
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/874

--- a/issues/archive/phase24-hir-analysis-consolidation-execution.md
+++ b/issues/archive/phase24-hir-analysis-consolidation-execution.md
@@ -160,13 +160,13 @@ Validation evidence:
 - Negative path: matrix `negative_diagnostic_stability` row asserts repeated failure diagnostics are stable across runs.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/875
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/877
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/878
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/879
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/880
-- Review pass 1 remediation: https://github.com/yaseralnajjar/sifr/pull/881
-- Review pass 2 closeout: https://github.com/yaseralnajjar/sifr/pull/882
+- Part 1: https://github.com/sifr-lang/sifr/pull/875
+- Part 2: https://github.com/sifr-lang/sifr/pull/877
+- Part 3: https://github.com/sifr-lang/sifr/pull/878
+- Part 4: https://github.com/sifr-lang/sifr/pull/879
+- Part 5: https://github.com/sifr-lang/sifr/pull/880
+- Review pass 1 remediation: https://github.com/sifr-lang/sifr/pull/881
+- Review pass 2 closeout: https://github.com/sifr-lang/sifr/pull/882
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase24-review.md` (2026-03-06, APPROVED with notes)
@@ -178,9 +178,9 @@ Validation evidence:
   - `cargo test -q -p sifr_codegen hir_analysis::traversal::tests::` -> pass.
   - `cargo test -q -p sifr_codegen hir_analysis::queries::tests::` -> pass.
   - `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass.
-- Remediation PR (pass 1): https://github.com/yaseralnajjar/sifr/pull/881
+- Remediation PR (pass 1): https://github.com/sifr-lang/sifr/pull/881
 - External review pass 2 output: `reviews/phase24-production-grade-review.md` (2026-03-06, APPROVED FOR PRODUCTION)
 - Pass 2 reviewer note validation:
   - Reviewed all listed risks/recommendations; all were non-blocking and already covered by current validation/architecture guarantees.
   - No additional correctness or architecture defects were identified requiring code changes in this pass.
-- Remediation PR (pass 2): https://github.com/yaseralnajjar/sifr/pull/882
+- Remediation PR (pass 2): https://github.com/sifr-lang/sifr/pull/882

--- a/issues/archive/phase25-cfg-flow-analysis-activation-execution.md
+++ b/issues/archive/phase25-cfg-flow-analysis-activation-execution.md
@@ -157,12 +157,12 @@ Validation evidence:
 - Negative path: matrix row `negative_diagnostic_stability` asserts repeated diagnostics are byte-identical.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/883
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/884
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/885
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/886
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/887
-- Review pass 1 remediation: https://github.com/yaseralnajjar/sifr/pull/889
+- Part 1: https://github.com/sifr-lang/sifr/pull/883
+- Part 2: https://github.com/sifr-lang/sifr/pull/884
+- Part 3: https://github.com/sifr-lang/sifr/pull/885
+- Part 4: https://github.com/sifr-lang/sifr/pull/886
+- Part 5: https://github.com/sifr-lang/sifr/pull/887
+- Review pass 1 remediation: https://github.com/sifr-lang/sifr/pull/889
 
 ## Reviewer Follow-up
 - External review pass 1 output: `reviews/phase25-review.md` (2026-03-06, APPROVED with notes)

--- a/issues/archive/phase26-type-system-soundness-execution.md
+++ b/issues/archive/phase26-type-system-soundness-execution.md
@@ -176,9 +176,9 @@ Validated reviewer notes and actions:
 - Documentation action: recorded the second reviewer output and phase closeout status.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/891
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/892
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/893
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/894
-- External review pass 1: https://github.com/yaseralnajjar/sifr/pull/895
-- External review pass 2: https://github.com/yaseralnajjar/sifr/pull/896
+- Part 1: https://github.com/sifr-lang/sifr/pull/891
+- Part 2: https://github.com/sifr-lang/sifr/pull/892
+- Part 3: https://github.com/sifr-lang/sifr/pull/893
+- Part 4: https://github.com/sifr-lang/sifr/pull/894
+- External review pass 1: https://github.com/sifr-lang/sifr/pull/895
+- External review pass 2: https://github.com/sifr-lang/sifr/pull/896

--- a/issues/archive/phase27-runtime-safety-and-diagnostics-execution.md
+++ b/issues/archive/phase27-runtime-safety-and-diagnostics-execution.md
@@ -233,19 +233,19 @@ Validation evidence:
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass.
 
 ## PR Log
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/897
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/898
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/899
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/900
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/901
-- Part 6: https://github.com/yaseralnajjar/sifr/pull/902
-- Part 7: https://github.com/yaseralnajjar/sifr/pull/908
+- Part 1: https://github.com/sifr-lang/sifr/pull/897
+- Part 2: https://github.com/sifr-lang/sifr/pull/898
+- Part 3: https://github.com/sifr-lang/sifr/pull/899
+- Part 4: https://github.com/sifr-lang/sifr/pull/900
+- Part 5: https://github.com/sifr-lang/sifr/pull/901
+- Part 6: https://github.com/sifr-lang/sifr/pull/902
+- Part 7: https://github.com/sifr-lang/sifr/pull/908
 
 ## External Review Passes
 - Reviewer pass 1 prompt output: `reviews/phase27-review.md`
-- Review pass 1 remediation PR: https://github.com/yaseralnajjar/sifr/pull/904
+- Review pass 1 remediation PR: https://github.com/sifr-lang/sifr/pull/904
 - Reviewer pass 2 prompt output: `reviews/phase27-production-grade-review.md`
-- Review pass 2 remediation PR: https://github.com/yaseralnajjar/sifr/pull/905
+- Review pass 2 remediation PR: https://github.com/sifr-lang/sifr/pull/905
 - Reviewer pass 3 prompt output: `reviews/phase27-production-grade-review-3.md`
 - Review pass 3 outcome: no additional critical/required fixes identified; no code remediation required
 - Reviewer pass 4 (goal verification 1) prompt output: `reviews/phase27-unwrap-goal-review-1.md`

--- a/issues/archive/phase28-decimal-semantics-execution.md
+++ b/issues/archive/phase28-decimal-semantics-execution.md
@@ -163,16 +163,16 @@ Validation evidence:
 - Full suite: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (407 pass e2e fixtures, 0 failures).
 
 ## PR Log
-- Part 1: merged https://github.com/yaseralnajjar/sifr/pull/910
-- Part 2: merged https://github.com/yaseralnajjar/sifr/pull/911
-- Part 3: merged https://github.com/yaseralnajjar/sifr/pull/912
-- Part 4: merged https://github.com/yaseralnajjar/sifr/pull/913
-- Part 5: merged https://github.com/yaseralnajjar/sifr/pull/914
+- Part 1: merged https://github.com/sifr-lang/sifr/pull/910
+- Part 2: merged https://github.com/sifr-lang/sifr/pull/911
+- Part 3: merged https://github.com/sifr-lang/sifr/pull/912
+- Part 4: merged https://github.com/sifr-lang/sifr/pull/913
+- Part 5: merged https://github.com/sifr-lang/sifr/pull/914
 
 ## External Review Passes
 - Reviewer pass 1 prompt output: `reviews/phase-28-review.md`
-- Reviewer pass 1 remediation PR: merged https://github.com/yaseralnajjar/sifr/pull/915
+- Reviewer pass 1 remediation PR: merged https://github.com/sifr-lang/sifr/pull/915
 - Reviewer pass 2 prompt output: `reviews/phase-28-production-grade-review.md`
-- Reviewer pass 2 remediation PR: merged https://github.com/yaseralnajjar/sifr/pull/916
+- Reviewer pass 2 remediation PR: merged https://github.com/sifr-lang/sifr/pull/916
 - Reviewer pass 3 prompt output: `reviews/phase-28-production-grade-review-2.md`
 - Reviewer pass 3 remediation PR: none required (review concluded production-grade with no remaining issues)

--- a/issues/archive/phase29-verification-hardening-execution.md
+++ b/issues/archive/phase29-verification-hardening-execution.md
@@ -171,13 +171,13 @@ Validation evidence:
 - Negative path: quarantine metadata file `verification/flake/quarantine.json` is schema-validated; malformed entries or unknown suites fail the hardening gate.
 
 ## PR Log
-- Part 1: merged https://github.com/yaseralnajjar/sifr/pull/920
-- Part 2: merged https://github.com/yaseralnajjar/sifr/pull/921
-- Part 3: merged https://github.com/yaseralnajjar/sifr/pull/922
-- Part 4: merged https://github.com/yaseralnajjar/sifr/pull/923
-- Part 5: merged https://github.com/yaseralnajjar/sifr/pull/924
-- External review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/926
-- External review pass 2 remediation: merged https://github.com/yaseralnajjar/sifr/pull/927
+- Part 1: merged https://github.com/sifr-lang/sifr/pull/920
+- Part 2: merged https://github.com/sifr-lang/sifr/pull/921
+- Part 3: merged https://github.com/sifr-lang/sifr/pull/922
+- Part 4: merged https://github.com/sifr-lang/sifr/pull/923
+- Part 5: merged https://github.com/sifr-lang/sifr/pull/924
+- External review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/926
+- External review pass 2 remediation: merged https://github.com/sifr-lang/sifr/pull/927
 
 ## External Review Passes
 - Reviewer pass 1 request: `reviews/phase-29-review.md` (requested via talk-to-claude external app)

--- a/issues/archive/phase30-reliability-parity-and-performance-budgets-execution.md
+++ b/issues/archive/phase30-reliability-parity-and-performance-budgets-execution.md
@@ -79,12 +79,12 @@ Loop per part: Work -> Validate -> PR -> Review -> Merge -> External review pass
 
 ### milestone_30_4 wave-by-wave plan and status
 - Execution mode: wave-by-wave structural remediation, validation, PR merge, reviewer pass 1, reviewer pass 2, then next wave.
-- [x] `wave_30_1a` (`env`, `bytes`, `base64`, `hashlib`) - implementation merged in https://github.com/yaseralnajjar/sifr/pull/1048; review pass 1 and pass 2 approved; wave completion and wave production-grade closures approved
-- [x] `wave_30_1b` (`math`, `statistics`, `bisect`, `heapq`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1053; reviewer pass 1 remediation merged in https://github.com/yaseralnajjar/sifr/pull/1054; reviewer pass 2 approved; wave completion closure and production-grade closure approved)
-- [x] `wave_30_1c` (`string`, `textwrap`, `fnmatch`, `re`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1058; reviewer pass 1 and pass 2 approved; wave completion closure and production-grade closure approved)
-- [x] `wave_30_1d` (`collections`, `itertools`, `json`, `datetime`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1063; reviewer pass 1 remediation merged in https://github.com/yaseralnajjar/sifr/pull/1064; reviewer pass 2 tracking and supplemental datetime consolidation merged in https://github.com/yaseralnajjar/sifr/pull/1065; wave completion closure merged in https://github.com/yaseralnajjar/sifr/pull/1066; wave production-grade closure approved via external review follow-up)
-- [x] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 blockers resolved in https://github.com/yaseralnajjar/sifr/pull/1070; wave completion closure merged in https://github.com/yaseralnajjar/sifr/pull/1071; wave production-grade closure approved)
-- [x] `wave_30_1f` (`logging`, `time`, `timeit`, `platform`, `uuid`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1073; reviewer pass 1 merged in https://github.com/yaseralnajjar/sifr/pull/1074; reviewer pass 2 merged in https://github.com/yaseralnajjar/sifr/pull/1075; wave completion closure merged in https://github.com/yaseralnajjar/sifr/pull/1076; wave production-grade closure approved)
+- [x] `wave_30_1a` (`env`, `bytes`, `base64`, `hashlib`) - implementation merged in https://github.com/sifr-lang/sifr/pull/1048; review pass 1 and pass 2 approved; wave completion and wave production-grade closures approved
+- [x] `wave_30_1b` (`math`, `statistics`, `bisect`, `heapq`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1053; reviewer pass 1 remediation merged in https://github.com/sifr-lang/sifr/pull/1054; reviewer pass 2 approved; wave completion closure and production-grade closure approved)
+- [x] `wave_30_1c` (`string`, `textwrap`, `fnmatch`, `re`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1058; reviewer pass 1 and pass 2 approved; wave completion closure and production-grade closure approved)
+- [x] `wave_30_1d` (`collections`, `itertools`, `json`, `datetime`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1063; reviewer pass 1 remediation merged in https://github.com/sifr-lang/sifr/pull/1064; reviewer pass 2 tracking and supplemental datetime consolidation merged in https://github.com/sifr-lang/sifr/pull/1065; wave completion closure merged in https://github.com/sifr-lang/sifr/pull/1066; wave production-grade closure approved via external review follow-up)
+- [x] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 blockers resolved in https://github.com/sifr-lang/sifr/pull/1070; wave completion closure merged in https://github.com/sifr-lang/sifr/pull/1071; wave production-grade closure approved)
+- [x] `wave_30_1f` (`logging`, `time`, `timeit`, `platform`, `uuid`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1073; reviewer pass 1 merged in https://github.com/sifr-lang/sifr/pull/1074; reviewer pass 2 merged in https://github.com/sifr-lang/sifr/pull/1075; wave completion closure merged in https://github.com/sifr-lang/sifr/pull/1076; wave production-grade closure approved)
 
 ### Milestone 30_2 Evidence (Complexity and Resource Parity)
 - Canonical patterns + module API-class matrix:
@@ -117,7 +117,7 @@ Loop per part: Work -> Validate -> PR -> Review -> Merge -> External review pass
 ### milestone_30_4 wave_30_1a progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1048
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1048
 - Reviewer pass 1 output: `reviews/phase-30-m30_4-wave-30-1a-review-1.md`
 - Reviewer verdict: all reviewed fixtures are compliant with `audits/stdlib/cpython_parity_fixture_format.md` and production-grade quality for approved scope.
 - Action taken: reviewer notes validated; no additional code remediation required in wave_30_1a scope.
@@ -133,11 +133,11 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 ### milestone_30_4 wave_30_1b progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1053
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1053
 - Reviewer pass 1 output: `reviews/phase-30-m30_4-wave-30_1b-review-1.md`
 - Reviewer pass 1 verdict: actionable structural blockers due to fragmented legacy `stdlib_*` fixtures in wave scope.
 - Remediation scope: consolidate legacy math/statistics/bisect/heapq `stdlib_*` fixtures into canonical consolidated fixtures and remove superseded fragmented fixtures.
-- Reviewer pass 1 remediation PR: merged https://github.com/yaseralnajjar/sifr/pull/1054
+- Reviewer pass 1 remediation PR: merged https://github.com/sifr-lang/sifr/pull/1054
 - Reviewer pass 2 output: `reviews/phase-30-m30_4-wave-30_1b-review-2.md`
 - Reviewer pass 2 delayed output copy: `reviews/phase-30-m30_4-wave-30_1b-review-2a.md`
 - Reviewer pass 2 verdict: production-grade approved; no additional structural blockers in wave scope.
@@ -151,7 +151,7 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 ### milestone_30_4 wave_30_1c progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1058
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1058
 - Reviewer pass 1 output: `reviews/phase-30-m30_4-wave-30_1c-review-1.md`
 - Reviewer pass 1 verdict: approved with no blocking remediation items for wave scope.
 - Reviewer pass 2 output: `reviews/phase-30-m30_4-wave-30_1c-review-2.md`
@@ -165,10 +165,10 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 ### milestone_30_4 wave_30_1d progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1063
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1063
 - Reviewer pass 1 output: `reviews/phase-30-m30_4-wave-30_1d-review-1.md`
 - Reviewer pass 1 verdict: wave fixture structure is deterministic and maintainable, but rule-5 format-extension justification must be explicitly recorded for helper-oriented boolean vectors in this structured-data wave scope.
-- Reviewer pass 1 remediation PR: merged https://github.com/yaseralnajjar/sifr/pull/1064
+- Reviewer pass 1 remediation PR: merged https://github.com/sifr-lang/sifr/pull/1064
 - Reviewer pass 1 remediation actions:
   - documented wave-specific extension rationale in `internal_docs/phases/30_reliability_parity_and_performance_budgets.md` under `wave_30_1d`
   - recorded matching extension rationale in this execution tracker for explicit rule-5 auditability
@@ -190,7 +190,7 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 ### milestone_30_4 wave_30_1e progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1068
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1068
 - Implementation scope delivered:
   - refactored `cpython_{io,csv,os,pathlib,glob,tempfile,shutil}_subset.sifr` fixtures to keep `main()` orchestration-only with helper-grouped behavior sections
   - refactored `cpython_pathlib.sifr` to helper-organized canonical bool-vector structure for parity reviewability
@@ -200,7 +200,7 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 - Reviewer pass 1 verdict: approved with no blocking remediation required for wave scope.
 - Reviewer pass 2 output: `reviews/phase-30-m30_4-wave-30_1e-review-2.md`
 - Reviewer pass 2 verdict: structural/doc blockers identified and remediated in follow-up PR.
-- Reviewer pass 2 remediation PR: merged https://github.com/yaseralnajjar/sifr/pull/1070
+- Reviewer pass 2 remediation PR: merged https://github.com/sifr-lang/sifr/pull/1070
 - Reviewer pass 2 remediation actions:
   - refactored `stdlib_glob_consolidated.sifr` into helper-organized `collect_*_actual()` sections with orchestration-only `main()`.
   - added wave_30_1e wave-specific handling notes in `internal_docs/phases/30_reliability_parity_and_performance_budgets.md`.
@@ -218,7 +218,7 @@ status: wave closure complete (review pass 1 + review pass 2 + wave completion c
 ### milestone_30_4 wave_30_1f progress
 status: wave closure complete (review pass 1 + review pass 2 + wave completion closure + wave production-grade closure approved) (2026-03-10)
 
-- Implementation PR: merged https://github.com/yaseralnajjar/sifr/pull/1073
+- Implementation PR: merged https://github.com/sifr-lang/sifr/pull/1073
 - Implementation scope delivered:
   - consolidate legacy `stdlib_{logging,time,timeit,platform,uuid}*.sifr` fixtures into canonical consolidated fixtures
   - refactor `cpython_{logging,time,timeit,platform,uuid}_subset.sifr` into helper-structured orchestration-only `main()` layout
@@ -284,7 +284,7 @@ Validation evidence:
 - Positive path: `cargo test -q -p sifr_codegen lowers_env_intrinsics_via_registry` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: invalid key vectors (`""`, `"A=B"`) in `crates/sifr/tests/e2e/pass/cpython_env_subset.sifr` and `demos/m30_1a_env_parity_demo/main.sifr` validate panic-free no-op/`None` behavior.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/929
+- PR: merged https://github.com/sifr-lang/sifr/pull/929
 - Review pass 1 note validation: reviewer-mentioned determinism failure (`DET-0002`) was validated as non-reproducible in local gate output for this part; no env-scope remediation required.
 - Review pass 2 remediation: renamed invalid-key fixture vector names for clearer semantics (`invalid_*_lookup_found`) and revalidated module demo + CPython fixture.
 
@@ -312,7 +312,7 @@ Validation evidence:
 - Positive path: `cargo test -q -p sifr_codegen lowers_bytes_intrinsics_via_registry` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_bytes_subset.sifr` validate odd-hex and non-ASCII hex parse errors plus decode out-of-range byte rejection (`[300]`).
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/939
+- PR: merged https://github.com/sifr-lang/sifr/pull/939
 - Review pass 1 status: approved with observations; no code remediation required for bytes scope.
 - Review pass 2 status: approved; no code remediation required for bytes scope.
 
@@ -337,7 +337,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_base64_rfc4648_vectors.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_base64_subset.sifr` validate `b64decode` parse-failure signaling for invalid payloads and success-path decode for valid payloads.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/942
+- PR: merged https://github.com/sifr-lang/sifr/pull/942
 - Review pass 1 status: approved; no code remediation required for base64 scope.
 - Review pass 2 note validation: explicit wrapper-export and re-raise simplification suggestions were validated against current intrinsic lowering and Result typing; no safe production-grade code change was warranted for this module scope.
 
@@ -364,7 +364,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run demos/m30_1a_hashlib_parity_demo/main.sifr` -> expected object-model flow prints.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_hashlib_api_subset.sifr` and `cpython_hashlib_object_model_subset.sifr` validate unsupported constructor/error adaptation (`ValueError`/`HashlibError`) behavior.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/945
+- PR: merged https://github.com/sifr-lang/sifr/pull/945
 - Review pass 1 status: approved with observations (intrinsic-coverage/safety-test notes); no module-scope code remediation required.
 - Review pass 2 status: approved with same tracked observations; no safe module-scope code remediation required.
 
@@ -392,7 +392,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run demos/m30_1b_math_parity_demo/main.sifr` -> expected numeric parity flow prints.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: mismatched-dimension `dist(...)` and invalid-tolerance `isclose(...)` semantic checks are asserted in canonical vectors (`cpython_math_semantic_corrections_subset.sifr`, `cpython_math_missing_surface_subset.sifr`).
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/948
+- PR: merged https://github.com/sifr-lang/sifr/pull/948
 - Review pass 1 remediation: added explicit `factorial(-1)` and typed `dist([], [])` semantic coverage in canonical fixture; no module runtime code changes required.
 - Review pass 2 status: approved for production use with optional future enhancements only; no additional module-scope changes required.
 
@@ -420,7 +420,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/error_stdlib_statistics.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_statistics_subset.sifr` validate empty/invalid dataset error adaptation for central tendency, spread, harmonic/geometric mean, correlation, and linear-regression paths.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/951
+- PR: merged https://github.com/sifr-lang/sifr/pull/951
 - Review pass 1 remediation: replaced `mode`/`multimode` O(n²) nested counting with O(n) dictionary counting while preserving deterministic first-seen ordering; revalidated full suite.
 - Review pass 2 status: approved for production use; no additional module-scope code remediation required.
 
@@ -449,7 +449,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_bisect_generic.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: no exception/error-path surface is in approved bisect subset; fixture vectors assert boundary safety for empty inputs and duplicate insertion semantics.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/955
+- PR: merged https://github.com/sifr-lang/sifr/pull/955
 - Review pass 1 status: approved with observations; no module-scope remediation required.
 - Review pass 2 status: approved for production use; no additional module-scope remediation required.
 
@@ -479,7 +479,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/heapq_mut_param.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_heapq_subset.sifr` validate empty `heappop`/`heapreplace` safety adaptation (`None`) and non-mutating helper semantics for `heappushpop`.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/958
+- PR: merged https://github.com/sifr-lang/sifr/pull/958
 - Review pass 1 status: approved with observations; no module-scope remediation required.
 - Review pass 2 remediation: removed unused `_swap` dead code from `lib/sifr/heapq.sifr`; revalidated heapq demo/fixtures and full local suite.
 
@@ -506,7 +506,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_string_capwords.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: no exception/error-path surface is in approved `string` subset; canonical vectors validate whitespace normalization semantics for `capwords` across tabs/newlines/carriage returns/vertical tabs/form feeds.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/963
+- PR: merged https://github.com/sifr-lang/sifr/pull/963
 - Review pass 1 remediation: expanded `string.whitespace`/`printable` to include vertical-tab/form-feed and aligned `capwords` normalization to full CPython whitespace class subset; revalidated demo + full suite.
 - Review pass 2 status: approved for production use with full whitespace parity; no additional module-scope remediation required.
 
@@ -533,7 +533,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/edge_case_safety.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_textwrap_subset.sifr` validate width guards for `wrap`/`fill` and safe behavior for empty-input wrapping and non-content line handling in `indent`.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/967
+- PR: merged https://github.com/sifr-lang/sifr/pull/967
 - Review pass 1 remediation: parity matrix classification corrected to `intentional-diff` for deterministic whitespace normalization contract and `dedent` magic-number sentinel removed; revalidated demo + full suite.
 - Review pass 2 status: approved for production use; no additional module-scope remediation required.
 
@@ -559,7 +559,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_fnmatch.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: no exception/error-path surface is in approved `fnmatch` subset; canonical vectors validate mismatch and empty-result behaviors for wildcard patterns.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/970
+- PR: merged https://github.com/sifr-lang/sifr/pull/970
 - Review pass 1 status: approved (`reviews/phase-30-part-11-fnmatch-review.md`); reviewer findings were validated as either out-of-scope intentional-diff items or pre-existing non-module blockers, so no part-11 code remediation was required.
 - Review pass 2 status: approved (`reviews/phase-30-part-11-fnmatch-review-2.md`); production-grade confirmation reported no blocking issues and no additional module-scope remediation was required.
 
@@ -587,7 +587,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/re_flags_ignorecase.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_re_subset.sifr` validate invalid-pattern rejection (`"("`) with panic-free typed `RegexError` handling.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/974
+- PR: merged https://github.com/sifr-lang/sifr/pull/974
 - Review pass 1 status: approved (`reviews/phase-30-part-12-re-review.md`) with non-blocking observations only; no additional part-12 code remediation was required for approved scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-12-re-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -617,7 +617,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_collections_deque.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_collections_subset.sifr` validate empty deque pop (`None`) and absent-key counter lookups (`0`) with panic-free behavior.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/981
+- PR: merged https://github.com/sifr-lang/sifr/pull/981
 - Review pass 1 status: approved (`reviews/phase-30-part-13-collections-review.md`) with non-blocking observations only; no additional part-13 code remediation was required for approved scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-13-collections-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -645,7 +645,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_itertools_new.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_itertools_subset.sifr` validate `batched(..., 0)` rejection with panic-free typed `ValueError` behavior.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/985
+- PR: merged https://github.com/sifr-lang/sifr/pull/985
 - Review pass 1 status: approved (`reviews/phase-30-part-14-itertools-review.md`) with no blocking issues; no additional part-14 remediation was required for approved scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-14-itertools-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -671,7 +671,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_json.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_json_subset.sifr` validate invalid JSON parse rejection (`"{"`, `"tru"`) with panic-free typed `JSONDecodeError` handling.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/989
+- PR: merged https://github.com/sifr-lang/sifr/pull/989
 - Review pass 1 status: approved (`reviews/phase-30-part-15-json-review.md`); reviewer concern about `unwrap_or_default` was validated as non-blocking because `unwrap_or_default` is panic-free and returns default on serialization failure, so no module-scope remediation was required.
 - Review pass 2 status: approved (`reviews/phase-30-part-15-json-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -700,7 +700,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/datetime_time_class.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_datetime_subset.sifr` validate out-of-range `from_timestamp(...)` rejection with panic-free typed `ValueError` behavior.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/993
+- PR: merged https://github.com/sifr-lang/sifr/pull/993
 - Review pass 1 remediation: fixed `datetime.timestamp()` pre-epoch year handling in `lib/sifr/datetime.sifr` and added regression coverage (`1969-12-31T23:59:59 -> -1`) in `cpython_datetime_subset.sifr`; revalidated targeted datetime fixtures and full suite.
 - Review pass 2 status: approved (`reviews/phase-30-part-16-datetime-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -732,7 +732,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/open_binary_write.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_io_subset.sifr` validate panic-free typed `IOError` adaptation for missing-file open/read and invalid mode rejection.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/999
+- PR: merged https://github.com/sifr-lang/sifr/pull/999
 - Review pass 1 status: approved (`reviews/phase-30-part-17-io-review.md`) with non-blocking observations only; no additional module-scope remediation was required for approved scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-17-io-review-2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -759,7 +759,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/csv_reader_file.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_csv_subset.sifr` validate panic-free typed `IOError` adaptation for missing-file path rejection in `reader_from_path`.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1002
+- PR: merged https://github.com/sifr-lang/sifr/pull/1002
 - Review pass 1 remediation: optimized `lib/sifr/csv.sifr` root-cause inefficiencies in `reader.__next__`, `writer.writerow`/`writerows`, `DictReader.rows`, and `DictWriter` mutation paths while preserving approved subset semantics; revalidated module demos/fixtures and full suite.
 - Review pass 1 note validation: reviewer flag about `Result` + `raise` pattern was validated as non-blocking for this module because the same safe adaptation pattern is canonical across current stdlib `Result` wrappers in the approved architecture.
 - Review pass 2 status: reviewer raised the same `Result`+`raise` concern (`reviews/phase-30-part-18-csv-review-2.md`); validation confirmed this remains a non-blocking architectural pattern for current stdlib wrappers, and no additional module-scope remediation was required for approved scope.
@@ -787,7 +787,7 @@ Validation evidence:
 - Positive path: `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_os_intrinsics.sifr` -> pass.
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_os_subset.sifr` validate panic-free typed `IOError` adaptation for failing `rmdir`/`chdir` paths.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1005
+- PR: merged https://github.com/sifr-lang/sifr/pull/1005
 - Review pass 1 status: approved (`reviews/phase-30-part-19-os-review.md`) with no blocking issues and no additional module-scope remediation required.
 - Review pass 2 status: approved (`reviews/phase-30-part-19-os-review-r2.md`) with no blockers; module is production-grade for approved scope with no additional remediation required.
 
@@ -818,7 +818,7 @@ Validation evidence:
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_pathlib_subset.sifr` and `demos/m30_1e_pathlib_parity_demo/main.sifr` validate panic-free typed `IOError` adaptation for missing-path reads.
 - Root-cause fix: `sifr.pathlib` now requests the `regex` crate during codegen dependency synthesis, eliminating unresolved-crate failures when `Path.glob`/`Path.rglob` are used from pathlib modules.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1008
+- PR: merged https://github.com/sifr-lang/sifr/pull/1008
 - Review pass 1 status: approved (`reviews/phase-30-part-20-pathlib-review.md`) with no blocking issues; minor observations (`Path.__str__` ergonomics and broader glob metachar support) were validated as out-of-scope for the approved subset and require no additional module-scope remediation.
 - Review pass 2 status: approved (`reviews/phase-30-part-20-pathlib-review-2.md`) with no blockers; production-grade re-review validated no unresolved correctness or safety issues for approved scope.
 
@@ -846,7 +846,7 @@ Validation evidence:
 - Positive path: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh` -> pass (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`).
 - Negative path: canonical bool vectors in `cpython_glob_subset.sifr` and `demos/m30_1e_glob_parity_demo/main.sifr` validate panic-free empty-list behavior for missing directories and unmatched patterns.
 - Root-cause fix: `sifr.glob` now removes silent print fallback, enforces deterministic sorted output, and applies CPython-aligned hidden-file filtering (hidden entries only matched when pattern starts with `.`) for approved wildcard subset; reviewer-raised `pathlib` glob parity gaps were remediated in intrinsic lowering (`?` wildcard conversion, hidden-entry filtering, and missing-directory empty-result behavior) with dedicated regression coverage in `pathlib_glob_semantics.sifr`.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1012
+- PR: merged https://github.com/sifr-lang/sifr/pull/1012
 - Review pass 1 status: reviewer raised `pathlib.Path.glob`/`rglob` concerns (`reviews/phase-30-part-21-glob-review.md`); validation confirmed the findings were reproducible and required remediation for production-grade wave closure.
 - Review pass 2 status: blocker report (`reviews/phase-30-part-21-glob-review-2.md`) confirmed `pathlib` glob parity gaps; remediation was applied before closeout.
 - Review pass 3 status: approved after remediation (`reviews/phase-30-part-21-glob-review-3.md`) with no remaining blockers for approved `glob` scope.
@@ -874,7 +874,7 @@ Validation evidence:
 - Negative path: canonical bool vectors in `cpython_tempfile_subset.sifr` and `demos/m30_1e_tempfile_parity_demo/main.sifr` validate panic-free `IOError` propagation for `mkstemp` on missing-parent paths (`<temp-root>/__sifr_*_missing_parent__/...`) without retrying non-collision I/O failures.
 - Root-cause fix: `sifr.tempfile` now uses `_sifr.fs.gettempdir()` for temp-root placement, performs bounded collision retries for `mkstemp`/`mkdtemp`, and retries only on actual collision races (`exists(path)` after failure) while re-raising non-collision `IOError` immediately.
 - Parity governance update: tempfile API-shape divergence (prefix-only args, path-string return surface, no fd tuple, no `suffix`/`dir` options in approved scope) is now explicitly documented as `intentional-diff` in the phase parity matrix.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1016
+- PR: merged https://github.com/sifr-lang/sifr/pull/1016
 - Review pass 1 status: reviewer output in `reviews/phase-30-part-22-tempfile-review.md`; validated out-of-scope claims (`suffix`/`dir`/descriptor parity and full object API surface), and applied actionable remediation (negative-path evidence + explicit API-shape intentional-diff documentation).
 - Review pass 2 status: approved (`reviews/phase-30-part-22-tempfile-review-2.md`) with no blocking correctness/safety issues; note about `path + ""` copy was validated as non-actionable because current lowering needs a stable pre-`try` path copy to avoid move-after-try borrow failures.
 
@@ -902,7 +902,7 @@ Validation evidence:
 - Negative path: canonical bool vectors in `cpython_shutil_subset.sifr` and `demos/m30_1e_shutil_parity_demo/main.sifr` validate panic-free typed `IOError` adaptation for missing source/tree paths in `copy`, `move_file`, and `rmtree`.
 - Root-cause fix: `move_file` now lowers to `rename` directly for deterministic single-step move semantics in approved scope, eliminating prior two-step copy/remove partial-state risk.
 - Parity governance update: `verification/stdlib/phase30_parity_matrix.md` now includes explicit `shutil` parity and intentional-diff rows (name adaptation `move_file`, subset option matrix boundary, and `disk_usage` list-shape adaptation).
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1019
+- PR: merged https://github.com/sifr-lang/sifr/pull/1019
 - Review pass 1 status: approved (`reviews/phase-30-part-23-shutil-review.md`) with no blocking issues; reviewer notes about cross-device rename behavior and re-export visibility were validated as non-blocking and aligned with approved intentional-diff boundaries.
 - Review pass 2 status: approved (`reviews/phase-30-part-23-shutil-review-2.md`) with no blockers; production-grade re-review confirmed no unresolved correctness/safety risk in approved scope.
 
@@ -933,7 +933,7 @@ Validation evidence:
 - Negative path: canonical bool vectors in `cpython_logging_subset.sifr` and `demos/m30_1f_logging_parity_demo/main.sifr` validate panic-free behavior for invalid file targets (no crash, no file creation) while preserving level-filter semantics.
 - Root-cause fix: `log_warn` now emits CPython-aligned `WARNING` label; logging parity coverage was expanded with dedicated CPython-subset fixture and wave demo to lock level/filter/formatter/global-level behavior.
 - Parity governance update: `verification/stdlib/phase30_parity_matrix.md` now includes explicit `logging` parity and intentional-diff rows for approved subset boundaries.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1024
+- PR: merged https://github.com/sifr-lang/sifr/pull/1024
 - Review pass 1 status: approved (`reviews/phase-30-part-24-logging-review.md`) with no blockers; reviewer observations about silent handler error swallowing and helper-function scope were validated as intentional within approved panic-free subset boundaries.
 - Review pass 2 status: approved (`reviews/phase-30-part-24-logging-review-2.md`) with no blockers; production-grade re-review confirmed no unresolved correctness/safety risks in approved subset.
 
@@ -963,7 +963,7 @@ Validation evidence:
 - Root-cause fix: `sleep` intrinsic now guards invalid durations and uses panic-free `Duration::from_nanos` lowering; this removes user-triggerable panic paths from negative/invalid sleep inputs.
 - Root-cause fix: `perf_counter`/`monotonic` no longer use call-site-local baseline statics; both now lower through stable epoch-seconds timing to prevent per-call-site reset regressions in parity vectors.
 - Parity governance update: `verification/stdlib/phase30_parity_matrix.md` now includes explicit `time` parity and intentional-diff rows for approved subset boundaries.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1027
+- PR: merged https://github.com/sifr-lang/sifr/pull/1027
 - Review pass 1 status: approved (`reviews/phase-30-part-25-time-review.md`) with no blockers; reviewer observations about wall-clock `perf_counter`/`monotonic` behavior and empty-string fallback for out-of-range epochs were validated as documented intentional-diff boundaries for approved subset scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-25-time-review-2.md`) with no blockers; production-grade re-review confirmed no unresolved correctness/safety risks in approved subset.
 
@@ -990,7 +990,7 @@ Validation evidence:
 - Negative path: canonical bool vectors in `cpython_timeit_subset.sifr` and `demos/m30_1f_timeit_parity_demo/main.sifr` validate panic-free handling for zero/negative loop-count inputs and non-negative elapsed outputs.
 - Root-cause fix: elapsed-time calculation in `timeit`/`repeat` now clamps to non-negative values to prevent backward wall-clock drift from producing negative durations in approved subset behavior.
 - Parity governance update: `verification/stdlib/phase30_parity_matrix.md` now includes explicit `timeit` parity and intentional-diff rows for approved subset boundaries.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1030
+- PR: merged https://github.com/sifr-lang/sifr/pull/1030
 - Review pass 1 status: approved (`reviews/phase-30-part-26-timeit-review.md`) with no blockers; reviewer observations about wall-clock timer mapping were validated as documented intentional-diff boundaries for approved subset scope.
 - Review pass 2 status: approved (`reviews/phase-30-part-26-timeit-review-2.md`) with no blockers; production-grade re-review confirmed no unresolved correctness/safety risks in approved subset.
 
@@ -1020,7 +1020,7 @@ Validation evidence:
 - Root-cause fix: `platform_system` intrinsic now maps host OS to CPython-style names (`Windows`/`Darwin`/`Linux`) instead of returning raw lowercase `std::env::consts::OS` values.
 - Root-cause fix: `platform_node`, `platform_release`, and `platform_version` no longer rely solely on shell command availability; deterministic non-empty fallbacks prevent empty-string metadata on hosts without `hostname`/`uname`.
 - Parity governance update: `verification/stdlib/phase30_parity_matrix.md` now includes explicit `platform` parity and intentional-diff rows for approved subset boundaries.
-- PR: merged https://github.com/yaseralnajjar/sifr/pull/1033
+- PR: merged https://github.com/sifr-lang/sifr/pull/1033
 - Review pass 1 status: approved (`reviews/phase-30-part-27-platform-review.md`) with no blockers; reviewer observations about `processor()` and command availability were validated as documented intentional-diff boundaries with deterministic fallback behavior.
 - Review pass 2 status: approved (`reviews/phase-30-part-27-platform-review-2.md`) with no blockers; production-grade re-review confirmed no unresolved correctness/safety risks in approved subset.
 
@@ -1074,120 +1074,120 @@ Validation evidence:
 - Negative path:
 
 ## PR Log
-- Part 1 implementation: merged https://github.com/yaseralnajjar/sifr/pull/929
-- Part 1 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/930
-- Part 1 review pass 2 remediation + sign-off: merged https://github.com/yaseralnajjar/sifr/pull/931
-- Part 1 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/932
-- Wave completion closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/933
-- Wave production-grade closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/934
-- Milestone completion closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/935
-- Milestone production-grade closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/936
-- Phase completion closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/937
-- Part 2 implementation: merged https://github.com/yaseralnajjar/sifr/pull/939
-- Part 2 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/940
-- Part 2 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/941
-- Phase production-grade closure cycle: merged https://github.com/yaseralnajjar/sifr/pull/938
-- Part 3 implementation: merged https://github.com/yaseralnajjar/sifr/pull/942
-- Part 3 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/943
-- Part 3 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/944
-- Part 4 implementation: merged https://github.com/yaseralnajjar/sifr/pull/945
-- Part 4 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/946
-- Part 4 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/947
-- Part 5 implementation: merged https://github.com/yaseralnajjar/sifr/pull/948
-- Part 5 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/949
-- Part 5 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/950
-- Part 6 implementation: merged https://github.com/yaseralnajjar/sifr/pull/951
-- Part 6 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/953
-- Part 6 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/954
-- Part 7 implementation: merged https://github.com/yaseralnajjar/sifr/pull/955
-- Part 7 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/956
-- Part 7 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/957
-- Part 8 implementation: merged https://github.com/yaseralnajjar/sifr/pull/958
-- Part 8 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/959
-- Part 8 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/960
-- Wave completion closure cycle (wave_30_1b): merged https://github.com/yaseralnajjar/sifr/pull/961
-- Wave production-grade closure cycle (wave_30_1b): merged https://github.com/yaseralnajjar/sifr/pull/962
-- Part 9 implementation: merged https://github.com/yaseralnajjar/sifr/pull/963
-- Part 9 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/964
-- Part 9 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/965
-- Part 10 implementation: merged https://github.com/yaseralnajjar/sifr/pull/967
-- Part 10 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/968
-- Part 11 implementation: merged https://github.com/yaseralnajjar/sifr/pull/970
-- Part 11 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/971
-- Part 11 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/972
-- Part 12 implementation: merged https://github.com/yaseralnajjar/sifr/pull/974
-- Part 12 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/975
-- Part 12 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/976
-- Wave completion closure cycle (wave_30_1c): merged https://github.com/yaseralnajjar/sifr/pull/978
-- Wave production-grade closure cycle (wave_30_1c): merged https://github.com/yaseralnajjar/sifr/pull/979
-- Part 13 implementation: merged https://github.com/yaseralnajjar/sifr/pull/981
-- Part 13 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/982
-- Part 13 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/983
-- Part 14 implementation: merged https://github.com/yaseralnajjar/sifr/pull/985
-- Part 14 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/986
-- Part 14 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/987
-- Part 15 implementation: merged https://github.com/yaseralnajjar/sifr/pull/989
-- Part 15 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/990
-- Part 15 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/991
-- Part 16 implementation: merged https://github.com/yaseralnajjar/sifr/pull/993
-- Part 16 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/994
-- Part 16 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/995
-- Part 10 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/969
-- Part 11 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/973
-- Part 12 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/977
-- Wave closure log sync (wave_30_1c): merged https://github.com/yaseralnajjar/sifr/pull/980
-- Part 13 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/984
-- Part 14 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/988
-- Part 15 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/992
-- Part 16 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/996
-- Wave completion closure cycle (wave_30_1d): merged https://github.com/yaseralnajjar/sifr/pull/997
-- Wave production-grade closure cycle (wave_30_1d): merged https://github.com/yaseralnajjar/sifr/pull/998
-- Part 17 implementation: merged https://github.com/yaseralnajjar/sifr/pull/999
-- Part 17 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1000
-- Part 17 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1001
-- Part 18 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1002
-- Part 18 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/1003
-- Part 18 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1004
-- Part 19 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1005
-- Part 19 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1006
-- Part 19 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1007
-- Part 20 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1008
-- Part 20 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1009
-- Part 20 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1010
-- Part 21 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1012
-- Part 21 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1013
-- Part 21 review pass 2 remediation + pass 3 approval: merged https://github.com/yaseralnajjar/sifr/pull/1014
-- Part 21 closeout log sync: merged https://github.com/yaseralnajjar/sifr/pull/1015
-- Part 22 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1016
-- Part 22 review pass 1 remediation: merged https://github.com/yaseralnajjar/sifr/pull/1017
-- Part 22 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1018
-- Part 23 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1019
-- Part 23 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1020
-- Part 23 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1021
-- Wave completion closure cycle (wave_30_1e): merged https://github.com/yaseralnajjar/sifr/pull/1022
-- Wave production-grade closure cycle (wave_30_1e): merged https://github.com/yaseralnajjar/sifr/pull/1023
-- Part 24 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1024
-- Part 24 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1025
-- Part 24 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1026
-- Part 25 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1027
-- Part 25 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1028
-- Part 25 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1029
-- Part 26 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1030
-- Part 26 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1031
-- Part 26 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1032
-- Part 27 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1033
-- Part 27 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1034
-- Part 27 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1035
-- Part 28 implementation: merged https://github.com/yaseralnajjar/sifr/pull/1036
-- Part 28 review pass 1 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1037
-- Part 28 review pass 2 tracking: merged https://github.com/yaseralnajjar/sifr/pull/1038
-- Wave completion closure cycle (wave_30_1f): merged https://github.com/yaseralnajjar/sifr/pull/1039
-- Wave production-grade closure cycle (wave_30_1f): merged https://github.com/yaseralnajjar/sifr/pull/1040
-- Milestone completion review cycle (updated): merged https://github.com/yaseralnajjar/sifr/pull/1041
-- Milestone 30_2/30_3 remediation: merged https://github.com/yaseralnajjar/sifr/pull/1042
-- Milestone completion closure cycle (approved rerun): merged https://github.com/yaseralnajjar/sifr/pull/1043
-- Milestone production-grade closure cycle (approved rerun): merged https://github.com/yaseralnajjar/sifr/pull/1044
-- Phase completion closure cycle (approved rerun): merged https://github.com/yaseralnajjar/sifr/pull/1045
+- Part 1 implementation: merged https://github.com/sifr-lang/sifr/pull/929
+- Part 1 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/930
+- Part 1 review pass 2 remediation + sign-off: merged https://github.com/sifr-lang/sifr/pull/931
+- Part 1 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/932
+- Wave completion closure cycle: merged https://github.com/sifr-lang/sifr/pull/933
+- Wave production-grade closure cycle: merged https://github.com/sifr-lang/sifr/pull/934
+- Milestone completion closure cycle: merged https://github.com/sifr-lang/sifr/pull/935
+- Milestone production-grade closure cycle: merged https://github.com/sifr-lang/sifr/pull/936
+- Phase completion closure cycle: merged https://github.com/sifr-lang/sifr/pull/937
+- Part 2 implementation: merged https://github.com/sifr-lang/sifr/pull/939
+- Part 2 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/940
+- Part 2 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/941
+- Phase production-grade closure cycle: merged https://github.com/sifr-lang/sifr/pull/938
+- Part 3 implementation: merged https://github.com/sifr-lang/sifr/pull/942
+- Part 3 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/943
+- Part 3 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/944
+- Part 4 implementation: merged https://github.com/sifr-lang/sifr/pull/945
+- Part 4 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/946
+- Part 4 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/947
+- Part 5 implementation: merged https://github.com/sifr-lang/sifr/pull/948
+- Part 5 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/949
+- Part 5 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/950
+- Part 6 implementation: merged https://github.com/sifr-lang/sifr/pull/951
+- Part 6 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/953
+- Part 6 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/954
+- Part 7 implementation: merged https://github.com/sifr-lang/sifr/pull/955
+- Part 7 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/956
+- Part 7 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/957
+- Part 8 implementation: merged https://github.com/sifr-lang/sifr/pull/958
+- Part 8 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/959
+- Part 8 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/960
+- Wave completion closure cycle (wave_30_1b): merged https://github.com/sifr-lang/sifr/pull/961
+- Wave production-grade closure cycle (wave_30_1b): merged https://github.com/sifr-lang/sifr/pull/962
+- Part 9 implementation: merged https://github.com/sifr-lang/sifr/pull/963
+- Part 9 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/964
+- Part 9 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/965
+- Part 10 implementation: merged https://github.com/sifr-lang/sifr/pull/967
+- Part 10 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/968
+- Part 11 implementation: merged https://github.com/sifr-lang/sifr/pull/970
+- Part 11 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/971
+- Part 11 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/972
+- Part 12 implementation: merged https://github.com/sifr-lang/sifr/pull/974
+- Part 12 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/975
+- Part 12 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/976
+- Wave completion closure cycle (wave_30_1c): merged https://github.com/sifr-lang/sifr/pull/978
+- Wave production-grade closure cycle (wave_30_1c): merged https://github.com/sifr-lang/sifr/pull/979
+- Part 13 implementation: merged https://github.com/sifr-lang/sifr/pull/981
+- Part 13 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/982
+- Part 13 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/983
+- Part 14 implementation: merged https://github.com/sifr-lang/sifr/pull/985
+- Part 14 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/986
+- Part 14 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/987
+- Part 15 implementation: merged https://github.com/sifr-lang/sifr/pull/989
+- Part 15 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/990
+- Part 15 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/991
+- Part 16 implementation: merged https://github.com/sifr-lang/sifr/pull/993
+- Part 16 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/994
+- Part 16 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/995
+- Part 10 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/969
+- Part 11 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/973
+- Part 12 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/977
+- Wave closure log sync (wave_30_1c): merged https://github.com/sifr-lang/sifr/pull/980
+- Part 13 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/984
+- Part 14 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/988
+- Part 15 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/992
+- Part 16 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/996
+- Wave completion closure cycle (wave_30_1d): merged https://github.com/sifr-lang/sifr/pull/997
+- Wave production-grade closure cycle (wave_30_1d): merged https://github.com/sifr-lang/sifr/pull/998
+- Part 17 implementation: merged https://github.com/sifr-lang/sifr/pull/999
+- Part 17 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1000
+- Part 17 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1001
+- Part 18 implementation: merged https://github.com/sifr-lang/sifr/pull/1002
+- Part 18 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/1003
+- Part 18 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1004
+- Part 19 implementation: merged https://github.com/sifr-lang/sifr/pull/1005
+- Part 19 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1006
+- Part 19 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1007
+- Part 20 implementation: merged https://github.com/sifr-lang/sifr/pull/1008
+- Part 20 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1009
+- Part 20 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1010
+- Part 21 implementation: merged https://github.com/sifr-lang/sifr/pull/1012
+- Part 21 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1013
+- Part 21 review pass 2 remediation + pass 3 approval: merged https://github.com/sifr-lang/sifr/pull/1014
+- Part 21 closeout log sync: merged https://github.com/sifr-lang/sifr/pull/1015
+- Part 22 implementation: merged https://github.com/sifr-lang/sifr/pull/1016
+- Part 22 review pass 1 remediation: merged https://github.com/sifr-lang/sifr/pull/1017
+- Part 22 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1018
+- Part 23 implementation: merged https://github.com/sifr-lang/sifr/pull/1019
+- Part 23 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1020
+- Part 23 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1021
+- Wave completion closure cycle (wave_30_1e): merged https://github.com/sifr-lang/sifr/pull/1022
+- Wave production-grade closure cycle (wave_30_1e): merged https://github.com/sifr-lang/sifr/pull/1023
+- Part 24 implementation: merged https://github.com/sifr-lang/sifr/pull/1024
+- Part 24 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1025
+- Part 24 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1026
+- Part 25 implementation: merged https://github.com/sifr-lang/sifr/pull/1027
+- Part 25 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1028
+- Part 25 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1029
+- Part 26 implementation: merged https://github.com/sifr-lang/sifr/pull/1030
+- Part 26 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1031
+- Part 26 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1032
+- Part 27 implementation: merged https://github.com/sifr-lang/sifr/pull/1033
+- Part 27 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1034
+- Part 27 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1035
+- Part 28 implementation: merged https://github.com/sifr-lang/sifr/pull/1036
+- Part 28 review pass 1 tracking: merged https://github.com/sifr-lang/sifr/pull/1037
+- Part 28 review pass 2 tracking: merged https://github.com/sifr-lang/sifr/pull/1038
+- Wave completion closure cycle (wave_30_1f): merged https://github.com/sifr-lang/sifr/pull/1039
+- Wave production-grade closure cycle (wave_30_1f): merged https://github.com/sifr-lang/sifr/pull/1040
+- Milestone completion review cycle (updated): merged https://github.com/sifr-lang/sifr/pull/1041
+- Milestone 30_2/30_3 remediation: merged https://github.com/sifr-lang/sifr/pull/1042
+- Milestone completion closure cycle (approved rerun): merged https://github.com/sifr-lang/sifr/pull/1043
+- Milestone production-grade closure cycle (approved rerun): merged https://github.com/sifr-lang/sifr/pull/1044
+- Phase completion closure cycle (approved rerun): merged https://github.com/sifr-lang/sifr/pull/1045
 
 ## External Review Passes
 - Reviewer pass 1 request output: `reviews/phase-30-part-1-env-review.md`

--- a/issues/archive/phase31-algorithmic-compatibility-execution.md
+++ b/issues/archive/phase31-algorithmic-compatibility-execution.md
@@ -142,7 +142,7 @@ Carry-forward planning:
 - Status:
   - complete (merged on 2026-03-11)
 - Implementation PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1100
+  - https://github.com/sifr-lang/sifr/pull/1100
 - Delivered artifacts:
   - `verification/leetcode/phase31_seed_corpus.json`
   - `verification/leetcode/phase31_corpus_inventory.json`
@@ -183,7 +183,7 @@ Carry-forward planning:
 - Status:
   - complete (merged on 2026-03-11)
 - Implementation PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1101
+  - https://github.com/sifr-lang/sifr/pull/1101
 - Delivered artifacts:
   - `verification/leetcode/phase31_failure_taxonomy.json`
   - `verification/leetcode/phase31_failure_repros.json`
@@ -221,7 +221,7 @@ Carry-forward planning:
 - Status:
   - complete (merged on 2026-03-11)
 - Implementation PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1102
+  - https://github.com/sifr-lang/sifr/pull/1102
 - Delivered artifacts:
   - `verification/leetcode/phase31_remediation_backlog.json`
   - `verification/leetcode/phase31_remediation_backlog.md`
@@ -304,7 +304,7 @@ Carry-forward planning:
 - Status:
   - complete (merged on 2026-03-11; external review sign-off recorded on 2026-03-11)
 - Implementation PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1104
+  - https://github.com/sifr-lang/sifr/pull/1104
 - Delivered artifacts:
   - `verification/leetcode/phase31_scorecard.json`
   - `verification/leetcode/phase31_scorecard.md`

--- a/issues/archive/phase31-sifr-driver-decomposition-and-boundary-hardening-execution.md
+++ b/issues/archive/phase31-sifr-driver-decomposition-and-boundary-hardening-execution.md
@@ -40,7 +40,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_1: Public API Spine and Diagnostic Extraction
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1089
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1089
 - Implementation target:
   - reduce `crates/sifr_driver/src/lib.rs` to module wiring plus public re-exports for the stable public API
   - extract diagnostics, compile/public result types, panic-boundary helpers, and crate-root API surface into dedicated modules
@@ -61,7 +61,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_2: Stdlib Bootstrap Extraction
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1090
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1090
 - Demo target:
   - `cargo run -q -p sifr -- run demos/m_driver_2_stdlib_bootstrap_demo.sifr`
 - Validation target:
@@ -76,7 +76,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_3: Frontend and Project-Graph Extraction
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1091
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1091
 - Demo target:
   - `cargo run -q -p sifr -- run demos/m_driver_3_frontend_project_graph_demo/main.sifr`
 - Validation target:
@@ -93,7 +93,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_4: Discovery, Workspace, and Build Orchestration Extraction
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1092
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1092
 - Demo target:
   - `cargo run -q -p sifr -- run demos/m_driver_4_build_orchestration_demo/main.sifr`
 - Validation target:
@@ -111,7 +111,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_5: Test Runner Extraction
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1093
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1093
 - Demo target:
   - `cargo run -q -p sifr -- test demos/m_driver_5_test_runner_demo`
 - Validation target:
@@ -128,7 +128,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
 
 ### milestone_driver_6: Test Suite Decomposition and Maintainability Guardrail
 - Status: complete
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1094
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1094
 - Demo target:
   - `python3 scripts/check_sifr_driver_maintainability_guardrails.py`
 - Validation target:
@@ -158,7 +158,7 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
   - positive path: `cargo run -q -p sifr -- test demos/m_driver_5_test_runner_demo` -> executed the demo test runner successfully with `test_import_parity ... ok`
   - local gate: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh --profile quick` -> passed (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`)
 - Follow-up PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1095
+  - https://github.com/sifr-lang/sifr/pull/1095
 
 ### review_pass_2
 - Reviewer artifact:
@@ -172,4 +172,4 @@ Loop per part: Plan -> Implement -> Validate -> Demo -> PR -> Review -> Merge ->
   - positive path: `cargo run -q -p sifr -- test demos/m_driver_5_test_runner_demo` -> executed the demo test runner successfully with `test_import_parity ... ok`
   - local gate: `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh --profile quick` -> passed (`verification ok: variants=64, failures=0, blocking_failures=0, non_blocking_failures=0`)
 - Follow-up PR:
-  - https://github.com/yaseralnajjar/sifr/pull/1097
+  - https://github.com/sifr-lang/sifr/pull/1097

--- a/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
+++ b/issues/leetcode-ws6-silent-fallback-remediation-2026-04-25.md
@@ -3,8 +3,8 @@
 Status: closed
 Owner: ad_hoc_leetcode_divergence_closure_followup
 Source phase: `issues/ad-hoc-leetcode-divergence-closure-2026-04-24.md`
-Source PR: `https://github.com/yaseralnajjar/sifr/pull/1632`
-Merged remediation PR: `https://github.com/yaseralnajjar/sifr/pull/1635`
+Source PR: `https://github.com/sifr-lang/sifr/pull/1632`
+Merged remediation PR: `https://github.com/sifr-lang/sifr/pull/1635`
 Created: 2026-04-25
 
 ## Progress
@@ -19,7 +19,7 @@ Created: 2026-04-25
 - Fixed codegen for constant-index projection of non-Copy fields from optional tuples by cloning the projected field when the tuple is accessed through `Option.as_ref()`.
 - Added `crates/sifr/tests/e2e/pass/optional_tuple_string_projection.sifr`.
 - Full corpus rerun artifact: `verification/leetcode/full_corpus_current_results_20260425_ws6_fallback_remediation.json` with `208 PASS`, `203 NO_ORACLE`, and no `CHECK_ERROR`, `RUN_ERROR`, or `TIMEOUT`.
-- Merged as PR `https://github.com/yaseralnajjar/sifr/pull/1635`.
+- Merged as PR `https://github.com/sifr-lang/sifr/pull/1635`.
 
 ## Problem
 

--- a/reviews/archive/cleanup-review-pass-2.md
+++ b/reviews/archive/cleanup-review-pass-2.md
@@ -4,7 +4,7 @@
 **Date:** 2026-03-11
 **PR Title:** Clean up internal docs, audits, and duplicate demos
 **Branch:** `codex/cleanup`
-**URL:** https://github.com/yaseralnajjar/sifr/pull/1106
+**URL:** https://github.com/sifr-lang/sifr/pull/1106
 
 ---
 

--- a/reviews/archive/phase-30-m30_4-wave-30_1e-completion-review.md
+++ b/reviews/archive/phase-30-m30_4-wave-30_1e-completion-review.md
@@ -171,12 +171,12 @@ The checklist at line 86 of the execution tracker still shows wave_30_1e as "in 
 
 **Current:**
 ```markdown
-- [ ] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - in progress (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 reported structural/doc blockers and remediation is in progress; wave closure cycles pending)
+- [ ] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - in progress (implementation merged in https://github.com/sifr-lang/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 reported structural/doc blockers and remediation is in progress; wave closure cycles pending)
 ```
 
 **Recommended:**
 ```markdown
-- [x] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - complete (implementation merged in https://github.com/yaseralnajjar/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 blockers resolved in https://github.com/yaseralnajjar/sifr/pull/1070; wave completion closure and production-grade closure approved)
+- [x] `wave_30_1e` (`io`, `csv`, `os`, `pathlib`, `glob`, `tempfile`, `shutil`) - complete (implementation merged in https://github.com/sifr-lang/sifr/pull/1068; reviewer pass 1 approved; reviewer pass 2 blockers resolved in https://github.com/sifr-lang/sifr/pull/1070; wave completion closure and production-grade closure approved)
 ```
 
 ---

--- a/reviews/archive/phase-30-wave-30-1f-completion-review.md
+++ b/reviews/archive/phase-30-wave-30-1f-completion-review.md
@@ -22,27 +22,27 @@
 ## Detailed Findings
 
 ### Part 24: `logging`
-- **PR**: https://github.com/yaseralnajjar/sifr/pull/1024
+- **PR**: https://github.com/sifr-lang/sifr/pull/1024
 - **Review files**: `reviews/phase-30-part-24-logging-review.md`, `reviews/phase-30-part-24-logging-review-2.md`
 - **Status**: Complete - All checklist items passed, parity matrix updated
 
 ### Part 25: `time`
-- **PR**: https://github.com/yaseralnajjar/sifr/pull/1027
+- **PR**: https://github.com/sifr-lang/sifr/pull/1027
 - **Review files**: `reviews/phase-30-part-25-time-review.md`, `reviews/phase-30-part-25-time-review-2.md`
 - **Status**: Complete - All checklist items passed, parity matrix updated
 
 ### Part 26: `timeit`
-- **PR**: https://github.com/yaseralnajjar/sifr/pull/1030
+- **PR**: https://github.com/sifr-lang/sifr/pull/1030
 - **Review files**: `reviews/phase-30-part-26-timeit-review.md`, `reviews/phase-30-part-26-timeit-review-2.md`
 - **Status**: Complete - All checklist items passed, parity matrix updated
 
 ### Part 27: `platform`
-- **PR**: https://github.com/yaseralnajjar/sifr/pull/1033
+- **PR**: https://github.com/sifr-lang/sifr/pull/1033
 - **Review files**: `reviews/phase-30-part-27-platform-review.md`, `reviews/phase-30-part-27-platform-review-2.md`, `reviews/phase-30-part-27-platform-review-r2a.md`
 - **Status**: Complete - All checklist items passed, parity matrix updated
 
 ### Part 28: `uuid`
-- **PR**: https://github.com/yaseralnajjar/sifr/pull/1038
+- **PR**: https://github.com/sifr-lang/sifr/pull/1038
 - **Review files**: `reviews/phase-30-part-28-uuid-review.md`, `reviews/phase-30-part-28-uuid-review-2a.md`
 - **Status**: Complete - All checklist items passed, parity matrix updated
 

--- a/reviews/archive/phase-ad-hoc-python-source-parity-extension-waiver-reduction-wave-psp-ext-1-review-pass-2a.md
+++ b/reviews/archive/phase-ad-hoc-python-source-parity-extension-waiver-reduction-wave-psp-ext-1-review-pass-2a.md
@@ -174,7 +174,7 @@ From `issues/ad-hoc-python-source-parity-extension-waiver-reduction-execution.md
 ### 7.2 Wave Progress
 
 - Status: merged ✅
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1254 ✅
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1254 ✅
 - Validation evidence recorded ✅
 
 ### 7.3 Review Chain

--- a/reviews/archive/phase-ad-hoc-structured-data-and-class-surface-parity-expansion-wave-psp-struct-3-review-pass-2.md
+++ b/reviews/archive/phase-ad-hoc-structured-data-and-class-surface-parity-expansion-wave-psp-struct-3-review-pass-2.md
@@ -241,7 +241,7 @@ None - the implementation is complete and meets all contract requirements for pr
 
 ## References
 
-- Implementation PR: https://github.com/yaseralnajjar/sifr/pull/1278
+- Implementation PR: https://github.com/sifr-lang/sifr/pull/1278
 - Pass 1 Review: `reviews/phase-ad-hoc-structured-data-and-class-surface-parity-expansion-wave-psp-struct-3-review-pass-1.md`
 - Execution Ledger: `issues/ad-hoc-structured-data-and-class-surface-parity-expansion-execution.md`
 - Architecture Lock: `verification/stdlib/phase_psp_struct_architecture_lock.md`

--- a/reviews/archive/phase25-production-grade-review-2.md
+++ b/reviews/archive/phase25-production-grade-review-2.md
@@ -280,8 +280,8 @@ Phase 25 is **production-grade** and approved for use. The implementation:
 
 ### PR Links
 
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/883
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/884
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/885
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/886
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/887
+- Part 1: https://github.com/sifr-lang/sifr/pull/883
+- Part 2: https://github.com/sifr-lang/sifr/pull/884
+- Part 3: https://github.com/sifr-lang/sifr/pull/885
+- Part 4: https://github.com/sifr-lang/sifr/pull/886
+- Part 5: https://github.com/sifr-lang/sifr/pull/887

--- a/reviews/archive/phase25-review.md
+++ b/reviews/archive/phase25-review.md
@@ -410,8 +410,8 @@ test result: ok. 39 passed; 0 failed
 
 ### PR Links
 
-- Part 1: https://github.com/yaseralnajjar/sifr/pull/883
-- Part 2: https://github.com/yaseralnajjar/sifr/pull/884
-- Part 3: https://github.com/yaseralnajjar/sifr/pull/885
-- Part 4: https://github.com/yaseralnajjar/sifr/pull/886
-- Part 5: https://github.com/yaseralnajjar/sifr/pull/887
+- Part 1: https://github.com/sifr-lang/sifr/pull/883
+- Part 2: https://github.com/sifr-lang/sifr/pull/884
+- Part 3: https://github.com/sifr-lang/sifr/pull/885
+- Part 4: https://github.com/sifr-lang/sifr/pull/886
+- Part 5: https://github.com/sifr-lang/sifr/pull/887

--- a/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md
+++ b/reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass5.md
@@ -9,7 +9,7 @@ Inputs reviewed:
 - `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25.md` (phase plan, status: closed)
 - `issues/ad-hoc-sifr-workspace-sifr-toml-import-resolution-2026-04-25-execution.md` (execution checklist, status: closed)
 - `reviews/sifr-workspace-sifr-toml-import-resolution-2026-04-25-review-pass4.md` (pre-merge READY)
-- Local `main` at `b60ff461` representing merged PRs [#1639–#1645](https://github.com/yaseralnajjar/sifr/pulls)
+- Local `main` at `b60ff461` representing merged PRs [#1639–#1645](https://github.com/sifr-lang/sifr/pulls)
 - Spot checks against `crates/sifr/src/main.rs`, `crates/sifr_driver/src/workspace/`, `crates/sifr_driver/src/project/`, `crates/sifr_driver/src/build/`, `crates/sifr_driver/src/test_runner/`, `crates/sifr_driver/src/tests/`, `crates/sifr/tests/verification/project/`, `verification/suites/manifest.json`, `audits/leetcode/`, `internal_docs/sifr_workspace_design.md`, `internal_docs/architecture.md`, `internal_docs/roadmap.md`, `verification/leetcode/`, `scripts/run_all_tests.sh`
 - Local validation re-run: `cargo build --release -p sifr`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test -p sifr_driver workspace`, `cargo test -p sifr_driver --lib`, `cargo run -p sifr -- {check,run,emit} audits/leetcode/0021_merge_two_sorted_lists.sifr`
 

--- a/verification/fixedbugs/index.json
+++ b/verification/fixedbugs/index.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "id": "FB-0001",
-      "issue": "https://github.com/yaseralnajjar/sifr/pull/898",
+      "issue": "https://github.com/sifr-lang/sifr/pull/898",
       "root_cause_category": "negative-index-mutation-lowering-parity",
       "suite_location": "crates/sifr/tests/e2e/pass/negative_index_mutations.sifr",
       "command": "run",
@@ -12,7 +12,7 @@
     },
     {
       "id": "FB-0002",
-      "issue": "https://github.com/yaseralnajjar/sifr/pull/899",
+      "issue": "https://github.com/sifr-lang/sifr/pull/899",
       "root_cause_category": "unsupported-default-expression-diagnostic-path",
       "suite_location": "crates/sifr/tests/e2e/fail/unsupported_default_expr_call.sifr",
       "command": "check",
@@ -21,7 +21,7 @@
     },
     {
       "id": "FB-0003",
-      "issue": "https://github.com/yaseralnajjar/sifr/pull/913",
+      "issue": "https://github.com/sifr-lang/sifr/pull/913",
       "root_cause_category": "decimal-literal-validation-contract",
       "suite_location": "crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr",
       "command": "check",


### PR DESCRIPTION
## Summary
- update repository metadata, README links, and tracked historical docs from yaseralnajjar/sifr to sifr-lang/sifr
- remove stale tracked references to the old user-owned project URL

## Validation
- scripts/run_all_tests.sh --profile quick