### PR TITLE
[codex] Update Sifr stable dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,29 +37,29 @@ sifr_hir = { path = "crates/sifr_hir" }
 sifr_codegen = { path = "crates/sifr_codegen" }
 sifr_driver = { path = "crates/sifr_driver" }
 
-# External dependencies (versions from ruff upstream)
-aho-corasick = { version = "1.1.3" }
-annotate-snippets = { version = "0.9.2", features = ["color"] }
-anyhow = { version = "1.0.80" }
-bitflags = { version = "2.5.0" }
-bstr = { version = "1.9.1" }
-insta = { version = "1.35.1" }
-is-macro = { version = "0.3.5" }
-itertools = { version = "0.13.0" }
-memchr = { version = "2.7.1" }
-once_cell = { version = "1.19.0" }
-rustc-hash = { version = "1.1.0" }
-schemars = { version = "0.8.16" }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = { version = "1.0.113", features = ["preserve_order"] }
-serde_test = { version = "1.0.152" }
+# External dependencies (latest stable for Sifr; the excluded Ruff fork carries its own pins).
+aho-corasick = { version = "1.1.4" }
+annotate-snippets = { version = "0.12.15", features = ["color"] }
+anyhow = { version = "1.0.102" }
+bitflags = { version = "2.11.1" }
+bstr = { version = "1.12.1" }
+insta = { version = "1.47.2" }
+is-macro = { version = "0.3.7" }
+itertools = { version = "0.14.0" }
+memchr = { version = "2.8.0" }
+once_cell = { version = "1.21.4" }
+rustc-hash = { version = "2.1.2" }
+schemars = { version = "1.2.1" }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
+serde_test = { version = "1.0.177" }
 static_assertions = { version = "1.1.0" }
-toml = { version = "0.8" }
+toml = { version = "1.1.2" }
 unic-ucd-category = { version = "0.9" }
-unicode-ident = { version = "1.0.12" }
-unicode_names2 = { version = "1.2.2" }
-unicode-normalization = { version = "0.1.23" }
-walkdir = { version = "2.3.2" }
+unicode-ident = { version = "1.0.24" }
+unicode_names2 = { version = "2.0.0" }
+unicode-normalization = { version = "0.1.25" }
+walkdir = { version = "2.5.0" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 sifr_driver = { workspace = true }
 sifr_python_ast = { workspace = true }
 sifr_python_parser = { workspace = true }
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -494,11 +494,32 @@ fn infer_dependencies(
     if rust_source.contains("regex::") {
         crates.insert("regex".to_string());
     }
-    if rust_source.contains("rand::thread_rng") {
+    if rust_source.contains("rand::rng") {
         crates.insert("rand".to_string());
     }
     if rust_source.contains("rand_distr::") {
         crates.insert("rand_distr".to_string());
+    }
+    if rust_source.contains("chrono::") {
+        crates.insert("chrono".to_string());
+    }
+    if rust_source.contains("md5::") {
+        crates.insert("md5".to_string());
+    }
+    if rust_source.contains("uuid::") {
+        crates.insert("uuid".to_string());
+    }
+    if rust_source.contains("toml::") {
+        crates.insert("toml".to_string());
+    }
+    if rust_source.contains("flate2::") {
+        crates.insert("flate2".to_string());
+    }
+    if rust_source.contains("zip::") {
+        crates.insert("zip".to_string());
+    }
+    if rust_source.contains("base64::") {
+        crates.insert("base64".to_string());
     }
     if rust_source.contains("sha1::") {
         crates.insert("sha1".to_string());
@@ -883,41 +904,50 @@ fn generate_cargo_toml(
         match module_name.as_str() {
             "sifr.json" | "sifr.collections" | "_sifr.json" | "_sifr.collections" => {
                 deps.insert(
-                    "serde_json = { version = \"1\", features = [\"preserve_order\"] }".to_string(),
+                    "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
+                        .to_string(),
                 );
-                deps.insert("serde = { version = \"1\", features = [\"derive\"] }".to_string());
+                deps.insert(
+                    "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
+                );
             }
             "sifr.time" | "_sifr.time" | "sifr.datetime" | "_sifr.datetime" => {
-                deps.insert("chrono = \"0.4\"".to_string());
+                deps.insert("chrono = \"0.4.44\"".to_string());
             }
-            "sifr.random" | "_sifr.crypto" | "sifr.uuid" | "_sifr.uuid" => {
-                deps.insert("rand = \"0.8\"".to_string());
-                deps.insert("rand_distr = \"0.4\"".to_string());
+            "sifr.random" | "_sifr.crypto" => {
+                deps.insert("rand = \"0.10.1\"".to_string());
+                deps.insert("rand_distr = \"0.6.0\"".to_string());
+            }
+            "sifr.uuid" | "_sifr.uuid" => {
+                deps.insert("rand = \"0.10.1\"".to_string());
+                deps.insert(
+                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string(),
+                );
             }
             "sifr.re" | "_sifr.regex" => {
-                deps.insert("regex = \"1\"".to_string());
+                deps.insert("regex = \"1.12.3\"".to_string());
             }
             "sifr.hash" | "sifr.hashlib" => {
-                deps.insert("sha2 = \"0.10\"".to_string());
-                deps.insert("md5 = \"0.7\"".to_string());
-                deps.insert("sha1 = \"0.10\"".to_string());
-                deps.insert("blake2 = \"0.10\"".to_string());
+                deps.insert("sha2 = \"0.11.0\"".to_string());
+                deps.insert("md5 = \"0.8.0\"".to_string());
+                deps.insert("sha1 = \"0.11.0\"".to_string());
+                deps.insert("blake2 = \"0.10.6\"".to_string());
             }
             "sifr.encoding" | "sifr.base64" => {
-                deps.insert("base64 = \"0.22\"".to_string());
+                deps.insert("base64 = \"0.22.1\"".to_string());
             }
             "sifr.tomllib" | "_sifr.toml" => {
                 deps.insert(
-                    "toml = { version = \"0.8\", features = [\"preserve_order\"] }".to_string(),
+                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string(),
                 );
             }
             "sifr.gzip" | "sifr.zipfile" | "_sifr.compress" => {
-                deps.insert("flate2 = \"1\"".to_string());
-                deps.insert("zip = \"0.6\"".to_string());
+                deps.insert("flate2 = \"1.1.9\"".to_string());
+                deps.insert("zip = \"8.6.0\"".to_string());
             }
             "_bigint" => {
-                deps.insert("num-bigint = \"0.4\"".to_string());
-                deps.insert("num-traits = \"0.2\"".to_string());
+                deps.insert("num-bigint = \"0.4.6\"".to_string());
+                deps.insert("num-traits = \"0.2.19\"".to_string());
             }
             _ => {}
         }
@@ -927,62 +957,70 @@ fn generate_cargo_toml(
         match crate_name.as_str() {
             "serde_json" => {
                 deps.insert(
-                    "serde_json = { version = \"1\", features = [\"preserve_order\"] }".to_string(),
+                    "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
+                        .to_string(),
                 );
-                deps.insert("serde = { version = \"1\", features = [\"derive\"] }".to_string());
+                deps.insert(
+                    "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
+                );
             }
             "chrono" => {
-                deps.insert("chrono = \"0.4\"".to_string());
+                deps.insert("chrono = \"0.4.44\"".to_string());
             }
             "rand" => {
-                deps.insert("rand = \"0.8\"".to_string());
+                deps.insert("rand = \"0.10.1\"".to_string());
             }
             "rand_distr" => {
-                deps.insert("rand_distr = \"0.4\"".to_string());
+                deps.insert("rand_distr = \"0.6.0\"".to_string());
             }
             "regex" => {
-                deps.insert("regex = \"1\"".to_string());
+                deps.insert("regex = \"1.12.3\"".to_string());
             }
             "sha2" => {
-                deps.insert("sha2 = \"0.10\"".to_string());
+                deps.insert("sha2 = \"0.11.0\"".to_string());
             }
             "md5" => {
-                deps.insert("md5 = \"0.7\"".to_string());
+                deps.insert("md5 = \"0.8.0\"".to_string());
             }
             "sha1" => {
-                deps.insert("sha1 = \"0.10\"".to_string());
+                deps.insert("sha1 = \"0.11.0\"".to_string());
+            }
+            "uuid" => {
+                deps.insert(
+                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string(),
+                );
             }
             "blake2" => {
-                deps.insert("blake2 = \"0.10\"".to_string());
+                deps.insert("blake2 = \"0.10.6\"".to_string());
             }
             "base64" => {
-                deps.insert("base64 = \"0.22\"".to_string());
+                deps.insert("base64 = \"0.22.1\"".to_string());
             }
             "toml" => {
                 deps.insert(
-                    "toml = { version = \"0.8\", features = [\"preserve_order\"] }".to_string(),
+                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string(),
                 );
             }
             "flate2" => {
-                deps.insert("flate2 = \"1\"".to_string());
+                deps.insert("flate2 = \"1.1.9\"".to_string());
             }
             "zip" => {
-                deps.insert("zip = \"0.6\"".to_string());
+                deps.insert("zip = \"8.6.0\"".to_string());
             }
             "num-bigint" => {
-                deps.insert("num-bigint = \"0.4\"".to_string());
+                deps.insert("num-bigint = \"0.4.6\"".to_string());
             }
             "num-traits" => {
-                deps.insert("num-traits = \"0.2\"".to_string());
+                deps.insert("num-traits = \"0.2.19\"".to_string());
             }
             "rust_decimal" => {
                 deps.insert(
-                    "rust_decimal = { version = \"1\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
+                    "rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
                 );
             }
             "bigdecimal" => {
                 deps.insert(
-                    "bigdecimal = { version = \"0.4\", features = [\"serde\"] }".to_string(),
+                    "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
                 );
             }
             _ => {}
@@ -3059,7 +3097,7 @@ fn test_generate_cargo_toml_tomllib_uses_preserve_order_feature() {
     let required_crates = BTreeSet::new();
 
     let cargo_toml = generate_cargo_toml(&stdlib_modules, &required_crates, "sifr_output");
-    assert!(cargo_toml.contains("toml = { version = \"0.8\", features = [\"preserve_order\"] }"));
+    assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 }
 
 #[test]
@@ -3068,7 +3106,7 @@ fn test_generate_cargo_toml_required_toml_uses_preserve_order_feature() {
     let required_crates = normalize_dependency_set(vec!["toml".to_string()].into_iter());
 
     let cargo_toml = generate_cargo_toml(&stdlib_modules, &required_crates, "sifr_output");
-    assert!(cargo_toml.contains("toml = { version = \"0.8\", features = [\"preserve_order\"] }"));
+    assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 }
 
 fn sample_cache_entry(

--- a/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-compact.stderr.txt
+++ b/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-compact.stderr.txt
@@ -3,7 +3,6 @@ error [SIFR-WORKSPACE-0001] could not parse sifr.toml at '<WORKSPACE>/crates/sif
   |
 1 | [source
   |        ^
-invalid table header
-expected `.`, `]`
+unclosed table, expected `]`
  (x1)
   url: https://sifr.dev/docs/errors/SIFR-WORKSPACE-0001

--- a/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-human.stderr.txt
+++ b/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-human.stderr.txt
@@ -2,6 +2,5 @@ error: could not parse sifr.toml at '<WORKSPACE>/crates/sifr/tests/verification/
   |
 1 | [source
   |        ^
-invalid table header
-expected `.`, `]`
+unclosed table, expected `]`
 

--- a/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-json.stderr.txt
+++ b/crates/sifr/tests/verification/project/workspace_malformed_manifest/baselines/check-json.stderr.txt
@@ -2,7 +2,7 @@
   {
     "code": "SIFR-WORKSPACE-0001",
     "severity": "Error",
-    "message": "could not parse sifr.toml at '<WORKSPACE>/crates/sifr/tests/verification/project/workspace_malformed_manifest/sifr.toml': TOML parse error at line 1, column 8\n  |\n1 | [source\n  |        ^\ninvalid table header\nexpected `.`, `]`\n",
+    "message": "could not parse sifr.toml at '<WORKSPACE>/crates/sifr/tests/verification/project/workspace_malformed_manifest/sifr.toml': TOML parse error at line 1, column 8\n  |\n1 | [source\n  |        ^\nunclosed table, expected `]`\n",
     "url": "https://sifr.dev/docs/errors/SIFR-WORKSPACE-0001",
     "primary_span": null,
     "related_spans": [],

--- a/crates/sifr_codegen/Cargo.toml
+++ b/crates/sifr_codegen/Cargo.toml
@@ -9,9 +9,9 @@ license = { workspace = true }
 [dependencies]
 sifr_hir = { workspace = true }
 sifr_type_system = { workspace = true }
-syn = { version = "2", features = ["full", "visit"] }
-prettyplease = "0.2"
-proc-macro2 = "1"
+syn = { version = "2.0.117", features = ["full", "visit"] }
+prettyplease = "0.2.37"
+proc-macro2 = "1.0.106"
 
 [dev-dependencies]
 sifr_python_parser = { workspace = true }

--- a/crates/sifr_codegen/src/intrinsics/digest_format.rs
+++ b/crates/sifr_codegen/src/intrinsics/digest_format.rs
@@ -1,0 +1,44 @@
+//! Shared digest formatting helpers for hash intrinsics.
+
+use crate::{RustExpr, RustLiteral, RustParam, RustType};
+
+fn empty_str_slice_expr() -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Literal(RustLiteral::Str(String::new()))),
+        method: "as_str".to_string(),
+        args: vec![],
+    }
+}
+
+pub(super) fn bytes_to_hex_expr(bytes: RustExpr) -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::MethodCall {
+                    receiver: Box::new(bytes),
+                    method: "iter".to_string(),
+                    args: vec![],
+                }),
+                method: "map".to_string(),
+                args: vec![RustExpr::Closure {
+                    params: vec![RustParam::Named {
+                        name: "__byte".to_string(),
+                        ty: RustType::Named("_".to_string()),
+                    }],
+                    body: Box::new(RustExpr::FormatMacro {
+                        name: "format".to_string(),
+                        format_str: "{:02x}".to_string(),
+                        args: vec![RustExpr::Deref(Box::new(RustExpr::Ident(
+                            "__byte".to_string(),
+                        )))],
+                    }),
+                    is_move: false,
+                }],
+            }),
+            method: "collect::<Vec<String>>".to_string(),
+            args: vec![],
+        }),
+        method: "join".to_string(),
+        args: vec![empty_str_slice_expr()],
+    }
+}

--- a/crates/sifr_codegen/src/intrinsics/hash.rs
+++ b/crates/sifr_codegen/src/intrinsics/hash.rs
@@ -1,5 +1,6 @@
 //! Hash intrinsic lowerers for registry lowering.
 
+use super::digest_format::bytes_to_hex_expr;
 use crate::RustExpr;
 
 fn parenthesized(expr: &RustExpr) -> RustExpr {
@@ -10,31 +11,24 @@ pub(super) fn lower_sha256(args: &[RustExpr]) -> Option<RustExpr> {
     if args.len() != 1 {
         return None;
     }
-    Some(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:x}".to_string(),
-        args: vec![RustExpr::FnCall {
-            func: Box::new(RustExpr::Ident(
-                "<sha2::Sha256 as sha2::Digest>::digest".to_string(),
-            )),
-            args: vec![RustExpr::MethodCall {
-                receiver: Box::new(parenthesized(&args[0])),
-                method: "as_bytes".to_string(),
-                args: vec![],
-            }],
+    Some(bytes_to_hex_expr(RustExpr::FnCall {
+        func: Box::new(RustExpr::Ident(
+            "<sha2::Sha256 as sha2::Digest>::digest".to_string(),
+        )),
+        args: vec![RustExpr::MethodCall {
+            receiver: Box::new(parenthesized(&args[0])),
+            method: "as_bytes".to_string(),
+            args: vec![],
         }],
-    })
+    }))
 }
 
 pub(super) fn lower_md5(args: &[RustExpr]) -> Option<RustExpr> {
     if args.len() != 1 {
         return None;
     }
-    // format!("{:x}", md5::compute(arg.as_bytes()))
-    Some(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:x}".to_string(),
-        args: vec![RustExpr::FnCall {
+    Some(bytes_to_hex_expr(RustExpr::Field {
+        expr: Box::new(RustExpr::FnCall {
             func: Box::new(RustExpr::Path(vec![
                 "md5".to_string(),
                 "compute".to_string(),
@@ -44,6 +38,7 @@ pub(super) fn lower_md5(args: &[RustExpr]) -> Option<RustExpr> {
                 method: "as_bytes".to_string(),
                 args: vec![],
             }],
-        }],
-    })
+        }),
+        field: "0".to_string(),
+    }))
 }

--- a/crates/sifr_codegen/src/intrinsics/hashlib.rs
+++ b/crates/sifr_codegen/src/intrinsics/hashlib.rs
@@ -1,5 +1,6 @@
 //! Hashlib intrinsic lowerers for registry lowering.
 
+use super::digest_format::bytes_to_hex_expr;
 use crate::RustExpr;
 
 fn parenthesized(expr: &RustExpr) -> RustExpr {
@@ -7,18 +8,14 @@ fn parenthesized(expr: &RustExpr) -> RustExpr {
 }
 
 fn digest_hex(digest_path: &str, arg: &RustExpr) -> RustExpr {
-    RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "{:x}".to_string(),
-        args: vec![RustExpr::FnCall {
-            func: Box::new(RustExpr::Ident(digest_path.to_string())),
-            args: vec![RustExpr::MethodCall {
-                receiver: Box::new(parenthesized(arg)),
-                method: "as_bytes".to_string(),
-                args: vec![],
-            }],
+    bytes_to_hex_expr(RustExpr::FnCall {
+        func: Box::new(RustExpr::Ident(digest_path.to_string())),
+        args: vec![RustExpr::MethodCall {
+            receiver: Box::new(parenthesized(arg)),
+            method: "as_bytes".to_string(),
+            args: vec![],
         }],
-    }
+    })
 }
 
 fn digest_bytes(digest_path: &str, arg: &RustExpr) -> RustExpr {

--- a/crates/sifr_codegen/src/intrinsics/mod.rs
+++ b/crates/sifr_codegen/src/intrinsics/mod.rs
@@ -6,6 +6,7 @@ mod bytes;
 mod calendar;
 mod collections;
 mod datetime;
+mod digest_format;
 mod env;
 mod file_handles;
 mod gzip;
@@ -39,7 +40,7 @@ pub(crate) struct LoweredIntrinsic {
 
 fn additional_required_crates(name: &str) -> &'static [&'static str] {
     match name {
-        // random_gauss uses rand_distr::Normal in addition to rand::thread_rng.
+        // random_gauss uses rand_distr::Normal in addition to rand::rng.
         "random_gauss" => &["rand_distr"],
         _ => &[],
     }
@@ -687,7 +688,7 @@ mod tests {
         let rint =
             lower_intrinsic("random_int", &["1".to_string(), "9".to_string()]).expect("random_int");
         assert_eq!(rint.required_crate, Some("rand"));
-        assert!(render_expr(&rint.expr).contains("rand::Rng::gen_range"));
+        assert!(render_expr(&rint.expr).contains("rand::RngExt::random_range"));
 
         let rfloat = lower_intrinsic("random_float", &[]).expect("random_float");
         assert_eq!(rfloat.required_crate, Some("rand"));
@@ -707,7 +708,7 @@ mod tests {
 
         let sample = lower_intrinsic("random_sample", &["vals".to_string(), "3".to_string()])
             .expect("random_sample");
-        assert!(render_expr(&sample.expr).contains("choose_multiple"));
+        assert!(render_expr(&sample.expr).contains("IndexedRandom::sample"));
 
         let randrange = lower_intrinsic(
             "random_randrange",
@@ -888,7 +889,7 @@ mod tests {
     fn lowers_toml_intrinsic_with_dependency_metadata() {
         let parsed = lower_intrinsic("toml_parse", &["payload".to_string()]).expect("toml_parse");
         assert_eq!(parsed.required_crate, Some("toml"));
-        assert!(render_expr(&parsed.expr).contains("parse::<toml::Value>()"));
+        assert!(render_expr(&parsed.expr).contains("parse::<toml::Table>()"));
         assert!(render_expr(&parsed.expr).contains("TOMLDecodeError"));
     }
 

--- a/crates/sifr_codegen/src/intrinsics/random.rs
+++ b/crates/sifr_codegen/src/intrinsics/random.rs
@@ -6,12 +6,9 @@ fn arg_expr(args: &[RustExpr], idx: usize) -> RustExpr {
     args[idx].clone()
 }
 
-fn thread_rng_expr() -> RustExpr {
+fn rng_expr() -> RustExpr {
     RustExpr::FnCall {
-        func: Box::new(RustExpr::Path(vec![
-            "rand".to_string(),
-            "thread_rng".to_string(),
-        ])),
+        func: Box::new(RustExpr::Path(vec!["rand".to_string(), "rng".to_string()])),
         args: vec![],
     }
 }
@@ -51,17 +48,17 @@ fn ok_expr(expr: RustExpr) -> RustExpr {
     }
 }
 
-fn gen_range_expr(start: RustExpr, end: RustExpr) -> RustExpr {
+fn random_range_expr(start: RustExpr, end: RustExpr) -> RustExpr {
     RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec![
             "rand".to_string(),
-            "Rng".to_string(),
-            "gen_range".to_string(),
+            "RngExt".to_string(),
+            "random_range".to_string(),
         ])),
         args: vec![
             RustExpr::Ref {
                 mutable: true,
-                expr: Box::new(thread_rng_expr()),
+                expr: Box::new(rng_expr()),
             },
             RustExpr::Range {
                 start: Box::new(start),
@@ -116,7 +113,7 @@ pub(super) fn lower_random_int(args: &[RustExpr]) -> Option<RustExpr> {
         expr: Some(Box::new(RustExpr::BinOp {
             left: Box::new(RustExpr::Ident("__start".to_string())),
             op: "+".to_string(),
-            right: Box::new(gen_range_expr(
+            right: Box::new(random_range_expr(
                 int(0),
                 RustExpr::BinOp {
                     left: Box::new(RustExpr::BinOp {
@@ -153,7 +150,7 @@ pub(super) fn lower_random_choice(args: &[RustExpr]) -> Option<RustExpr> {
         expr: Some(Box::new(RustExpr::MethodCall {
             receiver: Box::new(RustExpr::Index {
                 expr: Box::new(RustExpr::Ident("items".to_string())),
-                index: Box::new(gen_range_expr(
+                index: Box::new(random_range_expr(
                     int(0),
                     RustExpr::MethodCall {
                         receiver: Box::new(RustExpr::Ident("items".to_string())),
@@ -234,7 +231,7 @@ pub(super) fn lower_random_shuffle(args: &[RustExpr]) -> Option<RustExpr> {
                     },
                     RustExpr::Ref {
                         mutable: true,
-                        expr: Box::new(thread_rng_expr()),
+                        expr: Box::new(rng_expr()),
                     },
                 ],
             }),
@@ -293,8 +290,8 @@ pub(super) fn lower_random_sample(args: &[RustExpr]) -> Option<RustExpr> {
                         func: Box::new(RustExpr::Path(vec![
                             "rand".to_string(),
                             "seq".to_string(),
-                            "SliceRandom".to_string(),
-                            "choose_multiple".to_string(),
+                            "IndexedRandom".to_string(),
+                            "sample".to_string(),
                         ])),
                         args: vec![
                             RustExpr::MethodCall {
@@ -304,7 +301,7 @@ pub(super) fn lower_random_sample(args: &[RustExpr]) -> Option<RustExpr> {
                             },
                             RustExpr::Ref {
                                 mutable: true,
-                                expr: Box::new(thread_rng_expr()),
+                                expr: Box::new(rng_expr()),
                             },
                             RustExpr::Ident("__k".to_string()),
                         ],
@@ -407,7 +404,7 @@ pub(super) fn lower_random_randrange(args: &[RustExpr]) -> Option<RustExpr> {
                         left: Box::new(RustExpr::Ident("__start".to_string())),
                         op: "+".to_string(),
                         right: Box::new(RustExpr::BinOp {
-                            left: Box::new(gen_range_expr(
+                            left: Box::new(random_range_expr(
                                 int(0),
                                 RustExpr::Ident("__n".to_string()),
                             )),
@@ -472,7 +469,7 @@ pub(super) fn lower_random_gauss(args: &[RustExpr]) -> Option<RustExpr> {
                             },
                             RustExpr::Ref {
                                 mutable: true,
-                                expr: Box::new(thread_rng_expr()),
+                                expr: Box::new(rng_expr()),
                             },
                         ],
                     }),

--- a/crates/sifr_codegen/src/intrinsics/toml.rs
+++ b/crates/sifr_codegen/src/intrinsics/toml.rs
@@ -329,9 +329,13 @@ pub(super) fn lower_toml_parse(args: &[RustExpr]) -> Option<RustExpr> {
         expr: Some(Box::new(RustExpr::MethodCall {
             receiver: Box::new(RustExpr::MethodCall {
                 receiver: Box::new(RustExpr::MethodCall {
-                    receiver: Box::new(RustExpr::Ident("__toml_input".to_string())),
-                    method: "parse::<toml::Value>".to_string(),
-                    args: vec![],
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__toml_input".to_string())),
+                        method: "parse::<toml::Table>".to_string(),
+                        args: vec![],
+                    }),
+                    method: "map".to_string(),
+                    args: vec![RustExpr::Ident("toml::Value::Table".to_string())],
                 }),
                 method: "map_err".to_string(),
                 args: vec![RustExpr::Closure {

--- a/crates/sifr_codegen/src/intrinsics/zipfile.rs
+++ b/crates/sifr_codegen/src/intrinsics/zipfile.rs
@@ -170,7 +170,7 @@ pub(super) fn lower_zip_add_file(args: &[RustExpr]) -> Option<RustExpr> {
                     func: Box::new(RustExpr::Path(vec![
                         "zip".to_string(),
                         "write".to_string(),
-                        "FileOptions".to_string(),
+                        "SimpleFileOptions".to_string(),
                         "default".to_string(),
                     ])),
                     args: vec![],
@@ -290,7 +290,7 @@ pub(super) fn lower_zip_add_file_bytes(args: &[RustExpr]) -> Option<RustExpr> {
                     func: Box::new(RustExpr::Path(vec![
                         "zip".to_string(),
                         "write".to_string(),
-                        "FileOptions".to_string(),
+                        "SimpleFileOptions".to_string(),
                         "default".to_string(),
                     ])),
                     args: vec![],

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -835,86 +835,88 @@ edition = "2021"
         match module_name.as_str() {
             "sifr.json" | "sifr.collections" | "_sifr.json" | "_sifr.collections" => {
                 if !deps.contains(
-                    &"serde_json = { version = \"1\", features = [\"preserve_order\"] }"
+                    &"serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
                         .to_string(),
                 ) {
                     deps.push(
-                        "serde_json = { version = \"1\", features = [\"preserve_order\"] }"
+                        "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
                             .to_string(),
                     );
-                    deps.push("serde = { version = \"1\", features = [\"derive\"] }".to_string());
+                    deps.push(
+                        "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
+                    );
                 }
             }
             "sifr.time" | "_sifr.time" => {
-                if !deps.contains(&"chrono = \"0.4\"".to_string()) {
-                    deps.push("chrono = \"0.4\"".to_string());
+                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
+                    deps.push("chrono = \"0.4.44\"".to_string());
                 }
             }
             "sifr.random" | "_sifr.crypto" => {
-                if !deps.contains(&"rand = \"0.8\"".to_string()) {
-                    deps.push("rand = \"0.8\"".to_string());
+                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
+                    deps.push("rand = \"0.10.1\"".to_string());
                 }
-                if !deps.contains(&"rand_distr = \"0.4\"".to_string()) {
-                    deps.push("rand_distr = \"0.4\"".to_string());
+                if !deps.contains(&"rand_distr = \"0.6.0\"".to_string()) {
+                    deps.push("rand_distr = \"0.6.0\"".to_string());
                 }
             }
             "sifr.uuid" | "_sifr.uuid" => {
-                if !deps.contains(&"rand = \"0.8\"".to_string()) {
-                    deps.push("rand = \"0.8\"".to_string());
+                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
+                    deps.push("rand = \"0.10.1\"".to_string());
                 }
                 let uuid_dep =
-                    "uuid = { version = \"1\", features = [\"v3\", \"v5\"] }".to_string();
+                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string();
                 if !deps.contains(&uuid_dep) {
                     deps.push(uuid_dep);
                 }
             }
             "sifr.re" | "_sifr.regex" => {
-                if !deps.contains(&"regex = \"1\"".to_string()) {
-                    deps.push("regex = \"1\"".to_string());
+                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
+                    deps.push("regex = \"1.12.3\"".to_string());
                 }
             }
             "sifr.pathlib" => {
-                if !deps.contains(&"regex = \"1\"".to_string()) {
-                    deps.push("regex = \"1\"".to_string());
+                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
+                    deps.push("regex = \"1.12.3\"".to_string());
                 }
             }
             "sifr.hash" | "sifr.hashlib" => {
-                if !deps.contains(&"sha2 = \"0.10\"".to_string()) {
-                    deps.push("sha2 = \"0.10\"".to_string());
-                    deps.push("md5 = \"0.7\"".to_string());
-                    deps.push("sha1 = \"0.10\"".to_string());
-                    deps.push("blake2 = \"0.10\"".to_string());
+                if !deps.contains(&"sha2 = \"0.11.0\"".to_string()) {
+                    deps.push("sha2 = \"0.11.0\"".to_string());
+                    deps.push("md5 = \"0.8.0\"".to_string());
+                    deps.push("sha1 = \"0.11.0\"".to_string());
+                    deps.push("blake2 = \"0.10.6\"".to_string());
                 }
             }
             "sifr.encoding" | "sifr.base64" => {
-                if !deps.contains(&"base64 = \"0.22\"".to_string()) {
-                    deps.push("base64 = \"0.22\"".to_string());
+                if !deps.contains(&"base64 = \"0.22.1\"".to_string()) {
+                    deps.push("base64 = \"0.22.1\"".to_string());
                 }
             }
             "sifr.tomllib" | "_sifr.toml" => {
                 let toml_dep =
-                    "toml = { version = \"0.8\", features = [\"preserve_order\"] }".to_string();
+                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string();
                 if !deps.contains(&toml_dep) {
                     deps.push(toml_dep);
                 }
             }
             "sifr.datetime" | "_sifr.datetime" => {
-                if !deps.contains(&"chrono = \"0.4\"".to_string()) {
-                    deps.push("chrono = \"0.4\"".to_string());
+                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
+                    deps.push("chrono = \"0.4.44\"".to_string());
                 }
             }
             "sifr.gzip" | "sifr.zipfile" | "_sifr.compress" => {
-                if !deps.contains(&"flate2 = \"1\"".to_string()) {
-                    deps.push("flate2 = \"1\"".to_string());
+                if !deps.contains(&"flate2 = \"1.1.9\"".to_string()) {
+                    deps.push("flate2 = \"1.1.9\"".to_string());
                 }
-                if !deps.contains(&"zip = \"0.6\"".to_string()) {
-                    deps.push("zip = \"0.6\"".to_string());
+                if !deps.contains(&"zip = \"8.6.0\"".to_string()) {
+                    deps.push("zip = \"8.6.0\"".to_string());
                 }
             }
             "_bigint" => {
-                if !deps.contains(&"num-bigint = \"0.4\"".to_string()) {
-                    deps.push("num-bigint = \"0.4\"".to_string());
-                    deps.push("num-traits = \"0.2\"".to_string());
+                if !deps.contains(&"num-bigint = \"0.4.6\"".to_string()) {
+                    deps.push("num-bigint = \"0.4.6\"".to_string());
+                    deps.push("num-traits = \"0.2.19\"".to_string());
                 }
             }
             // sifr.io, sifr.env, sifr.os, sifr.math, sifr.test, sifr.bytes, sifr.sys,
@@ -927,114 +929,114 @@ edition = "2021"
         match crate_name.as_str() {
             "serde_json" => {
                 if !deps.contains(
-                    &"serde_json = { version = \"1\", features = [\"preserve_order\"] }"
+                    &"serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
                         .to_string(),
                 ) {
                     deps.push(
-                        "serde_json = { version = \"1\", features = [\"preserve_order\"] }"
+                        "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
                             .to_string(),
                     );
                 }
                 if !deps
-                    .contains(&"serde = { version = \"1\", features = [\"derive\"] }".to_string())
+                    .contains(&"serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string())
                 {
-                    deps.push("serde = { version = \"1\", features = [\"derive\"] }".to_string());
+                    deps.push("serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string());
                 }
             }
             "chrono" => {
-                if !deps.contains(&"chrono = \"0.4\"".to_string()) {
-                    deps.push("chrono = \"0.4\"".to_string());
+                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
+                    deps.push("chrono = \"0.4.44\"".to_string());
                 }
             }
             "rand" => {
-                if !deps.contains(&"rand = \"0.8\"".to_string()) {
-                    deps.push("rand = \"0.8\"".to_string());
+                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
+                    deps.push("rand = \"0.10.1\"".to_string());
                 }
             }
             "rand_distr" => {
-                if !deps.contains(&"rand_distr = \"0.4\"".to_string()) {
-                    deps.push("rand_distr = \"0.4\"".to_string());
+                if !deps.contains(&"rand_distr = \"0.6.0\"".to_string()) {
+                    deps.push("rand_distr = \"0.6.0\"".to_string());
                 }
             }
             "regex" => {
-                if !deps.contains(&"regex = \"1\"".to_string()) {
-                    deps.push("regex = \"1\"".to_string());
+                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
+                    deps.push("regex = \"1.12.3\"".to_string());
                 }
             }
             "sha2" => {
-                if !deps.contains(&"sha2 = \"0.10\"".to_string()) {
-                    deps.push("sha2 = \"0.10\"".to_string());
+                if !deps.contains(&"sha2 = \"0.11.0\"".to_string()) {
+                    deps.push("sha2 = \"0.11.0\"".to_string());
                 }
             }
             "md5" => {
-                if !deps.contains(&"md5 = \"0.7\"".to_string()) {
-                    deps.push("md5 = \"0.7\"".to_string());
+                if !deps.contains(&"md5 = \"0.8.0\"".to_string()) {
+                    deps.push("md5 = \"0.8.0\"".to_string());
                 }
             }
             "sha1" => {
-                if !deps.contains(&"sha1 = \"0.10\"".to_string()) {
-                    deps.push("sha1 = \"0.10\"".to_string());
+                if !deps.contains(&"sha1 = \"0.11.0\"".to_string()) {
+                    deps.push("sha1 = \"0.11.0\"".to_string());
                 }
             }
             "uuid" => {
                 let uuid_dep =
-                    "uuid = { version = \"1\", features = [\"v3\", \"v5\"] }".to_string();
+                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string();
                 if !deps.contains(&uuid_dep) {
                     deps.push(uuid_dep);
                 }
             }
             "blake2" => {
-                if !deps.contains(&"blake2 = \"0.10\"".to_string()) {
-                    deps.push("blake2 = \"0.10\"".to_string());
+                if !deps.contains(&"blake2 = \"0.10.6\"".to_string()) {
+                    deps.push("blake2 = \"0.10.6\"".to_string());
                 }
             }
             "base64" => {
-                if !deps.contains(&"base64 = \"0.22\"".to_string()) {
-                    deps.push("base64 = \"0.22\"".to_string());
+                if !deps.contains(&"base64 = \"0.22.1\"".to_string()) {
+                    deps.push("base64 = \"0.22.1\"".to_string());
                 }
             }
             "toml" => {
                 let toml_dep =
-                    "toml = { version = \"0.8\", features = [\"preserve_order\"] }".to_string();
+                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string();
                 if !deps.contains(&toml_dep) {
                     deps.push(toml_dep);
                 }
             }
             "flate2" => {
-                if !deps.contains(&"flate2 = \"1\"".to_string()) {
-                    deps.push("flate2 = \"1\"".to_string());
+                if !deps.contains(&"flate2 = \"1.1.9\"".to_string()) {
+                    deps.push("flate2 = \"1.1.9\"".to_string());
                 }
             }
             "zip" => {
-                if !deps.contains(&"zip = \"0.6\"".to_string()) {
-                    deps.push("zip = \"0.6\"".to_string());
+                if !deps.contains(&"zip = \"8.6.0\"".to_string()) {
+                    deps.push("zip = \"8.6.0\"".to_string());
                 }
             }
             "num-bigint" => {
-                if !deps.contains(&"num-bigint = \"0.4\"".to_string()) {
-                    deps.push("num-bigint = \"0.4\"".to_string());
+                if !deps.contains(&"num-bigint = \"0.4.6\"".to_string()) {
+                    deps.push("num-bigint = \"0.4.6\"".to_string());
                 }
             }
             "num-traits" => {
-                if !deps.contains(&"num-traits = \"0.2\"".to_string()) {
-                    deps.push("num-traits = \"0.2\"".to_string());
+                if !deps.contains(&"num-traits = \"0.2.19\"".to_string()) {
+                    deps.push("num-traits = \"0.2.19\"".to_string());
                 }
             }
             "rust_decimal" => {
                 if !deps.contains(
-                    &"rust_decimal = { version = \"1\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
+                    &"rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
                 ) {
                     deps.push(
-                        "rust_decimal = { version = \"1\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
+                        "rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
                     );
                 }
             }
             "bigdecimal" => {
                 if !deps.contains(
-                    &"bigdecimal = { version = \"0.4\", features = [\"serde\"] }".to_string(),
+                    &"bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
                 ) {
                     deps.push(
-                        "bigdecimal = { version = \"0.4\", features = [\"serde\"] }".to_string(),
+                        "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
                     );
                 }
             }

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -342,8 +342,8 @@ fn test_build_project_includes_support_module_required_crates_in_manifest() {
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(cargo_toml.contains("num-bigint = \"0.4\""));
-    assert!(cargo_toml.contains("num-traits = \"0.2\""));
+    assert!(cargo_toml.contains("num-bigint = \"0.4.6\""));
+    assert!(cargo_toml.contains("num-traits = \"0.2.19\""));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -375,8 +375,8 @@ fn test_build_project_manifest_ignores_unreachable_required_crates() {
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(!cargo_toml.contains("num-bigint = \"0.4\""));
-    assert!(!cargo_toml.contains("num-traits = \"0.2\""));
+    assert!(!cargo_toml.contains("num-bigint = \"0.4.6\""));
+    assert!(!cargo_toml.contains("num-traits = \"0.2.19\""));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -404,7 +404,7 @@ def render() -> str:\n    try:\n        parsed: TomlValue = loads(\"name = \\\"p
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(cargo_toml.contains("toml = { version = \"0.8\", features = [\"preserve_order\"] }"));
+    assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -437,7 +437,7 @@ def unused() -> str:\n    try:\n        parsed: str = loads(\"name = \\\"unused\
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(!cargo_toml.contains("toml = { version = \"0.8\", features = [\"preserve_order\"] }"));
+    assert!(!cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -470,8 +470,8 @@ def render() -> str:\n    return render_value()\n",
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(cargo_toml.contains("num-bigint = \"0.4\""));
-    assert!(cargo_toml.contains("num-traits = \"0.2\""));
+    assert!(cargo_toml.contains("num-bigint = \"0.4.6\""));
+    assert!(cargo_toml.contains("num-traits = \"0.2.19\""));
 
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -509,8 +509,8 @@ def unused() -> str:\n    return render_value()\n",
 
     let cargo_toml = std::fs::read_to_string(build_out.join("sifr_output").join("Cargo.toml"))
         .expect("cargo manifest should be written");
-    assert!(!cargo_toml.contains("num-bigint = \"0.4\""));
-    assert!(!cargo_toml.contains("num-traits = \"0.2\""));
+    assert!(!cargo_toml.contains("num-bigint = \"0.4.6\""));
+    assert!(!cargo_toml.contains("num-traits = \"0.2.19\""));
 
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -363,9 +363,9 @@ fn test_generate_test_runner_cargo_toml_includes_required_crates() {
 
     let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
     assert!(cargo_toml.contains("name = \"sifr_tests\""));
-    assert!(cargo_toml.contains("regex = \"1\""));
-    assert!(cargo_toml.contains("rand = \"0.8\""));
-    assert!(cargo_toml.contains("rand_distr = \"0.4\""));
+    assert!(cargo_toml.contains("regex = \"1.12.3\""));
+    assert!(cargo_toml.contains("rand = \"0.10.1\""));
+    assert!(cargo_toml.contains("rand_distr = \"0.6.0\""));
 }
 
 #[test]
@@ -374,10 +374,9 @@ fn test_generate_test_runner_cargo_toml_preserves_stdlib_deps() {
     let required_crates = HashSet::new();
 
     let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
-    assert!(
-        cargo_toml.contains("serde_json = { version = \"1\", features = [\"preserve_order\"] }")
-    );
-    assert!(cargo_toml.contains("serde = { version = \"1\", features = [\"derive\"] }"));
+    assert!(cargo_toml
+        .contains("serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"));
+    assert!(cargo_toml.contains("serde = { version = \"1.0.228\", features = [\"derive\"] }"));
 }
 
 #[test]
@@ -386,7 +385,7 @@ fn test_generate_test_runner_cargo_toml_preserves_tomllib_ordering_deps() {
     let required_crates = HashSet::new();
 
     let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
-    assert!(cargo_toml.contains("toml = { version = \"0.8\", features = [\"preserve_order\"] }"));
+    assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 }
 
 #[test]

--- a/crates/sifr_driver/src/workspace/mod.rs
+++ b/crates/sifr_driver/src/workspace/mod.rs
@@ -62,7 +62,8 @@ fn parse_workspace_config(
 
 fn parse_manifest(manifest_path: &Path, source: &str) -> Result<SifrManifest, Vec<CompileError>> {
     let value = source
-        .parse::<toml::Value>()
+        .parse::<toml::Table>()
+        .map(toml::Value::Table)
         .map_err(|error| vec![parse_manifest_error(manifest_path, error)])?;
 
     let package_name = value

--- a/crates/sifr_hir/Cargo.toml
+++ b/crates/sifr_hir/Cargo.toml
@@ -11,8 +11,8 @@ sifr_python_ast = { workspace = true }
 sifr_python_parser = { workspace = true }
 sifr_type_system = { workspace = true }
 ruff_text_size = { workspace = true }
-rust_decimal = "1"
-bigdecimal = "0.4"
+rust_decimal = "1.41.0"
+bigdecimal = "0.4.10"
 
 [dev-dependencies]
 

--- a/demos/additional_modules/emitted.rs
+++ b/demos/additional_modules/emitted.rs
@@ -115,7 +115,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;
@@ -140,7 +140,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;

--- a/demos/additional_modules/idiomatic.rs
+++ b/demos/additional_modules/idiomatic.rs
@@ -233,12 +233,12 @@ fn rewrite_zip_entry(path: &str, name: &str, content: &[u8]) -> Result<(), IOErr
     let mut writer = zip::ZipWriter::new(temp_file);
     for (entry_name, entry_bytes) in existing_entries {
         writer
-            .start_file(entry_name, zip::write::FileOptions::default())
+            .start_file(entry_name, zip::write::SimpleFileOptions::default())
             .map_err(zip_err)?;
         writer.write_all(&entry_bytes).map_err(IOError::from)?;
     }
     writer
-        .start_file(name, zip::write::FileOptions::default())
+        .start_file(name, zip::write::SimpleFileOptions::default())
         .map_err(zip_err)?;
     writer.write_all(content).map_err(IOError::from)?;
     writer.finish().map_err(zip_err)?;

--- a/demos/extended_stdlib/emitted.rs
+++ b/demos/extended_stdlib/emitted.rs
@@ -609,7 +609,7 @@ fn main() {
     let r: i64 = {
     let __start = 1 as i64;
     let __end = 100 as i64;
-    __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+    __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
 };
     println!("Random int [1,100]: {}", r);
     let f: f64 = rand::random::<f64>();
@@ -631,8 +631,8 @@ fn main() {
         println!("regex error: {}", err.message);
     }
     println!("=== sifr.hashlib ===");
-    println!("SHA-256(\'sifr\'): {}", format!("{:x}", (<sha2::Sha256 as sha2::Digest>::digest)(("sifr".to_string()).as_bytes())));
-    println!("MD5(\'sifr\'): {}", format!("{:x}", md5::compute(("sifr".to_string()).as_bytes())));
+    println!("SHA-256(\'sifr\'): {}", (<sha2::Sha256 as sha2::Digest>::digest)(("sifr".to_string()).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()));
+    println!("MD5(\'sifr\'): {}", md5::compute(("sifr".to_string()).as_bytes()).0.iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()));
     println!("=== sifr.base64 ===");
     let encoded: String = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &"Hello, Sifr!".to_string().as_bytes());
     println!("Base64 encode: {}", encoded);

--- a/demos/extended_stdlib/idiomatic.rs
+++ b/demos/extended_stdlib/idiomatic.rs
@@ -103,11 +103,21 @@ fn re_replace(pattern: &str, replacement: &str, text: &str) -> Result<String, Re
 fn sha256(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 fn md5_hash(text: &str) -> String {
-    format!("{:x}", md5::compute(text.as_bytes()))
+    md5::compute(text.as_bytes())
+        .0
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 fn base64_encode(text: &str) -> String {

--- a/demos/filesystem_and_archives/emitted.rs
+++ b/demos/filesystem_and_archives/emitted.rs
@@ -705,7 +705,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }
@@ -929,7 +929,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;
@@ -954,7 +954,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;

--- a/demos/filesystem_and_archives/idiomatic.rs
+++ b/demos/filesystem_and_archives/idiomatic.rs
@@ -151,13 +151,13 @@ fn rewrite_zip_with_entry(path: &Path, name: &str, content: &[u8]) -> io::Result
 
     for (existing_name, existing_data) in existing_entries {
         writer
-            .start_file(existing_name, zip::write::FileOptions::default())
+            .start_file(existing_name, zip::write::SimpleFileOptions::default())
             .map_err(|error| io::Error::other(error.to_string()))?;
         writer.write_all(&existing_data)?;
     }
 
     writer
-        .start_file(name.to_string(), zip::write::FileOptions::default())
+        .start_file(name.to_string(), zip::write::SimpleFileOptions::default())
         .map_err(|error| io::Error::other(error.to_string()))?;
     writer.write_all(content)?;
     writer

--- a/demos/hashlib/emitted.rs
+++ b/demos/hashlib/emitted.rs
@@ -469,13 +469,13 @@ fn collect_positive_actual(tmp_path: &String) -> Vec<String> {
     let mut h: HashObject = sha256_obj(&"".to_string());
     h.update(&"a".to_string());
     h.update(&"bc".to_string());
-    actual.push(format!("{}", (h.hexdigest()).as_str() == (format!("{:x}", (<sha2::Sha256 as sha2::Digest>::digest)(("abc".to_string()).as_bytes()))).as_str()));
+    actual.push(format!("{}", (h.hexdigest()).as_str() == ((<sha2::Sha256 as sha2::Digest>::digest)(("abc".to_string()).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str())).as_str()));
     actual.push(format!("{}", ((h.digest().len() as i64) == (32 as i64)) && (h.digest_bytes() == h.digest())));
     let mut c: HashObject = copy_hash(&h);
     c.update(&"x".to_string());
-    actual.push(format!("{}", (c.hexdigest()).as_str() == (format!("{:x}", (<sha2::Sha256 as sha2::Digest>::digest)(("abcx".to_string()).as_bytes()))).as_str()));
+    actual.push(format!("{}", (c.hexdigest()).as_str() == ((<sha2::Sha256 as sha2::Digest>::digest)(("abcx".to_string()).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str())).as_str()));
     let mut m: HashObject = md5_obj(&"hello".to_string());
-    actual.push(format!("{}", (m.hexdigest()).as_str() == (format!("{:x}", md5::compute(("hello".to_string()).as_bytes()))).as_str()));
+    actual.push(format!("{}", (m.hexdigest()).as_str() == (md5::compute(("hello".to_string()).as_bytes()).0.iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str())).as_str()));
     actual.push(format!("{}", contains(&algorithms_guaranteed(), &"sha256".to_string())));
     actual.push(m.hexdigest());
     let __sifr_try_res: Result<(), HashlibError> = (|| {

--- a/demos/iterators_and_randomness/emitted.rs
+++ b/demos/iterators_and_randomness/emitted.rs
@@ -11,7 +11,7 @@ fn token_hex(nbytes: i64) -> String {
             let __start = 0 as i64;
             let __end = 15 as i64;
             __start
-                + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+                + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
         };
         let ch: Option<String> = {
             let __sifr_index_str = &hex_chars;
@@ -41,7 +41,7 @@ fn randbits(k: i64) -> Result<i64, ValueError> {
             let __start = 0 as i64;
             let __end = 1 as i64;
             __start
-                + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+                + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
         };
         result = (result * (2 as i64)) + bit;
         i = i + (1 as i64);

--- a/demos/iterators_and_randomness/idiomatic.rs
+++ b/demos/iterators_and_randomness/idiomatic.rs
@@ -1,5 +1,4 @@
-use rand::seq::SliceRandom;
-use rand::Rng;
+use rand::prelude::{IndexedRandom, SliceRandom};
 use std::fmt::{self, Display};
 
 #[derive(Debug, Clone)]
@@ -68,7 +67,7 @@ fn combinations_of_two(values: &[i64]) -> Vec<Vec<i64>> {
 
 fn choice(values: &[i64]) -> Result<i64, ValueError> {
     values
-        .choose(&mut rand::thread_rng())
+        .choose(&mut rand::rng())
         .copied()
         .ok_or_else(|| ValueError {
             message: "choice from empty sequence".to_string(),
@@ -81,10 +80,10 @@ fn choices(values: &[i64], k: usize) -> Result<Vec<i64>, ValueError> {
             message: "choices from empty sequence".to_string(),
         });
     }
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     Ok((0..k)
         .map(|_| {
-            let index = rng.gen_range(0..values.len());
+            let index = rand::RngExt::random_range(&mut rng, 0..values.len());
             values[index]
         })
         .collect())
@@ -96,7 +95,7 @@ fn randrange(stop: i64) -> Result<i64, ValueError> {
             message: "empty randrange".to_string(),
         });
     }
-    Ok(rand::thread_rng().gen_range(0..stop))
+    Ok(rand::RngExt::random_range(&mut rand::rng(), 0..stop))
 }
 
 fn compare_digest(left: &str, right: &str) -> bool {
@@ -112,9 +111,9 @@ fn compare_digest(left: &str, right: &str) -> bool {
 }
 
 fn token_hex(nbytes: usize) -> String {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..nbytes)
-        .map(|_| format!("{:02x}", rng.gen::<u8>()))
+        .map(|_| format!("{:02x}", rand::RngExt::random::<u8>(&mut rng)))
         .collect()
 }
 
@@ -124,10 +123,10 @@ fn randbits(bits: u32) -> Result<i64, ValueError> {
             message: "randbits: number of bits must be <= 62".to_string(),
         });
     }
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut value = 0_i64;
     for _ in 0..bits {
-        value = (value << 1) | i64::from(rng.gen_range(0..=1_u8));
+        value = (value << 1) | i64::from(rand::RngExt::random_range(&mut rng, 0..=1_u8));
     }
     Ok(value)
 }
@@ -162,7 +161,7 @@ fn main() {
     println!("callable object direct = {}", doubler.apply(4));
 
     let mut items = vec![1, 2, 3, 4, 5];
-    items.shuffle(&mut rand::thread_rng());
+    items.shuffle(&mut rand::rng());
     println!("shuffle(mut items) len = {}", items.len());
 
     match (choice(&items), choices(&items, 3), randrange(10)) {

--- a/demos/logging/emitted.rs
+++ b/demos/logging/emitted.rs
@@ -5,7 +5,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }

--- a/demos/pure_sifr_stdlib/emitted.rs
+++ b/demos/pure_sifr_stdlib/emitted.rs
@@ -294,7 +294,7 @@ fn main() {
     let result: f64 = (9.0 as f64).sqrt();
     assert!(result == (3.0 as f64));
     assert!(std::f64::consts::PI > (3.14 as f64));
-    let h: String = format!("{:x}", (<sha2::Sha256 as sha2::Digest>::digest)(("hello".to_string()).as_bytes()));
+    let h: String = (<sha2::Sha256 as sha2::Digest>::digest)(("hello".to_string()).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str());
     assert!((h.chars().count() as i64) == (64 as i64));
     let encoded: String = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &"Hello!".to_string().as_bytes());
     let __sifr_try_res: Result<(), ParseError> = (|| {

--- a/demos/pure_sifr_stdlib/idiomatic.rs
+++ b/demos/pure_sifr_stdlib/idiomatic.rs
@@ -21,7 +21,12 @@ fn sqrt(value: f64) -> f64 {
 fn sha256(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 fn base64_encode(text: &str) -> String {

--- a/demos/safe_edge_cases/emitted.rs
+++ b/demos/safe_edge_cases/emitted.rs
@@ -894,7 +894,7 @@ fn randbelow(n: i64) -> Result<i64, ValueError> {
     return Ok({
         let __start = 0 as i64;
         let __end = n - (1 as i64);
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     });
 }
 

--- a/demos/shutil/emitted.rs
+++ b/demos/shutil/emitted.rs
@@ -30,7 +30,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }

--- a/demos/stdlib_expansion/emitted.rs
+++ b/demos/stdlib_expansion/emitted.rs
@@ -628,7 +628,7 @@ fn token_hex(nbytes: i64) -> String {
             let __start = 0 as i64;
             let __end = 15 as i64;
             __start
-                + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+                + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
         };
         let ch: Option<String> = {
             let __sifr_index_str = &hex_chars;

--- a/demos/stdlib_intrinsics/emitted.rs
+++ b/demos/stdlib_intrinsics/emitted.rs
@@ -827,10 +827,10 @@ fn demo_os() {
 fn demo_hashlib() {
     println!("=== hashlib new intrinsics ===");
     let s: String = "hello".to_string();
-    println!("{}", format!("{}{}", "sha224 len = ".to_string(), format!("{}", format!("{:x}", (<sha2::Sha224 as sha2::Digest>::digest)((s).as_bytes())).chars().count() as i64)));
-    println!("{}", format!("{}{}", "sha384 len = ".to_string(), format!("{}", format!("{:x}", (<sha2::Sha384 as sha2::Digest>::digest)((s).as_bytes())).chars().count() as i64)));
-    println!("{}", format!("{}{}", "blake2b len = ".to_string(), format!("{}", format!("{:x}", (<blake2::Blake2b512 as blake2::Digest>::digest)((s).as_bytes())).chars().count() as i64)));
-    println!("{}", format!("{}{}", "blake2s len = ".to_string(), format!("{}", format!("{:x}", (<blake2::Blake2s256 as blake2::Digest>::digest)((s).as_bytes())).chars().count() as i64)));
+    println!("{}", format!("{}{}", "sha224 len = ".to_string(), format!("{}", (<sha2::Sha224 as sha2::Digest>::digest)((s).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()).chars().count() as i64)));
+    println!("{}", format!("{}{}", "sha384 len = ".to_string(), format!("{}", (<sha2::Sha384 as sha2::Digest>::digest)((s).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()).chars().count() as i64)));
+    println!("{}", format!("{}{}", "blake2b len = ".to_string(), format!("{}", (<blake2::Blake2b512 as blake2::Digest>::digest)((s).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()).chars().count() as i64)));
+    println!("{}", format!("{}{}", "blake2s len = ".to_string(), format!("{}", (<blake2::Blake2s256 as blake2::Digest>::digest)((s).as_bytes()).iter().map(|__byte| format!("{:02x}", *__byte)).collect::<Vec<String>>().join("".to_string().as_str()).chars().count() as i64)));
 }
 
 fn demo_platform() {

--- a/demos/tempfile/emitted.rs
+++ b/demos/tempfile/emitted.rs
@@ -3,7 +3,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }

--- a/demos/tempfiles_and_zip/emitted.rs
+++ b/demos/tempfiles_and_zip/emitted.rs
@@ -3,7 +3,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }
@@ -227,7 +227,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;
@@ -252,7 +252,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;

--- a/demos/tempfiles_and_zip/idiomatic.rs
+++ b/demos/tempfiles_and_zip/idiomatic.rs
@@ -123,13 +123,13 @@ fn rewrite_zip_with_entry(path: &Path, name: &str, content: &[u8]) -> io::Result
 
     for (existing_name, existing_data) in existing_entries {
         writer
-            .start_file(existing_name, zip::write::FileOptions::default())
+            .start_file(existing_name, zip::write::SimpleFileOptions::default())
             .map_err(|err| io::Error::other(err.to_string()))?;
         writer.write_all(&existing_data)?;
     }
 
     writer
-        .start_file(name.to_string(), zip::write::FileOptions::default())
+        .start_file(name.to_string(), zip::write::SimpleFileOptions::default())
         .map_err(|err| io::Error::other(err.to_string()))?;
     writer.write_all(content)?;
     writer

--- a/demos/zipfile_io/emitted.rs
+++ b/demos/zipfile_io/emitted.rs
@@ -90,7 +90,7 @@ fn _random_suffix() -> String {
     let n: i64 = {
         let __start = 100000 as i64;
         let __end = 999999 as i64;
-        __start + rand::Rng::gen_range(&mut rand::thread_rng(), 0..(__end - __start) + 1)
+        __start + rand::RngExt::random_range(&mut rand::rng(), 0..(__end - __start) + 1)
     };
     return format!("{}", n);
 }
@@ -241,7 +241,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;
@@ -266,7 +266,7 @@ impl ZipFile {
                 .map_err(__io_err)?;
             let mut __zip = zip::ZipWriter::new_append(__f)
                 .map_err(|e| IOError::new(e.to_string()))?;
-            let __opts = zip::write::FileOptions::default();
+            let __opts = zip::write::SimpleFileOptions::default();
             __zip
                 .start_file(__name.to_string(), __opts)
                 .map_err(|e| IOError::new(e.to_string()))?;

--- a/demos/zipfile_io/idiomatic.rs
+++ b/demos/zipfile_io/idiomatic.rs
@@ -191,13 +191,13 @@ fn rewrite_zip_with_entry(path: &Path, name: &str, content: &[u8]) -> io::Result
 
     for (existing_name, existing_data) in existing_entries {
         writer
-            .start_file(existing_name, zip::write::FileOptions::default())
+            .start_file(existing_name, zip::write::SimpleFileOptions::default())
             .map_err(|err| io::Error::other(err.to_string()))?;
         writer.write_all(&existing_data)?;
     }
 
     writer
-        .start_file(name.to_string(), zip::write::FileOptions::default())
+        .start_file(name.to_string(), zip::write::SimpleFileOptions::default())
         .map_err(|err| io::Error::other(err.to_string()))?;
     writer.write_all(content)?;
     writer

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -216,7 +216,7 @@ flowchart LR
 
 ## Crate Structure (Rust Workspace)
 
-**Hybrid dependency approach:** Infrastructure crates, parser, and AST crates are referenced from the Ruff fork submodule, currently based on Ruff 0.15.12. Parser and AST crates include the Sifr-specific parameter convention extension and are imported through Cargo aliases as `sifr_python_ast` and `sifr_python_parser`. The effective Rust toolchain floor follows the Ruff submodule crates and is currently Rust 1.93.
+**Hybrid dependency approach:** Infrastructure crates, parser, and AST crates are referenced from the Ruff fork submodule, currently based on Ruff 0.15.12. Parser and AST crates include the Sifr-specific parameter convention extension and are imported through Cargo aliases as `sifr_python_ast` and `sifr_python_parser`. The root workspace pins Sifr's direct and generated-runtime support crates to the latest stable releases independently from the excluded Ruff fork, which keeps its own sub-workspace dependency pins. The effective Rust toolchain floor follows the Ruff submodule crates and is currently Rust 1.93.
 
 ```
 sifr/

--- a/verification/stdlib/wave_psp_rng_2_cpython_traceability.md
+++ b/verification/stdlib/wave_psp_rng_2_cpython_traceability.md
@@ -20,11 +20,11 @@ Scope: advanced hash + binary surface expansion for `sifr.hashlib` and `sifr.bas
 
 ## Dependency Audit Note (Wave 2)
 
-- Active generated-runtime hash dependencies in this wave remain:
-  - `sha2 = "0.10"`
-  - `md5 = "0.7"`
-  - `sha1 = "0.10"`
-  - `blake2 = "0.10"`
+- Active generated-runtime hash dependencies in this wave are pinned to:
+  - `sha2 = "0.11.0"`
+  - `md5 = "0.8.0"`
+  - `sha1 = "0.11.0"`
+  - `blake2 = "0.10.6"`
 - No SHA3/SHAKE dependency is currently registered for generated runtime crates in this wave.
 - Outcome: SHA3/SHAKE remains explicitly unsupported and guarded by typed boundaries.
 


### PR DESCRIPTION
## Summary

- Bump Sifr workspace and generated-runtime dependency pins to latest stable releases while leaving the Ruff fork update separate.
- Migrate generated runtime APIs for rand 0.10, zip 8, toml 1.1, and digest 0.11 hash formatting.
- Address final review gaps: fix latent `random_sample` codegen for rand 0.10, clarify Sifr/Ruff dependency pin policy, remove unnecessary workspace `toml` `preserve_order`, and refresh stale demo transcripts.

## Validation

- `cargo test -p sifr_codegen intrinsics -- --nocapture`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo fmt --check && scripts/run_all_tests.sh`

## Review

A second Claude Code review was run locally. It found one latent `random_sample` regression and several pin/demo/documentation hygiene gaps; the actionable items were fixed before this PR was created.
