### PR TITLE
Inventory diagnostic emission surfaces

### DIFF
--- a/internal_docs/diagnostic_emission_inventory.md
+++ b/internal_docs/diagnostic_emission_inventory.md
@@ -1,0 +1,380 @@
+# Diagnostic Emission Inventory
+
+This inventory is the `milestone_diag_3` handoff into diagnostic registry population. It does not migrate emissions. It records the current emission surfaces, the target diagnostic identity for each user-facing category, representative fixtures, and notes that the migration milestones must preserve.
+
+Coverage snapshot from April 29, 2026:
+
+- `rg "ctx\\.error\\(" crates/sifr_hir/src -g '*.rs'` finds 489 raw HIR lowering emissions across 22 files.
+- `rg "CompileError \\{" crates/sifr_driver/src crates/sifr/src -g '*.rs'` has 54 raw textual matches, including `struct`, `impl`, and return-type lines. The actual legacy driver/CLI construction surface is 47 sites: 43 production `CompileError { ... }` literals plus 4 test-only diagnostic construction sites.
+- `rg "TypeErrorKind::" crates/sifr_type_system/src crates/sifr_hir/src -g '*.rs'` finds 24 current type-system typed-error construction sites.
+- `rg "# expect-error" crates/sifr/tests/e2e/fail crates/sifr/tests/e2e.rs -g '*.sifr' -g '*.rs'` finds 92 fail-fixture expectations plus 8 harness test samples.
+
+## HIR Lowering Surface
+
+Raw `ctx.error(...)` remains the largest source of user-facing semantic diagnostics. The migration target is domain-owned helpers that construct `SifrDiagnostic` directly with primary spans from the AST node being lowered.
+
+| File | Raw calls | Primary categories | Target families |
+| --- | ---: | --- | --- |
+| `crates/sifr_hir/src/lower/expressions.rs` | 205 | undefined names/functions, unsupported operators/calls, builtin and stdlib call validation, collection/method validation, comprehension/generator restrictions, tuple slicing, decimal constructor/method forwarding, protocol-style callable checks, unsupported expression/operator features | `NAME`, `TYPE`, `CALL`, `STDLIB`, `PROTO`, `DECIMAL`, `FLOW` |
+| `crates/sifr_hir/src/lower/statements.rs` | 61 | break/continue, raise/result rules, with/context-manager rules, match patterns and exhaustiveness, assignment shape, borrow/move assignment, for-loop target/iterable rules | `FLOW`, `RESULT`, `PROTO`, `MATCH`, `TYPE`, `OWN`, `CALL` |
+| `crates/sifr_hir/src/lower/builtin_calls.rs` | 55 | builtin call arity, argument type checks, constructor restrictions, exact numeric conversion checks | `CALL`, `TYPE`, `DECIMAL`, `STDLIB` |
+| `crates/sifr_hir/src/lower/typing_and_functions.rs` | 24 | unknown type names, invalid annotations, callable/result/dict/list annotation shape, TypeVar/generic arity and bounds, unsupported default argument expression | `NAME`, `TYPE`, `RESULT`, `PROTO`, `CALL` |
+| `crates/sifr_hir/src/lower/mod.rs` | 20 | TypeVar declarations, source-level import resolution, stdlib/intrinsic module member lookup, module lookup; workspace graph failures move to driver | `TYPE`, `IMPORT`, `NAME`, `STDLIB`; wrong-layer `WORKSPACE` moves to driver |
+| `crates/sifr_hir/src/lower/classes.rs` | 19 | class inheritance, constructor/field order, auto-init, enum duplicate values, field/method lookup, iterator/reversible protocol method shape | `CLASS`, `TYPE`, `NAME`, `PROTO` |
+| `crates/sifr_hir/src/lower/decimal_methods.rs` | 18 | decimal/bigdecimal round and quantize argument/type/context restrictions, decimal method arity, unknown decimal method | `DECIMAL`, `CALL`, `NAME` |
+| `crates/sifr_hir/src/lower/aug_assign_lowering.rs` | 17 | unsupported augmented assignment operators/targets, type-check forwarding, undefined assignment target, move/borrow forwarding | `TYPE`, `OWN`, `NAME` |
+| `crates/sifr_hir/src/lower/bytes_methods.rs` | 16 | bytes/str encode/decode method arity, type, and supported-encoding restrictions | `STDLIB`, `CALL`, `TYPE` |
+| `crates/sifr_hir/src/lower/method_call_args.rs` | 13 | method receiver/call arity, unexpected keywords, duplicate arguments, missing required arguments | `CALL`, `TYPE` |
+| `crates/sifr_hir/src/lower/tuple_unpack.rs` | 13 | tuple/list unpack arity and target restrictions | `TYPE`, `FLOW` |
+| `crates/sifr_hir/src/lower/container_literal_specialization.rs` | 11 | list/set/dict/tuple literal element type conflicts and type-check forwarding | `TYPE` |
+| `crates/sifr_hir/src/lower/subscript_type.rs` | 3 | tuple index bounds and non-indexable types | `TYPE` |
+| `crates/sifr_hir/src/lower/nonlocal_support.rs` | 3 | invalid nonlocal declarations and missing enclosing binding | `FLOW`, `NAME` |
+| `crates/sifr_hir/src/lower/min_max_validation.rs` | 2 | min/max argument validation | `CALL`, `TYPE` |
+| `crates/sifr_hir/src/lower/nested_function_inference.rs` | 2 | nested function inference conflict and unsupported recursive nonlocal behavior | `TYPE`, `FLOW` |
+| `crates/sifr_hir/src/lower/type_aliases.rs` | 2 | invalid alias target and recursive alias detection | `TYPE`, `NAME` |
+| `crates/sifr_hir/src/lower/binding_mutability.rs` | 1 | mutability rebinding conflict | `OWN` |
+| `crates/sifr_hir/src/lower/control_flow_conditions.rs` | 1 | boolean condition type requirement | `FLOW`, `TYPE` |
+| `crates/sifr_hir/src/lower/if_expression.rs` | 1 | if-expression branch type incompatibility | `TYPE` |
+| `crates/sifr_hir/src/lower/module_function_registry.rs` | 1 | missing module-level callable declaration | `NAME` |
+| `crates/sifr_hir/src/lower/mutating_methods.rs` | 1 | mutation of immutable receiver | `OWN` |
+
+Wrong-layer notes:
+
+- Import resolution in `lower/mod.rs` currently emits ordinary type-check errors for workspace/module discovery failures. File-system workspace failures should remain in `sifr_driver`/`WORKSPACE`; source-level import syntax/member failures should be `IMPORT` or `NAME`.
+- Decimal pseudo-codes are embedded in `sifr_type_system` and HIR messages. They must become `DECIMAL-*` identity at construction, not message text.
+- Builtin and stdlib surface checks are split between `expressions.rs`, `builtin_calls.rs`, and dedicated modules. Migration should move helpers near the semantic owner but keep shared argument-shape utilities to avoid divergent `CALL-*` templates.
+
+## Parser Surface
+
+Parser errors originate in the Ruff fork (`sifr_python_parser`, exported from `third_party/ruff/crates/ruff_python_parser/src/error.rs`) and are currently wrapped by `sifr_driver::frontend::api` as phase-derived `SIFR-PARSE-0001`. `SIFR-PARSE-0001` should be retired as a catch-all in `milestone_diag_2b`; parser migration (`milestone_diag_7`) should map the exposed error categories below.
+
+| Proposed code | Ruff category / examples | Fixture plan |
+| --- | --- | --- |
+| `SIFR-PARSE-0001` | retired legacy phase bucket | registry-only retired entry, no active fixture |
+| `SIFR-PARSE-0002` | expected token or generic recovery context (`ExpectedToken`, `OtherError("Expected ...")`, `ExpectedExpression`, `UnexpectedExpressionToken`) | fixture pending in `milestone_diag_7`: missing delimiter/expression; existing invalid source unit tests can seed it |
+| `SIFR-PARSE-0003` | lexical and interpolated-string errors (`Lexical`, `FStringError`, `TStringError`) | fixture pending in `milestone_diag_7`: malformed string/f-string |
+| `SIFR-PARSE-0004` | indentation and same-line statement layout (`UnexpectedIndentation`, `SimpleStatementsOnSameLine`, `SimpleAndCompoundStatementOnSameLine`) | fixture pending in `milestone_diag_7`: indentation/layout |
+| `SIFR-PARSE-0005` | invalid assignment/delete/starred/named-expression targets (`InvalidAssignmentTarget`, `InvalidAnnotatedAssignmentTarget`, `InvalidNamedAssignmentTarget`, `InvalidAugmentedAssignmentTarget`, `InvalidDeleteTarget`, `InvalidStarredExpressionUsage`) | fixture pending in `milestone_diag_7`: invalid target |
+| `SIFR-PARSE-0006` | invalid call argument order/unpacking (`PositionalAfterKeywordArgument`, `PositionalAfterKeywordUnpacking`, `InvalidArgumentUnpackingOrder`, `DuplicateKeywordArgumentError`) | fixture pending in `milestone_diag_7`: invalid call syntax |
+| `SIFR-PARSE-0007` | empty or malformed declaration lists (`EmptyImportNames`, `EmptyGlobalNames`, `EmptyNonlocalNames`, `EmptyTypeParams`, parameter-order errors) | fixture pending in `milestone_diag_7`: malformed import/global/nonlocal/type-param |
+| `SIFR-PARSE-0008` | invalid pattern/match syntax (`InvalidStarPatternUsage`, invalid mapping/class pattern errors, expected pattern recovery) | fixture pending in `milestone_diag_7`: invalid match-pattern |
+| `SIFR-PARSE-0009` | explicitly unsupported parser syntax or interactive-only syntax (`UnsupportedSyntaxErrorKind`, `UnexpectedIpythonEscapeCommand`, unsupported async token contexts) | fixture pending in `milestone_diag_7`: unsupported syntax |
+
+## Type System Surface
+
+`sifr_type_system::TypeError` and `TypeErrorKind` are transitional only. They have typed payloads but no spans, no stable code, and no canonical renderer model. Migration should replace them with direct domain helper calls in HIR/type-checking code, then delete these symbols.
+
+| Current variant / construction | Current message category | Target code | Representative fixture |
+| --- | --- | --- | --- |
+| `TypeErrorKind::TypeMismatch` | ordinary expected/actual mismatch | `SIFR-TYPE-0002` | `crates/sifr/tests/e2e/fail/type_mismatch.sifr` |
+| `TypeErrorKind::TypeMismatch` | union/optional mismatch | `SIFR-TYPE-0002` with union args | `crates/sifr/tests/e2e/fail/union_type_mismatch.sifr` |
+| `TypeErrorKind::TypeMismatch` | decimal/bigdecimal comparison | `SIFR-DECIMAL-0004` | `crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr` |
+| `TypeErrorKind::TypeMismatch` | float compared with decimal family | `SIFR-DECIMAL-0003` | `crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr` |
+| `TypeErrorKind::UndefinedVariable` | unresolved local/name expression | `SIFR-NAME-0001` | `crates/sifr/tests/e2e/fail/undefined_var.sifr` |
+| `TypeErrorKind::UndefinedFunction` | unresolved callable name | `SIFR-NAME-0002` | `crates/sifr/tests/e2e/fail/stdlib_invalid_module.sifr` |
+| `TypeErrorKind::WrongArgumentCount` | positional arity mismatch | `SIFR-CALL-0001` | `crates/sifr/tests/e2e/fail/stdlib_wrong_arg_count.sifr` |
+| `TypeErrorKind::UseAfterMove` | moved value use | `SIFR-OWN-0001` | `crates/sifr/tests/e2e/fail/use_after_move.sifr` |
+| `TypeErrorKind::MissingTypeAnnotation` | annotation required for inference boundary | `SIFR-TYPE-0004` | fixture pending in `milestone_diag_2b` |
+| `TypeErrorKind::InvalidOperator` | unsupported arithmetic/comparison/unary/bool operator | `SIFR-TYPE-0005` | `crates/sifr/tests/e2e/fail/optional_arithmetic_without_narrowing.sifr` |
+| `TypeErrorKind::InvalidOperator` | int/bigint arithmetic or comparison requires conversion | `SIFR-TYPE-0006` | `crates/sifr/tests/e2e/fail/bigint_int_mixed_arithmetic.sifr`, `crates/sifr/tests/e2e/fail/bigint_int_mixed_comparison.sifr` |
+| `TypeErrorKind::InvalidOperator` | decimal-family mixed arithmetic | `SIFR-DECIMAL-0003`, `SIFR-DECIMAL-0004` | decimal mixed arithmetic fixtures |
+| `TypeErrorKind::NotCallable` | non-callable receiver/expression used as callable | `SIFR-CALL-0005` | fixture pending in call migration |
+
+## Driver And CLI Surface
+
+Legacy `CompileError` is the current outer transport and phase-derived code source. The migration target is `DiagnosticSink` plus `ErrorEmitted`; `CompileError` and `CompilerDiagnostic` should disappear by residual cleanup.
+
+| Surface | Current construction count | Current code source | Target handling |
+| --- | ---: | --- | --- |
+| `crates/sifr_driver/src/diagnostics.rs` | 1 | `CompilePhase` maps `Parse -> SIFR-PARSE-0001`, `TypeCheck -> SIFR-TYPE-0001`, `Codegen -> SIFR-CODEGEN-0001`, `Build -> SIFR-BUILD-0001`; workspace prefix classifier maps some build messages to `SIFR-WORKSPACE-*`; one actual construction is the codegen panic boundary | Delete phase-derived codes in `milestone_diag_4a`; route already-structured diagnostics through shared renderer. Workspace prefix classifier is replaced by typed `WORKSPACE-*` constructors. |
+| `crates/sifr_driver/src/frontend/api.rs` | 2 | parser frontend errors become `CompilePhase::Parse`; HIR lowering errors become `CompilePhase::TypeCheck` | Parser adapter emits `PARSE-*`; HIR returns `LoweringOutcome` diagnostics. |
+| `crates/sifr_driver/src/frontend/module_lowering.rs` | 1 | module lowering errors become `TypeCheck` | Preserve module/source span and direct HIR diagnostic identity. |
+| `crates/sifr_driver/src/project/discovery.rs` | 6 | workspace discovery and reachable parse failures | Keep workspace discovery in `WORKSPACE-*`; reachable source parse failures are `PARSE-*`. |
+| `crates/sifr_driver/src/project/compile_order.rs` | 1 | dependency cycle as `TypeCheck` | `SIFR-WORKSPACE-0104` or `SIFR-IMPORT-0004` depending on whether the cycle is workspace graph or source import graph. |
+| `crates/sifr_driver/src/project/frontend.rs` | 1 | project frontend setup as `Build` | Use `WORKSPACE-*` for project assembly failures. |
+| `crates/sifr_driver/src/build/entrypoint.rs` | 3 | build planning/materialization failures | `BUILD-*` for tool/build actions; `WORKSPACE-*` for project graph inputs. |
+| `crates/sifr_driver/src/build/materialize.rs` | 1 | file materialization failure | `SIFR-BUILD-0002`. |
+| `crates/sifr_driver/src/build/workspace.rs` | 7 | temporary dir, cargo manifest, rustc/cargo execution, binary artifact failures | `SIFR-BUILD-0002..0006` by operation. |
+| `crates/sifr_driver/src/stdlib/bootstrap.rs` | 4 | embedded stdlib parse/typecheck/bootstrap failure | `SIFR-STDLIB-0001..0003` for embedded stdlib bootstrap defects; internal if invariant-only. |
+| `crates/sifr_driver/src/stdlib/cache.rs` | 1 | stdlib cache build reuse failure | `SIFR-STDLIB-0004` or `SIFR-BUILD-*` depending on failing operation. |
+| `crates/sifr_driver/src/workspace/mod.rs` | 2 | manifest parse/source-root validation | Existing `SIFR-WORKSPACE-0001..0004` reviewed and kept if templates remain precise. |
+| `crates/sifr_driver/src/test_runner/execution.rs` | 8 | test-runner compile/run/build failures | `SIFR-BUILD-*` for generated Rust test harness build/run operations. |
+| `crates/sifr_driver/src/test_runner/orchestrator.rs` | 2 | test orchestration failure and frontend error forwarding | `BUILD-*` for orchestration; forwarded frontend diagnostics retain original identity. |
+| `crates/sifr/src/main.rs` | 3 | CLI command path build/typecheck/codegen failures | CLI should render diagnostics from driver; direct construction should disappear. |
+
+The 4 test-only `CompileError` construction sites in `crates/sifr_driver/src/tests/diagnostics.rs` intentionally exercise parse/typecheck/codegen/build phase mapping and recovery-limit behavior. They should be rewritten or deleted with the legacy diagnostic abstraction rather than treated as runtime emission sites.
+
+CLI and renderer tests also manually construct `CompilerDiagnostic` values. These are test-only surfaces but must be updated in `milestone_diag_5` when the harness and renderer contracts stop accepting phase-bucket and pseudo-code strings:
+
+| File | Manual `CompilerDiagnostic` sites | Current hard-coded identities | Migration owner |
+| --- | ---: | --- | --- |
+| `crates/sifr/src/main.rs` | 9 | `SIFR-TYPE-0001`, `SIFR-PARSE-0001`, `[E2507]`-style message content in compact-renderer tests | `milestone_diag_5` test harness/renderer contract cleanup |
+| `crates/sifr_driver/src/tests/diagnostics.rs` | 2 | `SIFR-TYPE-0001` recovery-limit fixtures | `milestone_diag_5` or residual legacy diagnostic cleanup |
+
+Current public-code mechanisms to remove:
+
+| Mechanism | Current owner | Current effect | Replacement |
+| --- | --- | --- | --- |
+| Phase-derived `CompilePhase` mapping | `crates/sifr_driver/src/diagnostics.rs` | assigns `SIFR-PARSE-0001`, `SIFR-TYPE-0001`, `SIFR-CODEGEN-0001`, or `SIFR-BUILD-0001` after the real rule has already been flattened | domain helpers construct `SifrDiagnostic` with the canonical code before driver rendering |
+| Workspace prefix classifier | `CompileError::workspace_diagnostic_code` | infers some `SIFR-WORKSPACE-*` identities from rendered message prefixes | typed workspace/project discovery constructors with structured path/module args |
+| Type-error string forwarding | HIR sites that call `ctx.error(e.message)` or `ctx.error(error.message)` | loses `TypeErrorKind`, source relation, expected/actual/operator args, and decimal identity | HIR call site emits the target `TYPE-*`, `DECIMAL-*`, `NAME-*`, `CALL-*`, or `OWN-*` diagnostic directly with the AST span |
+| Message-embedded pseudo-code | decimal/type-system messages and fixture expectations | keeps `[E25xx]` as text inside a broader `SIFR-TYPE-0001` diagnostic | top-level `SIFR-DECIMAL-*` diagnostic code and no secondary message code |
+| Test-only hard-coded diagnostics | CLI renderer and driver diagnostics tests | locks renderer behavior to legacy phase buckets and pseudo-code text | renderer/harness tests construct canonical diagnostics through `sifr_diagnostics` fixtures |
+
+Workspace code review for `milestone_diag_2b`:
+
+- Keep `SIFR-WORKSPACE-0001` for malformed `sifr.toml` parsing.
+- Keep `SIFR-WORKSPACE-0002` for `[source].roots` path escaping workspace root.
+- Keep `SIFR-WORKSPACE-0003` for `[source].roots` path not resolving to a directory.
+- Keep `SIFR-WORKSPACE-0004` for invalid source-root entry shape/path.
+- Keep `SIFR-WORKSPACE-0101` for unresolved import after workspace search path enumeration.
+- Keep `SIFR-WORKSPACE-0102` for ambiguous module resolution across workspace roots.
+- Keep `SIFR-WORKSPACE-0103` for namespace package directory collision.
+- Add `SIFR-WORKSPACE-0104` if project import-cycle diagnostics remain driver-owned.
+
+## E2E Expectation And Baseline Surface
+
+Current harness behavior in `crates/sifr/tests/e2e.rs` treats `# expect-error:` as substring matching. Harness sample tests explicitly accept `SIFR-PARSE-0001`, `SIFR-TYPE-0001`, and `[E2507]`. That is intentional legacy state until `milestone_diag_6`; inventory confirms these are the surfaces to tighten.
+
+Current fail-fixture and harness-sample code markers:
+
+| Marker | Count | Migration action |
+| --- | ---: | --- |
+| `SIFR-TYPE-0001` | 95 | Retire catch-all. Replace with category-specific codes during family migration milestones. |
+| `SIFR-PARSE-0001` | 2 harness samples | Replace parse harness samples with canonical parse codes once parser emits structured diagnostics. |
+| `[E2501]` | 1 | `SIFR-DECIMAL-0001`. |
+| `[E2502]` | 2 | `SIFR-DECIMAL-0002`. |
+| `[E2503]` | 1 | `SIFR-DECIMAL-0003`. |
+| `[E2504]` | 2 | `SIFR-DECIMAL-0004`. |
+| `[E2505]` | 3 | `SIFR-DECIMAL-0005`. |
+| `[E2506]` | 2 | `SIFR-DECIMAL-0006`. |
+| `[E2507]` | 5 | `SIFR-DECIMAL-0007`. |
+| `[E2508]` | 2 | `SIFR-DECIMAL-0008`. |
+
+Unannotated fail fixtures are also part of the migration surface. There are 88 fail fixtures with no `# expect-error` today; they currently assert only "compilation must fail". They should gain code assertions in the milestone that migrates the owning family, using the target-family grouping below.
+
+| Group | Files | Target family/code plan |
+| --- | --- | --- |
+| stdlib unsupported or constrained APIs | `argparse_*`, `async_popen_unsupported`, `bisect_key_unsupported`, `configparser_*`, `counter_*`, `csv_dynamic_registry_unsupported`, `datetime_*`, `difflib_*`, `functools_*`, `glob_*`, `graphlib_*`, `hashlib_*`, `html_*`, `io_*`, `ip_address_*`, `itertools_*`, `json_*`, `logging_*`, `math_isclose_*`, `operator_*`, `os_*`, `pathlib_*`, `pyio_*`, `random_*`, `re_*`, `secrets_*`, `sha3_*`, `shutil_*`, `spooled_*`, `statistics_*`, `subprocess_*`, `sys_*`, `system_random_*`, `timeit_*`, `timezone_*`, `uuid_*`, `zip_*`, `zipfile_*` | `SIFR-STDLIB-*` for unsupported stdlib surface; `SIFR-CALL-*` for arity/keyword shape; `SIFR-TYPE-*` for wrong argument type |
+| bytes and binary/text I/O | `bytes_*`, `bytesio_*`, `stringio_*` | `SIFR-STDLIB-*` for unsupported surface/codec limitations; `SIFR-CALL-*` for arity; `SIFR-TYPE-*` for wrong data type; `SIFR-OWN-*` for immutable bytes assignment |
+| ownership and mutability | `borrowed_mut_parameter_return_escape`, `nested_function_capture_mutates_immutable_param`, `own_parameter_*` | `SIFR-OWN-0003` for escape, `SIFR-OWN-*` mutability-specific codes for mutation without `mut` |
+| collection/container shape | `deque_index_invalid_bound`, `dict_*`, `list_unexpected_keyword`, `set_update_non_iterable`, `str_replace_invalid_count`, `tuple_*` | `SIFR-CALL-*` for keyword/arity/default conflicts; `SIFR-TYPE-*` for element/index type and tuple shape |
+| type alias / recursive typing | `recursive_*`, `type_alias_missing_dependency` | `SIFR-TYPE-*` for recursive alias boundaries/arity, `SIFR-NAME-*` for missing alias dependency |
+
+The full unannotated set at this snapshot is:
+
+```text
+argparse_formatter_class_unsupported.sifr
+argparse_parse_args_non_string_list.sifr
+async_popen_unsupported.sifr
+bisect_key_unsupported.sifr
+borrowed_mut_parameter_return_escape.sifr
+bytes_append_unsupported.sifr
+bytes_buffer_protocol_unsupported.sifr
+bytes_bytearray_unsupported.sifr
+bytes_bytes_subclass_unsupported.sifr
+bytes_constructor_non_int.sifr
+bytes_decode_non_string_codec.sifr
+bytes_encode_non_string_codec.sifr
+bytes_from_hex_non_string.sifr
+bytes_from_ints_non_int_list.sifr
+bytes_implicit_str_bytes_coercion_unsupported.sifr
+bytes_memoryview_unsupported.sifr
+bytes_non_utf8_codec_unsupported.sifr
+bytes_read_bytes_not_list.sifr
+bytes_subscript_assignment_unsupported.sifr
+bytes_write_bytes_rejects_int_list.sifr
+bytesio_text_write_unsupported.sifr
+configparser_converter_registration_unsupported.sifr
+counter_iterable_constructor_unsupported.sifr
+counter_kwargs_constructor_unsupported.sifr
+csv_dynamic_registry_unsupported.sifr
+datetime_from_timestamp_non_float.sifr
+datetime_tzinfo_zoneinfo_unsupported.sifr
+deque_index_invalid_bound.sifr
+dict_get_duplicate_default.sifr
+dict_setdefault_invalid_default.sifr
+dict_update_invalid_pairs.sifr
+difflib_sequence_matcher_isjunk_unsupported.sifr
+functools_partial_unsupported.sifr
+glob_non_string_pattern.sifr
+graphlib_add_non_int_predecessor.sifr
+hashlib_new_non_string_name.sifr
+hashlib_pbkdf2_hmac_unsupported.sifr
+hashlib_scrypt_unsupported.sifr
+html_package_parser_unsupported.sifr
+io_open_non_string_mode.sifr
+ip_address_non_string.sifr
+itertools_groupby_unsupported.sifr
+itertools_materialization_required.sifr
+itertools_starmap_non_binary_callable.sifr
+itertools_tee_unsupported.sifr
+json_dynamic_hooks_unsupported.sifr
+list_unexpected_keyword.sifr
+logging_dictconfig_unsupported.sifr
+logging_loggeradapter_unsupported.sifr
+math_isclose_non_float_tol.sifr
+nested_function_capture_mutates_immutable_param.sifr
+operator_attrgetter_unsupported.sifr
+operator_methodcaller_unsupported.sifr
+ordered_counter_kwargs_constructor_unsupported.sifr
+os_mkdir_non_string_path.sifr
+own_parameter_method_mutation_requires_mut.sifr
+own_parameter_mutation_requires_mut.sifr
+pathlib_iterator_materialization_required.sifr
+pyio_inheritance_unsupported.sifr
+random_choices_weights_unsupported.sifr
+re_search_non_string_pattern.sifr
+recursive_generic_type_alias_wrong_arity.sifr
+recursive_mutual_type_alias_missing_boundary.sifr
+recursive_tree_attribute_without_narrowing.sifr
+recursive_type_alias_missing_boundary.sifr
+reversed_runtime_iterator_not_reversible.sifr
+secrets_token_urlsafe_unsupported.sifr
+set_update_non_iterable.sifr
+sha3_object_model_unsupported.sifr
+shutil_copy_non_string_path.sifr
+spooled_tempfile_unsupported.sifr
+statistics_mean_non_float_list.sifr
+statistics_normaldist_unsupported.sifr
+str_replace_invalid_count.sifr
+stringio_read_bytes_unsupported.sifr
+subprocess_non_string_cmd.sifr
+sys_exit_non_int_code.sifr
+system_random_state_unsupported.sifr
+timeit_non_callable_stmt.sifr
+timeit_string_eval_unsupported.sifr
+timezone_mutation_unsupported.sifr
+tuple_heterogeneous_iteration_unsupported.sifr
+tuple_index_invalid_bound.sifr
+type_alias_missing_dependency.sifr
+uuid_from_hex_non_string.sifr
+zip_bzip2_constant_unsupported.sifr
+zip_ext_file_unsupported.sifr
+zipfile_write_non_string_content.sifr
+```
+
+## Verification Baseline Surface
+
+Checked-in verification baselines under `crates/sifr/tests/verification` are a separate migration surface from fail fixtures. They should be regenerated in the milestone that changes the corresponding renderer/harness behavior.
+
+| Verification case | Current baseline markers | Target / owner |
+| --- | --- | --- |
+| `diagnostics/decimal_invalid_literal` | `SIFR-TYPE-0001` plus message-embedded `[E2501]` in compact/json/human output | `SIFR-DECIMAL-0001`; regenerate in decimal migration and renderer integration |
+| `project/missing_import_reports_error` | `SIFR-WORKSPACE-0101` in compact/json output | keep `SIFR-WORKSPACE-0101`; renderer integration regenerates schema shape only |
+| `project/workspace_unresolved_import` | `SIFR-WORKSPACE-0101` in compact/json output | keep `SIFR-WORKSPACE-0101`; add related searched paths |
+| `project/workspace_ambiguous_import` | `SIFR-WORKSPACE-0102` in compact/json output | keep `SIFR-WORKSPACE-0102`; add related candidate paths |
+| `project/workspace_malformed_manifest` | `SIFR-WORKSPACE-0001` in compact/json output | keep `SIFR-WORKSPACE-0001`; add manifest span/path metadata where available |
+| `project/multi_module_run`, `project/workspace_dotted_helper_run` | no diagnostic marker; pass baselines exercise project mode stability | no diagnostic migration, but rerun with renderer tests |
+| `crashes/CR-0001_cfg_invariant_minimized`, `crashes/CR-0002_parser_invariant_minimized` | crash minimization inputs, no checked renderer baseline | panic-boundary/internal diagnostic validation, likely `SIFR-INTERNAL-0001` if surfaced through user path |
+
+## Non-Error Emission Paths
+
+Warnings and notes are part of the same diagnostic stream and cannot remain uncoded side channels.
+
+| Surface | Current sites | Current behavior | Target code / owner |
+| --- | ---: | --- | --- |
+| `ctx.warn(...)` arithmetic overflow risk | 5 in `lower/arithmetic_warnings.rs` | warning strings for int exponentiation, multiplication, and shift overflow risk | `SIFR-TYPE-0901` warning, owner `sifr_hir::lower::arithmetic_warnings` |
+| `ctx.warn(...)` unreachable statement | 1 in `lower/statements.rs` | warning string when a statement after guaranteed exit is ignored | `SIFR-FLOW-0901` warning |
+| `ctx.warn(...)` exhaustive-return validation panic recovery | 1 in `lower/typing_and_functions.rs` | warning string after `catch_unwind` skips control-flow validation | wrong-layer internal boundary; route as `SIFR-INTERNAL-0001` or eliminate panic path rather than keeping a user warning |
+| `ctx.reveal_types` | `reveal_type(...)` in `lower/builtin_calls.rs`; guarded-index reveal propagation in `lower/guarded_index.rs` | note-like developer output currently stored as strings | `SIFR-TYPE-0902` note with `revealed_type` arg and recovery-cap participation |
+| HIR-internal `catch_unwind` | `lower/typing_and_functions.rs` exhaustive-return check | catches an internal CFG invariant failure and downgrades it to warning | wrong-layer internal failure; should not be categorized as user-fixable |
+
+## Target Code And Fixture Plan
+
+These entries are the proposed active registry population for `milestone_diag_2b`. The exact templates and declared args can be adjusted during population, but every migrated category must keep a specific code and representative fixture.
+
+| Code | Category | Owner module | Representative fixture / proof |
+| --- | --- | --- | --- |
+| `SIFR-PARSE-0002` | expected token or generic parser recovery with source span | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: missing delimiter/expression or existing invalid source tests |
+| `SIFR-PARSE-0003` | lexical or interpolated-string parser error | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: malformed string/f-string |
+| `SIFR-PARSE-0004` | indentation or same-line statement layout error | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: indentation/layout |
+| `SIFR-PARSE-0005` | invalid assignment/delete/starred/named-expression target syntax | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: invalid target |
+| `SIFR-PARSE-0006` | invalid call argument order/unpacking syntax | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: invalid call syntax |
+| `SIFR-PARSE-0007` | empty or malformed declaration list syntax | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: malformed import/global/nonlocal/type-param |
+| `SIFR-PARSE-0008` | invalid match-pattern syntax | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: invalid match-pattern |
+| `SIFR-PARSE-0009` | unsupported parser syntax or interactive-only syntax | parser adapter / driver frontend | fixture pending in `milestone_diag_7`: unsupported syntax |
+| `SIFR-NAME-0001` | undefined variable | `sifr_hir::lower` name lookup | `crates/sifr/tests/e2e/fail/undefined_var.sifr` |
+| `SIFR-NAME-0002` | undefined function/callable | `sifr_hir::lower` call lowering | `crates/sifr/tests/e2e/fail/stdlib_invalid_module.sifr` |
+| `SIFR-NAME-0003` | unknown type or generic type name | type annotation lowering | `crates/sifr/tests/e2e/fail/generic_class_missing_type_arg.sifr` |
+| `SIFR-NAME-0004` | module/member does not exist | import/member lookup | `crates/sifr/tests/e2e/fail/stdlib_missing_function.sifr` |
+| `SIFR-IMPORT-0001` | forbidden `_sifr.*` intrinsic import | import lowering | `crates/sifr/tests/e2e/fail/import_intrinsic.sifr` |
+| `SIFR-IMPORT-0002` | unknown source module/import target | import lowering/project discovery | `crates/sifr/tests/e2e/fail/import_nonexistent_local.sifr` |
+| `SIFR-TYPE-0001` | retired catch-all | registry only | no active fixture; document retired replacement policy |
+| `SIFR-TYPE-0002` | expected/actual type mismatch | type checking / assignment/call helpers | `crates/sifr/tests/e2e/fail/type_mismatch.sifr` |
+| `SIFR-TYPE-0003` | if/conditional branch type mismatch | `if_expression` lowering | `crates/sifr/tests/e2e/fail/ternary_type_mismatch.sifr` |
+| `SIFR-TYPE-0004` | missing required type annotation/inference boundary | type annotation/inference | fixture pending in `milestone_diag_2b` |
+| `SIFR-TYPE-0005` | unsupported operator or operand types | `sifr_type_system` / HIR expression lowering | `crates/sifr/tests/e2e/fail/optional_arithmetic_without_narrowing.sifr` |
+| `SIFR-TYPE-0006` | int/bigint mixed arithmetic/comparison without conversion | type system numeric checks | bigint mixed arithmetic/comparison fixtures |
+| `SIFR-TYPE-0007` | invalid type annotation shape | type annotation lowering | fixture pending in `milestone_diag_2b` from annotation tests |
+| `SIFR-TYPE-0008` | container literal element/key/value type conflict | container literal specialization | fixture pending in `milestone_diag_2b` |
+| `SIFR-TYPE-0009` | tuple/list unpacking shape mismatch | tuple unpack lowering | `crates/sifr/tests/e2e/fail/tuple_dynamic_list_shape.sifr` |
+| `SIFR-DECIMAL-0001` | `Decimal()` invalid exact literal | decimal constructor lowering | `crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr` |
+| `SIFR-DECIMAL-0002` | `BigDecimal()` invalid or non-literal exact string | decimal constructor lowering | bigdecimal invalid/non-literal fixtures |
+| `SIFR-DECIMAL-0003` | float mixed with decimal family | type system decimal checks | `crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr` |
+| `SIFR-DECIMAL-0004` | decimal mixed with bigdecimal | type system decimal checks | `crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr` |
+| `SIFR-DECIMAL-0005` | decimal float construction/conversion forbidden | decimal constructor/conversion lowering | decimal float constructor/conversion fixtures |
+| `SIFR-DECIMAL-0006` | bigdecimal float construction/conversion forbidden | decimal constructor/conversion lowering | bigdecimal float constructor/conversion fixtures |
+| `SIFR-DECIMAL-0007` | decimal round/quantize scale invalid | `decimal_methods` | decimal round/quantize scale fixtures |
+| `SIFR-DECIMAL-0008` | bigdecimal round/quantize scale/context invalid | `decimal_methods` | bigdecimal round/quantize fixtures |
+| `SIFR-CALL-0001` | wrong positional argument count | call/method validation | `crates/sifr/tests/e2e/fail/stdlib_wrong_arg_count.sifr` |
+| `SIFR-CALL-0002` | unexpected keyword argument | call/method validation | `crates/sifr/tests/e2e/fail/sorted_unexpected_keyword.sifr` |
+| `SIFR-CALL-0003` | duplicate argument from positional/keyword overlap | call/method validation | `crates/sifr/tests/e2e/fail/keyword_after_positional_error.sifr` |
+| `SIFR-CALL-0004` | missing required argument | call/method validation | `crates/sifr/tests/e2e/fail/missing_keyword_only_arg.sifr` |
+| `SIFR-CALL-0005` | callable arity/non-callable mismatch | call/method validation | `crates/sifr/tests/e2e/fail/map_callable_arity_mismatch.sifr` |
+| `SIFR-OWN-0001` | use after move | ownership tracking | use-after-move fixtures |
+| `SIFR-OWN-0002` | double mutable borrow | ownership/borrow checker | `crates/sifr/tests/e2e/fail/double_mut_borrow.sifr` |
+| `SIFR-OWN-0003` | borrowed parameter escapes by return/store | ownership tracking | borrow escape fixtures |
+| `SIFR-OWN-0004` | moved value across loop iteration | ownership tracking | `crates/sifr/tests/e2e/fail/use_after_move_loop.sifr` |
+| `SIFR-FLOW-0001` | `break` outside loop | statement lowering | `crates/sifr/tests/e2e/fail/break_outside_loop.sifr` |
+| `SIFR-FLOW-0002` | `continue` outside loop | statement lowering | `crates/sifr/tests/e2e/fail/continue_outside_loop.sifr` |
+| `SIFR-FLOW-0003` | unsupported or invalid nonlocal/nested function flow | nested function/nonlocal lowering | `crates/sifr/tests/e2e/fail/nested_function_recursive_nonlocal_unsupported.sifr` |
+| `SIFR-MATCH-0001` | non-exhaustive match | match lowering | match non-exhaustive fixtures |
+| `SIFR-MATCH-0002` | match guard must be bool | match lowering | `crates/sifr/tests/e2e/fail/match_type_mismatch_guard.sifr` |
+| `SIFR-MATCH-0003` | invalid class pattern field | match lowering | `crates/sifr/tests/e2e/fail/match_invalid_field_name.sifr` |
+| `SIFR-PROTO-0001` | protocol bound/conformance failure | generic/protocol checking | generic bounds fixtures |
+| `SIFR-PROTO-0002` | invalid iterator/reversible protocol signature | protocol checking | invalid iterator/reversible fixtures |
+| `SIFR-PROTO-0003` | context-manager protocol missing | with-statement lowering | `crates/sifr/tests/e2e/fail/with_non_context_manager.sifr` |
+| `SIFR-PROTO-0004` | hashable/comparable protocol required | protocol checking | unhashable/comparable fixtures |
+| `SIFR-CLASS-0001` | class has fields but no required initializer/super initializer | class lowering | `crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr` |
+| `SIFR-CLASS-0002` | required field declared after default | class lowering | `crates/sifr/tests/e2e/fail/auto_init_required_after_default.sifr` |
+| `SIFR-CLASS-0003` | duplicate enum/class value or invalid variant | class/enum lowering | enum duplicate/invalid variant fixtures |
+| `SIFR-CLASS-0004` | missing class field/member | class lowering | `crates/sifr/tests/e2e/fail/missing_field.sifr` |
+| `SIFR-RESULT-0001` | unused `Result` value | result/error-flow checking | `crates/sifr/tests/e2e/fail/unused_result.sifr` |
+| `SIFR-RESULT-0002` | invalid `Result` error type | result/error type lowering | `crates/sifr/tests/e2e/fail/error_str_not_allowed.sifr` |
+| `SIFR-RESULT-0003` | invalid `raise` expression | statement lowering | `crates/sifr/tests/e2e/fail/error_raise_str.sifr` |
+| `SIFR-STDLIB-0001` | unsupported stdlib constructor/method surface | stdlib/builtin lowering | `crates/sifr/tests/e2e/fail/defaultdict_keyword_constructor_unsupported.sifr` |
+| `SIFR-STDLIB-0002` | stdlib method/argument type mismatch | stdlib call validation | stdlib wrong type/count fixtures, unless better represented by `CALL`/`TYPE` helper |
+| `SIFR-WORKSPACE-0001..0104` | workspace manifest/source-root/import graph diagnostics | `sifr_driver::workspace` and project discovery | existing driver workspace tests |
+| `SIFR-CODEGEN-0002` | codegen panic boundary/internal backend failure | driver codegen boundary | panic boundary tests |
+| `SIFR-BUILD-0002..0006` | build workspace/materialization/cargo/rustc/test harness failures | driver build/test runner | driver build tests |
+| `SIFR-INTERNAL-0001` | unclassified compiler panic after panic boundary | panic boundary | panic boundary tests |
+
+## Recovery Expectations By Category
+
+These expectations are not implemented until `milestone_diag_10`, but the code assignments above should preserve enough structured args to make them possible.
+
+| Category / codes | Recovery expectation | Dedupe key sketch |
+| --- | --- | --- |
+| `PARSE-*` | non-tainting at diagnostic level; parser recovery decides continuation; cap-summarize after canonical source order | code + primary span + parser category |
+| `NAME-0001..0004` | taint expression as `Unknown` where possible so dependent type errors do not cascade; unresolved import/module errors should stop the affected module path | code + name/module/member + primary span |
+| `IMPORT-*`, `WORKSPACE-*` | fail affected module/project resolution; do not generate downstream type diagnostics for unreachable modules | code + module id/path + primary span or workspace path |
+| `TYPE-0002..0009` | taint expression or binding as `Unknown` after primary mismatch; repeated mismatches cap/dedupe by same expected/actual/operator args | code + expected + actual/operator + primary span |
+| `DECIMAL-0001..0008` | taint expression as `Unknown` for invalid constructor/method/type operation; do not emit a secondary `TYPE-*` for the same expression | code + decimal operation + operand/scale args + primary span |
+| `CALL-0001..0005` | non-tainting for callable declaration; taint call expression result as `Unknown`; missing/duplicate/unexpected arg diagnostics should not poison later arguments | code + callable + arg name/index + primary span |
+| `OWN-0001..0004` | taint moved/borrowed binding state to suppress repeated use-after-move/borrow-escape cascades; keep distinct primary spans for independent ownership errors | code + binding + ownership state + primary span |
+| `FLOW-*` | non-tainting except invalid nested/nonlocal binding state; unreachable-statement warnings remain warnings and do not affect exit status | code + flow construct + primary span |
+| `MATCH-*` | non-tainting for subject expression; non-exhaustiveness emits once per match expression; invalid pattern field can taint only that pattern arm | code + match subject type + missing variants/field + primary span |
+| `PROTO-*` | taint conformance check result for that type/protocol pair; avoid repeating the same missing method/bound for every downstream call | code + type + protocol + method/bound + primary span |
+| `CLASS-*` | taint class declaration metadata so constructor/field follow-on diagnostics do not cascade from the same malformed class | code + class/field/variant + primary span |
+| `RESULT-*` | taint error-flow expression only; unused-result diagnostics are non-tainting warnings/errors depending on policy and should dedupe by expression span/type | code + result/error type + primary span |
+| `STDLIB-*` | taint the call expression or constructed value; unsupported-surface diagnostics should not also emit generic `CALL-*`/`TYPE-*` for the same call | code + stdlib symbol + operation + primary span |
+| `CODEGEN-*`, `BUILD-*`, `INTERNAL-*` | no semantic recovery; emit once per failing backend/build/internal boundary and preserve source diagnostics already emitted | code + operation/context + path if available |
+| `TYPE-0901`, `FLOW-0901`, `TYPE-0902` | warnings/notes do not affect exit status; reveal-type notes participate in the 50 top-level cap with explicit omission summaries | code + message template args + primary span/order |
+
+## Span, Related-Span, And Recovery Notes
+
+- Every HIR source diagnostic should use the AST node span that caused the semantic failure. Existing raw messages usually have the expression/statement node available at the emission site; the migration should not introduce spanless HIR diagnostics for those paths.
+- `TypeError` forwarding sites (`ctx.error(e.message)` / `ctx.error(error.message)`) currently lose the source relation between type-system payload and AST node. The migrated helper should be called at the HIR site that knows the node span and should pass expected/actual/operator/name args explicitly.
+- Import and workspace diagnostics need related spans/paths for "searched here", "ambiguous candidate", and "import requested here" notes. Do not encode those in message strings.
+- Recovery deduplication remains `milestone_diag_10`. Until then, repeated type errors keep the existing recovery behavior but must share `message_template` and explicit dedupe args once migrated.

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -8,7 +8,7 @@ Sifr is not production-released yet. This phase intentionally does not preserve 
 
 ## Execution Status
 
-Current wave: `milestone_diag_2a` diagnostic registry skeleton.
+Current wave: `milestone_diag_3` diagnostic emission inventory.
 
 - [x] Proposal reviewed through final loop and accepted for implementation.
 - [x] Added `crates/sifr_diagnostics` as the canonical leaf crate for diagnostic codes, source spans/source map, model builders, sink emission, rendering, and JSON schema generation.
@@ -20,7 +20,12 @@ Current wave: `milestone_diag_2a` diagnostic registry skeleton.
 - [x] Added the checked-in diagnostic registry skeleton and registry validation tests.
 - [x] Added generated diagnostic-code docs plus docs drift validation.
 - [x] Claude review for `milestone_diag_2a` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-2a-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2a-review-pass-2.md`.
-- [ ] `milestone_diag_2a` PR opened at https://github.com/sifr-lang/sifr/pull/1668; merge pending.
+- [x] `milestone_diag_2a` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1668.
+- [x] Inventoried raw HIR `ctx.error(...)` call sites, `CompileError` construction paths, `sifr_type_system::TypeError`/`TypeErrorKind` variants, and e2e expectation/baseline code surfaces in `internal_docs/diagnostic_emission_inventory.md`.
+- [x] Assigned each current user-facing diagnostic category to a target family/code and fixture plan in `internal_docs/diagnostic_emission_inventory.md`.
+- [x] Identified wrong-layer diagnostics, related-span/source-map needs, and recovery behavior expectations in `internal_docs/diagnostic_emission_inventory.md`.
+- [x] Claude review for `milestone_diag_3` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-2.md`.
+- [ ] `milestone_diag_3` PR opened and merged.
 
 Validation evidence for the current wave:
 
@@ -31,6 +36,10 @@ Validation evidence for the current wave:
 - `cargo check --workspace` passed.
 - `cargo clippy -p sifr_diagnostics --all-targets -- -D warnings` passed.
 - `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` on the `milestone_diag_2a` branch.
+
+Validation evidence for `milestone_diag_3`:
+
+- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` on the inventory-only branch.
 
 ## Relationship to Existing Roadmap
 

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -25,7 +25,7 @@ Current wave: `milestone_diag_3` diagnostic emission inventory.
 - [x] Assigned each current user-facing diagnostic category to a target family/code and fixture plan in `internal_docs/diagnostic_emission_inventory.md`.
 - [x] Identified wrong-layer diagnostics, related-span/source-map needs, and recovery behavior expectations in `internal_docs/diagnostic_emission_inventory.md`.
 - [x] Claude review for `milestone_diag_3` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-2.md`.
-- [ ] `milestone_diag_3` PR opened and merged.
+- [x] `milestone_diag_3` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1669.
 
 Validation evidence for the current wave:
 

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md
@@ -1,0 +1,217 @@
+# Review: milestone_diag_3 — Diagnostic Emission Inventory (Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-3`
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Validation evidence reported: `scripts/run_all_tests.sh --profile quick` (signature `e1bf653aaa770517`).
+
+## Scope reviewed
+
+- New file: [internal_docs/diagnostic_emission_inventory.md](../internal_docs/diagnostic_emission_inventory.md).
+- Phase tracker delta in [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md) (status flip `2a → 3`, three new checked DoD bullets, two unchecked, validation note).
+
+milestone_diag_3 is a paper-only milestone whose product is the inventory; the only correctness surface is whether the inventory faithfully and exhaustively describes today's emission state, and whether the family/code/fixture plan produced from it is internally consistent.
+
+## Verdict
+
+The inventory is in the right shape and most rows hold up. The HIR file/count breakdown reproduces exactly, the eight `TypeErrorKind` variants are all accounted for, and the `Target Code And Fixture Plan` table is the strongest section — every fixture path I spot-checked exists on disk and the family assignments largely match the issue's identity policy.
+
+There are, however, **four blocking coverage gaps** against the milestone DoD: the "Verification baselines" inventory target listed in the issue is not enumerated at all; 88 of 179 fail-fixture files have no `# expect-error` annotation and the inventory does not address them; the parser-frontend surface is collapsed to a single `SIFR-PARSE-0002` line with no Ruff-fork category breakdown despite `milestone_diag_7` requiring categorized parser codes; and per-category recovery expectations called out by the DoD are not recorded. There are also **three non-blocking but real issues** worth addressing in the same PR: a methodology error inflates the `CompileError` count by ~7 across four files, several HIR file rows have wrong/missing target families that the migration milestones will inherit, and several non-error emission paths (`ctx.warn`, `reveal_types`, the HIR-internal `catch_unwind`) are absent from the inventory even though they are user-visible diagnostic surfaces.
+
+A pass-2 update to the inventory should clear these. Nothing here invalidates `milestone_diag_2b` from starting once the gaps are filled.
+
+## Definition-of-done coverage
+
+| DoD bullet | Status | Evidence / notes |
+| --- | --- | --- |
+| Inventory covers all raw HIR `ctx.error(...)` call sites | ✅ | Per-file counts in the HIR Lowering Surface table sum to 489 and every per-file count reproduces under `rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs' -c`. All 22 emitting files are listed. |
+| Inventory covers all `CompileError` construction paths | ⚠️ partial | All 16 emitting files appear, but the headline count of 54 is inflated by struct/impl/fn-signature lines (see B2 / Findings → B2). Test-only sites (4) are correctly partitioned out. |
+| Inventory covers all `sifr_type_system::TypeError` and `TypeErrorKind` variants | ✅ | All 8 `TypeErrorKind` variants (TypeMismatch, UndefinedVariable, UndefinedFunction, WrongArgumentCount, UseAfterMove, MissingTypeAnnotation, InvalidOperator, NotCallable) appear in the Type System Surface table. The 24 construction sites in `sifr_type_system/src/check.rs` reproduce. |
+| Inventory covers e2e expectation parsing **and verification baselines** | ⚠️ partial | E2E `# expect-error` markers and harness samples are covered. **Verification baselines under `crates/sifr/tests/verification/` are not enumerated at all** despite the issue's `Existing Surface Inventory` listing them as a required target. See B1. |
+| No diagnostic category migrated without a known target code and fixture plan | ⚠️ partial | The Target Code And Fixture Plan covers most categories, but several rows defer fixtures to later milestones (`add/confirm fixture during milestone_diag_2b`, `add parser fail fixture or use existing invalid source tests`), the parser-family plan is a single line, and "category" coverage misses the 88 fail-fixtures with no `expect-error` annotation today (see B3, B4). |
+
+## Findings
+
+### Blocking
+
+#### B1. Verification baselines are not inventoried
+
+The issue's `Existing Surface Inventory` section explicitly lists **"Verification baselines under `crates/sifr/tests/verification`"** as one of the things the inventory must cover, and milestone DoD reads "covers e2e expectation parsing and verification baselines."
+
+The inventory's `E2E Expectation And Baseline Surface` section talks only about `# expect-error` markers in `crates/sifr/tests/e2e/fail/` plus `crates/sifr/tests/e2e.rs` harness samples. It does not enumerate `crates/sifr/tests/verification/`, which today contains:
+
+- `crashes/` — `CR-0001`, `CR-0002` (parser/cfg invariant minimized).
+- `diagnostics/decimal_invalid_literal/` — baselines that bake in `[E2501]` and `SIFR-TYPE-0001` for the same diagnostic.
+- `project/missing_import_reports_error/`, `project/multi_module_run/`, `project/workspace_ambiguous_import/`, `project/workspace_dotted_helper_run/`, `project/workspace_malformed_manifest/`, `project/workspace_unresolved_import/` — checked-in `check-{compact,human,json}.{stdout,stderr,exit-code}.txt` baselines that hard-code `SIFR-WORKSPACE-0001`, `SIFR-WORKSPACE-0101`, `SIFR-WORKSPACE-0102`, `SIFR-TYPE-0001`, `[E2501]`, and absolute-path remnants ("<WORKSPACE>" sentinel notwithstanding).
+
+Greppable proof:
+
+```bash
+grep -h "SIFR-\|\[E25" crates/sifr/tests/verification/**/baselines/*.txt | sort -u
+# returns SIFR-TYPE-0001, SIFR-WORKSPACE-0001, SIFR-WORKSPACE-0101, SIFR-WORKSPACE-0102, [E2501]
+```
+
+These baselines are exactly what `milestone_diag_4a`/`diag_5`/`diag_6`/`diag_11` will need to regenerate, so the inventory must list them so the migration plan does not accidentally treat them as out of scope. Action: add a `Verification Baseline Surface` subsection to the inventory enumerating each verification subdirectory, the diagnostic codes/markers it asserts today, and which migration milestone owns its regeneration.
+
+#### B2. Parser surface is collapsed to one line; Ruff-fork category breakdown is missing
+
+`milestone_diag_7` scope: "Map upstream Ruff-fork parser error categories to distinct `SIFR-PARSE-*` codes where the parser exposes a condition category." `milestone_diag_3`'s job is to surface those categories so 2b can populate the registry and 7 can migrate — categories cannot land in the registry if they are not first identified by the inventory.
+
+The inventory's Target Code And Fixture Plan has only a single parser entry:
+
+> `SIFR-PARSE-0002` | syntax parse failure with source span | parser adapter / driver frontend | add parser fail fixture or use existing invalid source tests
+
+That collapses every Ruff parser-error category into one bucket, which is exactly what the policy forbids ("`SIFR-PARSE-0001` must not remain a general semantic fallback"). It also leaves `SIFR-PARSE-0002` as a single catch-all that is structurally identical to the retired `SIFR-TYPE-0001`.
+
+The Driver And CLI Surface row for `frontend/api.rs` records the two `CompileError` construction sites that wrap parser failures but does not break out parser error categories. The upstream `parsed.errors()` source (Ruff fork at `sifr_python_parser`) does expose distinct error variants — those need to be enumerated here, with at least an initial cut into named groups (e.g., unbalanced brackets, indentation, invalid token, unsupported syntax, etc.) and a mapping to proposed `SIFR-PARSE-000x` codes. The exact taxonomy can be refined in 2b, but a single `0002` row is not "a known target code and fixture plan" for the parser family.
+
+Action: add a Parser Surface subsection that enumerates the Ruff-fork parser error variants currently produced by `sifr_python_parser::parse_module`, propose at least 3–5 distinct `SIFR-PARSE-000x` codes, and indicate which existing invalid-source tests (or new fixtures) lock each.
+
+#### B3. 88 of 179 fail-fixtures have no `# expect-error` annotation; the inventory ignores them
+
+`crates/sifr/tests/e2e/fail/` contains 179 `.sifr` files; only 91 of them contain any `expect-error` line. The other 88 fixtures are fail tests that today rely on bare "compilation must fail" without asserting a code. The harness loop in [crates/sifr/tests/e2e.rs:2532](../crates/sifr/tests/e2e.rs:2532) runs them through `compile_source` and panics if compilation succeeds, but performs no code assertion when `expected` is empty.
+
+That set is structurally part of the fixture migration scope: every one of those fixtures is a category that today has no fixture-asserted code, and milestone DoD #5 ("No diagnostic category is migrated without a known target code and fixture plan") requires the inventory to either (a) declare which target code each will assert post-migration, or (b) state explicitly that they are exempt and explain why.
+
+The 88 files cluster into recognizable categories by filename — `bytes_*`, `argparse_*`, `bisect_*`, `borrowed_mut_parameter_*`, `async_*`, etc. — which strongly suggests target families like `STDLIB`, `OWN`, etc. The inventory should map each filename pattern to its planned target code so milestone_diag_5/diag_8 do not need to re-derive that classification under time pressure.
+
+Action: either enumerate the 88 unannotated fail fixtures and assign each a target code (likely as a grouped table by category), or add an explicit policy line that those fixtures will gain `expect-error` annotations in the milestone that migrates their family, with the migration-milestone column populated.
+
+#### B4. Per-category recovery expectations are not recorded
+
+`milestone_diag_3` Scope bullet: "Identify expected recovery behavior for each diagnostic category." DoD does not list recovery as a separate facet, so this is debatable as a strict gate, but the Scope bullet is unambiguous.
+
+The inventory's `Span, Related-Span, And Recovery Notes` section says only:
+
+> Recovery deduplication remains `milestone_diag_10`. Until then, repeated type errors keep the existing recovery behavior but must share `message_template` and explicit dedupe args once migrated.
+
+That is a general policy statement, not a per-category identification. Recovery decisions differ materially per category — e.g., `OWN` use-after-move should taint the moved binding to suppress cascades; `CALL` arity should not poison the callable; `MATCH` non-exhaustiveness should not poison the subject; `TYPE` mismatch sometimes returns `Type::Any` to keep lowering progressing; decimal mixed arithmetic may return the inferred operand type. These per-category expectations are exactly what `milestone_diag_10` will encode; they should be inventoried now.
+
+Action: extend the Target Code And Fixture Plan with a "recovery expectation" column (or add a parallel table), with one of {`taint binding`, `taint expression`, `non-tainting`, `dedupe by primary span+args`, `cap-summarize`} per code.
+
+### Non-blocking — correctness/coverage issues that should be fixed in the same PR
+
+#### N1. The `CompileError` headline count is inflated by ~7 due to a methodology error
+
+The inventory's coverage-snapshot bullet:
+
+> `rg "CompileError \\{" crates/sifr_driver/src crates/sifr/src -g '*.rs'` finds 54 legacy driver/CLI construction sites: 50 production sites and 4 test-only diagnostic construction sites.
+
+The pattern `CompileError \{` matches `pub struct CompileError {`, `impl CompileError {`, `impl … for CompileError {`, and `fn …(…) -> CompileError {` in addition to genuine `CompileError { … }` literal constructions. Concretely:
+
+| File | Inventory says | Actual constructions | Inflated by |
+| --- | ---: | ---: | ---: |
+| `crates/sifr_driver/src/diagnostics.rs` | 4 | 1 (line 262) | +3 (struct decl line 26, `impl` block line 95, `impl Display` line 223) |
+| `crates/sifr_driver/src/build/materialize.rs` | 2 | 1 (line 138) | +1 (fn signature line 137) |
+| `crates/sifr_driver/src/workspace/mod.rs` | 4 | 2 (lines 162, 176) | +2 (fn signatures lines 161, 175) |
+| `crates/sifr_driver/src/project/discovery.rs` | 7 | 6 (lines 196, 200, 215, 392, 404, 414) | +1 (fn signature line 194) |
+
+True production+test count is **47** (43 production + 4 test), not 54. The inflation is concentrated in the file-by-file rows the migration plan will read line by line — particularly `diagnostics.rs`, where saying "4 sites" implies four separate code paths to migrate when there is only one (the codegen panic boundary at line 262); the other three "matches" are the type's own definition.
+
+Action: rerun with a stricter regex (e.g. `rg "(\\(|\\[|^\\s*)CompileError \{"` to filter struct/impl/return-type), or hand-correct the four affected rows, and update the headline. The Driver And CLI Surface table's interpretation column already correctly describes what each *file* does, so only the count column needs adjustment.
+
+#### N2. HIR row target families have wrong/missing assignments
+
+A few HIR file rows assign target families that don't match what those files actually emit:
+
+- **`lower/decimal_methods.rs`** is listed with target `DECIMAL` only. Inspection shows it also emits `decimal.sqrt() takes no arguments`, `decimal.abs() takes no arguments`, and `type 'decimal' has no method '{method}'` — the first two are arity (`CALL`), the third is method-not-found (`NAME` or `TYPE`). The 18 emissions are not all `DECIMAL`. Either widen the family list to `DECIMAL`, `CALL`, `NAME`, or split the row.
+
+- **`lower/classes.rs`** is listed with target `CLASS, TYPE, NAME`. It also emits iter/next/reversed protocol shape errors (`class 'X.__iter__' must not declare parameters besides self`, `class 'X.__iter__' must return 'Iterator[T]' or 'Iterable[T]'`, `class 'X' iteration protocol mismatch: ...`). Per the issue's family policy ("Missing or malformed protocol methods are `SIFR-PROTO-*`; ordinary missing class fields or constructors are `SIFR-CLASS-*`"), these are `PROTO`. Add `PROTO` to the row.
+
+- **`lower/expressions.rs`** is listed with target `NAME, TYPE, CALL, STDLIB, PROTO, DECIMAL, FLOW`. It also emits `ctx.error("unsupported expression type")` and `matrix multiplication operator (@) is not supported` — neither of these maps cleanly to any listed target. Per Wrong-Layer policy these would either be a new "unsupported language feature" code under `INTERNAL` (post-panic-boundary) or remain a TYPE-shaped error. Decide and record explicitly; don't leave them in an unnamed bucket.
+
+- **`lower/mod.rs`** is listed with target `TYPE, IMPORT, NAME, STDLIB, WORKSPACE`. Including `WORKSPACE` is contradictory because the Wrong-Layer note immediately below says workspace failures should *leave* HIR for the driver. The list reads as "this file will emit WORKSPACE codes" when the migration plan is "this file will stop emitting WORKSPACE codes and the driver will own them." Re-label the row's WORKSPACE entry as "→ moves to driver" or split off the wrong-layer subset into a separate table cell.
+
+#### N3. Non-error emission paths are not inventoried
+
+The inventory limits itself to `ctx.error(…)`. The HIR has at least three other user-visible diagnostic streams that need migration:
+
+- **`ctx.warn(...)`** — 8 sites across `lower/typing_and_functions.rs`, `lower/statements.rs`, `lower/arithmetic_warnings.rs`, `lower/mod.rs`. These flow into `LowerCtx::warnings` and are surfaced to the user. Once `Severity::Warning` becomes a first-class part of the diagnostic model (it already is in `sifr_diagnostics`), each of these warnings needs a code. Today they have none.
+
+- **`ctx.reveal_types`** — `reveal_type(...)` developer diagnostic. `milestone_diag_10` already calls out the recovery-cap fixture for >50 `reveal_type(...)` calls, so this is a known surface. The inventory should record it (presumably as `Severity::Note` with a dedicated `INTERNAL` or new family code, e.g. a `SIFR-DEV-*` or reusing `SIFR-INTERNAL-*` Note severity).
+
+- **HIR-internal `catch_unwind`** at [crates/sifr_hir/src/lower/typing_and_functions.rs:780](../crates/sifr_hir/src/lower/typing_and_functions.rs:780). On panic, it calls `ctx.warn(...)` to skip exhaustive-return validation. Per the Architecture Source Mapping section, codegen/HIR panics that survive boundaries should become `SIFR-INTERNAL-*`, not user warnings. This is a wrong-layer case the inventory misses.
+
+Action: add a "Non-Error Emission Paths" subsection enumerating warnings (with target family decision per call site), `reveal_type` (target code + recovery policy), and HIR-internal `catch_unwind` boundaries.
+
+#### N4. CLI renderer-test `CompilerDiagnostic` constructions are not enumerated
+
+The issue's `Existing Surface Inventory` lists "CLI renderer tests that manually construct `CompilerDiagnostic`" as a required target. The inventory's table tracks `CompileError` constructions but not `CompilerDiagnostic` constructions. There are 11 such test-only constructions today:
+
+- `crates/sifr/src/main.rs` — 9 sites at lines 1272, 1311, 1322, 1333, 1363, 1375, 1400, 1411, 1422 (all inside `#[test]` fns), each hard-coding `SIFR-TYPE-0001`/`SIFR-PARSE-0001`/`[E2507]`-style strings.
+- `crates/sifr_driver/src/tests/diagnostics.rs` — 2 sites at lines 74, 102.
+
+These will all need updating in `milestone_diag_5` (test harness contract cleanup). Add them to the inventory either as a row under Driver And CLI Surface or in a new `CLI Test Surface` subsection.
+
+#### N5. Marker-count table heading is misleading
+
+The `E2E Expectation And Baseline Surface` table is titled "Current fail-fixture code markers" and reports e.g. `SIFR-TYPE-0001 | 95` and `[E2507] | 5`. Reproducing those numbers requires counting **fail-fixture markers + `crates/sifr/tests/e2e.rs` harness samples together**:
+
+- `SIFR-TYPE-0001`: 91 in `tests/e2e/fail/*.sifr` (one fixture has 2 markers) + 4 in `e2e.rs` = 95.
+- `[E2507]`: 2 in `tests/e2e/fail/` + 3 in `e2e.rs` = 5.
+
+The numbers themselves are correct as totals, but the table heading says "fail-fixture code markers", which is what motivated me to verify and recount. Either rename the heading to "Fail-fixture and harness-sample code markers" or split fixture vs. harness-sample columns. Otherwise the migration plan may treat all 95 as fixture rewrites when 4 are harness-test rewrites (different milestone owner — `diag_5`, not the family-specific milestones).
+
+Same issue at the snapshot bullet: "92 fail-fixture expectations plus 8 harness test samples" is correct, but the marker-count table mixes the two streams.
+
+#### N6. Inventory doesn't separate "today's code source" from "today's code value"
+
+The Driver And CLI Surface table mixes two different "current code source" things into one column:
+
+1. Phase-derived (`CompilePhase::TypeCheck → SIFR-TYPE-0001`).
+2. Prefix-string-match classifier (`CompileError::workspace_diagnostic_code`).
+3. Hard-coded constructor strings (CLI test fixtures).
+
+For migration it matters which one applies to which row. For example, the `frontend/api.rs` row says "parser frontend errors become `CompilePhase::Parse`; HIR lowering errors become `CompilePhase::TypeCheck`" — so today's code source for those rows is "phase-derived", and the workspace classifier is irrelevant. The `workspace/mod.rs` row says "manifest parse/source-root validation" — today's code source for those is "phase=Build, then prefix-classified to WORKSPACE-000x", a two-stage pipeline that needs both stages eliminated.
+
+Adding a "current code mechanism" column ({phase-derived, prefix-classified, hard-coded string, typed-error-forwarded}) would make the migration plan unambiguous and surface the prefix classifier as a discrete deletion target rather than burying it in prose.
+
+### Non-blocking — minor
+
+#### M1. `lower/typing_and_functions.rs` row may be missing `CALL`
+
+Row lists targets `NAME, TYPE, RESULT, PROTO`. The file emits "unsupported default argument expression for parameter '{p}'", "function 'X' must return a value of type 'Y' on all control-flow paths", and callable annotation shape checks (`Callable[...]`). Some of these are CALL-flavored. Verify and add `CALL` if applicable.
+
+#### M2. Fixture-plan column uses two different "fixture pending" phrases
+
+Some rows use "add/confirm fixture during `milestone_diag_2b`", others use "add/confirm fixture", others use just "add parser fail fixture or use existing invalid source tests". Pick one phrasing and target milestone so the registry-population step has a single grep target for "fixture missing".
+
+#### M3. Decimal subscript on snapshot bullets vs. table
+
+The snapshot says `[E2507]` → 5, but the per-row table heading is "fail-fixture code markers". As noted in N5, the heading should be widened or the harness-sample contribution tabulated separately.
+
+#### M4. `SIFR-CLASS-0001`/`0002` scope is ambiguous
+
+Plan table:
+
+- `SIFR-CLASS-0001` | "class has fields but no required initializer/super initializer"
+- `SIFR-CLASS-0002` | "required field declared after default"
+
+There is also a fixture `auto_init_inheritance_missing_super.sifr` which today emits `SIFR-TYPE-0001` and lives in the same logical category as 0001. The inventory should pin which fixture locks 0001 (probably `auto_init_inheritance_missing_super.sifr` or the broader auto-init group) so 2b registry population is unambiguous.
+
+## What is solid
+
+- HIR `ctx.error(...)` per-file count table is exact, complete, and reproducible.
+- `TypeErrorKind` variant coverage is exhaustive (all 8 variants).
+- Family assignments at the code level (target codes in the plan) align with the issue's identity policy: `SIFR-NAME-0001` for undefined variable, `SIFR-CALL-0001..0005` for call shape errors, `SIFR-OWN-0001..0004` for ownership, `SIFR-DECIMAL-0001..0008` for decimal codes (matches the issue's Decimal Code Migration table exactly), `SIFR-FLOW-0001..0003` for break/continue/nonlocal — these are clean and consistent with the issue's stated policies.
+- All inventoried fixture paths I spot-checked exist on disk; none are broken references.
+- Wrong-Layer notes correctly identify three real wrong-layer cases (import resolution, decimal pseudo-codes, builtin/stdlib helper split) — they are the three that matter most for `diag_4a`/`diag_7`.
+- The 4 test-only `CompileError` sites in `crates/sifr_driver/src/tests/diagnostics.rs` are correctly partitioned out and explicitly marked for "rewrite or delete with the legacy diagnostic abstraction."
+- The `milestone_diag_2b` workspace-code review at the bottom of the Driver And CLI Surface section is the correct level of decisiveness — keep `0001..0004`, keep `0101..0103`, propose `0104` for project import-cycle if driver-owned. That's exactly the per-code review the policy demands.
+
+## Recommendation
+
+Address blockers B1–B4 in a pass-2 update to the inventory, then merge. The non-blocking items (N1–N6, M1–M4) are best fixed in the same pass since most are small text/cell edits in the same document. None of the non-blocking items would by themselves justify holding the milestone, but together they meaningfully reduce the inventory's load-bearing accuracy for `milestone_diag_2b` and `milestone_diag_4a`.
+
+## Validation
+
+Local validation evidence accepted:
+
+- `scripts/run_all_tests.sh --profile quick` (signature `e1bf653aaa770517`) — same signature reported on the `milestone_diag_2a` branch, which is consistent with this branch being inventory-only (no source changes that should affect the report).
+
+Inventory numbers re-verified against the working tree:
+
+- `rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs'` → 489 ✓
+- `rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs' -c` per-file totals reproduce the inventory's HIR table exactly ✓
+- `rg "TypeErrorKind::" crates/sifr_type_system/src crates/sifr_hir/src -g '*.rs'` → 24 ✓
+- `rg "# expect-error" crates/sifr/tests/e2e/fail crates/sifr/tests/e2e.rs -g '*.sifr' -g '*.rs'` → 100 (92 fixture + 8 harness) ✓
+- `rg "CompileError \{" crates/sifr_driver/src crates/sifr/src -g '*.rs'` → 54 raw matches; **actual constructions = 47** (43 production + 4 test). See N1.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-2.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-2.md
@@ -1,0 +1,163 @@
+# Review: milestone_diag_3 — Diagnostic Emission Inventory (Pass 2)
+
+Branch: `codex/semantic-diagnostics-diag-3`
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Pass-1 review: [reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md)
+Validation evidence reported: `scripts/run_all_tests.sh --profile quick` (signature `e1bf653aaa770517`).
+
+## Scope reviewed
+
+- Updated [internal_docs/diagnostic_emission_inventory.md](../internal_docs/diagnostic_emission_inventory.md).
+- Phase tracker delta in [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md) (status flip `2a → 3`, three new checked DoD bullets, two unchecked, validation note).
+
+milestone_diag_3 remains paper-only; this pass re-checks the four pass-1 blockers (B1–B4), the non-blocking accuracy items (N1–N6, M1–M4), and walks through the new sections to look for net-new gaps.
+
+## Verdict
+
+All four pass-1 blockers are resolved. The inventory now contains a Verification Baseline Surface section (B1), a Parser Surface section that maps Ruff-fork variants to eight proposed `SIFR-PARSE-000x` codes (B2), an "Unannotated fail fixtures" subsection that groups all 88 unannotated fixtures with target families plus the full filename list (B3), and a Recovery Expectations By Category table covering 14 family groups (B4).
+
+All six non-blocking accuracy items (N1–N6) and all four minor items (M1–M4) from pass 1 are also addressed: the `CompileError` count is corrected to 47 (43 production + 4 test) with the specific four file rows fixed, the four HIR family rows are widened to match what their files actually emit, ctx.warn / reveal_type / catch_unwind are inventoried as a new "Non-Error Emission Paths" section, the CLI test `CompilerDiagnostic` constructions are enumerated, the marker-count heading is renamed to fail-fixture-and-harness-sample, and the two stale "current code mechanism" details are surfaced as a separate "Current public-code mechanisms to remove" table.
+
+I found no new blocking issues. There are four small residual nits that are worth recording but do not gate the milestone — they're listed under "Residual nits" below and can be folded into `milestone_diag_2b`/`milestone_diag_7` when those milestones touch the same rows.
+
+Recommendation: proceed to merge.
+
+## Definition-of-done coverage
+
+| DoD bullet | Status | Evidence / notes |
+| --- | --- | --- |
+| Inventory covers all raw HIR `ctx.error(...)` call sites | ✅ | Per-file counts in HIR Lowering Surface table sum to 489 across 22 files; reproduces under `rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs' -c`. |
+| Inventory covers all `CompileError` construction paths | ✅ | All 16 emitting files appear; headline corrected to 47 actual constructions (43 production + 4 test); the four pass-1 inflated rows (`diagnostics.rs` 4→1, `materialize.rs` 2→1, `workspace/mod.rs` 4→2, `discovery.rs` 7→6) are now accurate. |
+| Inventory covers all `sifr_type_system::TypeError` and `TypeErrorKind` variants | ✅ | All 8 `TypeErrorKind` variants present; 24 construction sites in `sifr_type_system/src/check.rs` reproduce. |
+| Inventory covers e2e expectation parsing **and verification baselines** | ✅ | New Verification Baseline Surface subsection enumerates all nine `crates/sifr/tests/verification/` cases (decimal_invalid_literal, missing_import_reports_error, multi_module_run, workspace_ambiguous_import, workspace_dotted_helper_run, workspace_malformed_manifest, workspace_unresolved_import, CR-0001, CR-0002) with current markers and migration owners. |
+| No diagnostic category migrated without a known target code and fixture plan | ✅ | Target Code And Fixture Plan covers all migration families with representative fixtures or explicit "fixture pending in `milestone_diag_2b`/`milestone_diag_7`" notes; the 88 unannotated fail-fixture set is grouped by family with target codes; parser categories are no longer collapsed into one line. |
+
+## Pass-1 finding follow-up
+
+### Blocking (B1–B4) — all resolved
+
+#### B1. Verification baselines now inventoried — RESOLVED
+
+The new "Verification Baseline Surface" section (lines 257–269 of the inventory) enumerates each verification subdirectory, its current baseline markers, and the target/owner. Confirmed against the working tree:
+
+```bash
+ls crates/sifr/tests/verification/{crashes,diagnostics,project}
+# crashes: CR-0001_cfg_invariant_minimized.sifr  CR-0002_parser_invariant_minimized.sifr
+# diagnostics: decimal_invalid_literal
+# project: missing_import_reports_error  multi_module_run  workspace_ambiguous_import
+#          workspace_dotted_helper_run  workspace_malformed_manifest  workspace_unresolved_import
+```
+
+All seven `project/*` cases plus `diagnostics/decimal_invalid_literal` plus the two crash cases are listed. The migration-owner column correctly distinguishes "regenerate in decimal migration" (decimal_invalid_literal) from "renderer integration regenerates schema shape only" (the workspace cases that keep their codes) from "no diagnostic migration, but rerun with renderer tests" (multi_module_run, workspace_dotted_helper_run).
+
+#### B2. Parser surface decomposed — RESOLVED
+
+The new "Parser Surface" section (lines 47–62) and the parser block in the Target Code And Fixture Plan (lines 289–296) jointly propose eight active `SIFR-PARSE-000x` codes (`0002..0009`) plus retired `0001`, mapped to specific Ruff-fork error variants.
+
+Spot-check against `third_party/ruff/crates/ruff_python_parser/src/error.rs`:
+
+- `0003` lexical/interpolated: `Lexical(LexicalErrorType)` (line 202), `FStringError(InterpolatedStringErrorType)` (line 198), `TStringError(InterpolatedStringErrorType)` (line 200) — all present. ✓
+- `0004` indentation/layout: `UnexpectedIndentation` (line 189), `SimpleStatementsOnSameLine` (line 170), `SimpleAndCompoundStatementOnSameLine` (line 172) — all present. ✓
+- `0005` invalid targets: `InvalidAssignmentTarget` (150), `InvalidNamedAssignmentTarget` (152), `InvalidAnnotatedAssignmentTarget` (154), `InvalidAugmentedAssignmentTarget` (156), `InvalidDeleteTarget` (158), `InvalidStarredExpressionUsage` (135) — all present. ✓
+- `0006` invalid call argument order: `PositionalAfterKeywordArgument` (161), `PositionalAfterKeywordUnpacking` (163), `InvalidArgumentUnpackingOrder` (165), `DuplicateKeywordArgumentError(String)` (147) — all present. ✓
+- `0007` empty/malformed declaration lists: `EmptyImportNames` (119), `EmptyGlobalNames` (113), `EmptyNonlocalNames` (115), `EmptyTypeParams` (121), parameter-order = `ParamAfterVarKeywordParam`/`NonDefaultParamAfterDefaultParam`/`VarParameterWithDefault` (140/142/144) — all present. ✓
+- `0008` invalid match/pattern: `InvalidStarPatternUsage` (137); other mapping/class pattern errors flow through `OtherError`/`ExpectedToken` recovery, which is acceptable as documented. ✓
+- `0009` unsupported syntax: `UnsupportedSyntaxErrorKind`, `UnexpectedIpythonEscapeCommand` (193), `UnexpectedTokenAfterAsync(TokenKind)` (191) — present. ✓
+
+The decomposition is sufficient for `milestone_diag_2b` registry population and gives `milestone_diag_7` a concrete parser-bucket worklist instead of a single catch-all.
+
+#### B3. 88 unannotated fail fixtures inventoried — RESOLVED
+
+The new "Unannotated fail fixtures" block (lines 154–255) groups fixtures into five family categories (stdlib unsupported APIs; bytes and binary/text I/O; ownership/mutability; collection/container shape; type alias/recursive typing) with target family/code plans, followed by the full 88-file enumeration as a code block.
+
+I verified by reproducing the set:
+
+```bash
+comm -23 <(ls crates/sifr/tests/e2e/fail/ | sort) \
+         <(rg -l "# expect-error" crates/sifr/tests/e2e/fail/ -g '*.sifr' | xargs -n1 basename | sort) | wc -l
+# 88
+```
+
+The 88 filenames in the inventory match the diff output exactly (verified line-by-line). The grouping is internally consistent — each filename pattern in the table prefix list (`argparse_*`, `bytes_*`, `borrowed_*`, `dict_*`, `recursive_*`, etc.) maps to a covering family code in the Target Code And Fixture Plan.
+
+#### B4. Per-category recovery expectations recorded — RESOLVED
+
+The new "Recovery Expectations By Category" table (lines 357–374) covers 14 category groups: `PARSE-*`, `NAME-0001..0004`, `IMPORT-*/WORKSPACE-*`, `TYPE-0002..0009`, `DECIMAL-0001..0008`, `CALL-0001..0005`, `OWN-0001..0004`, `FLOW-*`, `MATCH-*`, `PROTO-*`, `CLASS-*`, `RESULT-*`, `STDLIB-*`, `CODEGEN-*/BUILD-*/INTERNAL-*`, plus the warning/note codes `TYPE-0901`/`FLOW-0901`/`TYPE-0902`. Each row carries a recovery expectation and a dedupe-key sketch. The expectations are concrete enough to validate against `milestone_diag_10`'s implementation (e.g. `OWN-*` taints binding state; `MATCH-*` non-exhaustiveness emits once per match expression; `CALL-*` is non-tainting for the callable but taints the call result; reveal-type notes participate in the 50 top-level cap).
+
+### Non-blocking (N1–N6) — all resolved
+
+- **N1.** `CompileError` headline is now `47 sites: 43 production CompileError { ... } literals plus 4 test-only` (line 8), and the per-file row counts for the four affected files (`diagnostics.rs:1`, `materialize.rs:1`, `workspace/mod.rs:2`, `discovery.rs:6`) are now actual-construction counts, not raw regex matches. Sum verifies: `1+2+1+6+1+1+3+1+7+4+1+2+8+2+3 = 43` production. ✓
+- **N2.** HIR family assignments are widened: `decimal_methods.rs` now lists `DECIMAL, CALL, NAME` (covers "no method", "takes no arguments", method arity); `classes.rs` now lists `CLASS, TYPE, NAME, PROTO` (covers iter/next/reversed protocol shape); `mod.rs` row WORKSPACE entry is annotated "wrong-layer `WORKSPACE` moves to driver"; `typing_and_functions.rs` now includes `CALL`. ✓
+- **N3.** A new "Non-Error Emission Paths" section (lines 271–281) covers ctx.warn arithmetic (5 sites in `arithmetic_warnings.rs` → `SIFR-TYPE-0901`), ctx.warn unreachable (1 site in `statements.rs` → `SIFR-FLOW-0901`), ctx.warn exhaustive-return panic recovery (1 in `typing_and_functions.rs` → wrong-layer `SIFR-INTERNAL-0001`), `ctx.reveal_types` (→ `SIFR-TYPE-0902` note), and HIR-internal `catch_unwind` (wrong-layer). ✓
+- **N4.** A new CLI Test Surface table (lines 109–112) lists `crates/sifr/src/main.rs` as 9 sites and `crates/sifr_driver/src/tests/diagnostics.rs` as 2 sites, both owned by `milestone_diag_5`. ✓
+- **N5.** Marker-count table heading is now "Current fail-fixture and harness-sample code markers:" (line 139). ✓
+- **N6.** A new "Current public-code mechanisms to remove" table (lines 114–122) calls out phase-derived `CompilePhase` mapping, the workspace prefix classifier, type-error string forwarding, message-embedded pseudo-code, and test-only hard-coded diagnostics with their replacement strategy. ✓
+
+### Minor (M1–M4) — all resolved
+
+- **M1.** `typing_and_functions.rs` row now includes `CALL`. ✓
+- **M2.** Fixture-pending phrasing is now consistent: most rows use "fixture pending in `milestone_diag_2b`" or "fixture pending in `milestone_diag_7`" with a target milestone explicit. ✓
+- **M3.** Resolved together with N5. ✓
+- **M4.** `SIFR-CLASS-0001` fixture is now pinned to `crates/sifr/tests/e2e/fail/auto_init_inheritance_missing_super.sifr` and `SIFR-CLASS-0002` to `auto_init_required_after_default.sifr`. ✓
+
+## Number reproductions
+
+All headline numbers in the inventory reproduce against the working tree:
+
+```bash
+rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs' | wc -l                        # 489 ✓
+rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs' -c                              # per-file matches HIR table exactly ✓
+rg "TypeErrorKind::" crates/sifr_type_system/src crates/sifr_hir/src -g '*.rs' -c
+                                                                                # check.rs: 24 ✓
+rg "CompileError \{" crates/sifr_driver/src crates/sifr/src -g '*.rs' | wc -l   # 54 raw; inventory says 47 actual constructions
+rg "# expect-error" crates/sifr/tests/e2e/fail crates/sifr/tests/e2e.rs -g '*.sifr' -g '*.rs' | wc -l
+                                                                                # 100 = 92 fixture + 8 harness ✓
+ls crates/sifr/tests/e2e/fail/ | wc -l                                          # 179 total fixtures
+# 179 - 91 annotated = 88 unannotated, matches inventory ✓
+```
+
+Marker totals also reproduce: `[E2501] 1`, `[E2502] 2`, `[E2503] 1`, `[E2504] 2`, `[E2505] 3`, `[E2506] 2`, `[E2507] 5`, `[E2508] 2` against grep across `crates/sifr/tests/e2e/fail/` plus `crates/sifr/tests/e2e.rs`. ✓
+
+## Residual nits — non-blocking, optional follow-up
+
+These are small accuracy points I noticed while re-reading the new sections. None gates the milestone, but each is a one-line edit that could be folded into a `milestone_diag_2b` or `milestone_diag_7` PR when those milestones touch the same row.
+
+1. **`reveal_type` propagation row is slightly off-source.** The Non-Error Emission Paths row says `reveal_type(...)` is in `lower/builtin_calls.rs`; guarded-index reveal propagation in `lower/guarded_index.rs`. The only emission site is [crates/sifr_hir/src/lower/builtin_calls.rs:744](../crates/sifr_hir/src/lower/builtin_calls.rs:744) (`lower_reveal_type_call` → `ctx.reveal_types.push(...)`). The references in [crates/sifr_hir/src/lower/guarded_index.rs](../crates/sifr_hir/src/lower/guarded_index.rs) are tests of reveal-type behavior, not separate emission paths — `guarded_index.rs` does narrow types so reveal_type shows narrowed forms, but it does not emit reveal_type diagnostics itself. Either drop the `guarded_index.rs` clause or rephrase as "type narrowing in `lower/guarded_index.rs` affects what `reveal_type` displays".
+
+2. **`expressions.rs` "unsupported expression/operator features" not pinned to a code.** The description column for the `expressions.rs` HIR row now mentions "unsupported expression/operator features", which captures the four leftover sites — `ctx.error("unsupported expression type")` ([expressions.rs:95](../crates/sifr_hir/src/lower/expressions.rs:95)), `"matrix multiplication operator (@) is not supported"` ([expressions.rs:337](../crates/sifr_hir/src/lower/expressions.rs:337) and [aug_assign_lowering.rs:28](../crates/sifr_hir/src/lower/aug_assign_lowering.rs:28)), `"unsupported comparison operator"` ([expressions.rs:476](../crates/sifr_hir/src/lower/expressions.rs:476)), and `"walrus operator target must be a simple name"` ([expressions.rs:3780](../crates/sifr_hir/src/lower/expressions.rs:3780)). The Target Code And Fixture Plan lists `SIFR-TYPE-0005` for "unsupported operator or operand types", which seems to cover the operator cases. The "unsupported expression type" fallback at [expressions.rs:95](../crates/sifr_hir/src/lower/expressions.rs:95) is more wrong-layer-shaped (it fires on any AST kind the lowerer hasn't implemented, e.g. lambdas, dict comprehensions if unsupported) and might belong under `SIFR-INTERNAL-*`. Pinning each of the four sites to a target code in `milestone_diag_2b` would remove the only ambiguity in the HIR target-family columns.
+
+3. **Several Ruff parser variants are not slotted.** The eight proposed `SIFR-PARSE-000x` buckets accept the column header "Ruff category / examples", but a non-trivial set of variants in [third_party/ruff/crates/ruff_python_parser/src/error.rs](../third_party/ruff/crates/ruff_python_parser/src/error.rs) is not explicitly mentioned in any bucket: `EmptySlice`, `EmptyDeleteTargets`, `IterableUnpackingInComprehension`, `UnparenthesizedNamedExpression`, `UnparenthesizedTupleExpression`, `UnparenthesizedGeneratorExpression`, `InvalidLambdaExpressionUsage`, `InvalidYieldExpressionUsage`, `ExpectedKeywordParam`, `ExpectedRealNumber`, `ExpectedImaginaryNumber`. These plausibly land in `0002` (generic recovery) or `0005` (invalid target) but `milestone_diag_7` will need a slotting decision. A one-line "remaining variants slot into `0002` by default" caveat in the parser table would prevent that decision from getting deferred forever.
+
+4. **Pass-1 said "8 ctx.warn sites including `lower/mod.rs`", actual is 7.** The inventory's per-row counts (`5 + 1 + 1 = 7`) are accurate; pass-1 was slightly off. No edit needed in the inventory; recording here for the record.
+
+## What is solid
+
+- HIR `ctx.error(...)` per-file count table is exact, complete, and reproducible (489 across 22 files).
+- All 8 `TypeErrorKind` variants are inventoried with target codes.
+- Family assignments at the code level (target codes in the plan) match the issue's identity policy: `SIFR-NAME-0001..0004`, `SIFR-CALL-0001..0005`, `SIFR-OWN-0001..0004`, `SIFR-DECIMAL-0001..0008`, `SIFR-FLOW-0001..0003`, `SIFR-MATCH-0001..0003`, `SIFR-PROTO-0001..0004`, `SIFR-CLASS-0001..0004`, `SIFR-RESULT-0001..0003`.
+- All inventoried fixture paths spot-checked exist on disk.
+- Wrong-Layer notes cover the three real wrong-layer cases (import resolution, decimal pseudo-codes, builtin/stdlib helper split) and now also flag the HIR `catch_unwind` boundary.
+- The new "Current public-code mechanisms to remove" table is the right level of decisiveness for `milestone_diag_4a` — each row names a concrete deletion target.
+- The `SIFR-PARSE-0001` row is correctly recorded as "retired legacy phase bucket" with no active fixture, matching the issue's identity policy.
+- The Workspace code review preserves `0001..0004` and `0101..0103` and proposes `0104` for project import-cycle, consistent with `milestone_diag_2b`'s mandate.
+
+## Recommendation
+
+Merge as-is. The four pass-1 blockers are resolved with new, content-bearing inventory sections; all six pass-1 non-blocking items are resolved; all four pass-1 minors are resolved. The four residual nits above are optional follow-up that fit naturally into `milestone_diag_2b` or `milestone_diag_7` PRs.
+
+The remaining unchecked DoD bullets in the issue ("Claude review for `milestone_diag_3` completed and all actionable findings addressed", "`milestone_diag_3` PR opened and merged") can be flipped once this review is filed and the PR lands.
+
+## Validation
+
+Local validation evidence accepted: `scripts/run_all_tests.sh --profile quick` (signature `e1bf653aaa770517`). The signature matches the `milestone_diag_2a` branch baseline, which is consistent with this branch being inventory-only (no source changes).
+
+Inventory numbers re-verified against the working tree at this snapshot (April 29, 2026):
+
+- `rg "ctx\.error\(" crates/sifr_hir/src -g '*.rs'` → 489 across 22 files ✓
+- Per-file HIR `ctx.error` counts reproduce the HIR Lowering Surface table exactly ✓
+- `rg "TypeErrorKind::" crates/sifr_type_system/src crates/sifr_hir/src -g '*.rs'` → 24 ✓
+- `rg "CompileError \{" crates/sifr_driver/src crates/sifr/src -g '*.rs'` → 54 raw matches; actual constructions = 47 (43 production + 4 test) ✓
+- `rg "# expect-error" crates/sifr/tests/e2e/fail crates/sifr/tests/e2e.rs -g '*.sifr' -g '*.rs'` → 100 (92 fixture + 8 harness) ✓
+- 179 fail-fixture files; 91 annotated; 88 unannotated set matches the enumerated list in the inventory exactly ✓
+- Verification baselines: 7 project subdirs, 1 diagnostics subdir, 2 crash inputs all enumerated ✓
+- `ctx.warn(...)`: 7 sites (5 in `arithmetic_warnings.rs`, 1 in `statements.rs`, 1 in `typing_and_functions.rs`); inventory's per-row counts of 5/1/1 are correct ✓


### PR DESCRIPTION
## Summary

- Adds `internal_docs/diagnostic_emission_inventory.md` for `milestone_diag_3`.
- Inventories HIR `ctx.error(...)`, non-error HIR emissions, `CompileError`, `CompilerDiagnostic` tests, parser categories, type-system errors, e2e markers, unannotated fail fixtures, and verification baselines.
- Assigns target diagnostic families/codes, fixture plans, wrong-layer notes, and recovery expectations for follow-on diagnostic migration milestones.
- Updates the phase tracker with `milestone_diag_3` review/validation status.

## Review

- Claude review pass 1: `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-1.md`
- Claude review pass 2: `reviews/semantic-diagnostic-code-taxonomy-diag-3-review-pass-2.md`
- Pass 2 recommendation: merge as-is; no blocking issues.

## Validation

- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517`.