### PR TITLE
Update LeetCode cleanup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,9 @@ scripts/clone_subrepos.sh
 The script is safe to run repeatedly. It clones missing sub-repositories and
 fast-forwards existing clean checkouts.
 
-LeetCode fixtures live under `audits/leetcode/src`.
-LeetCode-specific corpus scripts, verification artifacts, and audit notes live
-inside that sub-repository under `audits/leetcode/scripts`,
-`audits/leetcode/verification/leetcode`, and `audits/leetcode/internal_docs`.
+LeetCode fixtures live under `audits/leetcode/src`. Historical generated
+LeetCode reports, verification outputs, and old audit notes were removed from
+the lean LeetCode sub-repository and remain recoverable from its git history.
 
 ### Compile and run a `.sifr` file
 

--- a/internal_docs/phases/31_algorithmic_compatibility_and_leetcode_coverage.md
+++ b/internal_docs/phases/31_algorithmic_compatibility_and_leetcode_coverage.md
@@ -4,6 +4,12 @@ status: complete
 
 > 2026-03-11 update: milestones `31_1` through `31_5` are implemented in the workspace with a canonical 50-problem seed corpus, a deterministic runner, a generated failure taxonomy, a ranked remediation backlog, a first remediation wave, and stable scorecard/handoff artifacts. External review sign-off is recorded in `reviews/phase-31-review-pass-3.md` and `reviews/phase-31-review-pass-4.md`.
 
+> 2026-04-27 update: the LeetCode sub-repository was cleaned to keep only the
+> source corpus and root helper scripts. Historical Phase 31 generated artifacts,
+> old audit reports, internal notes, and obsolete helper scripts were removed
+> from the live tree and remain recoverable from `sifr-lang/leetcode` git
+> history.
+
 ## Objective
 Run a representative LeetCode corpus end-to-end on Sifr, identify failures, classify root causes, and define the language/compiler fixes required to improve algorithmic compatibility.
 
@@ -45,13 +51,13 @@ status: complete
   - Timeout and oracle policy are documented and enforced.
   - Baseline pass/fail/timeout metrics are generated.
 - Delivered artifacts:
-  - `audits/leetcode/verification/leetcode/phase31_seed_corpus.json`
-  - `audits/leetcode/verification/leetcode/phase31_corpus_inventory.json`
-  - `audits/leetcode/verification/leetcode/phase31_seed_summary.json`
-  - `audits/leetcode/internal_docs/verification/phase31_leetcode_corpus_policy.md`
-  - `audits/leetcode/scripts/build_phase31_leetcode_assets.py`
-  - `audits/leetcode/scripts/run_phase31_leetcode.py`
-  - `audits/leetcode/scripts/test_phase31_leetcode.py`
+  - historical artifact `phase31_seed_corpus.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_corpus_inventory.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_seed_summary.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical note artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
 - Baseline metrics (2026-03-11 seed run):
   - `case_count=50`
   - `status_counts={CHECK_ERROR: 46, RUN_ERROR: 2, PASS: 2}`
@@ -73,15 +79,15 @@ status: complete
   - Taxonomy report includes frequency and impact ranking.
   - Classification spot-audit accuracy is `>= 90%`.
 - Delivered artifacts:
-  - `audits/leetcode/verification/leetcode/phase31_failure_taxonomy.json`
-  - `audits/leetcode/verification/leetcode/phase31_failure_repros.json`
-  - `audits/leetcode/verification/leetcode/phase31_spot_audit.json`
-  - `audits/leetcode/verification/leetcode/phase31_spot_audit_cases.json`
-  - `audits/leetcode/verification/leetcode/phase31_failure_report.md`
-  - `audits/leetcode/verification/leetcode/phase31_failure_report.md`
-  - `audits/leetcode/scripts/phase31_leetcode_taxonomy.py`
-  - `audits/leetcode/scripts/build_phase31_leetcode_taxonomy.py`
-  - `audits/leetcode/scripts/test_phase31_leetcode_taxonomy.py`
+  - historical artifact `phase31_failure_taxonomy.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_failure_repros.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_spot_audit.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_spot_audit_cases.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_failure_report.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_failure_report.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
 - Baseline taxonomy metrics (2026-03-11 seed run):
   - classified failing seed cases: `48`
   - taxonomy buckets: `12`
@@ -109,12 +115,12 @@ status: complete
   - Plan is approved and linked into roadmap phases.
   - Unresolved `P1` blockers older than 14 days are escalated with explicit owner reassignment or defer decision.
 - Delivered artifacts:
-  - `audits/leetcode/verification/leetcode/phase31_remediation_backlog.json`
-  - `audits/leetcode/verification/leetcode/phase31_remediation_backlog.md`
-  - `audits/leetcode/verification/leetcode/phase31_remediation_backlog.md`
-  - `audits/leetcode/scripts/phase31_leetcode_remediation.py`
-  - `audits/leetcode/scripts/build_phase31_leetcode_remediation_backlog.py`
-  - `audits/leetcode/scripts/test_phase31_leetcode_remediation_backlog.py`
+  - historical artifact `phase31_remediation_backlog.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_remediation_backlog.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_remediation_backlog.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
 - Backlog summary (2026-03-11):
   - backlog entries: `12` (one per taxonomy bucket)
   - `P1` items: `6`
@@ -140,9 +146,9 @@ status: complete
   - Pass-rate improvement is measurable against baseline.
   - No regression in previously passing corpus slice.
 - Delivered artifacts:
-  - `audits/leetcode/verification/leetcode/phase31_seed_results_wave1.json`
-  - `audits/leetcode/verification/leetcode/phase31_wave1_delta.md`
-  - `audits/leetcode/verification/leetcode/phase31_wave1_summary.md`
+  - historical artifact `phase31_seed_results_wave1.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_wave1_delta.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_wave1_summary.md` (removed from the lean LeetCode subrepo; recoverable from git history)
   - `crates/sifr/tests/e2e/pass/function_shadowing_builtin_sum.sifr`
   - `crates/sifr/tests/e2e/pass/borrowed_param_shadowing.sifr`
   - `crates/sifr/tests/e2e/pass/tuple_unpack_reassignment.sifr`
@@ -174,12 +180,12 @@ status: complete
   - Open blockers are roadmap-mapped with owners.
   - Phase closure is approved with explicit handoff targets.
 - Delivered artifacts:
-  - `audits/leetcode/verification/leetcode/phase31_scorecard.json`
-  - `audits/leetcode/verification/leetcode/phase31_scorecard.md`
-  - `audits/leetcode/verification/leetcode/phase31_scorecard.md`
-  - `audits/leetcode/scripts/phase31_leetcode_scorecard.py`
-  - `audits/leetcode/scripts/build_phase31_leetcode_scorecard.py`
-  - `audits/leetcode/scripts/test_phase31_leetcode_scorecard.py`
+  - historical artifact `phase31_scorecard.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_scorecard.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `phase31_scorecard.md` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical helper artifact (removed from the lean LeetCode subrepo; recoverable from git history)
 - Scorecard summary (2026-03-11):
   - review status: `external_review_approved`
   - baseline status counts: `PASS=2`, `CHECK_ERROR=46`, `RUN_ERROR=2`
@@ -197,26 +203,26 @@ Phase 31 is closed, but its unresolved compatibility backlog now has a concrete 
 Latest closure-track plan (`2026-04-05`):
 - `issues/ad-hoc-codegen-runtime-build-gap-closure-phase-2026-04-05.md` is marked `ready_to_implement` for the live `codegen_runtime_build_gap=58` baseline.
 - Source artifacts:
-  - `audits/leetcode/verification/leetcode/full_corpus_current_results_20260405_live_rerun1.json`
-  - `audits/leetcode/verification/leetcode/full_corpus_failure_taxonomy_20260405_live_rerun1.json`
-  - `audits/leetcode/verification/leetcode/codegen_runtime_build_gap_breakdown_20260405_v3.csv`
+  - historical artifact `full_corpus_current_results_20260405_live_rerun1.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `full_corpus_failure_taxonomy_20260405_live_rerun1.json` (removed from the lean LeetCode subrepo; recoverable from git history)
+  - historical artifact `codegen_runtime_build_gap_breakdown_20260405_v3.csv` (removed from the lean LeetCode subrepo; recoverable from git history)
 - External review sign-off for this breakdown/phase basis:
   - `reviews/codegen-runtime-build-gap-root-cause-review-pass3.md` (`READY`)
   - `reviews/codegen-runtime-build-gap-root-cause-review-pass4.md` (`READY`)
 
 Latest execution note (`2026-03-11`):
 - `m31_c_stdlib_module_parity` slice 1 is locally validated and tracked in `issues/phase31-m31c-stdlib-module-parity-execution.md`.
-- Targeted six-case rerun artifact: `audits/leetcode/verification/leetcode/phase31_m31c_wave1_results.json`.
+- Targeted six-case rerun artifact: historical artifact `phase31_m31c_wave1_results.json` (removed from the lean LeetCode subrepo; recoverable from git history).
 - Measured outcome for that slice: `PASS=1`, `CHECK_ERROR=5`, `RUN_ERROR=0`, with `0007_reverse_integer` now passing and `0502_ipo` advanced past the original missing-stdlib blocker.
 
 Ownership/mutability boundary closure update (`2026-04-02`):
 - Analysis and execution ledger: `issues/ownership-mutability-boundary-root-cause-2026-04-02.md`.
-- Targeted post-fix artifact: `audits/leetcode/verification/leetcode/ownership_mutability_boundary_targeted_results_20260402_post_fix.md`.
-- Full-corpus rerun artifact: `audits/leetcode/verification/leetcode/full_corpus_current_results_20260402_live_after_ownership_boundary_closure.json`.
-- Post-closure breakdown artifact: `audits/leetcode/verification/leetcode/ownership_mutability_boundary_breakdown_20260402_live_after_closure.json`.
+- Targeted post-fix artifact: historical artifact `ownership_mutability_boundary_targeted_results_20260402_post_fix.md` (removed from the lean LeetCode subrepo; recoverable from git history).
+- Full-corpus rerun artifact: historical artifact `full_corpus_current_results_20260402_live_after_ownership_boundary_closure.json` (removed from the lean LeetCode subrepo; recoverable from git history).
+- Post-closure breakdown artifact: historical artifact `ownership_mutability_boundary_breakdown_20260402_live_after_closure.json` (removed from the lean LeetCode subrepo; recoverable from git history).
 - Outcome: ownership-category first-diagnostic count reduced to `0` in the corpus rerun; residual failures are secondary non-ownership defects.
-- Secondary check-remediation wave 1 artifact: `audits/leetcode/verification/leetcode/ownership_mutability_boundary_check_results_20260402_wave1.md` (`24/47` check-pass).
-- Secondary check-remediation wave 2 artifact: `audits/leetcode/verification/leetcode/ownership_mutability_boundary_check_results_20260402_wave2.md` (`47/47` check-pass).
+- Secondary check-remediation wave 1 artifact: historical artifact `ownership_mutability_boundary_check_results_20260402_wave1.md` (removed from the lean LeetCode subrepo; recoverable from git history) (`24/47` check-pass).
+- Secondary check-remediation wave 2 artifact: historical artifact `ownership_mutability_boundary_check_results_20260402_wave2.md` (removed from the lean LeetCode subrepo; recoverable from git history) (`47/47` check-pass).
 
 - Planned follow-up milestones:
   - `m31_a_optional_narrowing_core`
@@ -268,12 +274,11 @@ Ownership/mutability boundary closure update (`2026-04-02`):
 ### Local validation commands
 - Full local suite:
   - `/Users/yaseralnajjar/work/sifr/codebase/scripts/run_all_tests.sh`
-- Milestone demos:
-  - `cd audits/leetcode && python3 scripts/run_phase31_leetcode.py --manifest verification/leetcode/phase31_demo_corpus.json --output verification/leetcode/phase31_demo_results.json`
-- LeetCode corpus runner:
-  - `cd audits/leetcode && python3 scripts/run_phase31_leetcode.py --manifest verification/leetcode/phase31_seed_corpus.json --output verification/leetcode/phase31_seed_results.json`
+- Historical LeetCode Phase 31 runner artifacts:
+  - removed from the live LeetCode sub-repository; recover from git history if
+    auditing the completed phase.
 - Repeat determinism check:
-  - run the corpus command twice with identical config and diff outputs.
+  - historical requirement for the removed Phase 31 runner artifacts.
 
 ### E2E test expectations
 - Add/maintain E2E tests for:


### PR DESCRIPTION
## Summary

- update the main README to describe the lean LeetCode subrepo after cleanup
- mark Phase 31 generated LeetCode artifacts and obsolete helpers as historical/recoverable from git history instead of live paths
- remove stale parent-doc references to deleted LeetCode subrepo `scripts`, `verification`, and `internal_docs` paths

The corresponding LeetCode cleanup is merged in sifr-lang/leetcode#3.

## Validation

- `scripts/clone_subrepos.sh`
- `scripts/run_all_tests.sh --profile quick`
