### PR TITLE
Point Ruff submodule at Sifr maintenance branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third_party/ruff"]
 	path = third_party/ruff
 	url = https://github.com/sifr-lang/ruff.git
+	branch = sifr/v0.4.10-maintenance

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ the lean LeetCode sub-repository and remain recoverable from its git history.
 ### Restore maintenance submodules
 
 Sifr keeps a fork of Ruff at `third_party/ruff` for parser and AST maintenance.
+The submodule tracks the `sifr/v0.4.10-maintenance` branch.
 
 ```bash
 git submodule update --init --recursive third_party/ruff

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -216,7 +216,7 @@ flowchart LR
 
 ## Crate Structure (Rust Workspace)
 
-**Hybrid dependency approach:** Infrastructure crates are referenced as git dependencies from ruff v0.4.10 (unmodified). Parser and AST crates are vendored forks that may diverge from Python syntax in future milestones. The Ruff fork at `third_party/ruff` is kept as the maintenance reference for comparing and updating those vendored crates.
+**Hybrid dependency approach:** Infrastructure crates are referenced as git dependencies from ruff v0.4.10 (unmodified). Parser and AST crates are vendored forks that may diverge from Python syntax in future milestones. The Ruff fork at `third_party/ruff` tracks `sifr/v0.4.10-maintenance` as the maintenance reference for comparing and updating those vendored crates.
 
 ```
 sifr/
@@ -238,7 +238,7 @@ sifr/
   #   ruff_python_literal     -- literal parsing (string escapes, number formats)
 
   third_party/
-    ruff/                    (sifr-lang/ruff submodule used as the Ruff maintenance reference)
+    ruff/                    (sifr-lang/ruff submodule, branch sifr/v0.4.10-maintenance)
 ```
 
 New crates added per milestone as needed:


### PR DESCRIPTION
## Summary

- Added `sifr/v0.4.10-maintenance` in `sifr-lang/ruff`, based on Ruff `v0.4.10`, with the Sifr parser/AST changes imported under Ruff crate names.
- Updated the `third_party/ruff` submodule pointer to that maintenance branch commit.
- Documented the tracked branch in README and architecture docs.

## Validation
- In `third_party/ruff`: `cargo check -p ruff_python_ast -p ruff_python_parser`
- In `third_party/ruff`: `cargo test -p ruff_python_ast -p ruff_python_parser`
- `git submodule update --init --recursive third_party/ruff`
- `scripts/run_all_tests.sh --profile quick`









