### PR TITLE
[codex] Replace avoidable production unwraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ needless_raw_string_hashes = "allow"
 print_stdout = "warn"
 print_stderr = "warn"
 dbg_macro = "warn"
+# Production targets should stay free of unchecked unwrap/expect calls.
+# Test targets allow these while assertion cleanup is handled separately.
+unwrap_used = "warn"
+expect_used = "warn"
 
 [profile.release]
 lto = "thin"

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -5,6 +5,7 @@
 //!   sifr run <file.sifr>      Compile and run
 //!   sifr check <file.sifr>    Type-check only
 //!   sifr emit <file.sifr>     Show generated Rust code
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build, build_cached_project, build_cached_single_file,

--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -13,6 +13,7 @@
 //! - `SIFR_E2E_RUN_JOBS`: bounded parallel run workers.
 //! - `SIFR_E2E_CARGO_BUILD_JOBS`: cargo jobs per generated group build.
 //! - `SIFR_E2E_DISABLE_CACHE=1` disables cache reuse.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};

--- a/crates/sifr/tests/validation_contracts.rs
+++ b/crates/sifr/tests/validation_contracts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 #[path = "validation_contracts/mod.rs"]
 mod validation_contracts;
 

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -96,10 +96,10 @@ impl RustEmitter {
                 if matches!(func.as_ref(), RustExpr::Path(path) if path.len() == 1 && path[0] == "Some")
                     && args.len() == 1 =>
             {
-                let inner = args
-                    .into_iter()
-                    .next()
-                    .expect("checked Some(_) argument count");
+                let mut args_iter = args.into_iter();
+                let Some(inner) = args_iter.next() else {
+                    unreachable!("Some(_) call must have exactly one argument");
+                };
                 if Self::is_box_new_call_expr(&inner) {
                     RustExpr::FnCall {
                         func,

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -627,9 +627,9 @@ fn registry_ensure_some_box_inner(expr: RustExpr) -> RustExpr {
             if registry_is_some_ctor(func.as_ref()) && args.len() == 1 =>
         {
             let mut args_iter = args.into_iter();
-            let inner = args_iter
-                .next()
-                .expect("checked args.len() == 1 for Some(_) call");
+            let Some(inner) = args_iter.next() else {
+                unreachable!("Some(_) call must have exactly one argument");
+            };
             if matches!(&inner, RustExpr::FnCall { func, .. } if registry_is_box_new_ctor(func.as_ref()))
             {
                 RustExpr::FnCall {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1,5 +1,6 @@
 //! Sifr Code Generation: translates typed HIR into Rust source code.
 #![allow(dead_code)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 mod rust_ir;
 pub use rust_ir::*;
 mod render;

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -3800,9 +3800,9 @@ impl RustEmitter {
                 let mut lhs_expr = left.as_ref();
                 let mut lowered_chain: Option<crate::RustExpr> = None;
                 for (idx, op) in ops.iter().enumerate() {
-                    let rhs_expr = comparators
-                        .get(idx)
-                        .expect("compare ops/comparators length should match");
+                    let Some(rhs_expr) = comparators.get(idx) else {
+                        unreachable!("compare ops/comparators lengths checked equal");
+                    };
                     let lowered_op = match op.as_str() {
                         "==" | "!=" | "<" | "<=" | ">" | ">=" => op.clone(),
                         "is" => "==".to_string(),
@@ -5058,9 +5058,9 @@ impl RustEmitter {
                     && args.len() == 1 =>
             {
                 let mut args_iter = args.into_iter();
-                let inner = args_iter
-                    .next()
-                    .expect("checked args.len() == 1 for Some(_) call");
+                let Some(inner) = args_iter.next() else {
+                    unreachable!("Some(_) call must have exactly one argument");
+                };
                 if Self::is_box_new_call_expr_for_ir(&inner) {
                     crate::RustExpr::FnCall {
                         func,
@@ -6337,6 +6337,11 @@ impl RustEmitter {
                 crate::resolve_alias_type_for_plain_call(option_inner_ty),
                 Type::Int | Type::LiteralInt(_) | Type::BigInt | Type::Float
             ) {
+                let Some(zero_literal) =
+                    Self::zero_literal_for_numeric_truthiness_type_for_ir(option_inner_ty)
+                else {
+                    unreachable!("numeric Option truthiness guard must have a zero literal");
+                };
                 return Ok(Some(crate::RustExpr::MethodCall {
                     receiver: Box::new(lowered_option_expr),
                     method: "is_some_and".to_string(),
@@ -6348,12 +6353,7 @@ impl RustEmitter {
                         body: Box::new(crate::RustExpr::BinOp {
                             left: Box::new(crate::RustExpr::Ident("__v".to_string())),
                             op: "!=".to_string(),
-                            right: Box::new(
-                                Self::zero_literal_for_numeric_truthiness_type_for_ir(
-                                    option_inner_ty,
-                                )
-                                .expect("numeric option inner types should map to a zero literal"),
-                            ),
+                            right: Box::new(zero_literal),
                         }),
                         is_move: false,
                     }],

--- a/crates/sifr_driver/src/lib.rs
+++ b/crates/sifr_driver/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! Stdlib `.sifr` files are embedded in the compiler binary via `include_str!`.
 //! They are compiled before user code (two-phase compilation).
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 mod build;
 mod diagnostics;

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -253,7 +253,10 @@ fn is_test_module_name(module_name: &str) -> bool {
 pub(crate) fn discover_test_root_modules(test_dir: &Path) -> BTreeMap<String, PathBuf> {
     let mut test_files_by_module = BTreeMap::new();
     for path in discover_project_sifr_files(test_dir) {
-        let module_name = path.file_stem().unwrap().to_string_lossy().to_string();
+        let Some(file_stem) = path.file_stem() else {
+            continue;
+        };
+        let module_name = file_stem.to_string_lossy().to_string();
         if is_test_module_name(&module_name) {
             test_files_by_module.insert(module_name, path);
         }

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -123,7 +123,11 @@ pub(crate) fn build_test_runner_project(
         )
         .map_err(|error| vec![error])?;
         all_rust_code.push_str("// Tests from: ");
-        all_rust_code.push_str(&test_file.file_name().unwrap().to_string_lossy());
+        if let Some(file_name) = test_file.file_name() {
+            all_rust_code.push_str(&file_name.to_string_lossy());
+        } else {
+            all_rust_code.push_str(&test_file.display().to_string());
+        }
         all_rust_code.push('\n');
         all_rust_code.push_str(&codegen_result.rust_source);
         all_rust_code.push('\n');

--- a/crates/sifr_hir/src/lib.rs
+++ b/crates/sifr_hir/src/lib.rs
@@ -4,6 +4,7 @@
 //! - Name resolution (every name reference resolved to a definition)
 //! - Type checking (every expression carries its resolved type)
 //! - Ownership tracking (move vs copy semantics)
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod cfg;
 mod hir_nodes;

--- a/crates/sifr_hir/src/lower/nested_function_inference.rs
+++ b/crates/sifr_hir/src/lower/nested_function_inference.rs
@@ -770,13 +770,9 @@ fn analyze_stmt(
             }
         }
         Stmt::FunctionDef(func) => {
-            if !states.contains_key(func.name.as_str()) {
+            let Some(state) = states.get(func.name.as_str()).cloned() else {
                 return;
-            }
-            let state = states
-                .get(func.name.as_str())
-                .cloned()
-                .expect("state present");
+            };
             let outer_names = env.vars.keys().cloned().collect::<HashSet<_>>();
             let param_names = state
                 .params

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -953,11 +953,11 @@ pub(super) fn lower_pattern(
                     ..
                 }) = &class_ty
                 {
-                    let found = class_fields
+                    let Some(field_ty) = class_fields
                         .iter()
                         .find(|(n, _)| n == &field_name)
-                        .map(|(_, t)| t.clone());
-                    if found.is_none() {
+                        .map(|(_, t)| t.clone())
+                    else {
                         ctx.error(format!(
                             "class '{}' has no field '{}' — available fields: {}",
                             class_name,
@@ -969,8 +969,8 @@ pub(super) fn lower_pattern(
                                 .join(", ")
                         ));
                         return None;
-                    }
-                    found.unwrap()
+                    };
+                    field_ty
                 } else {
                     Type::Any
                 };
@@ -1903,7 +1903,7 @@ pub(super) fn detect_narrowing_condition(
             if conditions.is_empty() {
                 None
             } else if conditions.len() == 1 {
-                Some(conditions.into_iter().next().unwrap())
+                conditions.into_iter().next()
             } else {
                 Some(NarrowingCondition::And(conditions))
             }
@@ -1918,7 +1918,7 @@ pub(super) fn detect_narrowing_condition(
             if conditions.is_empty() {
                 None
             } else if conditions.len() == 1 {
-                Some(conditions.into_iter().next().unwrap())
+                conditions.into_iter().next()
             } else {
                 Some(NarrowingCondition::Or(conditions))
             }

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Defines the type representations, type inference, type checking,
 //! and subtyping rules for the Sifr language.
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 mod check;
 pub mod infer;

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -22,7 +22,14 @@ pub fn make_union(types: Vec<Type>) -> Type {
 
     match members.len() {
         0 => Type::Never,
-        1 => members.into_iter().next().unwrap(),
+        1 => {
+            let mut iter = members.into_iter();
+            if let Some(member) = iter.next() {
+                member
+            } else {
+                unreachable!("single-element union arm must contain one member")
+            }
+        }
         _ => Type::Union(members),
     }
 }

--- a/reviews/unwrap-expect-cleanup-review-2026-04-27.md
+++ b/reviews/unwrap-expect-cleanup-review-2026-04-27.md
@@ -1,0 +1,245 @@
+# Review: unwrap/expect cleanup + workspace `unwrap_used`/`expect_used` lints
+
+**Date:** 2026-04-27
+**Scope:** Uncommitted diff against `main` covering 9 files. The diff (a) enables workspace-wide `clippy::unwrap_used` and `clippy::expect_used` lints, and (b) rewrites a small number of `.unwrap()` / `.expect(...)` sites to satisfy them.
+
+**Verdict:** Functionally safe under current invariants. Most `unwrap`/`expect` removals were provably safe before and remain provably safe after. The cleanup, however, repeatedly trades **loud assertion failures** for **silent fallbacks that emit invalid Rust or drop information**, which weakens our defenses if those invariants ever drift. The lint enablement is also incomplete: ~1009 sites under `--all-targets` still trigger the lints, so `cargo clippy --workspace --all-targets -- -D warnings` fails. The default `cargo clippy --workspace -- -D warnings` (CI's command) passes.
+
+---
+
+## Findings (ordered by severity)
+
+### 🟠 Medium — `--all-targets` clippy gate is now broken
+
+**File:** [Cargo.toml](Cargo.toml:86-87)
+
+```toml
+unwrap_used = "warn"
+expect_used = "warn"
+```
+
+These lints inherit into every workspace crate via `[lints] workspace = true`.
+
+- `cargo clippy --workspace -- -D warnings` (the command from `AGENTS.md` and `.github/workflows/local-first-validation.yml:23`) — **passes**. Production lib code is clean.
+- `cargo clippy --workspace --all-targets -- -D warnings` — **fails with 1009 warnings → 140 errors in `sifr_hir` (lib test) alone**. Test files (`*_tests.rs`, `tests/*.rs`, `crates/sifr/tests/e2e.rs`, etc.) and bin targets are full of `.unwrap()` calls that the new lints now flag.
+
+The CI workflow currently runs the non-`--all-targets` form and the step is wrapped in `continue-on-error: true`, so this won't break the pipeline today. But:
+
+1. Anyone running `cargo clippy --all-targets` locally (a very common defensive pattern, and what most editor LSP integrations send) will be flooded with warnings the moment they touch a test file.
+2. If/when the CI step is promoted from advisory to required, or gains `--all-targets`, it will fail catastrophically.
+3. The advisory comment in the workflow says "until legacy workspace lint debt is burned down" — this change *adds* ~1000 lint hits in tests rather than burning anything down.
+
+**Recommendation:** Either (a) defer enabling these lints until tests are also cleaned, (b) add `#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]` (or per-test-module `#[allow]`) before flipping the workspace flag, or (c) explicitly carve `tests` out via `[lints.clippy]` overrides in test-only Cargo configurations.
+
+---
+
+### 🟡 Low — Dead-but-buggy fallback emits invalid `Some()` (no args)
+
+**Files / sites:**
+- [crates/sifr_codegen/src/class_method_emitter.rs:99-102](crates/sifr_codegen/src/class_method_emitter.rs:99-102) (`ensure_some_box_inner`)
+- [crates/sifr_codegen/src/intrinsic_method_emitters.rs:629-632](crates/sifr_codegen/src/intrinsic_method_emitters.rs:629-632) (`registry_ensure_some_box_inner`)
+- [crates/sifr_codegen/src/stmt_support_emitter.rs:5060-5063](crates/sifr_codegen/src/stmt_support_emitter.rs:5060-5063) (`ensure_some_box_inner_for_ir`)
+
+All three sites have the same shape:
+
+```rust
+let mut args_iter = args.into_iter();
+let Some(inner) = args_iter.next() else {
+    return RustExpr::FnCall { func, args: vec![] };
+};
+```
+
+The arm is guarded by `args.len() == 1`, so `next()` is provably `Some(_)` and the `else { ... }` branch is unreachable. But what the unreachable branch *does* is produce a `Some()` call with **zero arguments**, which is invalid Rust (`Some` is unary) — meaning if an upstream invariant ever broke, we'd silently emit code that fails at the rustc stage with a confusing error far from the cause, rather than panicking at the codegen site with the clear `expect` message that used to be there.
+
+**Recommendation:** Replace the silent `else { ... }` with `unreachable!("Some(_) call must have exactly one argument")` (clippy::unwrap_used does not flag `unreachable!`), or restructure to consume the single argument without re-emitting a `Some(...)` envelope. As written, the dead branch is a small bug waiting for an invariant slip.
+
+---
+
+### 🟡 Low — Compare lowering silently bails to generic fallback
+
+**File:** [crates/sifr_codegen/src/stmt_support_emitter.rs:3799-3805](crates/sifr_codegen/src/stmt_support_emitter.rs:3799-3805)
+
+Original:
+```rust
+let rhs_expr = comparators
+    .get(idx)
+    .expect("compare ops/comparators length should match");
+```
+
+New:
+```rust
+let Some(rhs_expr) = comparators.get(idx) else {
+    return Ok(None);
+};
+```
+
+The enclosing `if !ops.is_empty() && ops.len() == comparators.len()` guard at line 3799 makes `comparators.get(idx)` provably `Some(_)` for `idx ∈ 0..ops.len()`. Currently safe.
+
+The risk is that `Ok(None)` from this branch tells the parent to fall through to a generic lowering path. So if an upstream change ever produced `ops.len() != comparators.len()` (or any other inconsistent AST) **after** the guard — for instance, if the guard is loosened in a future refactor and someone forgets this site — the code would emit a *different* lowering for the comparison without raising any compile error, with potentially silent wrong-result behavior in user code. The original `.expect()` would have panicked loudly during compilation, exposing the bug.
+
+**Recommendation:** Same as above — `unreachable!("ops/comparators lengths checked equal")` preserves the loud failure while satisfying the lint.
+
+---
+
+### 🟡 Low — Numeric-truthiness lowering silently drops the special case
+
+**File:** [crates/sifr_codegen/src/stmt_support_emitter.rs:6336-6356](crates/sifr_codegen/src/stmt_support_emitter.rs:6336-6356)
+
+The early-out hoist:
+```rust
+let Some(zero_literal) =
+    Self::zero_literal_for_numeric_truthiness_type_for_ir(option_inner_ty)
+else {
+    return Ok(None);
+};
+```
+
+Cross-referencing the helper at [stmt_support_emitter.rs:6517-6539](crates/sifr_codegen/src/stmt_support_emitter.rs:6517-6539):
+- Outer guard accepts `Type::Int | Type::LiteralInt(_) | Type::BigInt | Type::Float` (after `resolve_alias_type_for_plain_call`).
+- `zero_literal_for_numeric_truthiness_type_for_ir` returns `Some(...)` for exactly the same set.
+
+So `None` is unreachable today — the change is semantically equivalent. The latent risk is the same as the previous two findings: if either the outer guard or the helper drifts, a numeric-`Option` truthiness check (e.g., `if x:` where `x: int | None`) would silently fall back to the generic `is_some_and(|v| v)` or default lowering paths instead of `is_some_and(|v| v != 0)`. That's a *behavioral* divergence — `Some(0)` is supposed to be falsy in Sifr, and the original `expect` would have caught the regression at compile time.
+
+**Recommendation:** `unreachable!()` (or keep the `expect` and `#[allow(clippy::expect_used)]` it). The early-return masks a class of bugs the `expect` was specifically designed to catch.
+
+---
+
+### 🟢 Very Low — Unreachable single-element `Type::Never` fallback in `make_union`
+
+**File:** [crates/sifr_type_system/src/union.rs:25-32](crates/sifr_type_system/src/union.rs:25-32)
+
+```rust
+1 => {
+    let mut iter = members.into_iter();
+    if let Some(member) = iter.next() {
+        member
+    } else {
+        Type::Never
+    }
+}
+```
+
+Inside the `1 =>` arm, `members.len() == 1` is established by the surrounding `match`, so `iter.next()` is always `Some`. The `Type::Never` fallback is dead code, and worse, **semantically misleading**: `Type::Never` means "this expression has no possible value" — a pathological value to return when you nominally have one type. A reader scanning `make_union` cold could plausibly conclude that single-element vectors sometimes normalize to `Never`, which is wrong.
+
+The existing test [union.rs:276-279](crates/sifr_type_system/src/union.rs:276-279) (`test_make_union_single_element`) covers the correct path; nothing exercises the dead branch.
+
+**Recommendation:** Either `_ => members.into_iter().next().expect("len == 1")` with `#[allow(clippy::expect_used)]`, or restructure with `match members.into_iter().next() { Some(t) if … => t, … }` so there's no dead arm. Failing that, leave a comment that the `Type::Never` is unreachable.
+
+---
+
+### 🟢 Very Low — Pattern-field lookup `let-else` rewrite
+
+**File:** [crates/sifr_hir/src/lower/statements.rs:953-973](crates/sifr_hir/src/lower/statements.rs:953-973)
+
+Replaces a `find(...).map(...)` + `is_none` check + `.unwrap()` with a `let-else`. Semantically identical, slightly cleaner, no regression. The error path (calling `ctx.error(...)` and returning `None`) is preserved verbatim.
+
+---
+
+### 🟢 Very Low — Narrowing-condition single-element rewrite
+
+**File:** [crates/sifr_hir/src/lower/statements.rs:1903-1924](crates/sifr_hir/src/lower/statements.rs:1903-1924)
+
+```rust
+} else if conditions.len() == 1 {
+    conditions.into_iter().next()  // was: Some(conditions.into_iter().next().unwrap())
+}
+```
+
+`conditions.into_iter().next()` returns `Option<NarrowingCondition>`, which under the `len() == 1` guard is always `Some(_)`. The original wrapped this in an explicit `Some(...)`, which was redundant. Fully equivalent semantically, and the surrounding function returns `Option<NarrowingCondition>` so types line up. **No regression.**
+
+---
+
+### 🟢 Very Low — Nested function inference `let-else` rewrite
+
+**File:** [crates/sifr_hir/src/lower/nested_function_inference.rs:772-775](crates/sifr_hir/src/lower/nested_function_inference.rs:772-775)
+
+Replaces `if !contains_key { return; }` + `.expect("state present")` with a single `let Some(state) = states.get(...).cloned() else { return; }`. Equivalent semantically, **strictly better**: it removes the redundant double hash lookup (`contains_key` then `get`) that the original used to satisfy the borrow checker. No regression.
+
+---
+
+### 🟢 Very Low — `discover_test_root_modules` skips paths without a stem
+
+**File:** [crates/sifr_driver/src/project/discovery.rs:255-262](crates/sifr_driver/src/project/discovery.rs:255-262)
+
+Original `path.file_stem().unwrap()` would panic if `file_stem()` returned `None`. New code does `continue` instead.
+
+`Path::file_stem()` returns `None` only when the final path component is `..`, which `read_dir` won't produce (it filters self/parent). The producer at [discovery.rs:235-247](crates/sifr_driver/src/project/discovery.rs:235-247) further filters by `extension == "sifr"`, which is impossible for `..` anyway. So the `continue` branch is unreachable today.
+
+The behavioral divergence (`continue` vs panic) only surfaces if some future caller bypasses `discover_project_sifr_files` or the dir layout changes. In that hypothetical, silently dropping a file is arguably worse than a panic — but it's a low-impact edge case in a pure discovery routine, not codegen.
+
+---
+
+### 🟢 Very Low — Test-runner comment fallback uses full path
+
+**File:** [crates/sifr_driver/src/test_runner/orchestrator.rs:125-130](crates/sifr_driver/src/test_runner/orchestrator.rs:125-130)
+
+The result is purely a `// Tests from: <name>` comment in the generated Rust source. Original would panic for paths ending in `..`; new code falls back to `test_file.display().to_string()` (full path with directory components). The fallback is a generated comment, so the worst case is a slightly noisier comment line. **No functional impact, no regression.**
+
+---
+
+## Cross-cutting observations
+
+### 1. The replacement style uniformly weakens diagnostics
+
+Six of the eight code-path changes (the three `Some(...)` envelope rewrites in codegen, the Compare lowering, the numeric-truthiness lowering, the Compare get-by-index) replace an `expect`/`unwrap` whose only role was to assert an *invariant maintained by code a few lines up*. The originals were intentional "this can never happen" panics — exactly the pattern AGENTS.md endorses ("`assert!` is only for programmer invariants").
+
+The new code converts those panics into one of:
+- `return Ok(None)` → silently bail out and let the caller emit different code,
+- `return RustExpr::FnCall { func, args: vec![] }` → silently emit invalid `Some()`,
+- `Type::Never` fallback → silently produce a semantically wrong type.
+
+This swaps "noisy compile-time bug" for "subtle codegen divergence". For a compiler whose stated guarantee is "if it compiles, it works," this is the wrong direction.
+
+The clippy `unwrap_used`/`expect_used` lints are not opposed to this guarantee — they're meant to push *user-input-driven* unwraps toward `Result`. For programmer-invariant assertions in compiler internals, the project-correct replacement is `unreachable!()` (which clippy permits) or a `#[allow(clippy::expect_used)]` with a comment, not a silent fallback.
+
+### 2. The change set is mechanically correct but doesn't audit upstream guards
+
+For each `expect`/`unwrap` removed, the only thing that makes the new code safe is an invariant established a few lines above. None of those invariants are commented or asserted independently. If a future refactor ever loosens (e.g.) the `ops.len() == comparators.len()` guard, the dead branch becomes live and produces wrong output silently. Adding `unreachable!()` instead of a fallback both satisfies the lint and pins the invariant.
+
+### 3. Lint enablement is partial
+
+The lint is on, but ~1009 hits in test code remain unaddressed. Either pre-suppress them per-target/per-crate, or finish the burndown before flipping the lint. Leaving it half-on creates a tax on future test edits and a tripwire for `--all-targets`.
+
+---
+
+## Actionable recommendations
+
+In rough priority order:
+
+1. **Replace silent fallbacks with `unreachable!()`** at these six sites — they all assert invariants, none should silently degrade:
+   - [class_method_emitter.rs:99-102](crates/sifr_codegen/src/class_method_emitter.rs:99-102)
+   - [intrinsic_method_emitters.rs:629-632](crates/sifr_codegen/src/intrinsic_method_emitters.rs:629-632)
+   - [stmt_support_emitter.rs:3803](crates/sifr_codegen/src/stmt_support_emitter.rs:3803)
+   - [stmt_support_emitter.rs:5061](crates/sifr_codegen/src/stmt_support_emitter.rs:5061)
+   - [stmt_support_emitter.rs:6340-6343](crates/sifr_codegen/src/stmt_support_emitter.rs:6340-6343)
+   - [union.rs:30](crates/sifr_type_system/src/union.rs:30)
+
+2. **Decide on the test-target lint policy** before this lands:
+   - **Option A** (recommended for a small change): add `#![allow(clippy::unwrap_used, clippy::expect_used)]` at the top of each `*_tests.rs` / `tests/*.rs` module, scoped under `#[cfg(test)]`.
+   - **Option B**: leave the lints at `warn` (current) but add a comment in `Cargo.toml` flagging that `--all-targets` is intentionally still dirty until follow-up cleanup.
+   - **Option C**: revert this commit's `Cargo.toml` change until the test-side cleanup is staged.
+
+3. **Restructure `make_union`** so the single-element arm doesn't have a dead `Type::Never` branch — either pop without the surrounding `match members.len()` arm, or keep the original `unwrap()` with `#[allow(clippy::unwrap_used)]` and a one-line justification comment.
+
+4. **Keep** the four refactors that strictly improve the code with no risk:
+   - [statements.rs:953-973](crates/sifr_hir/src/lower/statements.rs:953-973) (pattern field lookup `let-else`)
+   - [statements.rs:1903-1924](crates/sifr_hir/src/lower/statements.rs:1903-1924) (narrowing single-element)
+   - [nested_function_inference.rs:772-775](crates/sifr_hir/src/lower/nested_function_inference.rs:772-775) (state lookup `let-else`)
+   - [discovery.rs:255-262](crates/sifr_driver/src/project/discovery.rs:255-262) (file_stem skip)
+   - [orchestrator.rs:125-130](crates/sifr_driver/src/test_runner/orchestrator.rs:125-130) (comment fallback)
+
+5. **No tests added.** The cleanup doesn't change observable behavior, but the new dead-branch fallbacks now exist in the binary. Consider adding focused unit tests that exercise `make_union(vec![Type::Int])`, `ensure_some_box_inner` with a typical `Some(x)`, and the numeric-truthiness condition lowering for `int | None`, so a future regression in the upstream guard is caught at the level of the helper rather than as a downstream e2e drift.
+
+---
+
+## Risk summary
+
+| Concern | Severity | Triggered by |
+|---|---|---|
+| `--all-targets` clippy fails with ~1009 warnings | Medium | Any local clippy run with `--all-targets` |
+| Codegen helpers silently emit invalid `Some()` if invariants drift | Low | Future refactor that loosens an outer guard |
+| Compare/numeric-truthiness lowering silently bails to generic path | Low | Same — invariant drift |
+| `make_union` dead `Type::Never` branch is misleading | Very Low | Code reading / future refactor |
+| Behavior under current invariants | **None** | — |
+
+No correctness regression in the current, in-tree state. The risk is in the future: the cleanup makes the codegen pipeline quieter when its invariants break, which is a step backward for a compiler that needs loud failures during development.


### PR DESCRIPTION
## Summary
- Replace avoidable production `unwrap`/`expect` calls with explicit handling or invariant `unreachable!` paths.
- Add workspace Clippy lint coverage for production `unwrap`/`expect` use.
- Scope existing test-target `unwrap`/`expect` usage with explicit test-only allowances.
- Include the requested Claude review artifact under `reviews/`.

## Validation
- `cargo fmt`
- `cargo clippy --workspace --all-targets -- -A warnings -D clippy::unwrap_used -D clippy::expect_used`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`
- `git diff --check`

## Notes
`cargo clippy --workspace --all-targets -- -D warnings` still reports pre-existing test-only pedantic warnings unrelated to unwrap/expect cleanup.
