### PR TITLE
Clean planning vocabulary from diagnostics

### DIFF
--- a/crates/sifr/tests/e2e/fail/defaultdict_keyword_constructor_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/defaultdict_keyword_constructor_unsupported.sifr
@@ -1,4 +1,5 @@
 # Reference: phase_psp_b1_defaultdict_keyword_constructor_unsupported
+# expect-error: SIFR-TYPE-0001: defaultdict() does not support keyword arguments
 def main():
     groups = defaultdict(default_factory=list)
     groups["alpha"].append("beta")

--- a/crates/sifr_driver/src/diagnostics.rs
+++ b/crates/sifr_driver/src/diagnostics.rs
@@ -120,7 +120,7 @@ impl CompileError {
         }
         if message.starts_with("module ")
             && message.contains(" resolves to file ")
-            && message.contains("package directories are not supported in this phase")
+            && message.contains("package directories are not supported")
         {
             return Some("SIFR-WORKSPACE-0103");
         }

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -318,7 +318,7 @@ fn namespace_collision_message(
     parent_path: &Path,
 ) -> String {
     format!(
-        "module '{module_name}' resolves to file '{}' but parent name '{parent_name}' is also a module file '{}'; package directories are not supported in this phase",
+        "module '{module_name}' resolves to file '{}' but parent name '{parent_name}' is also a module file '{}'; package directories are not supported",
         path.display(),
         parent_path.display()
     )

--- a/crates/sifr_driver/src/tests/diagnostics.rs
+++ b/crates/sifr_driver/src/tests/diagnostics.rs
@@ -48,7 +48,7 @@ fn test_workspace_resolution_errors_have_stable_codes_and_urls() {
             "SIFR-WORKSPACE-0102",
         ),
         (
-            "module 'helpers.list_node' resolves to file '/tmp/ws/lib/helpers/list_node.sifr' but parent name 'helpers' is also a module file '/tmp/ws/lib/helpers.sifr'; package directories are not supported in this phase",
+            "module 'helpers.list_node' resolves to file '/tmp/ws/lib/helpers/list_node.sifr' but parent name 'helpers' is also a module file '/tmp/ws/lib/helpers.sifr'; package directories are not supported",
             "SIFR-WORKSPACE-0103",
         ),
     ];

--- a/crates/sifr_hir/src/lower/builtin_calls.rs
+++ b/crates/sifr_hir/src/lower/builtin_calls.rs
@@ -9,6 +9,22 @@ pub(super) const DEFAULTDICT_INT_ALIAS: &str = "__compat_defaultdict_int";
 pub(super) const DEFAULTDICT_LIST_ALIAS: &str = "__compat_defaultdict_list";
 pub(super) const DEFAULTDICT_SET_ALIAS: &str = "__compat_defaultdict_set";
 
+pub(super) fn reject_zip_keywords_if_present(call: &ExprCall, ctx: &mut LowerCtx) -> bool {
+    let Some(keyword) = call.arguments.keywords.first() else {
+        return false;
+    };
+    let Some(name) = keyword.arg.as_ref() else {
+        ctx.error("zip() does not support unpacked keyword arguments".to_string());
+        return true;
+    };
+    let message = match name.as_str() {
+        "strict" => "zip() keyword argument 'strict' is not supported".to_string(),
+        other => format!("zip() got an unexpected keyword argument '{other}'"),
+    };
+    ctx.error(message);
+    true
+}
+
 fn iterable_element_type_for_builtin(arg_ty: &Type) -> Option<Type> {
     arg_ty.iterable_element_type().or_else(|| {
         if matches!(arg_ty.resolve_alias(), Type::Any | Type::Unknown) {
@@ -388,7 +404,7 @@ pub(super) fn lower_defaultdict_constructor_call(
     ctx: &mut LowerCtx,
 ) -> Option<HirExpr> {
     if !call.arguments.keywords.is_empty() {
-        ctx.error("defaultdict() does not support keyword arguments in this slice".to_string());
+        ctx.error("defaultdict() does not support keyword arguments".to_string());
         return None;
     }
     if call.arguments.args.is_empty() || call.arguments.args.len() > 2 {

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -5,8 +5,8 @@ use super::builtin_calls::{
     lower_chr_call, lower_defaultdict_constructor_call, lower_dict_constructor_call,
     lower_isinstance_call, lower_len_call, lower_list_constructor_call, lower_ord_call,
     lower_range_call, lower_reveal_type_call, lower_set_constructor_call,
-    lower_tuple_constructor_call, DEFAULTDICT_INT_ALIAS, DEFAULTDICT_LIST_ALIAS,
-    DEFAULTDICT_SET_ALIAS,
+    lower_tuple_constructor_call, reject_zip_keywords_if_present, DEFAULTDICT_INT_ALIAS,
+    DEFAULTDICT_LIST_ALIAS, DEFAULTDICT_SET_ALIAS,
 };
 use super::bytes_methods::{resolve_bytes_method_type, resolve_str_encode_method_type};
 use super::classes::is_hashable_type;
@@ -105,7 +105,7 @@ pub(super) fn lower_number_literal(num: &ExprNumberLiteral) -> Option<HirExpr> {
             Some(HirExpr::IntLiteral(val))
         }
         Number::Float(f) => Some(HirExpr::FloatLiteral(*f)),
-        Number::Complex { .. } => None, // Not supported in M1
+        Number::Complex { .. } => None, // Not supported.
     }
 }
 
@@ -1458,8 +1458,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
 
         // zip(*iters) -> iterator of tuples
         if func_name == "zip" {
-            if !call.arguments.keywords.is_empty() {
-                ctx.error("zip() does not accept keyword arguments in this phase".to_string());
+            if reject_zip_keywords_if_present(call, ctx) {
                 return None;
             }
             let mut args = Vec::with_capacity(call.arguments.args.len());
@@ -1517,7 +1516,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
     // map(func, iterable) -> iterator
     if func_name == "map" {
         if !call.arguments.keywords.is_empty() {
-            ctx.error("map() does not accept keyword arguments in this phase".to_string());
+            ctx.error("map() does not accept keyword arguments".to_string());
             return None;
         }
         if call.arguments.args.len() < 2 {
@@ -1561,7 +1560,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
     }
     if func_name == "filter" {
         if !call.arguments.keywords.is_empty() {
-            ctx.error("filter() does not accept keyword arguments in this phase".to_string());
+            ctx.error("filter() does not accept keyword arguments".to_string());
             return None;
         }
         if call.arguments.args.len() != 2 {

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -207,7 +207,7 @@ fn test_imported_counter_iterable_constructor_remains_unsupported() {
     );
     assert!(
         result.is_err(),
-        "imported sifr.collections.Counter(list[T]) should remain unsupported in this slice"
+        "imported sifr.collections.Counter(list[T]) should remain unsupported"
     );
 }
 
@@ -987,7 +987,7 @@ fn test_iterator_builtins_lower_to_canonical_iterator_call_nodes() {
         if let HirStmt::Let { value, .. } = stmt {
             assert!(
                 !call_uses_legacy_iterator_builtin(value),
-                "legacy iterator builtin call node found in canonical wave2 lowering: {value:?}"
+                "legacy iterator builtin call node found in canonical iterator lowering: {value:?}"
             );
         }
     }
@@ -1298,6 +1298,31 @@ fn test_reversed_enumerate_zip_are_typed_as_iterators() {
 }
 
 #[test]
+fn test_zip_keyword_diagnostics_are_stable() {
+    let strict_result = lower_source(
+        "def main():\n    nums: list[int] = [1, 2]\n    _paired = zip(nums, nums, strict=True)\n",
+    );
+    assert!(strict_result.is_err());
+    let strict_errors = strict_result.unwrap_err();
+    assert!(strict_errors.iter().any(|error| {
+        error
+            .message
+            .contains("zip() keyword argument 'strict' is not supported")
+    }));
+
+    let unexpected_result = lower_source(
+        "def main():\n    nums: list[int] = [1, 2]\n    _paired = zip(nums, nums, bogus=True)\n",
+    );
+    assert!(unexpected_result.is_err());
+    let unexpected_errors = unexpected_result.unwrap_err();
+    assert!(unexpected_errors.iter().any(|error| {
+        error
+            .message
+            .contains("zip() got an unexpected keyword argument 'bogus'")
+    }));
+}
+
+#[test]
 fn test_reversed_rejects_non_reversible_iterator_argument() {
     let result = lower_source(
         "def main():\n    nums: list[int] = [1, 2, 3]\n    it: Iterator[int] = iter(nums)\n    _rev = reversed(it)\n",
@@ -1368,6 +1393,20 @@ fn test_map_rejects_plain_list_annotation_without_materialization() {
 }
 
 #[test]
+fn test_map_rejects_keywords_with_stable_diagnostic() {
+    let result = lower_source(
+        "def add(x: int) -> int:\n    return x + 1\n\ndef main():\n    nums: list[int] = [1, 2]\n    _mapped = map(function=add, iterable=nums)\n",
+    );
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|error| {
+        error
+            .message
+            .contains("map() does not accept keyword arguments")
+    }));
+}
+
+#[test]
 fn test_filter_is_typed_as_iterator() {
     let module = lower_source(
         "def pred(x: int) -> bool:\n    return x % 2 == 0\n\ndef main():\n    nums: list[int] = [1, 2, 3, 4]\n    filtered: Iterator[int] = filter(pred, nums)\n    _vals: list[int] = list(filtered)\n",
@@ -1398,6 +1437,20 @@ fn test_filter_rejects_plain_list_annotation_without_materialization() {
     assert!(errors.iter().any(|e| e
         .message
         .contains("expected 'list[int]', got 'Iterator[int]'")));
+}
+
+#[test]
+fn test_filter_rejects_keywords_with_stable_diagnostic() {
+    let result = lower_source(
+        "def pred(x: int) -> bool:\n    return x > 0\n\ndef main():\n    nums: list[int] = [1, 2]\n    _filtered = filter(function=pred, iterable=nums)\n",
+    );
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|error| {
+        error
+            .message
+            .contains("filter() does not accept keyword arguments")
+    }));
 }
 
 #[test]

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -777,7 +777,7 @@ fn lower_module_impl(
             }
 
             // Check if this is a stdlib import (sifr.*)
-            // All sifr.* modules are now .sifr files compiled in the stdlib phase.
+            // All sifr.* modules are now compiled from .sifr stdlib sources.
             // Resolve from pre-compiled stdlib modules (via externals).
             if is_absolute_import && module_name.starts_with("sifr.") {
                 // Check if there's a pre-compiled stdlib .sifr module in externals

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -398,7 +398,7 @@ mod tests {
         assert!(!scope.is_moved("x"));
     }
 
-    // --- M3: Narrowing tests ---
+    // --- Narrowing tests ---
 
     #[test]
     fn test_narrowing() {

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -273,7 +273,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             })
         }
         "**" => {
-            // Decimal-family exponentiation (integral exponents only in this phase)
+            // Decimal-family exponentiation currently accepts integral exponents only.
             if is_decimal_type(left) && is_integral_numeric_type(right) {
                 return Ok(Type::Decimal);
             }

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -37,7 +37,7 @@ pub enum Type {
     /// Bottom type (function that never returns)
     Never,
 
-    // --- M3: Advanced Type System ---
+    // --- Advanced Type System ---
     /// Union type: value is one of several types (`int | str`)
     /// Members are normalized: flattened, deduplicated, sorted.
     Union(Vec<Type>),
@@ -62,7 +62,7 @@ pub enum Type {
     /// the programmer to prove the type before operating on it.
     Unknown,
 
-    // --- milestone_classes: Basic Classes ---
+    // --- Classes ---
     /// Result type: `Result[T, E]` -> `Result<T, E>` in Rust
     Result(Box<Type>, Box<Type>),
 
@@ -75,7 +75,7 @@ pub enum Type {
         parent_class: Option<String>,
     },
 
-    // --- milestone_protocols: Protocols, Operators, Discriminated Unions ---
+    // --- Protocols, Operators, Discriminated Unions ---
     /// Protocol type: structural interface that maps to Rust `trait`.
     /// Any class with the required methods satisfies the protocol.
     Protocol {
@@ -87,7 +87,7 @@ pub enum Type {
     /// `class Port(int)` -> `struct Port(i64)`
     Newtype { name: String, inner: Box<Type> },
 
-    // --- milestone_generics_impl: Generics ---
+    // --- Generics ---
     /// Type variable: a generic type parameter (e.g., `T` in `def first[T](items: list[T]) -> T`)
     TypeVar(String),
 
@@ -95,7 +95,7 @@ pub enum Type {
     /// Fields: (`parameter_types`, `parameter_conventions`, `return_type`).
     Callable(Vec<Type>, Vec<ParamConvention>, Box<Type>),
 
-    // --- milestone_enums: Enum Types ---
+    // --- Enum Types ---
     /// Enum type: `class Color(Enum): RED = 1; GREEN = 2; BLUE = 3`
     /// Maps to a Rust `#[repr(i64)] enum Color { RED = 1, GREEN = 2, BLUE = 3 }`
     Enum {
@@ -103,7 +103,7 @@ pub enum Type {
         variants: Vec<(String, Option<i64>)>,
     },
 
-    // --- milestone_integer_safety: BigInt ---
+    // --- Integer Safety ---
     /// Arbitrary-precision integer (`bigint` in Sifr, `num_bigint::BigInt` in Rust)
     /// Unlike `int` (i64), `bigint` never overflows — it grows as needed.
     BigInt,
@@ -571,7 +571,7 @@ impl Type {
     /// Returns the Rust type name for code generation.
     ///
     /// For union types, this returns a generated enum name.
-    /// The actual enum definition is emitted by the codegen phase.
+    /// The actual enum definition is emitted during code generation.
     pub fn rust_type(&self) -> String {
         match self {
             Self::Int => "i64".to_string(),
@@ -1627,7 +1627,7 @@ mod tests {
         assert_eq!(compat_defaultdict.contains_element_type(), Some(Type::Str));
     }
 
-    // --- M3: Union type tests ---
+    // --- Union type tests ---
 
     #[test]
     fn test_union_display_name() {


### PR DESCRIPTION
## Summary

- Remove planning vocabulary such as phase, milestone, wave, and slice from compiler diagnostics and nearby source comments.
- Make `zip`, `map`, `filter`, `defaultdict`, and workspace package-directory diagnostics stable and user-facing.
- Add focused regression coverage for iterator keyword diagnostics and update the `defaultdict` fail fixture expectation.

## Validation

- `cargo test -p sifr_hir stable_diagnostic -- --nocapture`
- `cargo test -p sifr_hir keyword_diagnostics -- --nocapture`
- `cargo test -p sifr_driver diagnostics -- --nocapture`
- `cargo test -p sifr_type_system -- --nocapture`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `cargo fmt --check -p sifr_type_system -p sifr_hir -p sifr_codegen -p sifr_driver -p sifr`
- `scripts/run_all_tests.sh --profile quick`
