### PR TITLE
Add diag_4a renderer helpers and explicit workspace codes

### DIFF
--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -7,6 +7,7 @@
 //!   sifr emit <file.sifr>     Show generated Rust code
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 use clap::{Parser, Subcommand, ValueEnum};
+use sifr_diagnostics::DiagnosticCode;
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build, build_cached_project, build_cached_single_file,
     build_project, check, check_project, compile, compile_errors_to_diagnostics, emit_project,
@@ -248,15 +249,16 @@ fn run_with_panic_boundary<T>(
     let context = context.into();
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(value) => Ok(value),
-        Err(payload) => Err(CompileError {
-            message: format!("{context}: {}", panic_payload_message(payload.as_ref())),
+        Err(payload) => Err(CompileError::with_code(
+            format!("{context}: {}", panic_payload_message(payload.as_ref())),
             phase,
-        }),
+            DiagnosticCode::INTERNAL_COMPILER_PANIC,
+        )),
     }
 }
 
 fn is_internal_compile_error(error: &CompileError) -> bool {
-    error.message.starts_with("internal compiler panic during ")
+    error.code == Some(DiagnosticCode::INTERNAL_COMPILER_PANIC)
 }
 
 fn compile_error_exit_code(errors: &[CompileError]) -> i32 {
@@ -1205,16 +1207,14 @@ mod tests {
 
     #[test]
     fn test_compile_error_exit_code_contract_user_vs_internal() {
-        let user_error = CompileError {
-            message: "type mismatch".to_string(),
-            phase: CompilePhase::TypeCheck,
-        };
+        let user_error = CompileError::new("type mismatch", CompilePhase::TypeCheck);
         assert_eq!(compile_error_exit_code(&[user_error]), EXIT_USER_DIAGNOSTIC);
 
-        let internal_error = CompileError {
-            message: "internal compiler panic during single-file code generation: boom".to_string(),
-            phase: CompilePhase::Codegen,
-        };
+        let internal_error = CompileError::with_code(
+            "internal compiler panic during single-file code generation: boom",
+            CompilePhase::Codegen,
+            DiagnosticCode::INTERNAL_COMPILER_PANIC,
+        );
         assert_eq!(
             compile_error_exit_code(&[internal_error]),
             EXIT_INTERNAL_COMPILER_FAILURE

--- a/crates/sifr_diagnostics/src/lib.rs
+++ b/crates/sifr_diagnostics/src/lib.rs
@@ -12,5 +12,9 @@ pub use model::{
     DiagnosticSuggestion, ErrorEmitted, InternalDiagnostic, RelatedKind, RelatedSpan, Severity,
     SifrDiagnostic, SourceDiagnostic, SuggestionApplicability, SuggestionEdit,
 };
-pub use render::{DiagnosticEnvelope, DiagnosticSpan, DiagnosticSpanLine, RenderedDiagnostic};
+pub use render::{
+    render_compact_envelope, render_human_envelope, render_json_envelope, render_sink_compact,
+    render_sink_human, render_sink_json, DiagnosticEnvelope, DiagnosticSpan, DiagnosticSpanLine,
+    PresentationRenderError, RenderedDiagnostic,
+};
 pub use source_map::{SourceId, SourceMap, SourceMapError, SourceSpan};

--- a/crates/sifr_diagnostics/src/render/mod.rs
+++ b/crates/sifr_diagnostics/src/render/mod.rs
@@ -5,6 +5,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+mod presentation;
+
+pub use presentation::{
+    render_compact_envelope, render_human_envelope, render_json_envelope, render_sink_compact,
+    render_sink_human, render_sink_json, PresentationRenderError,
+};
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DiagnosticEnvelope {

--- a/crates/sifr_diagnostics/src/render/presentation.rs
+++ b/crates/sifr_diagnostics/src/render/presentation.rs
@@ -1,0 +1,361 @@
+use super::{DiagnosticEnvelope, DiagnosticSpan, RenderedDiagnostic};
+use crate::model::Severity;
+use crate::source_map::{SourceMap, SourceMapError};
+use crate::DiagnosticSink;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+const MAX_COMPACT_REPRESENTATIVE_LOCATIONS: usize = 5;
+
+#[derive(Debug)]
+pub enum PresentationRenderError {
+    SourceMap(SourceMapError),
+    Json(serde_json::Error),
+}
+
+impl From<SourceMapError> for PresentationRenderError {
+    fn from(error: SourceMapError) -> Self {
+        Self::SourceMap(error)
+    }
+}
+
+impl From<serde_json::Error> for PresentationRenderError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub fn render_sink_human(
+    sink: &DiagnosticSink,
+    source_map: &SourceMap,
+) -> Result<String, SourceMapError> {
+    let envelope = super::render_sink(sink, source_map)?;
+    Ok(render_human_envelope(&envelope))
+}
+
+pub fn render_sink_compact(
+    sink: &DiagnosticSink,
+    source_map: &SourceMap,
+) -> Result<String, SourceMapError> {
+    let envelope = super::render_sink(sink, source_map)?;
+    Ok(render_compact_envelope(&envelope))
+}
+
+pub fn render_sink_json(
+    sink: &DiagnosticSink,
+    source_map: &SourceMap,
+) -> Result<String, PresentationRenderError> {
+    let envelope = super::render_sink(sink, source_map)?;
+    Ok(render_json_envelope(&envelope)?)
+}
+
+#[must_use]
+pub fn render_human_envelope(envelope: &DiagnosticEnvelope) -> String {
+    let mut output = String::new();
+    for diagnostic in &envelope.diagnostics {
+        let _ = writeln!(
+            output,
+            "{}[{}]: {}",
+            severity_label(diagnostic.severity),
+            diagnostic.code,
+            diagnostic.message
+        );
+        if let Some(primary) = primary_span(diagnostic) {
+            let _ = writeln!(output, "  --> {}", location_label(primary));
+            for line in &primary.lines {
+                let _ = writeln!(output, "   | {}", line.text);
+            }
+        }
+        for child in &diagnostic.children {
+            let _ = writeln!(
+                output,
+                "  {}: {}",
+                child_severity_label(child.severity),
+                child.message
+            );
+        }
+        if let Some(help) = &diagnostic.help {
+            let _ = writeln!(output, "  help: {help}");
+        }
+        let _ = writeln!(output, "  url: {}", diagnostic.url);
+    }
+    output
+}
+
+#[must_use]
+pub fn render_compact_envelope(envelope: &DiagnosticEnvelope) -> String {
+    let diagnostics = envelope.diagnostics.as_slice();
+    let mut grouped: BTreeMap<CompactKey, Vec<&RenderedDiagnostic>> = BTreeMap::new();
+    for diagnostic in diagnostics {
+        grouped
+            .entry(CompactKey::from_diagnostic(diagnostic))
+            .or_default()
+            .push(diagnostic);
+    }
+
+    let mut output = String::new();
+    output.push_str(&compact_severity_summary(diagnostics));
+    output.push('\n');
+
+    for (key, group) in grouped {
+        let severity = group[0].severity;
+        let _ = writeln!(
+            output,
+            "{} [{}] {} (x{})",
+            severity_label(severity),
+            key.code,
+            group[0].message,
+            group.len()
+        );
+
+        let mut locations = BTreeSet::new();
+        for diagnostic in &group {
+            if let Some(span) = primary_span(diagnostic) {
+                locations.insert(location_label(span));
+            }
+        }
+
+        for location in locations.iter().take(MAX_COMPACT_REPRESENTATIVE_LOCATIONS) {
+            let _ = writeln!(output, "  at {location}");
+        }
+        if locations.len() > MAX_COMPACT_REPRESENTATIVE_LOCATIONS {
+            let _ = writeln!(
+                output,
+                "  ... +{} more",
+                locations.len() - MAX_COMPACT_REPRESENTATIVE_LOCATIONS
+            );
+        }
+
+        if let Some(help) = group
+            .iter()
+            .find_map(|diagnostic| diagnostic.help.as_deref())
+        {
+            let _ = writeln!(output, "  help: {help}");
+        }
+        let _ = writeln!(output, "  url: {}", group[0].url);
+    }
+
+    output
+}
+
+pub fn render_json_envelope(envelope: &DiagnosticEnvelope) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(envelope)
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct CompactKey {
+    severity_rank: u8,
+    code: String,
+    message_template: String,
+    primary_display_file: Option<String>,
+}
+
+impl CompactKey {
+    fn from_diagnostic(diagnostic: &RenderedDiagnostic) -> Self {
+        Self {
+            severity_rank: severity_rank(diagnostic.severity),
+            code: diagnostic.code.clone(),
+            message_template: diagnostic.message_template.clone(),
+            primary_display_file: primary_span(diagnostic).and_then(|span| span.file.clone()),
+        }
+    }
+}
+
+fn compact_severity_summary(diagnostics: &[RenderedDiagnostic]) -> String {
+    let mut error_count = 0usize;
+    let mut warning_count = 0usize;
+    let mut note_count = 0usize;
+    for diagnostic in diagnostics {
+        match diagnostic.severity {
+            Severity::Error => error_count += 1,
+            Severity::Warning => warning_count += 1,
+            Severity::Note => note_count += 1,
+        }
+    }
+    format!("summary: {error_count} error(s), {warning_count} warning(s), {note_count} note(s)")
+}
+
+fn primary_span(diagnostic: &RenderedDiagnostic) -> Option<&DiagnosticSpan> {
+    diagnostic.spans.iter().find(|span| span.is_primary)
+}
+
+fn location_label(span: &DiagnosticSpan) -> String {
+    match (&span.file, span.line, span.column) {
+        (Some(file), Some(line), Some(column)) => format!("{file}:{line}:{column}"),
+        (Some(file), Some(line), None) => format!("{file}:{line}"),
+        (Some(file), None, _) => file.clone(),
+        (None, Some(line), Some(column)) => format!("<unknown>:{line}:{column}"),
+        (None, Some(line), None) => format!("<unknown>:{line}"),
+        (None, None, Some(column)) => format!("<unknown>:0:{column}"),
+        (None, None, None) => "<unknown>".to_string(),
+    }
+}
+
+fn severity_rank(severity: Severity) -> u8 {
+    match severity {
+        Severity::Error => 0,
+        Severity::Warning => 1,
+        Severity::Note => 2,
+    }
+}
+
+fn severity_label(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Note => "note",
+    }
+}
+
+fn child_severity_label(severity: crate::model::ChildSeverity) -> &'static str {
+    match severity {
+        crate::model::ChildSeverity::Note => "note",
+        crate::model::ChildSeverity::Help => "help",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        render_compact_envelope, render_human_envelope, render_json_envelope, render_sink_compact,
+        render_sink_human, render_sink_json,
+    };
+    use crate::model::{ChildSeverity, DiagnosticBuilder, DiagnosticSink, Severity};
+    use crate::render::render_sink;
+    use crate::source_map::{SourceMap, SourceSpan};
+    use crate::DiagnosticCode;
+    use ruff_text_size::{TextRange, TextSize};
+
+    #[test]
+    fn compact_groups_by_template_and_primary_file_not_rendered_message() {
+        let mut source_map = SourceMap::new();
+        let first = source_map.register_source("a.sifr", "alpha\n");
+        let second = source_map.register_source("b.sifr", "beta\n");
+        let mut sink = DiagnosticSink::new();
+
+        for (source_id, name) in [(first, "x"), (first, "y"), (second, "z")] {
+            let diagnostic = DiagnosticBuilder::source(
+                DiagnosticCode::NAME_UNDEFINED_VARIABLE,
+                Severity::Error,
+                SourceSpan::new(
+                    source_id,
+                    TextRange::new(TextSize::new(0), TextSize::new(1)),
+                ),
+            )
+            .message_template("undefined variable `{name}`")
+            .arg("name", name)
+            .build();
+            let _ = sink.emit_error(diagnostic);
+        }
+
+        let envelope = render_sink(&sink, &source_map).expect("rendering succeeds");
+        let compact = render_compact_envelope(&envelope);
+        let compact_from_sink =
+            render_sink_compact(&sink, &source_map).expect("rendering succeeds");
+
+        assert!(compact.contains("error [SIFR-NAME-0001] undefined variable `x` (x2)"));
+        assert!(compact.contains("error [SIFR-NAME-0001] undefined variable `z` (x1)"));
+        assert!(compact.contains("  at a.sifr:1:1"));
+        assert!(compact.contains("  at b.sifr:1:1"));
+        assert_eq!(compact_from_sink, compact);
+    }
+
+    #[test]
+    fn presentation_helpers_share_the_canonical_rendered_stream() {
+        let mut source_map = SourceMap::new();
+        let source = source_map.register_source("main.sifr", "value\n");
+        let mut sink = DiagnosticSink::new();
+        let diagnostic = DiagnosticBuilder::source(
+            DiagnosticCode::TYPE_MISMATCH,
+            Severity::Error,
+            SourceSpan::new(source, TextRange::new(TextSize::new(0), TextSize::new(5))),
+        )
+        .message_template("expected `{expected}`, got `{actual}`")
+        .arg("expected", "int")
+        .arg("actual", "str")
+        .child(ChildSeverity::Help, "convert the value before assignment")
+        .build();
+        let _ = sink.emit_error(diagnostic);
+
+        let envelope = render_sink(&sink, &source_map).expect("rendering succeeds");
+        let human = render_human_envelope(&envelope);
+        let json = render_json_envelope(&envelope).expect("json rendering succeeds");
+        let human_from_sink = render_sink_human(&sink, &source_map).expect("rendering succeeds");
+        let json_from_sink = render_sink_json(&sink, &source_map).expect("json rendering succeeds");
+
+        assert!(human.contains("error[SIFR-TYPE-0002]: expected `int`, got `str`"));
+        assert!(human.contains("  --> main.sifr:1:1"));
+        assert!(json.contains("\"message_template\": \"expected `{expected}`, got `{actual}`\""));
+        assert!(json.contains("\"code\": \"SIFR-TYPE-0002\""));
+        assert_eq!(human_from_sink, human);
+        assert_eq!(json_from_sink, json);
+    }
+
+    #[test]
+    fn presentation_helpers_render_internal_and_mixed_severity_diagnostics() {
+        let mut source_map = SourceMap::new();
+        let source = source_map.register_source("main.sifr", "value\n");
+        let primary = SourceSpan::new(source, TextRange::new(TextSize::new(0), TextSize::new(5)));
+        let mut sink = DiagnosticSink::new();
+
+        let internal =
+            DiagnosticBuilder::internal(DiagnosticCode::INTERNAL_COMPILER_PANIC, Severity::Error)
+                .message_template("internal compiler panic during {phase}")
+                .arg("phase", "codegen")
+                .help("please report this compiler bug")
+                .build();
+        let _ = sink.emit_error(internal);
+
+        let warning = DiagnosticBuilder::source(
+            DiagnosticCode::TYPE_ARITHMETIC_OVERFLOW_RISK,
+            Severity::Warning,
+            primary.clone(),
+        )
+        .message_template("int multiplication may overflow")
+        .build();
+        sink.emit(warning);
+
+        let note =
+            DiagnosticBuilder::source(DiagnosticCode::TYPE_REVEAL_TYPE, Severity::Note, primary)
+                .message_template("revealed type is `{revealed_type}`")
+                .arg("revealed_type", "int")
+                .build();
+        sink.emit(note);
+
+        let human = render_sink_human(&sink, &source_map).expect("rendering succeeds");
+        let compact = render_sink_compact(&sink, &source_map).expect("rendering succeeds");
+
+        assert!(human.contains("error[SIFR-INTERNAL-0001]: internal compiler panic during codegen"));
+        assert!(human.contains("  help: please report this compiler bug"));
+        assert!(!human.contains("<unknown>"));
+        assert!(compact.starts_with("summary: 1 error(s), 1 warning(s), 1 note(s)\n"));
+        assert!(compact
+            .contains("error [SIFR-INTERNAL-0001] internal compiler panic during codegen (x1)"));
+        assert!(compact.contains("warning [SIFR-TYPE-0901] int multiplication may overflow (x1)"));
+        assert!(compact.contains("note [SIFR-TYPE-0902] revealed type is `int` (x1)"));
+    }
+
+    #[test]
+    fn compact_groups_internal_diagnostics_without_locations() {
+        let source_map = SourceMap::new();
+        let mut sink = DiagnosticSink::new();
+
+        for phase in ["codegen", "codegen"] {
+            let diagnostic = DiagnosticBuilder::internal(
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+                Severity::Error,
+            )
+            .message_template("internal compiler panic during {phase}")
+            .arg("phase", phase)
+            .build();
+            let _ = sink.emit_error(diagnostic);
+        }
+
+        let compact = render_sink_compact(&sink, &source_map).expect("rendering succeeds");
+
+        assert!(compact.contains("summary: 2 error(s), 0 warning(s), 0 note(s)"));
+        assert!(compact
+            .contains("error [SIFR-INTERNAL-0001] internal compiler panic during codegen (x2)"));
+        assert!(!compact.contains("  at "));
+    }
+}

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -14,6 +14,7 @@ use crate::project::{
 use crate::stdlib::{compile_stdlib, StdlibCompiled};
 use crate::workspace::find_workspace_root;
 use sifr_codegen::generate_rust_with_stdlib;
+use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::LoweringResult;
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -162,13 +163,11 @@ impl RootedEntrypointPlan {
                     .file_stem()
                     .map(|stem| stem.to_string_lossy().to_string())
                 else {
-                    return Err(vec![CompileError {
-                        message: format!(
-                            "invalid project entrypoint path '{}'",
-                            main_file.display()
-                        ),
-                        phase: CompilePhase::Build,
-                    }]);
+                    return Err(vec![CompileError::with_code(
+                        format!("invalid project entrypoint path '{}'", main_file.display()),
+                        CompilePhase::Build,
+                        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                    )]);
                 };
                 let root_modules = BTreeSet::from([main_module_name.clone()]);
                 let resolver = match find_workspace_root(main_file)? {
@@ -206,20 +205,20 @@ impl RootedEntrypointPlan {
 
     fn into_single_file_frontend(self) -> Result<FrontendCompiled, Vec<CompileError>> {
         if self.shape != RootedEntrypointShape::SingleFile {
-            return Err(vec![CompileError {
-                message:
-                    "internal error: rooted project entrypoint cannot be converted into a single-file frontend result"
-                        .to_string(),
-                phase: CompilePhase::Build,
-            }]);
+            return Err(vec![CompileError::with_code(
+                "internal error: rooted project entrypoint cannot be converted into a single-file frontend result",
+                CompilePhase::Build,
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+            )]);
         }
 
         let mut project_lowering = self.project_lowering;
         let main_module = project_lowering.hir_modules.remove("main").ok_or_else(|| {
-            vec![CompileError {
-                message: "internal error: frontend lowering missing 'main' module".to_string(),
-                phase: CompilePhase::TypeCheck,
-            }]
+            vec![CompileError::with_code(
+                "internal error: frontend lowering missing 'main' module",
+                CompilePhase::Build,
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+            )]
         })?;
         let main_diag = project_lowering
             .module_diagnostics

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -3,6 +3,7 @@ use super::project_codegen::GeneratedBinaryProject;
 use super::{prepare_cached_artifact, CachedArtifactEntry, PreparedArtifactCache};
 use crate::diagnostics::{CompileError, CompilePhase};
 use crate::project::{namespace_module_files, rust_module_file_path};
+use sifr_diagnostics::DiagnosticCode;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -112,11 +113,17 @@ fn materialize_binary_project_at_path(
         .args(["build", "--release"])
         .current_dir(project_path)
         .output()
-        .map_err(|error| vec![build_error(format!("failed to run cargo build: {error}"))])?;
+        .map_err(|error| {
+            vec![cargo_build_error(format!(
+                "failed to run cargo build: {error}"
+            ))]
+        })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(vec![build_error(format!("cargo build failed:\n{stderr}"))]);
+        return Err(vec![cargo_build_error(format!(
+            "cargo build failed:\n{stderr}"
+        ))]);
     }
     Ok(())
 }
@@ -135,10 +142,19 @@ fn write_project_file(
 }
 
 fn build_error(message: String) -> CompileError {
-    CompileError {
+    CompileError::with_code(
         message,
-        phase: CompilePhase::Build,
-    }
+        CompilePhase::Build,
+        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+    )
+}
+
+fn cargo_build_error(message: String) -> CompileError {
+    CompileError::with_code(
+        message,
+        CompilePhase::Build,
+        DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
+    )
 }
 
 fn binary_project_cache_key(

--- a/crates/sifr_driver/src/build/workspace.rs
+++ b/crates/sifr_driver/src/build/workspace.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::{CompileError, CompilePhase};
 use serde::{Deserialize, Serialize};
+use sifr_diagnostics::DiagnosticCode;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -27,19 +28,19 @@ pub(crate) fn create_invocation_workspace(prefix: &str) -> Result<PathBuf, Vec<C
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
             Err(error) => {
                 let workspace_display = workspace.display();
-                return Err(vec![CompileError {
-                    message: format!(
-                        "failed to create invocation workspace '{workspace_display}': {error}"
-                    ),
-                    phase: CompilePhase::Build,
-                }]);
+                return Err(vec![CompileError::with_code(
+                    format!("failed to create invocation workspace '{workspace_display}': {error}"),
+                    CompilePhase::Build,
+                    DiagnosticCode::BUILD_TEMP_WORKSPACE_FAILURE,
+                )]);
             }
         }
     }
-    Err(vec![CompileError {
-        message: format!("failed to allocate unique invocation workspace for prefix '{prefix}'"),
-        phase: CompilePhase::Build,
-    }])
+    Err(vec![CompileError::with_code(
+        format!("failed to allocate unique invocation workspace for prefix '{prefix}'"),
+        CompilePhase::Build,
+        DiagnosticCode::BUILD_TEMP_WORKSPACE_FAILURE,
+    )])
 }
 
 const ARTIFACT_CACHE_SCHEMA_VERSION: u32 = 1;
@@ -120,13 +121,14 @@ impl PendingCachedArtifact {
         for required_path in required_paths {
             let absolute = self.staging_root.join(required_path);
             if !absolute.exists() {
-                return Err(vec![CompileError {
-                    message: format!(
+                return Err(vec![CompileError::with_code(
+                    format!(
                         "generated artifact cache staging directory is missing required path '{}'",
                         absolute.display()
                     ),
-                    phase: CompilePhase::Build,
-                }]);
+                    CompilePhase::Build,
+                    DiagnosticCode::BUILD_ARTIFACT_MISSING,
+                )]);
             }
         }
 
@@ -158,14 +160,15 @@ impl PendingCachedArtifact {
                     },
                 })
             }
-            Err(error) => Err(vec![CompileError {
-                message: format!(
+            Err(error) => Err(vec![CompileError::with_code(
+                format!(
                     "failed to promote generated artifact cache directory '{}' into '{}': {error}",
                     self.staging_root.display(),
                     self.final_root.display()
                 ),
-                phase: CompilePhase::Build,
-            }]),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+            )]),
         }
     }
 }
@@ -204,13 +207,14 @@ pub(crate) fn prepare_cached_artifact(
     ));
     let cache_root = artifact_cache_root().join(namespace);
     std::fs::create_dir_all(&cache_root).map_err(|error| {
-        vec![CompileError {
-            message: format!(
+        vec![CompileError::with_code(
+            format!(
                 "failed to create generated artifact cache root '{}': {error}",
                 cache_root.display()
             ),
-            phase: CompilePhase::Build,
-        }]
+            CompilePhase::Build,
+            DiagnosticCode::BUILD_TEMP_WORKSPACE_FAILURE,
+        )]
     })?;
 
     let final_root = cache_root.join(&cache_key);
@@ -287,16 +291,18 @@ fn write_cache_metadata(
     metadata: &ArtifactCacheMetadata,
 ) -> Result<(), Vec<CompileError>> {
     let content = serde_json::to_string_pretty(metadata).map_err(|error| {
-        vec![CompileError {
-            message: format!("failed to serialize generated artifact cache metadata: {error}"),
-            phase: CompilePhase::Build,
-        }]
+        vec![CompileError::with_code(
+            format!("failed to serialize generated artifact cache metadata: {error}"),
+            CompilePhase::Build,
+            DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+        )]
     })?;
     std::fs::write(workspace_root.join(ARTIFACT_CACHE_METADATA_FILE), content).map_err(|error| {
-        vec![CompileError {
-            message: format!("failed to write generated artifact cache metadata: {error}"),
-            phase: CompilePhase::Build,
-        }]
+        vec![CompileError::with_code(
+            format!("failed to write generated artifact cache metadata: {error}"),
+            CompilePhase::Build,
+            DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+        )]
     })
 }
 

--- a/crates/sifr_driver/src/diagnostics.rs
+++ b/crates/sifr_driver/src/diagnostics.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use sifr_diagnostics::DiagnosticCode;
 use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
@@ -26,6 +27,7 @@ pub enum CompileResultFull {
 pub struct CompileError {
     pub message: String,
     pub phase: CompilePhase,
+    pub code: Option<DiagnosticCode>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,44 +95,43 @@ pub struct CompilerDiagnostic {
 }
 
 impl CompileError {
-    fn workspace_diagnostic_code(&self) -> Option<&'static str> {
-        if self.phase != CompilePhase::Build {
-            return None;
+    /// Creates a temporary legacy phase-bucket error for unmigrated paths.
+    ///
+    /// Do not use this for workspace diagnostics or any newly migrated emission
+    /// site; those must use [`Self::with_code`] with an active `DiagnosticCode`.
+    #[must_use]
+    pub fn new(message: impl Into<String>, phase: CompilePhase) -> Self {
+        Self {
+            message: message.into(),
+            phase,
+            code: None,
         }
-        let message = self.message.as_str();
-        if message.starts_with("could not parse sifr.toml at ") {
-            return Some("SIFR-WORKSPACE-0001");
+    }
+
+    /// Creates a legacy transport error that already carries canonical identity.
+    #[must_use]
+    pub fn with_code(
+        message: impl Into<String>,
+        phase: CompilePhase,
+        code: DiagnosticCode,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            phase,
+            code: Some(code),
         }
-        if message.starts_with("[source].roots entry ") {
-            if message.contains(" escapes the workspace root via '..'") {
-                return Some("SIFR-WORKSPACE-0002");
-            }
-            if message.contains(" is not a directory under the workspace root") {
-                return Some("SIFR-WORKSPACE-0003");
-            }
-            if message.contains(" must be a relative non-empty path under the workspace root") {
-                return Some("SIFR-WORKSPACE-0004");
-            }
-        }
-        if message.starts_with("could not resolve import ") {
-            return Some("SIFR-WORKSPACE-0101");
-        }
-        if message.starts_with("module ") && message.contains(" is ambiguous in workspace ") {
-            return Some("SIFR-WORKSPACE-0102");
-        }
-        if message.starts_with("module ")
-            && message.contains(" resolves to file ")
-            && message.contains("package directories are not supported")
-        {
-            return Some("SIFR-WORKSPACE-0103");
-        }
-        None
     }
 
     fn diagnostic_code(&self) -> &'static str {
-        if let Some(code) = self.workspace_diagnostic_code() {
-            return code;
+        if let Some(code) = self.code {
+            return code.code();
         }
+        // Transitional legacy bridge for unmigrated non-workspace paths in
+        // diag_4a slice 1. Slice 2 removes the TypeCheck fallback after HIR
+        // LoweringError carries structured DiagnosticCode values and affected
+        // fixtures are re-keyed.
+        // Workspace diagnostics must use `with_code`; this function no longer
+        // infers identity from rendered message text.
         match self.phase {
             CompilePhase::Parse => "SIFR-PARSE-0001",
             CompilePhase::TypeCheck => "SIFR-TYPE-0001",
@@ -259,9 +260,10 @@ pub(crate) fn run_codegen_with_boundary<T>(
     let context = context.into();
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(value) => Ok(value),
-        Err(payload) => Err(CompileError {
-            message: format!("{context}: {}", panic_payload_message(payload.as_ref())),
-            phase: CompilePhase::Codegen,
-        }),
+        Err(payload) => Err(CompileError::with_code(
+            format!("{context}: {}", panic_payload_message(payload.as_ref())),
+            CompilePhase::Codegen,
+            DiagnosticCode::INTERNAL_COMPILER_PANIC,
+        )),
     }
 }

--- a/crates/sifr_driver/src/frontend/api.rs
+++ b/crates/sifr_driver/src/frontend/api.rs
@@ -2,6 +2,7 @@ use crate::build::{compile_single_file_entrypoint_with_metadata, compile_single_
 use crate::diagnostics::{CompileError, CompilePhase, CompileResult, CompileResultFull};
 use crate::frontend::module_lowering::emit_frontend_diagnostics;
 use crate::stdlib::StdlibCompiled;
+use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::LoweringResult;
 use sifr_python_ast::Stmt;
 use sifr_python_parser::parse_module;
@@ -15,22 +16,30 @@ pub fn parse_source(source: &str) -> Result<Vec<Stmt>, Vec<CompileError>> {
     match parse_module(source) {
         Ok(parsed) => {
             if !parsed.has_valid_syntax() {
+                // TODO(diag_4a slice 2): classify Ruff parse failures into
+                // the precise active parse-code buckets.
                 let errors: Vec<CompileError> = parsed
                     .errors()
                     .iter()
-                    .map(|e| CompileError {
-                        message: format!("{e}"),
-                        phase: CompilePhase::Parse,
+                    .map(|e| {
+                        CompileError::with_code(
+                            format!("{e}"),
+                            CompilePhase::Parse,
+                            DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+                        )
                     })
                     .collect();
                 return Err(errors);
             }
             Ok(parsed.into_suite())
         }
-        Err(e) => Err(vec![CompileError {
-            message: format!("failed to parse: {e}"),
-            phase: CompilePhase::Parse,
-        }]),
+        // TODO(diag_4a slice 2): classify Ruff parse failures into the
+        // precise active parse-code buckets.
+        Err(e) => Err(vec![CompileError::with_code(
+            format!("failed to parse: {e}"),
+            CompilePhase::Parse,
+            DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+        )]),
     }
 }
 

--- a/crates/sifr_driver/src/frontend/module_lowering.rs
+++ b/crates/sifr_driver/src/frontend/module_lowering.rs
@@ -25,14 +25,16 @@ pub(crate) fn lower_frontend_module(
         Err(errors) => {
             let compile_errors: Vec<CompileError> = errors
                 .into_iter()
-                .map(|e| CompileError {
-                    message: match diagnostic_style {
-                        FrontendDiagnosticStyle::Bare => e.message,
-                        FrontendDiagnosticStyle::ModulePrefixed => {
-                            format!("[{}] {}", module_name, e.message)
-                        }
-                    },
-                    phase: CompilePhase::TypeCheck,
+                .map(|e| {
+                    CompileError::new(
+                        match diagnostic_style {
+                            FrontendDiagnosticStyle::Bare => e.message,
+                            FrontendDiagnosticStyle::ModulePrefixed => {
+                                format!("[{}] {}", module_name, e.message)
+                            }
+                        },
+                        CompilePhase::TypeCheck,
+                    )
                 })
                 .collect();
             return Err(compile_errors);

--- a/crates/sifr_driver/src/project/compile_order.rs
+++ b/crates/sifr_driver/src/project/compile_order.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{CompileError, CompilePhase};
+use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::Stmt;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -188,10 +189,11 @@ pub(crate) fn compute_module_compile_order(
     let message = format!(
         "module dependency cycle detected: {cycle_render}; import chain: {edge_render}. Break the cycle by moving shared declarations into a separate module."
     );
-    Err(vec![CompileError {
+    Err(vec![CompileError::with_code(
         message,
-        phase: CompilePhase::TypeCheck,
-    }])
+        CompilePhase::Build,
+        DiagnosticCode::WORKSPACE_IMPORT_CYCLE,
+    )])
 }
 
 fn canonicalize_cycle_path(cycle_path: Vec<String>) -> Vec<String> {

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::{CompileError, CompilePhase};
 use crate::workspace::WorkspaceRoot;
+use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::Stmt;
 use sifr_python_parser::parse_module;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -193,14 +194,16 @@ enum ResolutionFailureKind {
 impl ResolutionError {
     fn to_compile_error(&self, resolver: &ModuleResolver) -> CompileError {
         match &self.kind {
-            ResolutionFailureKind::Unresolved => CompileError {
-                message: unresolved_import_message(&self.module_name, &self.tried_paths),
-                phase: CompilePhase::Build,
-            },
-            ResolutionFailureKind::Ambiguous => CompileError {
-                message: ambiguous_import_message(&self.module_name, resolver, &self.matches),
-                phase: CompilePhase::Build,
-            },
+            ResolutionFailureKind::Unresolved => CompileError::with_code(
+                unresolved_import_message(&self.module_name, &self.tried_paths),
+                CompilePhase::Build,
+                DiagnosticCode::WORKSPACE_UNRESOLVED_IMPORT,
+            ),
+            ResolutionFailureKind::Ambiguous => CompileError::with_code(
+                ambiguous_import_message(&self.module_name, resolver, &self.matches),
+                CompilePhase::Build,
+                DiagnosticCode::WORKSPACE_AMBIGUOUS_IMPORT,
+            ),
             ResolutionFailureKind::NamespaceFileCollision { parent_name } => {
                 let resolved_path = self
                     .tried_paths
@@ -212,15 +215,16 @@ impl ResolutionError {
                     .get(1)
                     .cloned()
                     .unwrap_or_else(|| resolver.module_source_path(parent_name));
-                CompileError {
-                    message: namespace_collision_message(
+                CompileError::with_code(
+                    namespace_collision_message(
                         &self.module_name,
                         &resolved_path,
                         parent_name,
                         &parent_path,
                     ),
-                    phase: CompilePhase::Build,
-                }
+                    CompilePhase::Build,
+                    DiagnosticCode::WORKSPACE_NAMESPACE_COLLISION,
+                )
             }
         }
     }
@@ -389,21 +393,27 @@ pub(crate) fn parse_import_closure_modules(
                 .unwrap_or_else(|| resolver.module_source_path(&module_name)),
         };
         let source = std::fs::read_to_string(&path).map_err(|e| {
-            vec![CompileError {
-                message: format!("failed to read '{}': {}", path.display(), e),
-                phase: CompilePhase::Build,
-            }]
+            vec![CompileError::with_code(
+                format!("failed to read '{}': {}", path.display(), e),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+            )]
         })?;
         let label = discovery_label(&module_name, &path, diagnostic_style);
         let parsed = match parse_module(&source) {
             Ok(parsed) => {
                 if !parsed.has_valid_syntax() {
+                    // TODO(diag_4a slice 2): classify Ruff parse failures
+                    // into the precise active parse-code buckets.
                     let errors: Vec<CompileError> = parsed
                         .errors()
                         .iter()
-                        .map(|e| CompileError {
-                            message: format!("[{label}] {e}"),
-                            phase: CompilePhase::Parse,
+                        .map(|e| {
+                            CompileError::with_code(
+                                format!("[{label}] {e}"),
+                                CompilePhase::Parse,
+                                DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+                            )
                         })
                         .collect();
                     return Err(errors);
@@ -411,10 +421,13 @@ pub(crate) fn parse_import_closure_modules(
                 parsed
             }
             Err(e) => {
-                return Err(vec![CompileError {
-                    message: format!("[{label}] failed to parse: {e}"),
-                    phase: CompilePhase::Parse,
-                }]);
+                // TODO(diag_4a slice 2): classify Ruff parse failures into
+                // the precise active parse-code buckets.
+                return Err(vec![CompileError::with_code(
+                    format!("[{label}] failed to parse: {e}"),
+                    CompilePhase::Parse,
+                    DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+                )]);
             }
         };
         let suite = parsed.into_suite();

--- a/crates/sifr_driver/src/project/frontend.rs
+++ b/crates/sifr_driver/src/project/frontend.rs
@@ -2,6 +2,7 @@ use super::compile_order::compute_module_compile_order;
 use super::exports::collect_module_exports;
 use crate::diagnostics::{write_stderr_line, CompileError, CompilePhase};
 use crate::frontend::{lower_frontend_module, FrontendDiagnosticStyle, FrontendModuleDiagnostics};
+use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::{ExternalDefs, HirModule, LoweringResult};
 use sifr_python_ast::Stmt;
 use std::collections::HashMap;
@@ -24,10 +25,11 @@ pub(crate) fn compile_frontend_modules(
 
     for module_name in &compile_order {
         let Some(stmts) = parsed_modules.get(module_name.as_str()) else {
-            return Err(vec![CompileError {
-                message: format!("[{module_name}] module was not parsed"),
-                phase: CompilePhase::Build,
-            }]);
+            return Err(vec![CompileError::with_code(
+                format!("[{module_name}] module was not parsed"),
+                CompilePhase::Build,
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+            )]);
         };
         let result = lower_frontend_module(module_name, stmts, &external_defs, diagnostic_style)?;
         let LoweringResult {

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -5,6 +5,7 @@ use crate::stdlib::intrinsics::intrinsic_constant_rust_expr;
 use crate::stdlib::registry::STDLIB_FILES;
 use crate::stdlib::types::StdlibCompiled;
 use sifr_codegen::StdlibCode;
+use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::{lower_module_stdlib_with_externals, ExternalDefs, HirParam};
 use sifr_python_parser::parse_module;
 use sifr_type_system::{FunctionType, ParamConvention, Type};
@@ -26,12 +27,17 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<CompileError>> {
         let parsed = match parse_module(source) {
             Ok(parsed) => {
                 if !parsed.has_valid_syntax() {
+                    // TODO(diag_4a slice 2): classify Ruff parse failures
+                    // into the precise active parse-code buckets.
                     let errors: Vec<CompileError> = parsed
                         .errors()
                         .iter()
-                        .map(|e| CompileError {
-                            message: format!("[stdlib:{module_name}] {e}"),
-                            phase: CompilePhase::Parse,
+                        .map(|e| {
+                            CompileError::with_code(
+                                format!("[stdlib:{module_name}] {e}"),
+                                CompilePhase::Parse,
+                                DiagnosticCode::STDLIB_BOOTSTRAP_FAILURE,
+                            )
                         })
                         .collect();
                     return Err(errors);
@@ -39,10 +45,13 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<CompileError>> {
                 parsed
             }
             Err(e) => {
-                return Err(vec![CompileError {
-                    message: format!("[stdlib:{module_name}] failed to parse: {e}"),
-                    phase: CompilePhase::Parse,
-                }]);
+                // TODO(diag_4a slice 2): classify Ruff parse failures into
+                // the precise active parse-code buckets.
+                return Err(vec![CompileError::with_code(
+                    format!("[stdlib:{module_name}] failed to parse: {e}"),
+                    CompilePhase::Parse,
+                    DiagnosticCode::STDLIB_BOOTSTRAP_FAILURE,
+                )]);
             }
         };
 
@@ -51,9 +60,12 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<CompileError>> {
             Err(errors) => {
                 let compile_errors: Vec<CompileError> = errors
                     .into_iter()
-                    .map(|e| CompileError {
-                        message: format!("[stdlib:{}] {}", module_name, e.message),
-                        phase: CompilePhase::TypeCheck,
+                    .map(|e| {
+                        CompileError::with_code(
+                            format!("[stdlib:{}] {}", module_name, e.message),
+                            CompilePhase::TypeCheck,
+                            DiagnosticCode::STDLIB_BOOTSTRAP_FAILURE,
+                        )
                     })
                     .collect();
                 return Err(compile_errors);
@@ -190,6 +202,9 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<CompileError>> {
                 vec![CompileError {
                     message: format!("[stdlib:{module_name}] {}", e.message),
                     phase: e.phase,
+                    // Preserves the internal panic code set by
+                    // run_codegen_with_boundary.
+                    code: e.code,
                 }]
             })?;
             stdlib_code

--- a/crates/sifr_driver/src/stdlib/cache.rs
+++ b/crates/sifr_driver/src/stdlib/cache.rs
@@ -50,10 +50,10 @@ mod tests {
 
         let first = match get_or_init_stdlib_cache(&cache, || {
             build_calls.fetch_add(1, Ordering::SeqCst);
-            Err(vec![CompileError {
-                message: "sentinel stdlib cache error".to_string(),
-                phase: CompilePhase::Build,
-            }])
+            Err(vec![CompileError::new(
+                "sentinel stdlib cache error",
+                CompilePhase::Build,
+            )])
         }) {
             Ok(_) => panic!("sentinel error should be cached"),
             Err(errors) => errors,

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -3,6 +3,7 @@ use super::orchestrator::GeneratedTestRunnerProject;
 use crate::build::{prepare_cached_artifact, ArtifactCacheReport, PreparedArtifactCache};
 use crate::diagnostics::{write_stderr, write_stderr_line, CompileError, CompilePhase};
 use crate::project::{namespace_module_files, rust_module_file_path};
+use sifr_diagnostics::DiagnosticCode;
 use std::path::Path;
 
 pub(crate) struct TestRunnerExecutionOutcome {
@@ -38,17 +39,19 @@ pub(crate) fn execute_test_runner_project(
     if let PreparedArtifactCache::Miss(_) = &prepared {
         let src_dir = project_dir.join("src");
         std::fs::create_dir_all(&src_dir).map_err(|error| {
-            vec![CompileError {
-                message: format!("failed to create test directory: {error}"),
-                phase: CompilePhase::Build,
-            }]
+            vec![CompileError::with_code(
+                format!("failed to create test directory: {error}"),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+            )]
         })?;
 
         std::fs::write(project_dir.join("Cargo.toml"), cargo_toml).map_err(|error| {
-            vec![CompileError {
-                message: format!("failed to write Cargo.toml: {error}"),
-                phase: CompilePhase::Build,
-            }]
+            vec![CompileError::with_code(
+                format!("failed to write Cargo.toml: {error}"),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_CARGO_MANIFEST_FAILURE,
+            )]
         })?;
 
         for module_name in &generated_project.support_module_names {
@@ -57,23 +60,25 @@ pub(crate) fn execute_test_runner_project(
                 let output_path = src_dir.join(&module_path);
                 if let Some(parent) = output_path.parent() {
                     std::fs::create_dir_all(parent).map_err(|error| {
-                        vec![CompileError {
-                            message: format!(
+                        vec![CompileError::with_code(
+                            format!(
                                 "failed to create test support module directory '{}': {error}",
                                 parent.display()
                             ),
-                            phase: CompilePhase::Build,
-                        }]
+                            CompilePhase::Build,
+                            DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                        )]
                     })?;
                 }
                 std::fs::write(&output_path, code).map_err(|error| {
-                    vec![CompileError {
-                        message: format!(
+                    vec![CompileError::with_code(
+                        format!(
                             "failed to write test support module '{}': {error}",
                             output_path.display()
                         ),
-                        phase: CompilePhase::Build,
-                    }]
+                        CompilePhase::Build,
+                        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                    )]
                 })?;
             }
         }
@@ -82,13 +87,14 @@ pub(crate) fn execute_test_runner_project(
             let output_path = src_dir.join(&namespace_file.path);
             if let Some(parent) = output_path.parent() {
                 std::fs::create_dir_all(parent).map_err(|error| {
-                    vec![CompileError {
-                        message: format!(
+                    vec![CompileError::with_code(
+                        format!(
                             "failed to create test support namespace directory '{}': {error}",
                             parent.display()
                         ),
-                        phase: CompilePhase::Build,
-                    }]
+                        CompilePhase::Build,
+                        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                    )]
                 })?;
             }
             let mut contents = String::new();
@@ -98,21 +104,23 @@ pub(crate) fn execute_test_runner_project(
                 contents.push_str(";\n");
             }
             std::fs::write(&output_path, contents).map_err(|error| {
-                vec![CompileError {
-                    message: format!(
+                vec![CompileError::with_code(
+                    format!(
                         "failed to write test support namespace '{}': {error}",
                         output_path.display()
                     ),
-                    phase: CompilePhase::Build,
-                }]
+                    CompilePhase::Build,
+                    DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                )]
             })?;
         }
 
         std::fs::write(src_dir.join("lib.rs"), &test_lib).map_err(|error| {
-            vec![CompileError {
-                message: format!("failed to write lib.rs: {error}"),
-                phase: CompilePhase::Build,
-            }]
+            vec![CompileError::with_code(
+                format!("failed to write lib.rs: {error}"),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+            )]
         })?;
     }
 
@@ -121,10 +129,11 @@ pub(crate) fn execute_test_runner_project(
         .current_dir(&project_dir)
         .output()
         .map_err(|error| {
-            vec![CompileError {
-                message: format!("failed to run cargo test: {error}"),
-                phase: CompilePhase::Build,
-            }]
+            vec![CompileError::with_code(
+                format!("failed to run cargo test: {error}"),
+                CompilePhase::Build,
+                DiagnosticCode::BUILD_RUSTC_OR_CARGO_FAILURE,
+            )]
         })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -9,6 +9,7 @@ use crate::project::{
 };
 use crate::stdlib::compile_stdlib;
 use sifr_codegen::{generate_rust_multi_with_metadata, generate_rust_test};
+use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::HirModule;
 use sifr_python_ast::Stmt;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -85,14 +86,15 @@ pub(crate) fn build_test_runner_project(
 
     for (module_name, test_file) in test_files_by_module {
         let Some(parsed) = test_modules.get(module_name.as_str()) else {
-            return Err(vec![CompileError {
-                message: format!(
+            return Err(vec![CompileError::with_code(
+                format!(
                     "missing parsed test module '{}' from '{}'",
                     module_name,
                     test_file.display()
                 ),
-                phase: CompilePhase::Build,
-            }]);
+                CompilePhase::Build,
+                DiagnosticCode::INTERNAL_COMPILER_PANIC,
+            )]);
         };
 
         let lowering_result = match lower_frontend_module(
@@ -108,6 +110,9 @@ pub(crate) fn build_test_runner_project(
                     .map(|error| CompileError {
                         message: format!("[{}] {}", test_file.display(), error.message),
                         phase: CompilePhase::TypeCheck,
+                        // Preserves None until HIR LoweringError carries a
+                        // structured code in the next diag_4a slice.
+                        code: error.code,
                     })
                     .collect();
                 return Err(compile_errors);

--- a/crates/sifr_driver/src/tests/diagnostics.rs
+++ b/crates/sifr_driver/src/tests/diagnostics.rs
@@ -2,38 +2,42 @@ use crate::{
     apply_diagnostic_recovery_limits, compile_errors_to_diagnostics, CompileError, CompilePhase,
     CompilerDiagnostic, DiagnosticSpan, Severity,
 };
+use sifr_diagnostics::DiagnosticCode;
 
 #[test]
 fn test_compile_error_to_diagnostic_has_stable_code_and_url() {
-    let err = CompileError {
-        message: "unexpected token".to_string(),
-        phase: CompilePhase::Parse,
-    };
+    let err = CompileError::with_code(
+        "unexpected token",
+        CompilePhase::Parse,
+        DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+    );
     let diag = err.to_diagnostic();
-    assert_eq!(diag.code, "SIFR-PARSE-0001");
+    assert_eq!(diag.code, "SIFR-PARSE-0002");
     assert_eq!(diag.severity, Severity::Error);
-    assert_eq!(diag.url, "https://sifr.sh/docs/errors/SIFR-PARSE-0001");
+    assert_eq!(diag.url, "https://sifr.sh/docs/errors/SIFR-PARSE-0002");
     assert_eq!(diag.message, "unexpected token");
 }
 
 #[test]
 fn test_compile_errors_to_diagnostics_preserves_order() {
     let errors = vec![
-        CompileError {
-            message: "first".to_string(),
-            phase: CompilePhase::TypeCheck,
-        },
-        CompileError {
-            message: "second".to_string(),
-            phase: CompilePhase::Codegen,
-        },
+        CompileError::with_code(
+            "first",
+            CompilePhase::TypeCheck,
+            DiagnosticCode::TYPE_MISMATCH,
+        ),
+        CompileError::with_code(
+            "second",
+            CompilePhase::Codegen,
+            DiagnosticCode::CODEGEN_BACKEND_FAILURE,
+        ),
     ];
     let diagnostics = compile_errors_to_diagnostics(&errors);
     assert_eq!(diagnostics.len(), 2);
     assert_eq!(diagnostics[0].message, "first");
     assert_eq!(diagnostics[1].message, "second");
-    assert_eq!(diagnostics[0].code, "SIFR-TYPE-0001");
-    assert_eq!(diagnostics[1].code, "SIFR-CODEGEN-0001");
+    assert_eq!(diagnostics[0].code, "SIFR-TYPE-0002");
+    assert_eq!(diagnostics[1].code, "SIFR-CODEGEN-0002");
 }
 
 #[test]
@@ -41,30 +45,39 @@ fn test_workspace_resolution_errors_have_stable_codes_and_urls() {
     let cases = [
         (
             "could not resolve import 'helper'; tried entry-relative '/tmp/helper.sifr' and workspace-relative '/tmp/lib/helper.sifr'",
-            "SIFR-WORKSPACE-0101",
+            DiagnosticCode::WORKSPACE_UNRESOLVED_IMPORT,
         ),
         (
             "module 'helper' is ambiguous in workspace '/tmp/ws': matches '/tmp/a/helper.sifr' and '/tmp/b/helper.sifr'; reorder [source].roots or rename one module to disambiguate",
-            "SIFR-WORKSPACE-0102",
+            DiagnosticCode::WORKSPACE_AMBIGUOUS_IMPORT,
         ),
         (
             "module 'helpers.list_node' resolves to file '/tmp/ws/lib/helpers/list_node.sifr' but parent name 'helpers' is also a module file '/tmp/ws/lib/helpers.sifr'; package directories are not supported",
-            "SIFR-WORKSPACE-0103",
+            DiagnosticCode::WORKSPACE_NAMESPACE_COLLISION,
         ),
     ];
 
     for (message, code) in cases {
-        let diagnostic = CompileError {
-            message: message.to_string(),
-            phase: CompilePhase::Build,
-        }
-        .to_diagnostic();
-        assert_eq!(diagnostic.code, code);
+        let diagnostic =
+            CompileError::with_code(message, CompilePhase::Build, code).to_diagnostic();
+        assert_eq!(diagnostic.code, code.code());
         assert_eq!(
             diagnostic.url,
-            format!("https://sifr.sh/docs/errors/{code}")
+            format!("https://sifr.sh/docs/errors/{}", code.code())
         );
     }
+}
+
+#[test]
+fn test_workspace_codes_do_not_derive_from_message_prefixes() {
+    let diagnostic = CompileError::with_code(
+        "could not resolve import 'helper'; this looks like a workspace diagnostic",
+        CompilePhase::Build,
+        DiagnosticCode::BUILD_TEMP_WORKSPACE_FAILURE,
+    )
+    .to_diagnostic();
+
+    assert_eq!(diagnostic.code, "SIFR-BUILD-0003");
 }
 
 #[test]

--- a/crates/sifr_driver/src/workspace/mod.rs
+++ b/crates/sifr_driver/src/workspace/mod.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{CompileError, CompilePhase};
+use sifr_diagnostics::DiagnosticCode;
 use std::path::{Component, Path, PathBuf};
 
 const MANIFEST_FILE: &str = "sifr.toml";
@@ -119,7 +120,7 @@ fn validate_source_root(
     if source_root.is_empty() || raw.is_absolute() {
         return Err(vec![source_root_error(
             source_root,
-            "must be a relative non-empty path under the workspace root",
+            SourceRootErrorKind::Invalid,
         )]);
     }
 
@@ -131,13 +132,13 @@ fn validate_source_root(
             Component::ParentDir => {
                 return Err(vec![source_root_error(
                     source_root,
-                    "escapes the workspace root via '..'",
+                    SourceRootErrorKind::Escapes,
                 )]);
             }
             Component::RootDir | Component::Prefix(_) => {
                 return Err(vec![source_root_error(
                     source_root,
-                    "must be a relative non-empty path under the workspace root",
+                    SourceRootErrorKind::Invalid,
                 )]);
             }
         }
@@ -152,31 +153,58 @@ fn validate_source_root(
     if !absolute.is_dir() {
         return Err(vec![source_root_error(
             source_root,
-            "is not a directory under the workspace root",
+            SourceRootErrorKind::NotDirectory,
         )]);
     }
     Ok(relative)
 }
 
 fn parse_manifest_error(path: &Path, reason: impl std::fmt::Display) -> CompileError {
-    CompileError {
-        message: format!(
+    CompileError::with_code(
+        format!(
             "could not parse sifr.toml at '{}': {reason}",
             path.display()
         ),
-        phase: CompilePhase::Build,
-    }
+        CompilePhase::Build,
+        DiagnosticCode::WORKSPACE_MALFORMED_MANIFEST,
+    )
 }
 
 fn parse_manifest_schema_error(path: &Path, reason: &'static str) -> Vec<CompileError> {
     vec![parse_manifest_error(path, reason)]
 }
 
-fn source_root_error(source_root: &str, reason: &'static str) -> CompileError {
-    CompileError {
-        message: format!("[source].roots entry '{source_root}' {reason}"),
-        phase: CompilePhase::Build,
+#[derive(Clone, Copy)]
+enum SourceRootErrorKind {
+    Escapes,
+    Invalid,
+    NotDirectory,
+}
+
+impl SourceRootErrorKind {
+    fn code(self) -> DiagnosticCode {
+        match self {
+            Self::Escapes => DiagnosticCode::WORKSPACE_SOURCE_ROOT_ESCAPES,
+            Self::Invalid => DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+            Self::NotDirectory => DiagnosticCode::WORKSPACE_SOURCE_ROOT_NOT_DIRECTORY,
+        }
     }
+
+    fn reason(self) -> &'static str {
+        match self {
+            Self::Escapes => "escapes the workspace root via '..'",
+            Self::Invalid => "must be a relative non-empty path under the workspace root",
+            Self::NotDirectory => "is not a directory under the workspace root",
+        }
+    }
+}
+
+fn source_root_error(source_root: &str, kind: SourceRootErrorKind) -> CompileError {
+    CompileError::with_code(
+        format!("[source].roots entry '{source_root}' {}", kind.reason()),
+        CompilePhase::Build,
+        kind.code(),
+    )
 }
 
 #[cfg(test)]

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -8,7 +8,7 @@ Sifr is not production-released yet. This phase intentionally does not preserve 
 
 ## Execution Status
 
-Current wave: `milestone_diag_2b` diagnostic registry population.
+Current wave: `milestone_diag_4a` renderer integration, split into reviewable transport slices.
 
 - [x] Proposal reviewed through final loop and accepted for implementation.
 - [x] Added `crates/sifr_diagnostics` as the canonical leaf crate for diagnostic codes, source spans/source map, model builders, sink emission, rendering, and JSON schema generation.
@@ -31,8 +31,12 @@ Current wave: `milestone_diag_2b` diagnostic registry population.
 - [x] Reviewed existing `SIFR-WORKSPACE-0001..0103` codes against the identity policy and kept them as active precise workspace diagnostics.
 - [x] Claude review for `milestone_diag_2b` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-3.md`.
 - [x] `milestone_diag_2b` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1670.
+- [ ] Started `milestone_diag_4a` slice 1: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport.
+- [ ] Deferred `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge deletion and affected fixture re-keying to `milestone_diag_4a` slice 2, where HIR `LoweringError` transport will carry structured diagnostic codes.
+- [x] Claude pre-implementation review for `milestone_diag_4a` completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md`.
+- [x] Claude implementation review for `milestone_diag_4a` slice 1 completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md`.
 
-Validation evidence for the current wave:
+Validation evidence for `milestone_diag_2a`:
 
 - `cargo test -p sifr_diagnostics` passed.
 - `python3 scripts/check_diagnostic_schema_sync.py` passed.
@@ -53,7 +57,18 @@ Validation evidence for `milestone_diag_2b`:
 - `python3 scripts/check_diagnostic_schema_sync.py` passed.
 - `cargo fmt --check -p sifr_diagnostics` passed.
 - `cargo clippy -p sifr_diagnostics --all-targets -- -D warnings` passed.
-- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` on the registry-population branch.
+- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` on the `milestone_diag_2b` branch.
+
+Validation evidence for current `milestone_diag_4a` slice 1:
+
+- `cargo fmt --check` passed.
+- `python3 scripts/check_diagnostic_schema_sync.py` passed.
+- `python3 scripts/check_diagnostic_docs_sync.py` passed.
+- `cargo test -p sifr_diagnostics` passed.
+- `cargo test -p sifr_driver diagnostics` passed.
+- `cargo test -p sifr --no-run` passed.
+- `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings` passed.
+- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` and wall time `79.70s`.
 
 ## Relationship to Existing Roadmap
 

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md
@@ -1,0 +1,271 @@
+# Review: milestone_diag_4a — Renderer Integration (Pre-Implementation, Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-4a` (based on `origin/main` after merged [PR #1670](https://github.com/sifr-lang/sifr/pull/1670))
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Inventory: [internal_docs/diagnostic_emission_inventory.md](../internal_docs/diagnostic_emission_inventory.md)
+Prior wave reviews: pass-1..3 for `diag_2b`, pass-1..2 for `diag_3`, pass-1..3 for `diag_2a`, pass-1..3 for `diag_1`.
+
+This is a pre-implementation review. No work has landed on the branch yet. The review focuses on what the code currently looks like, what `milestone_diag_4a` requires, and the concrete risks, code areas, test gaps, and sequencing decisions implementers should resolve before writing the first line of code.
+
+## Verdict
+
+**Proceed with explicit sequencing decisions.** The new diagnostic model from `diag_1`/`2a`/`2b` is in place — `crates/sifr_diagnostics` already exposes `SifrDiagnostic`, `DiagnosticBuilder`, `DiagnosticSink`, `SourceMap`/`SourceSpan`, the canonical ordering pipeline, and the human/compact/JSON envelope renderers ([crates/sifr_diagnostics/src/render/presentation.rs:10-32](../crates/sifr_diagnostics/src/render/presentation.rs:10)). What remains is the integration cliff: every `CompileError` construction site, the entire HIR `ctx.error(String)` surface, the workspace prefix classifier, `CompilePhase::TypeCheck => "SIFR-TYPE-0001"`, the `apply_diagnostic_recovery_limits` legacy grouper, and 91+ fail fixtures all live on the legacy path. The milestone's four-PR structure is the right shape, but several latent assumptions need to be made explicit before implementation, primarily around spans, workspace code timing, and the `Severity::Help` deletion.
+
+## Scope-bounded summary
+
+`milestone_diag_4a` covers (from [issues/…-diagnostics.md:837-867](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:837)):
+
+1. Human/compact/JSON renderers consume `SifrDiagnostic`.
+2. Remove workspace message-prefix code inference (`CompileError::workspace_diagnostic_code`).
+3. All renderers share one deterministic canonical post-admission diagnostic stream; admission is a no-op pass in `diag_4a` (the cap activates in `diag_10`).
+4. Compact grouping uses `(severity, code, message_template, primary display file)`.
+5. Delete `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` (any unmigrated `TypeCheck` path must already use an inventory-assigned canonical code through `SifrDiagnostic` transport, or fail to compile).
+6. Mechanical transport migration of every previously `CompilePhase::TypeCheck`-routed HIR/type-system call site to inventory-assigned `SifrDiagnostic` emission.
+7. Replace user-facing `LoweringError { message, line, col }` with `LoweringOutcome` + `DiagnosticSink`.
+8. Migrate parser adapters, workspace/project discovery, codegen boundaries, build/materialization/rustc, and test-runner emission paths covered by the inventory into `SifrDiagnostic` transport.
+
+The four expected sub-PRs from the issue are: (1) renderer integration + message-based code inference removal, (2) `LoweringError` replacement, (3) parser/workspace/codegen/build/rustc-boundary/test-runner transport, (4) `CompilePhase::TypeCheck` deletion + HIR/type-system mechanical transport.
+
+## Current-state inventory (pre-implementation snapshot)
+
+Shared diagnostic infrastructure (shipped by prior milestones):
+
+- [crates/sifr_diagnostics/src/lib.rs:9-17](../crates/sifr_diagnostics/src/lib.rs:9) re-exports `SifrDiagnostic`, `DiagnosticBuilder`, `DiagnosticSink`, `ErrorEmitted`, `SourceMap`, `SourceSpan`, `DiagnosticEnvelope`, plus `render_sink_human`, `render_sink_compact`, `render_sink_json`.
+- The canonical ordering pipeline and template-based compact grouping already exist: [crates/sifr_diagnostics/src/render/mod.rs:88-204](../crates/sifr_diagnostics/src/render/mod.rs:88) sorts by `(path_rank, path, byte_start, byte_end, severity_rank, kind_rank, code, message_template, args, insertion_order)`, and [crates/sifr_diagnostics/src/render/presentation.rs:133-149](../crates/sifr_diagnostics/src/render/presentation.rs:133) builds the `(severity_rank, code, message_template, primary_display_file)` compact key.
+- `Severity` is `Error | Warning | Note` only ([crates/sifr_diagnostics/src/model/mod.rs:9-16](../crates/sifr_diagnostics/src/model/mod.rs:9)). Top-level `Help` is intentionally absent. Help text flows through `help: Option<String>` or `ChildSeverity::Help` children.
+- `DiagnosticBuilder::source(...)` requires a `SourceSpan`; `DiagnosticBuilder::internal(...)` does not. Severity must match the registry-declared severity ([model/mod.rs:312-332](../crates/sifr_diagnostics/src/model/mod.rs:312)). Drop discipline trips a `debug_assert!` and increments `UNEMITTED_DIAGNOSTIC_DROP_COUNT` ([model/mod.rs:268-290, 432-442](../crates/sifr_diagnostics/src/model/mod.rs:268)).
+- Active codes the mechanical transport will need (sample): `SIFR-NAME-0001..0004`, `SIFR-IMPORT-0001..0002`, `SIFR-TYPE-0002..0009/0901/0902`, `SIFR-DECIMAL-0001..0008`, `SIFR-CALL-0001..0005`, `SIFR-OWN-0001..0004`, `SIFR-FLOW-0001..0003/0901`, `SIFR-MATCH-0001..0003`, `SIFR-PROTO-0001..0004`, `SIFR-CLASS-0001..0004`, `SIFR-RESULT-0001..0003`, `SIFR-STDLIB-0001..0004`, `SIFR-WORKSPACE-0001..0104`, `SIFR-CODEGEN-0002`, `SIFR-BUILD-0002..0006`, `SIFR-INTERNAL-0001` ([crates/sifr_diagnostics/src/codes.rs:10-119](../crates/sifr_diagnostics/src/codes.rs:10)).
+
+Legacy surface still in place (must be migrated or wired through):
+
+- [crates/sifr_driver/src/diagnostics.rs:25-160](../crates/sifr_driver/src/diagnostics.rs:25) — `CompileError`, `CompilePhase`, `CompilerDiagnostic`, `Severity` (with `Help`), `DiagnosticSpan` (line/col only, no byte offsets), and the prefix classifier `workspace_diagnostic_code` plus `CompilePhase => SIFR-…-0001` mapping.
+- [crates/sifr_driver/src/diagnostics.rs:166-221](../crates/sifr_driver/src/diagnostics.rs:166) — `apply_diagnostic_recovery_limits` does both message-text grouping (key includes the rendered `message`) and the per-group cap of 5 with a synthetic "... +N more similar diagnostics" diagnostic. This grouper is incompatible with the new pipeline (message-template grouping + canonical sort + admission pass).
+- [crates/sifr/src/main.rs:288-365](../crates/sifr/src/main.rs:288) — CLI compact rendering (uses `sifr_driver::DiagnosticSpan`/`Severity`), [main.rs:367-413](../crates/sifr/src/main.rs:367) — the legacy `render_compile_errors` dispatcher, [main.rs:215-231, 270-286](../crates/sifr/src/main.rs:215) — `Severity::Help` ranking and counting.
+- HIR lowering's user-facing emission is entirely string-based: [crates/sifr_hir/src/lower/mod.rs:83-97](../crates/sifr_hir/src/lower/mod.rs:83) defines `LoweringError { message, line, col }` and [mod.rs:209-215](../crates/sifr_hir/src/lower/mod.rs:209) is the `ctx.error(String)` constructor. The inventory counts 489 raw HIR `ctx.error(...)` call sites across 22 files ([internal_docs/diagnostic_emission_inventory.md:7](../internal_docs/diagnostic_emission_inventory.md:7)); a quick `rg "ctx\.error\(" crates/sifr_hir/src` confirms the same order of magnitude (≈510 including `self.error` variants).
+- HIR currently has no `SourceId`, no `SourceMap`, and no AST-range plumbing in `LowerCtx`. There is no `SourceMap` instance constructed anywhere outside `crates/sifr_diagnostics` tests (verified by grep — zero hits in driver/CLI/HIR).
+- Decimal pseudo-codes are still embedded in HIR/type-system messages: 18 occurrences in `expressions.rs`/`decimal_methods.rs` and 2 in `sifr_type_system::check` ([sifr_hir/src/lower/expressions.rs:875-1097](../crates/sifr_hir/src/lower/expressions.rs:875), [decimal_methods.rs:42-198](../crates/sifr_hir/src/lower/decimal_methods.rs:42), [sifr_type_system/src/check.rs:31-45](../crates/sifr_type_system/src/check.rs:31)). Decimal migration formally lands in `diag_6`, but `diag_4a`'s mechanical transport will route these via the retired `SIFR-TYPE-0001` unless the routing decision is made early.
+- `sifr_type_system::TypeError` and `TypeErrorKind` survive ([crates/sifr_type_system/src/lib.rs:30-65](../crates/sifr_type_system/src/lib.rs:30)). Their deletion is `diag_7`'s job, but `diag_4a` must decide how to forward `TypeError`-bearing call sites (e.g., 24 `TypeErrorKind::*` constructions per the inventory) into the canonical sink.
+- `LoweringResult { reveal_types: Vec<String>, warnings: Vec<String> }` is currently the side-channel for non-error diagnostics ([sifr_hir/src/lower/mod.rs:430-437](../crates/sifr_hir/src/lower/mod.rs:430)) and is consumed via `emit_frontend_diagnostics` writing raw `stderr` lines ([sifr_driver/src/frontend/module_lowering.rs:44-51](../crates/sifr_driver/src/frontend/module_lowering.rs:44)). `LoweringOutcome` is defined ([sifr_hir/src/lowering_outcome.rs:1-7](../crates/sifr_hir/src/lowering_outcome.rs:1)) but unused.
+- Test/baseline surface: 91 fail fixtures assert `SIFR-TYPE-0001` (95 total per inventory), 18 decimal fixtures embed `[E25xx]`, `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-{compact,json}.stderr.txt` lock the legacy code+message format ([decimal_invalid_literal/baselines/check-compact.stderr.txt:1-3](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt:1)), and the e2e harness still accepts both `SIFR-TYPE-0001` and `[E2507]` substring matches ([crates/sifr/tests/e2e.rs:584-685](../crates/sifr/tests/e2e.rs:584)).
+
+## Concrete implementation risks
+
+### R1 — HIR has no SourceId/SourceSpan plumbing; mechanical transport cannot fabricate spans (high)
+
+The mechanical transport migration in sub-PR 4 must produce `SifrDiagnostic` values for every HIR `ctx.error(String)` site. `DiagnosticBuilder::source(...)` requires a real `SourceSpan` ([model/mod.rs:312-323](../crates/sifr_diagnostics/src/model/mod.rs:312)), which requires a registered `SourceId`. Today, `LowerCtx::new()` knows nothing about a source map ([sifr_hir/src/lower/mod.rs:165-204](../crates/sifr_hir/src/lower/mod.rs:165)). Three options exist; one must be chosen explicitly in the implementation plan:
+
+- **(a) Thread `SourceId` only.** `LowerCtx` holds a `SourceId` (assigned by the driver per module). `ctx.error(message)` becomes `ctx.emit_error(diag)` where the call site supplies the AST node range; sites without an AST range use `TextRange::default()` and the resulting `SourceSpan` covers byte 0..0 of the module file. This is the spec-conformant approach: the milestone says "`primary_span` populated where source exists" is a `diag_9` deliverable, not `diag_4a`, but the model still requires *some* `SourceSpan` per source diagnostic. **Caveat:** [issues/…-diagnostics.md:709](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:709) says "Diagnostics that truly have no real source mapping are internal compiler diagnostics and use `SIFR-INTERNAL-*`; do not fabricate a source span." A `0..0` span on a real source file is *not* a fabricated source span — it points at the start of the module — but reviewers must accept this transitional convention.
+- **(b) Thread real AST ranges everywhere now.** Touch all ~510 call sites, accept the much larger PR, and finish what `diag_9` was scoped to do.
+- **(c) Route all HIR diagnostics as `SifrDiagnostic::Internal` until `diag_9`.** Forbidden by the issue: `SIFR-INTERNAL-*` is reserved for compiler invariants and panic-boundary failures, not user input errors ([issues/…-diagnostics.md:1217-1224](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:1217)).
+
+**Recommendation:** Option (a). The implementation plan should explicitly say "every HIR/type-system source diagnostic carries a `SourceSpan(module_source_id, ast_range_or_TextRange::default())` in `diag_4a`; `diag_9` widens to AST-accurate ranges". This needs to be declared up front so `diag_9`'s span-completion pass has a clear "fix `0..0` placeholder" signal.
+
+### R2 — Workspace prefix classifier deletion must follow, not precede, workspace construction-site migration (high)
+
+`CompileError::workspace_diagnostic_code` ([sifr_driver/src/diagnostics.rs:96-128](../crates/sifr_driver/src/diagnostics.rs:96)) is currently the only source of `SIFR-WORKSPACE-0001..0103` codes. It infers them from message prefixes against `CompileError`s constructed with `CompilePhase::Build` in `crates/sifr_driver/src/build/workspace.rs`, `crates/sifr_driver/src/project/discovery.rs`, `crates/sifr_driver/src/workspace/mod.rs`, and similar sites (~7 sites in `build/workspace.rs`, 6 in `project/discovery.rs`, 2 in `workspace/mod.rs` per the inventory). If the classifier is deleted before those construction sites are converted to use `WORKSPACE_*` `DiagnosticCode` constants, every workspace error degrades to the retired `SIFR-BUILD-0001` and the `decimal_invalid_literal`-style verification baselines flip to wrong codes silently.
+
+**Recommendation:** Within sub-PR 1 (renderer integration), delete the classifier *and* migrate the construction sites in the same PR. Alternatively, split sub-PR 1 into 1a (renderer scaffolding, classifier still present) and 1b (workspace construction-site migration + classifier deletion). The issue's sub-PR 3 ("Parser, workspace, codegen, build, rustc-boundary, and test-runner transport migration") is the cleaner home for the workspace migration — but then sub-PR 1 must keep the classifier alive. Pick one of those orderings and document it.
+
+### R3 — `apply_diagnostic_recovery_limits` becomes dead code with semantic differences (medium)
+
+The legacy grouper at [sifr_driver/src/diagnostics.rs:178-221](../crates/sifr_driver/src/diagnostics.rs:178) groups by *rendered message* and synthesizes a `... +N more similar diagnostics` summary diagnostic. Its replacement — the canonical sort + presentation compact renderer — groups by `message_template`, presents up to 5 representative *locations* per group, and never invents synthesized text-bearing diagnostics. The CLI tests at [main.rs:1268-1396](../crates/sifr/src/main.rs:1268) bake the legacy "x5 + ... +3 more similar diagnostics" shape into snapshots; those tests will fail or assert the wrong thing once the new pipeline is wired. The CLI also keys compact summary by message text and parses `message.starts_with("... +")` to detect summary groups ([main.rs:304-305](../crates/sifr/src/main.rs:304)) — that detection is no longer meaningful.
+
+**Recommendation:** sub-PR 1 must delete `apply_diagnostic_recovery_limits` (or quarantine it behind `#[deprecated]` test-only) and rewrite the four `test_compact_renderer_*` tests to assert the new grouping shape. Do not preserve the old behavior in parallel; the milestone's "all renderers consume the same canonical stream" rule forbids two competing groupers. The CLI also imports `apply_diagnostic_recovery_limits` from `sifr_driver` ([sifr_driver/src/lib.rs:23-27](../crates/sifr_driver/src/lib.rs:23)) — that re-export must die in the same PR or `diag_4b`.
+
+### R4 — `Severity::Help` is in the legacy CLI path but absent from the canonical model (medium)
+
+[sifr_diagnostics::Severity](../crates/sifr_diagnostics/src/model/mod.rs:9) is exactly `Error | Warning | Note`. The legacy `sifr_driver::Severity` adds `Help` ([sifr_driver/src/diagnostics.rs:39-45](../crates/sifr_driver/src/diagnostics.rs:39)), and existing tests/snapshots emit `Severity::Help` as a top-level rank ([main.rs:215-231, 270-286, 1422-1445](../crates/sifr/src/main.rs:215)). The `test_compact_renderer_snapshot_multi_severity_group_order` snapshot explicitly asserts `help [SIFR-CODEGEN-0001] consider adding a type annotation (x1)` rendering, which has no counterpart in the canonical renderer.
+
+**Recommendation:** sub-PR 1 deletes the legacy `Severity::Help` variant and the matching snapshot lines. The canonical model already handles "help" via `help: Option<String>` and `ChildSeverity::Help` children — there is no migration semantics to preserve, just snapshot deletion. Confirm no real emission site emits a top-level `Severity::Help`; a `rg "Severity::Help"` outside tests returns only the legacy enum and ranking infrastructure.
+
+### R5 — `CompilePhase::TypeCheck` is referenced from many non-HIR sites used as panic boundaries and stderr labels (high)
+
+`CompilePhase::TypeCheck` is *not* used only for code derivation — it is also passed to `run_with_panic_boundary` in `cmd_check` ([main.rs:471-479](../crates/sifr/src/main.rs:471)) and to `Display for CompileError` for the human-renderer label ([sifr_driver/src/diagnostics.rs:223-233](../crates/sifr_driver/src/diagnostics.rs:223)). Five non-HIR sites also construct `CompileError { phase: CompilePhase::TypeCheck, … }` for invariant/forwarding messages: [build/entrypoint.rs:221](../crates/sifr_driver/src/build/entrypoint.rs:221), [project/compile_order.rs:193](../crates/sifr_driver/src/project/compile_order.rs:193), [stdlib/bootstrap.rs:56](../crates/sifr_driver/src/stdlib/bootstrap.rs:56), [test_runner/orchestrator.rs:110](../crates/sifr_driver/src/test_runner/orchestrator.rs:110), and the CLI panic-boundary call. Deleting the `TypeCheck => "SIFR-TYPE-0001"` arm without addressing each of these collapses them onto a now-retired code or a fallthrough.
+
+**Recommendation:** Each non-HIR `CompilePhase::TypeCheck` site must be reassigned in sub-PR 4 (or its preparatory sub-PR):
+
+- The CLI `cmd_check` panic boundary → `SIFR-INTERNAL-0001` (it is an internal compiler panic).
+- `run_codegen_with_boundary` ([sifr_driver/src/diagnostics.rs:255-267](../crates/sifr_driver/src/diagnostics.rs:255)) currently uses `CompilePhase::Codegen` → `SIFR-INTERNAL-0001` is the right home for the panic case; the non-panic "codegen failed" path is `SIFR-CODEGEN-0002`.
+- `build/entrypoint.rs:221` is the "internal error: frontend lowering missing 'main' module" invariant → `SIFR-INTERNAL-0001`.
+- `project/compile_order.rs:193` (dependency cycle) → per inventory line 93, `SIFR-WORKSPACE-0104` (workspace import cycle, which is now an `Active` registry entry per [codes.rs:109](../crates/sifr_diagnostics/src/codes.rs:109)) or `SIFR-IMPORT-*` depending on graph layer.
+- `stdlib/bootstrap.rs:56` and `test_runner/orchestrator.rs:110` → forwarders that should now route the underlying frontend `SifrDiagnostic` directly rather than re-wrapping; if forwarding is impossible without losing identity, `SIFR-STDLIB-0003` for stdlib bootstrap failures and `SIFR-INTERNAL-0001` for orchestrator invariants are the inventory-assigned homes.
+
+The implementation plan must enumerate these five sites explicitly. The `CompileError::Display` label `"type error"` ([diagnostics.rs:227](../crates/sifr_driver/src/diagnostics.rs:227)) becomes useless once the variant is gone; both human and compact paths should derive labels from severity/code via the canonical renderers.
+
+### R6 — TypeError survives `diag_4a` but cannot leak into renderers (medium)
+
+`sifr_type_system::TypeError` and `TypeErrorKind` are deleted in `diag_7` ([issues/…-diagnostics.md:942](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:942)). But ~24 construction sites and the public functions `type_check_binary_op`, `type_check_bool_op`, `type_check_comparison`, `type_check_unary_op` continue to return `Result<Type, TypeError>` ([crates/sifr_type_system/src/check.rs:26](../crates/sifr_type_system/src/check.rs:26)). HIR call sites that today do `ctx.error(error.message)` (the inventory's "type-error string forwarding" pattern, [internal_docs/diagnostic_emission_inventory.md:120](../internal_docs/diagnostic_emission_inventory.md:120)) must be rewritten in sub-PR 4 so that *the HIR caller* synthesizes the canonical `SifrDiagnostic` from the typed `TypeErrorKind` payload (using its `expected`/`actual`/`op`/`ty` fields) plus the AST span.
+
+The issue [explicitly forbids](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:550) `impl From<TypeError> for SifrDiagnostic` as a long-term design but allows a "short-lived mechanical adapter" in a single migration PR. **Recommendation:** keep that mechanical adapter local to sub-PR 4, in the HIR call site (not as a `sifr_type_system` impl), and delete it in `diag_7`. Note that `TypeError` lacks a span — the HIR caller has the span; the adapter must take it as a parameter.
+
+### R7 — Decimal pseudo-codes still emit `SIFR-TYPE-0001` content during `diag_4a` (medium)
+
+Decimal migration to canonical `SIFR-DECIMAL-*` codes is `diag_6`'s deliverable. In `diag_4a`'s mechanical transport, the 18 decimal `[E25xx]`-bearing message strings in HIR will be assigned a code by inventory mapping. The inventory ([internal_docs/diagnostic_emission_inventory.md:312-319](../internal_docs/diagnostic_emission_inventory.md:312)) maps each pseudo-code 1:1 to a canonical decimal code, so the natural mechanical assignment in `diag_4a` is to *use the canonical decimal codes immediately*. That conflicts with `diag_6`'s framing as "decimal first migration" — but the only `diag_6` work that wouldn't be done by `diag_4a` is removing the literal `[E25xx]` substring from the rendered message and updating the 18 fixtures.
+
+**Recommendation:** the `diag_4a` mechanical transport should *not* emit `SIFR-TYPE-0001`-tagged decimal diagnostics — it cannot, since `SIFR-TYPE-0001` is retired and the registry rejects it. It should emit `SIFR-DECIMAL-*` directly with the existing `[E25xx]`-bearing message strings; `diag_6` then strips the embedded pseudo-code from the message templates and updates the 18 decimal fixtures. Document this overlap so reviewers don't flag "decimal migration before decimal milestone".
+
+### R8 — Fail-fixture annotation churn lands inside `diag_4a` whether the milestone admits it or not (medium)
+
+91 fail fixtures assert `# expect-error: SIFR-TYPE-0001` (or `[SIFR-TYPE-0001] [E25xx]`). Once sub-PR 4 lands and HIR emits inventory-assigned codes (`SIFR-NAME-0001`, `SIFR-TYPE-0002`, `SIFR-OWN-0001`, `SIFR-CALL-0001`, etc.), every one of those fixtures will fail until its `# expect-error:` line is updated. Test-harness contract cleanup (`diag_5`) is sequenced *after* `diag_6`, so the harness still permits both legacy and canonical strings; that's fine. But the fixture annotations themselves *must* be updated within sub-PR 4 of `diag_4a`, simultaneous with the emission change, otherwise the e2e suite breaks.
+
+**Recommendation:** sub-PR 4's PR description must call out the fixture annotation re-keying as a deliverable. The work is mechanical (the inventory maps each emission category to a code), but the volume is large (91 fixtures × 1 annotation each, plus the verification baselines under `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/`, plus the project verification baselines that already use canonical workspace codes and should not need changes). This is a real risk if the PR is cut without explicit fixture coverage.
+
+### R9 — `LoweringResult.reveal_types` and `.warnings` are still `Vec<String>` (low/medium)
+
+Replacing user-facing `LoweringError` with `LoweringOutcome` is sub-PR 2's job. But `LoweringResult` independently carries `reveal_types: Vec<String>` and `warnings: Vec<String>` ([sifr_hir/src/lower/mod.rs:430-437](../crates/sifr_hir/src/lower/mod.rs:430)) that the driver writes to stderr as raw lines ([frontend/module_lowering.rs:44-51](../crates/sifr_driver/src/frontend/module_lowering.rs:44)). The issue's [Non-Error Diagnostics section](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:1226) says these must become structured `Severity::Note` (`SIFR-TYPE-0902`) and `Severity::Warning` (`SIFR-TYPE-0901`, `SIFR-FLOW-0901`) diagnostics in the canonical stream, *not* stderr side-channels. Phase Definition of Done line [issues/…-diagnostics.md:1260](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:1260) says "warnings and `reveal_type` output are structured diagnostics in the canonical diagnostic stream".
+
+`milestone_diag_4a` doesn't explicitly schedule that conversion, but the milestone's wording — "All renderers operate on `SifrDiagnostic` exclusively" — implies that any user-visible renderer text must come from `SifrDiagnostic`. **Recommendation:** sub-PR 2 (LoweringError replacement) should also fold `reveal_types`/`warnings` into the same `LoweringOutcome.diagnostics: Vec<SifrDiagnostic>` stream using `TYPE_REVEAL_TYPE`/`TYPE_ARITHMETIC_OVERFLOW_RISK`/`FLOW_UNREACHABLE_STATEMENT`. If implementers prefer to keep the side-channel until `diag_10` (when `SIFR-INTERNAL-0002` cap-summary work activates), call that out explicitly so the renderer milestone doesn't claim "all output via canonical stream" while warnings still escape to stderr.
+
+### R10 — `LoweringError` symbol is used by 7 HIR unit-test files (low)
+
+The HIR unit tests at [own_mut_param_tests.rs](../crates/sifr_hir/src/lower/own_mut_param_tests.rs), [expressions_tests.rs](../crates/sifr_hir/src/lower/expressions_tests.rs), [nested_function_tests.rs](../crates/sifr_hir/src/lower/nested_function_tests.rs), [guarded_index.rs:183-194](../crates/sifr_hir/src/lower/guarded_index.rs:183), [type_alias_tests.rs](../crates/sifr_hir/src/lower/type_alias_tests.rs), [numeric_sentinels.rs:314](../crates/sifr_hir/src/lower/numeric_sentinels.rs:314), [own_mut_semantics_tests.rs](../crates/sifr_hir/src/lower/own_mut_semantics_tests.rs) all destructure `Result<HirModule, Vec<LoweringError>>`. Sub-PR 2 must update each test helper to consume `LoweringOutcome { result, diagnostics }`. The milestone says `LoweringError` becomes "private transitional plumbing" in `diag_4a` and is fully deleted in `diag_11`. Confirm with the implementer whether `LoweringError` survives as a private struct or is deleted now: the issue text at [issues/…-diagnostics.md:734](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:734) says "`LoweringError` becomes private transitional plumbing only" in `diag_1` and "is removed from user-facing paths in `milestone_diag_4a`" — that allows it to stay as an internal type. The cleanest path: keep `LoweringError` private, used as the input form for the new `LowerCtx` -> `SifrDiagnostic` conversion, and delete in `diag_11`.
+
+### R11 — Canonical sort uses display path, but driver doesn't yet feed display paths (medium)
+
+[crates/sifr_diagnostics/src/render/mod.rs:179-204](../crates/sifr_diagnostics/src/render/mod.rs:179) sorts by `source_map.display_path(span.source_id)`. In project mode, display paths must be set per module so multi-file fixtures show the correct file ([issues/…-diagnostics.md:638-646, 700-714](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:638)). The driver currently has no `SourceMap`. Sub-PR 1 (renderer integration) must:
+
+- Construct a `SourceMap` per compilation invocation (CLI level) and pass `&SourceMap` to the renderers.
+- For each parsed module, register it via `SourceMap::register_source_with_metadata(display_path, canonical_path, module_name, text)`. Display paths must follow the diagnostic path-remapping policy (project-relative or `<stdin>`).
+- Plumb the resulting `SourceId` into the parser adapter and HIR `LowerCtx` so emitted diagnostics carry valid spans.
+
+**Recommendation:** define a `DriverSession` (or similar) that owns the `SourceMap` and `DiagnosticSink`, and route every `compile_*`/`check_*`/`emit_*` flow through it. Without this, sub-PR 4's HIR transport has no `SourceId` to attach to diagnostics — back to R1.
+
+### R12 — Drop discipline trips a `debug_assert!` on every test path that abandons a builder (low/medium)
+
+[model/mod.rs:268-290, 432-442](../crates/sifr_diagnostics/src/model/mod.rs:268) panics in debug builds if a `SifrDiagnostic` or `DiagnosticBuilder` is dropped without `build`/`emit`/`return`/`cancel`. The HIR mechanical transport must propagate the diagnostic through `LowerCtx::emit_error(...)` synchronously; any `?` early-return that drops a partially built diagnostic, or any `if let Some(span) = … { … } else { /* discard */ }` pattern, will trip the assertion. This is healthy discipline, but it means tests must be explicit about builder consumption, and the mechanical transport cannot use the previously-loose pattern of "build a string, decide later whether to push to errors".
+
+**Recommendation:** introduce a small `LowerCtx::report(code, span, template, args)` helper that consumes the builder in one expression — every transport call site uses this helper, never raw `DiagnosticBuilder`. This both keeps the call sites short and avoids the drop-discipline trap.
+
+## Required code areas (file-level checklist)
+
+These are the files the implementation will need to touch, grouped by sub-PR:
+
+**Sub-PR 1 — Renderer integration + message-prefix removal:**
+- [crates/sifr/src/main.rs](../crates/sifr/src/main.rs) — replace `render_compile_errors` with a session-aware `render_sink_*` dispatcher; delete `render_compact_diagnostics`, `compact_severity_summary`, `compact_location_label`, `severity_rank`/`severity_label` for `Severity::Help`; rewrite `test_compact_renderer_*` tests against the canonical renderers; remove imports of `apply_diagnostic_recovery_limits`, `compile_errors_to_diagnostics`, `CompilerDiagnostic`, `Severity` from `sifr_driver`.
+- [crates/sifr_driver/src/diagnostics.rs](../crates/sifr_driver/src/diagnostics.rs) — delete `workspace_diagnostic_code`, `apply_diagnostic_recovery_limits`, `Severity::Help`, the `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` arm, the `to_diagnostic` method, and `compile_errors_to_diagnostics`. Either delete `CompilerDiagnostic`/`DiagnosticSpan`/`DiagnosticChild`/`DiagnosticSuggestion`/`RelatedSpan` outright or keep them as private bridge types until `diag_4b`. Decide explicitly.
+- [crates/sifr_driver/src/lib.rs:23-27](../crates/sifr_driver/src/lib.rs:23) — update re-exports; the milestone allows transitional `sifr_driver` re-exports of `sifr_diagnostics` types but mandates removal in `diag_4b`.
+- [crates/sifr_driver/src/tests/diagnostics.rs](../crates/sifr_driver/src/tests/diagnostics.rs) — delete or rewrite the four legacy tests (the `SIFR-TYPE-0001` recovery-limit fixtures explicitly named in the inventory).
+- New: a session/source-map owner in `sifr_driver` (probably `crates/sifr_driver/src/session.rs`) that constructs `SourceMap` + `DiagnosticSink` per invocation.
+
+**Sub-PR 2 — `LoweringError` → `LoweringOutcome`/`DiagnosticSink`:**
+- [crates/sifr_hir/src/lower/mod.rs:83-215, 430-437, 470-501](../crates/sifr_hir/src/lower/mod.rs:83) — `LowerCtx` accepts a `SourceId`; `lower_module*` returns `LoweringOutcome`; `LoweringError` becomes `pub(crate)`; `reveal_types`/`warnings` become `Vec<SifrDiagnostic>` (per R9 decision).
+- [crates/sifr_hir/src/lib.rs:17-22](../crates/sifr_hir/src/lib.rs:17) — update public exports.
+- [crates/sifr_hir/src/lowering_outcome.rs](../crates/sifr_hir/src/lowering_outcome.rs) — add `has_errors()` accessor; consider whether `result` is `Option`-bearing on hard-fail paths.
+- 7 HIR unit test files listed in R10 — update destructuring patterns.
+- [crates/sifr_codegen/src/lib_codegen_tests.rs:15](../crates/sifr_codegen/src/lib_codegen_tests.rs:15) — update one call site.
+
+**Sub-PR 3 — Parser/workspace/codegen/build/rustc-boundary/test-runner transport:**
+- [crates/sifr_driver/src/frontend/api.rs:14-35](../crates/sifr_driver/src/frontend/api.rs:14) — parser adapter emits `SIFR-PARSE-0002..0009` with `parser_category` JSON arg via the registry. Per the inventory ([internal_docs/diagnostic_emission_inventory.md:51-61](../internal_docs/diagnostic_emission_inventory.md:51)), this is mechanical: map Ruff `ParseErrorType` variants to category codes.
+- [crates/sifr_driver/src/build/workspace.rs](../crates/sifr_driver/src/build/workspace.rs) — 7 sites → `SIFR-WORKSPACE-0001..0004`, `SIFR-BUILD-0002..0006`.
+- [crates/sifr_driver/src/build/entrypoint.rs](../crates/sifr_driver/src/build/entrypoint.rs) — 3 sites → `SIFR-BUILD-*` or `SIFR-INTERNAL-0001` for invariants.
+- [crates/sifr_driver/src/build/materialize.rs](../crates/sifr_driver/src/build/materialize.rs) — 1 site → `SIFR-BUILD-0002`.
+- [crates/sifr_driver/src/project/discovery.rs](../crates/sifr_driver/src/project/discovery.rs) — 6 sites split between `SIFR-WORKSPACE-*` and reachable `SIFR-PARSE-*` paths.
+- [crates/sifr_driver/src/project/compile_order.rs:193](../crates/sifr_driver/src/project/compile_order.rs:193) → `SIFR-WORKSPACE-0104`.
+- [crates/sifr_driver/src/project/frontend.rs:29](../crates/sifr_driver/src/project/frontend.rs:29) → `SIFR-WORKSPACE-*`.
+- [crates/sifr_driver/src/stdlib/bootstrap.rs](../crates/sifr_driver/src/stdlib/bootstrap.rs) — 4 sites → `SIFR-STDLIB-0001..0003` / `SIFR-INTERNAL-0001`.
+- [crates/sifr_driver/src/stdlib/cache.rs:55](../crates/sifr_driver/src/stdlib/cache.rs:55) → `SIFR-STDLIB-0004` or `SIFR-BUILD-*`.
+- [crates/sifr_driver/src/workspace/mod.rs](../crates/sifr_driver/src/workspace/mod.rs) — 2 sites → `SIFR-WORKSPACE-0001..0004`.
+- [crates/sifr_driver/src/test_runner/execution.rs](../crates/sifr_driver/src/test_runner/execution.rs) — 8 sites → `SIFR-BUILD-*`.
+- [crates/sifr_driver/src/test_runner/orchestrator.rs](../crates/sifr_driver/src/test_runner/orchestrator.rs) — 2 sites; one forwards frontend diagnostics (must preserve identity), one is internal.
+- [crates/sifr_driver/src/diagnostics.rs:255-267](../crates/sifr_driver/src/diagnostics.rs:255) — `run_codegen_with_boundary` → `SIFR-INTERNAL-0001` for panic, `SIFR-CODEGEN-0002` for non-panic codegen failures.
+
+**Sub-PR 4 — `CompilePhase::TypeCheck` deletion + HIR/type-system mechanical transport:**
+- [crates/sifr_hir/src/lower/expressions.rs](../crates/sifr_hir/src/lower/expressions.rs) — 205 sites (largest single file). Inventory categories: NAME/TYPE/CALL/STDLIB/PROTO/DECIMAL/FLOW.
+- [crates/sifr_hir/src/lower/statements.rs](../crates/sifr_hir/src/lower/statements.rs) — 61 sites: FLOW/RESULT/PROTO/MATCH/TYPE/OWN/CALL.
+- [crates/sifr_hir/src/lower/builtin_calls.rs](../crates/sifr_hir/src/lower/builtin_calls.rs) — 55 sites: CALL/TYPE/DECIMAL/STDLIB.
+- [crates/sifr_hir/src/lower/typing_and_functions.rs](../crates/sifr_hir/src/lower/typing_and_functions.rs) — 24 sites: NAME/TYPE/RESULT/PROTO/CALL.
+- [crates/sifr_hir/src/lower/mod.rs](../crates/sifr_hir/src/lower/mod.rs) — 20 sites: TYPE/IMPORT/NAME/STDLIB. Note the wrong-layer workspace import diagnostics that should move to driver layer (per inventory line 41-43).
+- [crates/sifr_hir/src/lower/classes.rs](../crates/sifr_hir/src/lower/classes.rs) — 19 sites: CLASS/TYPE/NAME/PROTO.
+- [crates/sifr_hir/src/lower/decimal_methods.rs](../crates/sifr_hir/src/lower/decimal_methods.rs) — 18 sites: DECIMAL/CALL/NAME (per R7, emit canonical `SIFR-DECIMAL-*` directly).
+- [crates/sifr_hir/src/lower/aug_assign_lowering.rs](../crates/sifr_hir/src/lower/aug_assign_lowering.rs) — 17 sites: TYPE/OWN/NAME.
+- [crates/sifr_hir/src/lower/bytes_methods.rs](../crates/sifr_hir/src/lower/bytes_methods.rs) — 16 sites: STDLIB/CALL/TYPE.
+- [crates/sifr_hir/src/lower/method_call_args.rs](../crates/sifr_hir/src/lower/method_call_args.rs) — 13 sites: CALL/TYPE.
+- [crates/sifr_hir/src/lower/tuple_unpack.rs](../crates/sifr_hir/src/lower/tuple_unpack.rs) — 13 sites: TYPE/FLOW.
+- [crates/sifr_hir/src/lower/container_literal_specialization.rs](../crates/sifr_hir/src/lower/container_literal_specialization.rs) — 11 sites: TYPE.
+- 11 smaller files with 1–3 sites each (see [internal_docs/diagnostic_emission_inventory.md:30-40](../internal_docs/diagnostic_emission_inventory.md:30)).
+- `sifr_type_system::TypeError` forwarder bridging — short-lived adapter local to the HIR call sites that read `TypeErrorKind::*` payloads (not a `From` impl).
+- [crates/sifr_driver/src/frontend/module_lowering.rs](../crates/sifr_driver/src/frontend/module_lowering.rs) — replace `LoweringError` -> `CompileError { phase: TypeCheck }` mapping with direct `SifrDiagnostic` forwarding through the sink. The `[main] ` module-prefix style must move to a structured `module` arg (see [tests/project_graph.rs:40-43](../crates/sifr_driver/src/tests/project_graph.rs:40)) or to a related-span on the diagnostic; do not embed module names in the rendered message.
+- [crates/sifr/src/main.rs:471-479](../crates/sifr/src/main.rs:471) — `cmd_check` panic boundary → `SIFR-INTERNAL-0001`.
+- 91 fail fixtures under `crates/sifr/tests/e2e/fail/*.sifr` — annotation re-keying.
+- 2 verification baselines under `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/` — regenerate.
+- Workspace verification baselines under `crates/sifr/tests/verification/project/*/baselines/` — regenerate against the new schema (byte ranges, span lines, `version: 1` envelope, `args` object, `message_template` field, `spans` array). Existing baselines do not have those fields.
+
+## Likely test gaps
+
+- **Schema/baseline gap:** existing JSON baselines ([decimal_invalid_literal/baselines/check-json.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt)) emit a flat array, not the versioned envelope `{ "version": 1, "diagnostics": [...] }`. They lack `message_template`, `args`, `spans`, and the new `RenderedDiagnostic` shape. All workspace and decimal verification baselines need full regeneration in `diag_4a`. Add a fixture-level test (the milestone explicitly requires this in `diag_5`, but it can be staged here) that proves JSON/compact/human consume the same `Vec<SifrDiagnostic>`.
+- **No CLI test currently asserts that compact grouping uses `message_template`, not rendered `message`.** [presentation.rs:215-243](../crates/sifr_diagnostics/src/render/presentation.rs:215) covers it for the `sifr_diagnostics` crate-internal renderers, but there is no CLI-level integration test. Add one in sub-PR 1 that emits two diagnostics with the same template but different rendered text from two source files and asserts they appear under one compact group.
+- **No driver-level test asserts deterministic ordering across hash-map iteration.** The milestone calls this out as a hard rule. The `sifr_diagnostics` test at [render/mod.rs:481-543](../crates/sifr_diagnostics/src/render/mod.rs:481) covers it within the diagnostics crate, but the driver/CLI also needs a test that two compilations of the same project on different machines produce byte-identical JSON output.
+- **No test exercises the canonical-stream contract for `reveal_type(...)` and warnings.** Currently warnings/reveals go through stderr side-channels. Once they fold into the canonical stream, add a fixture that emits a `reveal_type(x)` plus a real error and asserts both appear in the same JSON envelope and are sorted correctly.
+- **`ErrorEmitted` proof discipline is unenforced in HIR.** The milestone allows `LowerCtx::emit_error(...)` to discard the proof for now ([issues/…-diagnostics.md:443](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:443)), but the proof is needed for tainted HIR values in `diag_10`. Sub-PR 2's `LowerCtx::emit_error(...)` signature should already return `ErrorEmitted` so `diag_10` doesn't have to widen the API later.
+- **Workspace-classifier deletion needs negative tests.** Add a test that asserts `CompileError` (or its replacement) does *not* attempt message-prefix code derivation, e.g., a workspace error whose message coincidentally starts with `"could not resolve import "` but is constructed via the canonical `SIFR-WORKSPACE-0101` constant — assert that the code is `0101` *because* of the constructor, not the message.
+- **Snapshot rewrite plan:** the four `test_compact_renderer_*` tests in [main.rs:1268-1446](../crates/sifr/src/main.rs:1268) and the two `crates/sifr_driver/src/tests/diagnostics.rs` tests assert the legacy "x5 + ... +N more" shape. They should be deleted and replaced with snapshot tests over the new compact shape (`(severity, code, message_template, file)` grouping, locations aggregation, no synthesized text-bearing diagnostics).
+- **`scripts/check_diagnostic_cancel_usage.py` is referenced by the issue's validation plan but does not exist** (verified by `ls scripts/`). It is required to land in `diag_1` per [issues/…-diagnostics.md:760](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:760), but does not appear in the scripts directory. Either it was missed in `diag_1` (a separate gap to flag) or it's hidden under a different name; confirm before claiming `diag_4a` validation. Same comment for `scripts/check_diagnostic_code_coverage.py` and `scripts/check_diagnostic_baseline_hygiene.py` — both referenced by the validation plan, both absent. (These are technically prerequisite gaps from earlier milestones, but they will block the `diag_4a` `Validation Plan` checklist if the implementer runs the full list.)
+
+## Sequencing recommendations
+
+The issue lists four sub-PRs; the order matters. Recommended sequencing:
+
+1. **Sub-PR 1: Renderer integration + classifier+grouping deletion + session/source-map owner.** Deletes `apply_diagnostic_recovery_limits`, `workspace_diagnostic_code`, `Severity::Help`, the `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` arm. Builds the `DriverSession` (or equivalent) that owns `SourceMap` + `DiagnosticSink`. CLI dispatches via `render_sink_human/compact/json`. **Critical:** this PR must keep the legacy `CompileError` -> `SifrDiagnostic` bridge alive for the workspace/parser/test-runner sites that haven't yet been migrated — otherwise it breaks every workspace verification baseline. The bridge maps `CompilePhase::Parse` to a temporary parser code, `CompilePhase::Build` to `SIFR-BUILD-0002` (no longer to `SIFR-BUILD-0001` since that's retired), and `CompilePhase::Codegen` to `SIFR-CODEGEN-0002`. Workspace codes still derive from the construction-site only after sub-PR 3. Document this transitional bridge as scoped to die in sub-PR 4.
+2. **Sub-PR 3 (out of issue order): Parser/workspace/codegen/build/test-runner transport.** Lands before sub-PR 2/4 because it eliminates the workspace `CompilePhase::Build` constructions that the prefix classifier covered. After this PR, the only `CompileError` constructions left are HIR-frontend ones (`CompilePhase::TypeCheck`) and the panic boundaries (`Codegen`/`Build`).
+3. **Sub-PR 2: `LoweringError` → `LoweringOutcome`/`DiagnosticSink`.** Adds `SourceId` plumbing into `LowerCtx`. Replaces `Vec<LoweringError>` returns with `LoweringOutcome`. Folds `reveal_types`/`warnings` into the diagnostic stream (R9). Updates 7 HIR unit-test files. Does *not* yet rewrite the 510 `ctx.error` call sites — they keep emitting `LoweringError` internally, which the new outer adapter converts to `SifrDiagnostic` with a temporary catch-all. This is a brief stepping stone — it cannot ship as the final state because the catch-all would emit `SIFR-TYPE-0001` (retired). The PR therefore must also assign at least one inventory code per file (e.g., a temporary `LowerCtx::error_with_code(code, span, msg)` helper) and cannot reasonably split from sub-PR 4.
+4. **Sub-PR 4: HIR/type-system mechanical transport + 91 fixture re-keying + verification baseline regeneration.** The biggest PR. This is where the inventory's per-call-site mapping is realized, decimal pseudo-codes get canonical `SIFR-DECIMAL-*` codes, `SIFR-TYPE-0001` stops appearing in the wild, and the e2e suite stays green.
+
+**Alternative (simpler but riskier) sequencing:** merge sub-PR 2 and sub-PR 4 into one. The HIR call sites cannot really be split from `LoweringError` removal because both must change atomically — the moment `LoweringError` is gone, every `ctx.error(String)` must already have become `ctx.emit_error(SifrDiagnostic)`. The issue's separation of (2) and (4) is artificial. Recommend explicitly merging them in the implementation plan.
+
+**Hard-coded ordering constraints:**
+
+- Sub-PR 1 must precede sub-PR 3 (renderer + session must exist before transport sites can call `session.sink.emit_error(...)`).
+- Sub-PR 3 must precede the `workspace_diagnostic_code` deletion *or* the deletion must happen in sub-PR 1 alongside in-place workspace migration. Pick one.
+- Sub-PR 4 must include 91 fixture annotation updates *and* regeneration of the decimal verification baseline. Splitting into "code first, fixtures later" leaves CI red between PRs.
+- Verify `scripts/check_diagnostic_cancel_usage.py`, `scripts/check_diagnostic_code_coverage.py`, `scripts/check_diagnostic_baseline_hygiene.py` exist before this milestone closes; if missing, add them in sub-PR 1 since `diag_4a`'s validation plan depends on them.
+
+## Decisions to make before the first commit
+
+These are explicit choices the implementer should record in the PR description (or `internal_docs/`) so reviewers don't relitigate them mid-PR:
+
+1. **Span placeholder convention for HIR transport (R1):** confirm "every HIR source diagnostic carries `SourceSpan(module_source_id, ast_range_or TextRange::default())` in `diag_4a`; `diag_9` widens to AST-accurate ranges". State this explicitly.
+2. **Workspace classifier removal timing (R2):** confirm sub-PR 1 deletes the classifier *and* keeps a transitional `CompilePhase::Build => SIFR-BUILD-0002` bridge (not `0001`) until sub-PR 3 completes the workspace site migration.
+3. **`apply_diagnostic_recovery_limits` fate (R3):** confirm it is deleted in sub-PR 1, not preserved as a parallel grouping path. Confirm the "x5 + ... +N more" snapshot tests are deleted, not migrated.
+4. **`Severity::Help` removal (R4):** confirm sub-PR 1 deletes the legacy variant and updates all snapshots.
+5. **`CompilePhase::TypeCheck` site reassignments (R5):** record the per-site code for each of the 5 non-HIR `TypeCheck` sites.
+6. **`TypeError` adapter scope (R6):** confirm the adapter lives at HIR call sites, not as `impl From` on `TypeError`, and is deleted in `diag_7`.
+7. **Decimal codes in `diag_4a` vs `diag_6` (R7):** confirm `SIFR-DECIMAL-*` is emitted directly in `diag_4a`'s mechanical transport; `diag_6` only strips the `[E25xx]` prefix from message templates and updates fixtures.
+8. **Fixture annotation re-keying (R8):** confirm sub-PR 4 includes 91 fixture updates plus 2 decimal verification baseline regenerations plus 5 workspace verification baseline format-only regenerations.
+9. **`reveal_types`/`warnings` migration (R9):** decide whether to fold into the canonical stream in sub-PR 2 or defer to `diag_10`.
+10. **Sub-PR 2/4 merge (Sequencing):** decide whether to ship `LoweringError` removal and HIR transport in one PR or two. The issue lists two; the dependency graph argues for one.
+
+## Open questions for the implementer
+
+- The issue's validation plan references `scripts/check_diagnostic_cancel_usage.py` and `scripts/check_diagnostic_code_coverage.py` and `scripts/check_diagnostic_baseline_hygiene.py`. These do not exist in `scripts/` today. Were they punted from `diag_1`? If so, `diag_4a` should add at least the cancel-usage and code-coverage checks since this is the milestone that introduces real `DiagnosticBuilder` usage and the first family of active emission sites.
+- The `[main] ` module-prefix style at [tests/project_graph.rs:40-43](../crates/sifr_driver/src/tests/project_graph.rs:40) and [frontend/module_lowering.rs:31-33](../crates/sifr_driver/src/frontend/module_lowering.rs:31) is currently a string concatenation. The milestone implies module identity should be a structured field, not message text. Confirm whether `module_name` is added as a JSON-only declared arg to all family codes or attached via `RelatedSpan`/source-map module metadata. The cleaner shape is "diagnostic spans carry source IDs whose source-map metadata includes the module name; renderers may prefix the human label with `[module]` based on source-map lookup, never on string concatenation".
+- Confirm whether the ordering policy's `severity_rank` matches the canonical `Severity` enum. [model/mod.rs:9-16](../crates/sifr_diagnostics/src/model/mod.rs:9) defines `Error | Warning | Note` with `derive(PartialOrd, Ord)`, which gives the same total order as the `severity_rank` function at [render/mod.rs:220-226](../crates/sifr_diagnostics/src/render/mod.rs:220). Either remove the redundant function or document why it exists (it does protect against future enum reordering).
+
+## Validation expectations
+
+For `milestone_diag_4a` to satisfy the milestone's definition of done, local validation must include at minimum:
+
+- `cargo test -p sifr_diagnostics` (existing).
+- `cargo test -p sifr_hir` (existing — must still pass after `LoweringOutcome` migration).
+- `cargo test -p sifr_driver` (existing — must still pass after CLI/driver renderer migration).
+- `cargo test -p sifr -- test_e2e_fail` (the 91-fixture suite, including all re-keyed annotations).
+- `scripts/run_e2e_pass.sh` (existing).
+- `scripts/run_all_tests.sh --profile quick`.
+- `python3 scripts/check_diagnostic_docs_sync.py`.
+- `python3 scripts/check_diagnostic_schema_sync.py`.
+- `cargo run -p sifr_diagnostics --bin gen-error-docs -- --check`.
+- `cargo run -q -p sifr -- --diagnostic-format json check crates/sifr/tests/e2e/fail/type_mismatch.sifr` and the equivalent compact/human invocations as smoke tests.
+
+The full validation set in [issues/…-diagnostics.md:1140-1170](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:1140) names additional scripts that don't exist yet — see open questions above.
+
+## Out of scope (will surface as `diag_4b`/later milestones)
+
+- `CompilePhase` and `CompileError` deletion are formally `diag_4b`, not `diag_4a`. `CompilePhase::Display` remains; the public `CompileError` abstraction remains. Only the public *code mapping* dies.
+- Per-fixture span coverage is `diag_9`. `diag_4a` only requires *some* `SourceSpan` per source diagnostic, not a precise AST range.
+- `TypeError`/`TypeErrorKind` deletion is `diag_7`.
+- Recovery cap (50 top-level) and `SIFR-INTERNAL-0002` cap-omission summaries activate in `diag_10`. The admission pass added in `diag_4a` is a no-op pass that exists so `diag_10` has a clear hook.
+- `reveal_type(...)` and warnings *may* fold into the canonical stream in `diag_4a` (R9) or wait for `diag_10`. Either is defensible; record the choice.
+- Test harness contract cleanup (rejecting `[Edddd]` and message-substring expectations) is `diag_5`. `diag_4a` keeps the harness backwards-compatible.
+
+## Summary
+
+The shared diagnostic infrastructure is fully built; `diag_4a` is the integration cliff. The four sub-PR structure in the issue is approximately right but should be re-ordered (1, 3, then merged 2+4) and each sub-PR should record its sequencing decisions explicitly. The largest hidden cost is span plumbing through `LowerCtx` — the implementation cannot avoid it because the canonical `SourceDiagnostic` requires a `SourceSpan`. The largest fixture cost is the 91 annotation re-keys, which are mechanical given the inventory but must be co-merged with the HIR emission change to avoid red CI between PRs. Confirm the existence (or schedule the addition) of `scripts/check_diagnostic_cancel_usage.py`, `scripts/check_diagnostic_code_coverage.py`, and `scripts/check_diagnostic_baseline_hygiene.py` before the implementation claims `diag_4a` validation.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md
@@ -1,0 +1,186 @@
+# Review: milestone_diag_4a — Renderer + Workspace-Inference Slice (Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-4a` (uncommitted working tree on top of `73b4e32c`)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Pre-implementation review: [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+
+Slice scope (as stated by the implementer):
+
+1. Add canonical human/compact/JSON presentation helpers in `sifr_diagnostics` that render from `DiagnosticSink` through `render_sink`.
+2. Compact grouping uses `(severity, code, message_template, primary display file)`.
+3. Remove workspace message-prefix diagnostic-code inference from `CompileError`.
+4. Workspace/project discovery/build/test-runner construction sites carry an explicit `DiagnosticCode` where touched.
+5. HIR `LoweringError` replacement and `CompilePhase::TypeCheck` deletion are deferred to later `diag_4a` waves.
+
+## Verdict
+
+**Mostly aligned with the stated scope, with a handful of concrete miss-fires.** The presentation helpers are well-shaped and tested against the canonical 4-tuple compact key. The workspace prefix classifier is gone and replaced by explicit `with_code` calls at every site that previously fed it. However the slice introduces a `code: Option<DiagnosticCode>` field on `CompileError` while leaving the legacy fallback bridge mapping all four `CompilePhase` arms to **retired** codes (`SIFR-PARSE-0001`, `SIFR-TYPE-0001`, `SIFR-CODEGEN-0001`, `SIFR-BUILD-0001`); several "where touched" sites are migrated only syntactically (`{ … }` → `::new`) and never receive an active code, so they are now wired into the retired-code path more visibly than before. The legacy CLI renderer (`apply_diagnostic_recovery_limits`, `Severity::Help`) is intentionally untouched, which is consistent with the stated scope. No HIR or `TypeCheck` deletions leaked in.
+
+## Slice fidelity
+
+| Scope item | State |
+| --- | --- |
+| Canonical `render_sink_human/compact/json` helpers | ✓ landed in [crates/sifr_diagnostics/src/render/presentation.rs](../crates/sifr_diagnostics/src/render/presentation.rs) and re-exported from [crates/sifr_diagnostics/src/lib.rs:15-19](../crates/sifr_diagnostics/src/lib.rs:15) |
+| Compact key `(severity, code, message_template, primary_display_file)` | ✓ [presentation.rs:145-162](../crates/sifr_diagnostics/src/render/presentation.rs:145) — matches the issue's contract exactly |
+| Workspace message-prefix classifier removed | ✓ `CompileError::workspace_diagnostic_code` deleted ([diagnostics.rs:97-118](../crates/sifr_driver/src/diagnostics.rs:97)); regression test added at [tests/diagnostics.rs:60-69](../crates/sifr_driver/src/tests/diagnostics.rs:60) |
+| Workspace/project/build/test-runner sites carry `DiagnosticCode` | Mostly ✓; partial misses listed under R1–R4 below |
+| HIR `LoweringError` left untouched | ✓ no changes under `crates/sifr_hir/`; [module_lowering.rs:23-44](../crates/sifr_driver/src/frontend/module_lowering.rs:23) still bridges via `CompilePhase::TypeCheck` |
+| `CompilePhase::TypeCheck` deletion deferred | ✓ enum and Display arm preserved ([diagnostics.rs:34-39, 217-225](../crates/sifr_driver/src/diagnostics.rs:34)); `cmd_check` panic boundary still uses `CompilePhase::TypeCheck` |
+| `Severity::Help`, `apply_diagnostic_recovery_limits`, legacy CLI renderer untouched | ✓ — explicitly within scope (the renderer wiring is the next wave) |
+
+## Concrete findings (in priority order)
+
+### R1 — Legacy fallback bridge emits *retired* codes for any unmigrated site (high)
+
+[crates/sifr_driver/src/diagnostics.rs:120-133](../crates/sifr_driver/src/diagnostics.rs:120):
+
+```rust
+fn diagnostic_code(&self) -> &'static str {
+    if let Some(code) = self.code {
+        return code.code();
+    }
+    // Transitional legacy bridge for unmigrated non-workspace paths in diag_4a.
+    match self.phase {
+        CompilePhase::Parse => "SIFR-PARSE-0001",
+        CompilePhase::TypeCheck => "SIFR-TYPE-0001",
+        CompilePhase::Codegen => "SIFR-CODEGEN-0001",
+        CompilePhase::Build => "SIFR-BUILD-0001",
+    }
+}
+```
+
+All four codes are **retired** in the registry ([codes.rs:392-415](../crates/sifr_diagnostics/src/codes.rs:392)). This was the state pre-slice as well, so it is not a regression from the slice's own changes — but the pre-implementation review explicitly recommended re-pointing the bridge to *active* codes (`SIFR-BUILD-0002` etc.) when the workspace classifier was removed, precisely so the bridge would never emit retired strings into JSON/compact output and external `https://sifr.sh/docs/errors/SIFR-BUILD-0001` URLs.
+
+The slice did not adopt that recommendation. Combined with R2–R4 below, the slice expands the surface that visibly relies on the retired-code fallback (sites like [build/entrypoint.rs:208-220](../crates/sifr_driver/src/build/entrypoint.rs:208) were previously *also* using struct literals without explicit codes — but since they were syntactically rewritten to `CompileError::new` here and several siblings were given codes, they now stand out as the only ones still falling through). At minimum, the bridge should map to active codes; ideally the slice would also migrate these few remaining touched-but-uncoded sites (see R3).
+
+Additionally:
+
+- [tests/diagnostics.rs:8-15](../crates/sifr_driver/src/tests/diagnostics.rs:8) and [tests/diagnostics.rs:17-29](../crates/sifr_driver/src/tests/diagnostics.rs:17) still positively assert `SIFR-PARSE-0001`, `SIFR-TYPE-0001`, `SIFR-CODEGEN-0001`. These tests are now codifying the retired-code fallback as the expected behavior. Either delete them or update them to assert active codes once the bridge is repointed.
+
+### R2 — `materialize.rs` collapses cargo-build failures into `BUILD_MATERIALIZATION_FAILURE` (medium)
+
+[crates/sifr_driver/src/build/materialize.rs:138-144](../crates/sifr_driver/src/build/materialize.rs:138) defines:
+
+```rust
+fn build_error(message: String) -> CompileError {
+    CompileError::with_code(
+        message,
+        CompilePhase::Build,
+        DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+    )
+}
+```
+
+…and every site in the file routes through it, including:
+
+- [materialize.rs:116](../crates/sifr_driver/src/build/materialize.rs:116): `"failed to run cargo build: {error}"`
+- [materialize.rs:120](../crates/sifr_driver/src/build/materialize.rs:120): `"cargo build failed:\n{stderr}"`
+
+Both should be `BUILD_RUSTC_OR_CARGO_FAILURE` (`SIFR-BUILD-0005`). The parallel test-runner path already gets this distinction right at [test_runner/execution.rs:131-137](../crates/sifr_driver/src/test_runner/execution.rs:131) (cargo test failure → `BUILD_RUSTC_OR_CARGO_FAILURE`). The asymmetry is the smell — same operation, different code, no rationale. Splitting `build_error` into a filesystem helper (`BUILD_MATERIALIZATION_FAILURE`) and a cargo helper (`BUILD_RUSTC_OR_CARGO_FAILURE`) keeps both call patterns local.
+
+### R3 — Touched sites that should carry a code but were left as `CompileError::new` (medium)
+
+The slice scope says "where touched by this slice." The following sites were touched (struct literal → `::new` syntactic rewrites in the diff) but did not receive a `DiagnosticCode`. Each currently routes through R1's retired fallback.
+
+- [build/entrypoint.rs:208-211](../crates/sifr_driver/src/build/entrypoint.rs:208) — `"internal error: rooted project entrypoint cannot be converted into a single-file frontend result"` → falls to `SIFR-BUILD-0001`. Per the pre-impl review R5, this is a compiler invariant and should be `INTERNAL_COMPILER_PANIC` (`SIFR-INTERNAL-0001`).
+- [build/entrypoint.rs:215-219](../crates/sifr_driver/src/build/entrypoint.rs:215) — `"internal error: frontend lowering missing 'main' module"` → falls to `SIFR-TYPE-0001`. Same: `SIFR-INTERNAL-0001`.
+- [project/discovery.rs:395-400](../crates/sifr_driver/src/project/discovery.rs:395) — `"failed to read '{}': {}"` → falls to `SIFR-BUILD-0001`. Discovery I/O failure; `BUILD_MATERIALIZATION_FAILURE` (or a fresh "discovery I/O" code in a follow-up) is the sensible home, and the file is unambiguously in scope ("workspace/project discovery").
+- [project/frontend.rs:27-30](../crates/sifr_driver/src/project/frontend.rs:27) — `"[{module_name}] module was not parsed"` → falls to `SIFR-BUILD-0001`. Internal invariant; `INTERNAL_COMPILER_PANIC`.
+- [test_runner/orchestrator.rs:88-95](../crates/sifr_driver/src/test_runner/orchestrator.rs:88) — `"missing parsed test module '{}' from '{}'"` → falls to `SIFR-BUILD-0001`. Internal invariant; `INTERNAL_COMPILER_PANIC`.
+- [test_runner/orchestrator.rs:107-113](../crates/sifr_driver/src/test_runner/orchestrator.rs:107) — keeps the struct-literal form and forwards `error.code` from the HIR lowering bridge. `error.code` is always `None` today (since [module_lowering.rs:29-37](../crates/sifr_driver/src/frontend/module_lowering.rs:29) emits `CompileError::new`, no code), so the field is defensive but presently inert. That is acceptable scope-wise (HIR LoweringError replacement is a later wave), but the comment-free `code: error.code` reads like wired-up forwarding when it is not.
+
+The first five fall squarely under "test-runner / build / project-discovery construction sites" called out in the slice scope and should ship with explicit codes in this slice or its immediate follow-up.
+
+### R4 — `workspace/mod.rs` picks codes via message-text matching (low)
+
+[crates/sifr_driver/src/workspace/mod.rs:177-190](../crates/sifr_driver/src/workspace/mod.rs:177):
+
+```rust
+fn source_root_error(source_root: &str, reason: &'static str) -> CompileError {
+    let code = match reason {
+        "escapes the workspace root via '..'" => DiagnosticCode::WORKSPACE_SOURCE_ROOT_ESCAPES,
+        "is not a directory under the workspace root" => DiagnosticCode::WORKSPACE_SOURCE_ROOT_NOT_DIRECTORY,
+        _ => DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+    };
+    …
+}
+```
+
+This is functionally equivalent to a typed dispatch (callers pass exact `&'static str` literals from a closed set), but it is *ironic* in a slice whose headline change is "Remove workspace message-prefix diagnostic code inference from `CompileError`." A future contributor changing the literal at one of three call sites will silently flip the code to `WORKSPACE_INVALID_SOURCE_ROOT`. Replace with an enum (or take the `DiagnosticCode` directly at the call site as the other migrated helpers do) so the intent is local and typed. Not a correctness blocker, but worth fixing while the surface is small.
+
+### R5 — `discovery.rs` parse-error mapping is single-bucket (low)
+
+[crates/sifr_driver/src/project/discovery.rs:402-426](../crates/sifr_driver/src/project/discovery.rs:402) routes every Ruff parse failure to `PARSE_EXPECTED_TOKEN_OR_RECOVERY` (`SIFR-PARSE-0002`). The same single-bucket choice exists in [frontend/api.rs:21-38](../crates/sifr_driver/src/frontend/api.rs:21) and [stdlib/bootstrap.rs:33-50](../crates/sifr_driver/src/stdlib/bootstrap.rs:33). The inventory and pre-impl review describe categorising Ruff `ParseErrorType` variants across `SIFR-PARSE-0002..0009`. This is a transitional shortcut and is acceptable for this slice as long as the next parser-transport wave splits the buckets; if the parser-transport is not the immediate next wave, leave a `// TODO(diag_4a): split by ParseErrorType` near these sites so reviewers don't accept the single bucket as final.
+
+### R6 — Tests for the canonical helpers do not exercise internal (no-primary-span) diagnostics (low)
+
+[crates/sifr_diagnostics/src/render/presentation.rs:229-292](../crates/sifr_diagnostics/src/render/presentation.rs:229) covers two cases:
+
+1. Compact grouping by template + primary file across two source files.
+2. Human/JSON pass-through equivalence between `render_sink_*` and `render_*_envelope`.
+
+What is not tested:
+
+- An `InternalDiagnostic` (no primary span) flowing through `render_sink_human` — the current implementation guards `if let Some(primary) = primary_span(diagnostic)` ([presentation.rs:63](../crates/sifr_diagnostics/src/render/presentation.rs:63)) so it should produce just the header + `url` line; assert it explicitly because internal diagnostics are how panic boundaries surface.
+- Compact severity-summary line for a sink with mixed Error/Warning/Note diagnostics.
+- A diagnostic with `help: Some(_)` or related spans rendered through the human helper.
+- A grouping case where two diagnostics share `(severity, code, message_template)` but differ in primary display file (covered) *and* a case where they share *no* file because both are internal — these should stay in one group keyed on `primary_display_file: None`.
+
+These are small additions in the existing `tests` module; they prevent regressions when the human renderer grows.
+
+### R7 — `is_internal_compile_error` keeps the message-prefix check alive (low)
+
+[crates/sifr/src/main.rs:260-265](../crates/sifr/src/main.rs:260):
+
+```rust
+fn is_internal_compile_error(error: &CompileError) -> bool {
+    if error.code == Some(DiagnosticCode::INTERNAL_COMPILER_PANIC) {
+        return true;
+    }
+    error.message.starts_with("internal compiler panic during ")
+}
+```
+
+The `Some(INTERNAL_COMPILER_PANIC)` branch is now the structured path, but the `message.starts_with(...)` fallback is still required because the touched-but-uncoded invariants in R3 emit messages that begin with `"internal error: "` (note: not `"internal compiler panic during "`), which would *miss* the prefix check anyway and therefore be classified as user errors → `EXIT_USER_DIAGNOSTIC` (1) instead of `EXIT_INTERNAL_COMPILER_FAILURE` (3). Repro: an entrypoint with a path whose `file_stem()` is `None` (rare on Unix, plausible on Windows for malformed inputs) goes through [build/entrypoint.rs:165-171](../crates/sifr_driver/src/build/entrypoint.rs:165), but the `"invalid project entrypoint path"` site is at least coded as `BUILD_MATERIALIZATION_FAILURE` so it remains a user-facing build error. The two unmigrated invariants in entrypoint.rs (R3) hit the gap: their `"internal error: …"` text neither matches the prefix nor carries the panic code. This is a latent exit-code regression that the slice doesn't introduce but exposes by making the structured path the primary check.
+
+Once R3 assigns `INTERNAL_COMPILER_PANIC` to those invariants, the prefix fallback can be deleted.
+
+### R8 — `compile_order.rs` cycle phase change is harmless but undocumented (low)
+
+[crates/sifr_driver/src/project/compile_order.rs:191-197](../crates/sifr_driver/src/project/compile_order.rs:191) flips the cycle-detection error from `CompilePhase::TypeCheck` to `CompilePhase::Build` and assigns `WORKSPACE_IMPORT_CYCLE`. Both changes are right (the issue's R5 expects exactly this rehoming), and the legacy `Display` label `"build error"` is more accurate than `"type error"` for an import cycle. Worth a one-line note in the PR description so reviewers don't misread it as a TypeCheck-deletion drift; otherwise correct.
+
+## Test-coverage gaps that map to this slice's contract
+
+- **No driver-level test asserts the canonical helpers integrate with workspace error construction.** Adding one `cargo test -p sifr_driver` test that builds a `DiagnosticSink` from a `CompileError::with_code(WORKSPACE_UNRESOLVED_IMPORT)` (via a thin shim) and asserts `render_sink_compact` produces the canonical 4-tuple grouping would tie the two halves of the slice together.
+- **No regression test for the now-removed prefix classifier short-circuiting an explicit code.** The new test at [tests/diagnostics.rs:60-69](../crates/sifr_driver/src/tests/diagnostics.rs:60) covers "explicit code wins over a workspace-shaped message"; it does *not* cover "non-`Build` phase with a workspace-shaped message no longer infers `WORKSPACE-*`". Add a case with `CompilePhase::Codegen` and a message starting with `"could not resolve import"` and assert the code is *not* `WORKSPACE-0101`. The classifier's old `if self.phase != Build { return None; }` early-out makes this case already handled by deletion, but a test prevents regression.
+- **No test asserts schema-stability of the new `DiagnosticEnvelope` JSON shape against the existing baselines.** This wave does not wire the canonical renderer into the CLI, so existing `crates/sifr/tests/verification/project/*/baselines/check-json.stderr.txt` continue to come from `compile_errors_to_diagnostics`. That is fine for now; flag explicitly in the PR description that baseline regeneration lands with the renderer-wiring wave so reviewers don't conflate the two milestones.
+
+## Out-of-scope drift check (negative findings — *good*)
+
+- No HIR file under `crates/sifr_hir/` is modified.
+- `CompilePhase::TypeCheck` enum variant and `Display` arm are retained.
+- `apply_diagnostic_recovery_limits`, `compile_errors_to_diagnostics`, `Severity::Help`, and the legacy `render_compile_errors` dispatcher in [main.rs:288-418](../crates/sifr/src/main.rs:288) all remain in place. The CLI is still on the legacy path.
+- `LoweringError` and `LoweringResult` are untouched; `LoweringOutcome` from prior milestones remains unused.
+- 91 fail fixtures and the two decimal verification baselines are untouched. This matches the slice scope and avoids contaminating this slice with the fixture re-keying that the HIR transport wave will need.
+
+## Sequencing recommendations for the next wave
+
+1. Decide whether to keep the bridge mapping retired codes or reroute it (`Build → BUILD_MATERIALIZATION_FAILURE`, `Codegen → CODEGEN_BACKEND_FAILURE`, `Parse → PARSE_EXPECTED_TOKEN_OR_RECOVERY`, `TypeCheck → INTERNAL_COMPILER_PANIC` until HIR transport lands). Whichever is chosen, update [tests/diagnostics.rs:8-29](../crates/sifr_driver/src/tests/diagnostics.rs:8) so the assertions pin the *current* policy rather than codifying retired strings.
+2. Migrate the five touched-but-uncoded sites in R3 — they are all in files this slice already modified, so adding the `DiagnosticCode` argument is a one-line change per site.
+3. Either split `build_error` in `materialize.rs` or accept that materialization and cargo-build failures share `BUILD_MATERIALIZATION_FAILURE`. The asymmetry with `test_runner/execution.rs` is the only correctness-relevant smell.
+4. Replace the message-string match in `source_root_error` (R4) with a typed dispatch.
+5. Add the four small renderer tests in R6 before the renderer wiring wave — they will catch the wiring slip when it happens.
+
+## Validation snapshot (as reported by implementer)
+
+- `cargo fmt --check` ✓
+- `cargo test -p sifr_diagnostics` ✓
+- `cargo test -p sifr_driver diagnostics` ✓
+- `cargo test -p sifr --no-run` ✓
+- `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings` ✓
+
+These cover the unit-level scope of this slice. The full e2e suite (`scripts/run_e2e_pass.sh`, `scripts/run_all_tests.sh --profile quick`) was not part of the reported run; this is acceptable because the CLI rendering surface is unchanged in this slice, but worth running before merge to confirm no workspace verification baseline drifted.
+
+## Summary
+
+The presentation helpers and the workspace-classifier removal are the cleanest parts of the slice and match the issue's contract precisely. The construction-site migration is ~85% complete: every workspace and test-runner code path that previously fed the prefix classifier now carries an explicit `DiagnosticCode`, which is the load-bearing piece. The five sites in R3 and the `materialize.rs` cargo-failure smell in R2 are the only places where the slice's "where touched" promise is honored only syntactically. The retired-code fallback in R1 is a pre-existing condition that this slice exposes more starkly without addressing; it should be the first thing the next wave fixes. None of the deferred work (HIR LoweringError, `TypeCheck` deletion, CLI renderer wiring, fixture re-keying) leaked in.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md
@@ -1,0 +1,136 @@
+# Review: milestone_diag_4a — Renderer + Workspace-Inference Slice (Pass 2)
+
+Branch: `codex/semantic-diagnostics-diag-4a` (uncommitted working tree on top of `73b4e32c`)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Pass-1 review: [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+
+## Verdict
+
+**Pass-1 actionable findings are addressed; the slice is mergeable subject to one explicit deferral and a handful of polish items.** The five touched-but-uncoded sites called out in pass-1 R3 now carry `INTERNAL_COMPILER_PANIC` or `BUILD_MATERIALIZATION_FAILURE`. Materialize cargo failures now route through `BUILD_RUSTC_OR_CARGO_FAILURE`, restoring symmetry with the test-runner cargo path. The workspace source-root code selection is now driven by a typed `SourceRootErrorKind` enum, removing the message-string match. Presentation tests cover internal (no-primary-span) diagnostics and a mixed Error/Warning/Note compact summary. Driver diagnostics tests no longer positively assert retired phase-bucket codes.
+
+The legacy `CompileError::diagnostic_code` bridge still maps every unmigrated phase to a **retired** code (`SIFR-PARSE-0001`, `SIFR-TYPE-0001`, `SIFR-CODEGEN-0001`, `SIFR-BUILD-0001`). The implementer's note proposes deferring the repointing/deletion to the later HIR-transport / `TypeCheck` wave. **For this slice that deferral is acceptable** — see the dedicated section below — provided the deferral is recorded explicitly in the issue and the next slice is the one that lands HIR transport with fixture re-keying.
+
+## Pass-1 finding fidelity
+
+| Pass-1 finding | Status in pass 2 | Evidence |
+| --- | --- | --- |
+| R1 — bridge emits retired codes | **Deferred (acceptable)** | [diagnostics.rs:125-138](../crates/sifr_driver/src/diagnostics.rs:125) retains the 4-arm fallback with a transitional comment. Tests no longer pin retired codes through `with_code` calls — see N1 below. |
+| R2 — `materialize.rs` cargo failures | ✓ **Fixed** | [materialize.rs:144-158](../crates/sifr_driver/src/build/materialize.rs:144) splits `build_error` (filesystem → `BUILD_MATERIALIZATION_FAILURE`) from `cargo_build_error` (cargo → `BUILD_RUSTC_OR_CARGO_FAILURE`). [materialize.rs:117](../crates/sifr_driver/src/build/materialize.rs:117) and [materialize.rs:124](../crates/sifr_driver/src/build/materialize.rs:124) route through `cargo_build_error`. Symmetric with [test_runner/execution.rs:131-137](../crates/sifr_driver/src/test_runner/execution.rs:131). |
+| R3 — touched-but-uncoded sites | ✓ **5 of 6 fixed** | [build/entrypoint.rs:208-221](../crates/sifr_driver/src/build/entrypoint.rs:208) → `INTERNAL_COMPILER_PANIC`. [project/discovery.rs:395-401](../crates/sifr_driver/src/project/discovery.rs:395) → `BUILD_MATERIALIZATION_FAILURE`. [project/frontend.rs:27-32](../crates/sifr_driver/src/project/frontend.rs:27) → `INTERNAL_COMPILER_PANIC`. [test_runner/orchestrator.rs:88-97](../crates/sifr_driver/src/test_runner/orchestrator.rs:88) → `INTERNAL_COMPILER_PANIC`. The orchestrator forwarder at [orchestrator.rs:107-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:107) is intentionally left as struct literal — see N2 below. |
+| R4 — workspace source-root match | ✓ **Fixed** | [workspace/mod.rs:177-208](../crates/sifr_driver/src/workspace/mod.rs:177) introduces `SourceRootErrorKind::{Escapes, Invalid, NotDirectory}`, with `code()` and `reason()` methods, and replaces the message-string match with typed dispatch. Existing baselines and `test_source_roots_reject_escape_absolute_empty_missing_and_file_paths` still pass because the `reason()` strings preserve the substrings the tests look for. |
+| R5 — single-bucket parse mapping | **Deferred (acceptable, no TODO marker)** | Three sites still funnel every Ruff parse failure into `PARSE_EXPECTED_TOKEN_OR_RECOVERY` — [discovery.rs:402-426](../crates/sifr_driver/src/project/discovery.rs:402), [frontend/api.rs:21-38](../crates/sifr_driver/src/frontend/api.rs:21), [stdlib/bootstrap.rs:33-50](../crates/sifr_driver/src/stdlib/bootstrap.rs:33). No `TODO(diag_4a)` marker was added. Pass-1 R5 explicitly accepted this if the parser-transport wave is next; if it isn't, a one-line marker is still cheap insurance. |
+| R6 — renderer test coverage | ✓ **Fixed** | [presentation.rs:294-336](../crates/sifr_diagnostics/src/render/presentation.rs:294) adds a single multi-purpose test covering internal (no-primary-span) diagnostics, a mixed Error/Warning/Note compact summary header, and `help` propagation through `render_sink_human`. The "two diagnostics share `(severity, code, message_template)` but both are internal" grouping case is *not* covered — minor, tracked as N3 below. |
+| R7 — `is_internal_compile_error` prefix fallback | ✓ **Effectively neutralized** | Every production site that emits `"internal compiler panic during ..."` now also carries `INTERNAL_COMPILER_PANIC` (see [main.rs:244-258](../crates/sifr/src/main.rs:244) and [diagnostics.rs:253-266](../crates/sifr_driver/src/diagnostics.rs:253)). The prefix branch in [main.rs:260-265](../crates/sifr/src/main.rs:260) is now dead code in production but is exercised by the synthetic-error test at [main.rs:1212-1224](../crates/sifr/src/main.rs:1212). See N4. |
+| R8 — `compile_order` cycle phase change | ✓ **Unchanged from pass 1** | [compile_order.rs:191-197](../crates/sifr_driver/src/project/compile_order.rs:191) keeps the new `WORKSPACE_IMPORT_CYCLE` assignment. |
+
+## Decision: is deferring the bridge repoint and `TypeCheck` deletion acceptable for this slice?
+
+**Acceptable, but the deferral is *not* yet recorded honestly in the issue file.** Two facts are in tension:
+
+1. The issue's plan explicitly says diag_4a deletes the `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` arm so any missed TypeCheck path becomes a build/validation failure rather than silently using a fallback ([issue line 1124, slice description](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md#L1124)).
+2. The slice keeps the arm intact at [diagnostics.rs:132-137](../crates/sifr_driver/src/diagnostics.rs:132) because production fixtures (e.g. [decimal_invalid_literal/baselines/check-json.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt) emits `SIFR-TYPE-0001`) and 80+ e2e fail fixtures depend on the bridge until HIR `LoweringError` carries a structured code.
+
+Bundling the bridge deletion with HIR transport in the next slice is the right scoping call — re-keying the baselines without simultaneously moving HIR diagnostics off `LoweringError` would create churn and a transient state where multiple TYPE bucket codes are emitted. The slice is internally consistent: every site this slice *did* touch is now coded, so the bridge is doing strictly less work than before.
+
+What's missing is a visible audit trail. Concretely:
+
+- The issue's "Started milestone_diag_4a slice 1" bullet at [issue line 34](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md#L34) does not mention that the `TypeCheck => SIFR-TYPE-0001` deletion (a stated diag_4a deliverable) is being moved to a later slice. Without that bullet, a reviewer comparing the merged slice against the issue plan will read it as scope drift rather than scope splitting.
+- The transitional comment at [diagnostics.rs:128-131](../crates/sifr_driver/src/diagnostics.rs:128) says "Transitional legacy bridge for unmigrated non-workspace paths in diag_4a" but does not name the specific later slice that owns the deletion (e.g. "removed in `diag_4a` slice 2 once HIR `LoweringError` carries codes"). The comment will rot if the next slice's name changes.
+
+**Recommendation:** before the slice 1 PR opens, edit the issue to add an explicit deferred-item bullet ("`TypeCheck => SIFR-TYPE-0001` bridge deletion + fixture re-keying deferred to slice 2 alongside HIR transport") and tighten the comment in `diagnostics.rs` to point at that slice. No code change beyond comments is required for this slice to merge.
+
+## New findings introduced or exposed by pass-2 changes
+
+### N1 — Driver diagnostics test now exercises the *active* code paths only (good, but R7 dead-code branch is now only test-covered)
+
+[tests/diagnostics.rs:7-19](../crates/sifr_driver/src/tests/diagnostics.rs:7) now asserts `SIFR-PARSE-0002` (active) instead of `SIFR-PARSE-0001` (retired). [tests/diagnostics.rs:21-41](../crates/sifr_driver/src/tests/diagnostics.rs:21) asserts `SIFR-TYPE-0002` and `SIFR-CODEGEN-0002` (both active). [tests/diagnostics.rs:71-81](../crates/sifr_driver/src/tests/diagnostics.rs:71) confirms an explicit `BUILD_TEMP_WORKSPACE_FAILURE` code wins over a workspace-shaped message. This is exactly what pass-1 recommended.
+
+The `apply_diagnostic_recovery_limits` tests at [tests/diagnostics.rs:84-129](../crates/sifr_driver/src/tests/diagnostics.rs:84) still construct `CompilerDiagnostic` literals with hard-coded `"SIFR-TYPE-0001"` strings. That is fine — those tests exercise the recovery limiter on synthetic input and are not making a claim about which code the bridge produces. Worth a one-line comment if a future contributor mistakes them for bridge regressions, but not a blocker.
+
+### N2 — `test_runner/orchestrator.rs` forwarder still uses struct literal with `code: error.code` (low)
+
+[test_runner/orchestrator.rs:107-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:107):
+
+```rust
+let compile_errors: Vec<CompileError> = errors
+    .into_iter()
+    .map(|error| CompileError {
+        message: format!("[{}] {}", test_file.display(), error.message),
+        phase: CompilePhase::TypeCheck,
+        code: error.code,
+    })
+    .collect();
+```
+
+`error.code` is always `None` today because [module_lowering.rs:23-44](../crates/sifr_driver/src/frontend/module_lowering.rs:23) emits `CompileError::new(...)` with no code. The forwarding is therefore inert until HIR LoweringError gains a code, which is the deferred work. Pass-1 already noted this is acceptable scope-wise.
+
+What was not picked up in pass 2: the lack of a one-line comment explaining that `code: error.code` is forwarding for forward-compatibility, not a wired path. A comment like `// Preserve None until HIR LoweringError carries a DiagnosticCode (next diag_4a slice).` keeps the next reviewer from assuming the forward is live.
+
+The same shape exists in [stdlib/bootstrap.rs:198-203](../crates/sifr_driver/src/stdlib/bootstrap.rs:198), but there `e.code` is `Some(INTERNAL_COMPILER_PANIC)` (set by [run_codegen_with_boundary](../crates/sifr_driver/src/diagnostics.rs:253)), so the forward is *live* and the struct literal is genuinely necessary. A short comment distinguishing the two would help.
+
+### N3 — Compact-grouping test does not pin the "two internals share a key" case (low)
+
+[presentation.rs:294-336](../crates/sifr_diagnostics/src/render/presentation.rs:294) covers internal diagnostics rendered through `render_sink_human` and the mixed-severity summary. It does not cover the case where two internal diagnostics share `(severity, code, message_template)` and therefore should land in one compact group keyed on `primary_display_file: None`. This was called out in pass-1 R6 as a small addition. The current `CompactKey::from_diagnostic` already handles this correctly via `primary_span(...).and_then(|span| span.file.clone())` returning `None`, but absent a test, a future change to that key derivation could silently flip the behavior. Consider adding a 5-line test that emits two internal diagnostics with identical code and template and asserts the compact output contains a single `(x2)` entry with no `at` location lines.
+
+### N4 — `is_internal_compile_error` prefix fallback is now production-dead
+
+[main.rs:260-265](../crates/sifr/src/main.rs:260):
+
+```rust
+fn is_internal_compile_error(error: &CompileError) -> bool {
+    if error.code == Some(DiagnosticCode::INTERNAL_COMPILER_PANIC) {
+        return true;
+    }
+    error.message.starts_with("internal compiler panic during ")
+}
+```
+
+I traced every production site that emits `"internal compiler panic during ..."`:
+
+- [main.rs:422](../crates/sifr/src/main.rs:422), [main.rs:445](../crates/sifr/src/main.rs:445), [main.rs:478](../crates/sifr/src/main.rs:478), [main.rs:530](../crates/sifr/src/main.rs:530) — all go through `run_with_panic_boundary` which sets `INTERNAL_COMPILER_PANIC` ([main.rs:244-258](../crates/sifr/src/main.rs:244)).
+- [build/project_codegen.rs:66](../crates/sifr_driver/src/build/project_codegen.rs:66), [build/entrypoint.rs:246](../crates/sifr_driver/src/build/entrypoint.rs:246), [stdlib/bootstrap.rs:193](../crates/sifr_driver/src/stdlib/bootstrap.rs:193), [test_runner/orchestrator.rs:78,121](../crates/sifr_driver/src/test_runner/orchestrator.rs:78) — all go through `run_codegen_with_boundary` which sets `INTERNAL_COMPILER_PANIC` ([diagnostics.rs:253-266](../crates/sifr_driver/src/diagnostics.rs:253)).
+
+So the prefix branch can never fire from production code. The only thing exercising it is [main.rs:1212-1224](../crates/sifr/src/main.rs:1212), which manually constructs a `CompileError::new(...)` with the prefix string. That test was reasonable when the prefix was the canonical signal; with the structured code present, deleting the prefix branch and updating the test to construct a `CompileError::with_code(..., INTERNAL_COMPILER_PANIC)` would remove dead code. Not a correctness blocker — the existing path still classifies correctly — but worth doing in the same wave as the bridge repoint.
+
+### N5 — `INTERNAL_COMPILER_PANIC` is paired with `CompilePhase::TypeCheck` at one site (cosmetic)
+
+[build/entrypoint.rs:215-221](../crates/sifr_driver/src/build/entrypoint.rs:215) attaches `INTERNAL_COMPILER_PANIC` to `CompilePhase::TypeCheck`. The structured code is what `is_internal_compile_error` and the JSON output use, so behavior is correct. The legacy `Display` for this error renders `"type error: internal error: frontend lowering missing 'main' module"` ([diagnostics.rs:221-231](../crates/sifr_driver/src/diagnostics.rs:221)), which reads oddly for an internal-invariant violation. Pairing it with `CompilePhase::Build` would render as `"build error: ..."` and match the sibling site at [build/entrypoint.rs:208-212](../crates/sifr_driver/src/build/entrypoint.rs:208). One-line change, cosmetic only.
+
+### N6 — `compile_errors_to_diagnostics` legacy renderer still classifies severity by code prefix (low)
+
+[main.rs:372-417](../crates/sifr/src/main.rs:372) inside `render_compile_errors` sniffs `diagnostic.code.starts_with("SIFR-PARSE-")` etc. to choose the human-format label. With the bridge still emitting `SIFR-PARSE-0001` for unmigrated parse paths, this classifier still produces sensible labels. Once the bridge is repointed in the next slice, codes like `SIFR-INTERNAL-0001` will fall into the catch-all `match diagnostic.severity` arm and render as `error:` (lowercase). That is fine, but a future contributor might be tempted to add a `SIFR-INTERNAL-` arm here. The slice scope is unchanged ("legacy CLI renderer untouched"), so this is just flagging a near-future surface — no action this slice.
+
+## Out-of-scope drift check (negative findings — *good*)
+
+- No HIR file under `crates/sifr_hir/` is modified.
+- `CompilePhase::TypeCheck` enum variant and `Display` arm are retained at [diagnostics.rs:34-39, 217-225](../crates/sifr_driver/src/diagnostics.rs:34).
+- `apply_diagnostic_recovery_limits` and `compile_errors_to_diagnostics` are unchanged in signature.
+- 91 fail fixtures and the two decimal verification baselines are untouched. The decimal baseline still emits `SIFR-TYPE-0001` via the deferred bridge, which is the documented transitional state.
+- The `Severity::Help` variant on the driver-side `Severity` enum and the help-aware compact renderer in `main.rs` are unchanged. The new presentation-layer compact summary uses three categories (Error/Warning/Note) because `sifr_diagnostics::Severity` has no `Help` variant — that is by design.
+- `LoweringError`, `LoweringResult`, and `LoweringOutcome` are untouched.
+
+## Validation
+
+The implementer's reported run is the right scope for this slice:
+
+- `cargo fmt --check`
+- `python3 scripts/check_diagnostic_schema_sync.py`
+- `python3 scripts/check_diagnostic_docs_sync.py`
+- `cargo test -p sifr_diagnostics`
+- `cargo test -p sifr_driver diagnostics`
+- `cargo test -p sifr --no-run`
+- `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings`
+
+Because the renderer is not wired into the CLI in this slice (the JSON / compact baselines still come from `compile_errors_to_diagnostics`), no e2e baseline regeneration is required. Running `scripts/run_all_tests.sh --profile quick` once before merge is still recommended to confirm the workspace verification fixtures (`workspace_unresolved_import`, `workspace_ambiguous_import`, `workspace_malformed_manifest`) still match — the workspace baseline JSONs depend on `with_code` continuing to emit the active workspace identity, and that is what the slice rewires.
+
+## Sequencing recommendations for slice 2
+
+1. Repoint the legacy bridge so unmigrated paths emit *active* codes (`Build → BUILD_MATERIALIZATION_FAILURE`, `Codegen → CODEGEN_BACKEND_FAILURE`, `Parse → PARSE_EXPECTED_TOKEN_OR_RECOVERY`, `TypeCheck → INTERNAL_COMPILER_PANIC` until HIR transport lands), then delete the `TypeCheck => SIFR-TYPE-0001` arm as the issue requires. Re-key the affected verification and e2e baselines in the same slice so the test surface and the bridge land together.
+2. Migrate HIR `LoweringError` to carry a `DiagnosticCode`, then drop the inert `code: error.code` forward in [orchestrator.rs:107-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:107) and [module_lowering.rs:23-44](../crates/sifr_driver/src/frontend/module_lowering.rs:23) to use `CompileError::with_code` directly.
+3. Delete the `is_internal_compile_error` prefix fallback (N4) and update the synthetic test to use `CompileError::with_code(..., INTERNAL_COMPILER_PANIC)`.
+4. Pair `CompilePhase::Build` with the second `INTERNAL_COMPILER_PANIC` site in `entrypoint.rs` for `Display` consistency (N5).
+5. Add the small "two internals share a compact key" test (N3) and consider splitting Ruff parse failures into the `SIFR-PARSE-0002..0009` buckets (R5) — these can land independently.
+
+## Summary
+
+Pass 2 cleanly addresses every actionable pass-1 finding except the explicit deferral of the bridge repoint and `TypeCheck => SIFR-TYPE-0001` deletion. That deferral is acceptable as a slicing decision because re-keying the affected baselines belongs in the same slice as the HIR `LoweringError` transport. Before merge, the issue file should be updated with a one-line bullet documenting the deferral and the in-code transitional comment should name the slice that owns the deletion. Six minor follow-ups (N2–N6 plus the parse-bucket TODO marker from R5) are easy wins for the next slice but none are correctness blockers for this one.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md
@@ -1,0 +1,114 @@
+# Review: milestone_diag_4a — Renderer + Workspace-Inference Slice (Pass 3)
+
+Branch: `codex/semantic-diagnostics-diag-4a` (uncommitted working tree on top of `73b4e32c`)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+
+## Verdict
+
+**Ready to PR/merge.** The follow-up patch fully addresses the two pass-2 gating items (record the deferral honestly in the issue; tighten the transitional comment to name the owning slice) and additionally lands four of the five low-risk polish items pass 2 had marked optional (N2 forwarder comments, N3 internal-grouping test, N4 dead prefix branch, N5 `CompilePhase` cosmetic). R5's TODO markers are now in place at all six parse-failure spots. No correctness regressions, no scope drift, validation evidence is the right scope and signature matches the prior quick-profile run (`e1bf653aaa770517`, 79.70 s).
+
+## Pass-2 gate items
+
+| Pass-2 requirement | Status | Evidence |
+| --- | --- | --- |
+| Issue file records the `TypeCheck => SIFR-TYPE-0001` deletion deferral | ✓ **Recorded** | [issue lines 34-35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34) adds two new bullets: "Started `milestone_diag_4a` slice 1: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport" and "Deferred `CompilePhase::TypeCheck => \"SIFR-TYPE-0001\"` bridge deletion and affected fixture re-keying to `milestone_diag_4a` slice 2, where HIR `LoweringError` transport will carry structured diagnostic codes." Reviewers comparing the merged slice against the issue plan ([issue line 1121](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:1121) — "`diag_4a` deletes the `CompilePhase::TypeCheck => SIFR-TYPE-0001` public mapping…") will read this as a scope split rather than scope drift. |
+| Transitional comment names the owning slice | ✓ **Tightened** | [diagnostics.rs:129-134](../crates/sifr_driver/src/diagnostics.rs:129) now reads "Transitional legacy bridge for unmigrated non-workspace paths in diag_4a slice 1. Slice 2 removes the TypeCheck fallback after HIR LoweringError carries structured DiagnosticCode values and affected fixtures are re-keyed. Workspace diagnostics must use `with_code`; this function no longer infers identity from rendered message text." Names the specific owning slice and re-states the workspace invariant. |
+
+## Pass-2 polish items (N2-N5, R5)
+
+| Pass-2 finding | Status | Evidence |
+| --- | --- | --- |
+| N2 — forwarder comments distinguishing inert vs live `code: error.code` | ✓ **Done** | [orchestrator.rs:113-115](../crates/sifr_driver/src/test_runner/orchestrator.rs:113) — `// Preserves None until HIR LoweringError carries a structured code in the next diag_4a slice.` The sibling forwarder at [bootstrap.rs:205-207](../crates/sifr_driver/src/stdlib/bootstrap.rs:205) — `// Preserves the internal panic code set by run_codegen_with_boundary.` Both now correctly distinguish the inert forwarder (TypeCheck path) from the live one (Codegen panic path). |
+| N3 — compact-grouping test for two internals sharing `(severity, code, template)` | ✓ **Added** | [presentation.rs:338-360](../crates/sifr_diagnostics/src/render/presentation.rs:338) `compact_groups_internal_diagnostics_without_locations` emits two `INTERNAL_COMPILER_PANIC` errors with identical phase arg `"codegen"`, asserts the compact summary contains `"(x2)"`, and asserts `!compact.contains("  at ")` to pin the no-location grouping behavior. Pinning `"  at "` (with trailing spaces) avoids accidentally matching the `at` in any future help/url text. |
+| N4 — `is_internal_compile_error` prefix fallback dead in production | ✓ **Deleted** | [main.rs:260-262](../crates/sifr/src/main.rs:260) is now a one-liner: `error.code == Some(DiagnosticCode::INTERNAL_COMPILER_PANIC)`. The synthetic test at [main.rs:1209-1221](../crates/sifr/src/main.rs:1209) constructs the user error via `CompileError::new("type mismatch", CompilePhase::TypeCheck)` (no code, falls through to the user exit) and the internal error via `CompileError::with_code(..., INTERNAL_COMPILER_PANIC)`, exercising the structured path. The downstream `test_run_with_panic_boundary_converts_panic_to_internal_compile_error` at [main.rs:1252-1266](../crates/sifr/src/main.rs:1252) still passes because `run_with_panic_boundary` itself sets the code. |
+| N5 — `INTERNAL_COMPILER_PANIC` paired with `CompilePhase::TypeCheck` at [build/entrypoint.rs:215-221](../crates/sifr_driver/src/build/entrypoint.rs:215) | ✓ **Re-paired with `Build`** | [build/entrypoint.rs:217-221](../crates/sifr_driver/src/build/entrypoint.rs:217) now uses `CompilePhase::Build`, matching the sibling site at [build/entrypoint.rs:208-212](../crates/sifr_driver/src/build/entrypoint.rs:208). The legacy `Display` ([diagnostics.rs:226-232](../crates/sifr_driver/src/diagnostics.rs:226)) renders this as `"build error: internal error: frontend lowering missing 'main' module"` instead of the previously odd `"type error: internal error: …"`. JSON/structured-code behavior is unchanged because identity comes from `INTERNAL_COMPILER_PANIC`. |
+| R5 — `TODO(diag_4a)` markers on the three single-bucket parse sites | ✓ **Added at all 6 spots** | Two markers each in [frontend/api.rs:18-19, 36-38](../crates/sifr_driver/src/frontend/api.rs:18), [project/discovery.rs:406-407, 424-425](../crates/sifr_driver/src/project/discovery.rs:406), and [stdlib/bootstrap.rs:30-31, 48-49](../crates/sifr_driver/src/stdlib/bootstrap.rs:30). All carry the same `TODO(diag_4a slice 2)` ownership tag, consistent with the comment in [diagnostics.rs:130-131](../crates/sifr_driver/src/diagnostics.rs:130). Pass-2 N6 (legacy CLI renderer prefix sniffing) is correctly left untouched — that surface is owned by a later wave. |
+
+## New observations from pass 3
+
+### O1 — Out-of-scope identity assignment for `compile_order` cycle (low, intentional)
+
+[compile_order.rs:189-195](../crates/sifr_driver/src/project/compile_order.rs:189) now emits the cycle diagnostic with `CompilePhase::Build` (was `TypeCheck` in pass 2's draft) plus `WORKSPACE_IMPORT_CYCLE`. This is internally consistent with the rest of the workspace family (all `SIFR-WORKSPACE-01xx` codes route through `CompilePhase::Build`) and matches the structural classification — an import cycle is a workspace-resolution failure, not a typecheck failure. The legacy `Display` will render as `"build error: module dependency cycle detected: …"`, which is consistent with the unresolved-import / ambiguous-import siblings. No fixtures depend on the old `"type error: module dependency cycle …"` rendering — `grep` for "module dependency cycle" turns up only this site and unit tests that look at the structured fields. Acceptable.
+
+### O2 — `STDLIB_BOOTSTRAP_FAILURE` pairs with a parse-classification TODO marker (cosmetic)
+
+[stdlib/bootstrap.rs:30-39](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) and [bootstrap.rs:48-55](../crates/sifr_driver/src/stdlib/bootstrap.rs:48) attach a `TODO(diag_4a slice 2): classify Ruff parse failures into the precise active parse-code buckets.` marker but emit `STDLIB_BOOTSTRAP_FAILURE` (`SIFR-STDLIB-0003`). The other two parse sites emit `PARSE_EXPECTED_TOKEN_OR_RECOVERY` (`SIFR-PARSE-0002`) where the marker matches the intent. For the stdlib bootstrap site, classifying a stdlib parse failure as `STDLIB_BOOTSTRAP_FAILURE` is arguably *already* the correct identity — a malformed stdlib source is a compiler-bootstrap failure rather than a user-facing parse error — so the TODO marker may be misleading on this specific site. A minor doc nit: in slice 2 the bootstrap markers should either be deleted (if the stdlib identity is final) or rewritten to read "if stdlib parse failures should ever be reclassified into parse-family codes". Not a blocker for this slice.
+
+### O3 — `parse_manifest_error` takes `impl std::fmt::Display` but is single-call (style nit, low)
+
+[workspace/mod.rs:162](../crates/sifr_driver/src/workspace/mod.rs:162) is the only constructor for `WORKSPACE_MALFORMED_MANIFEST`, called from `parse_manifest_schema_error` and from the toml deserialization path. The `impl std::fmt::Display` parameter is genuinely useful (toml errors are `Display` rather than `String`), so this is fine as-is. Flagged only because pass 2 listed `source_root_error` polish; the manifest sibling is structurally the same shape after the typed-kind refactor at [workspace/mod.rs:177-204](../crates/sifr_driver/src/workspace/mod.rs:177). No action.
+
+### O4 — `is_internal_compile_error` is now structurally tied to a single code (intended, but worth flagging)
+
+The simplification at [main.rs:260-262](../crates/sifr/src/main.rs:260) means the exit-code classifier now treats *only* `INTERNAL_COMPILER_PANIC` as internal. If a future internal-error code is introduced (e.g. `INTERNAL_INVARIANT_VIOLATION` or `INTERNAL_LOWERING_BUG`), the classifier must be updated in the same change-set, otherwise the new code's errors would route to `EXIT_USER_DIAGNOSTIC`. This is a property of the simplification, not a bug — but the next contributor adding an `SIFR-INTERNAL-` family member needs to update [main.rs:260](../crates/sifr/src/main.rs:260) and the `EXIT_INTERNAL_COMPILER_FAILURE` test at [main.rs:1209](../crates/sifr/src/main.rs:1209). Consider, in slice 2, replacing the equality check with a "code starts with `SIFR-INTERNAL-`" predicate — but that decision is correctly out of scope here.
+
+### O5 — Issue heading rename `"the current wave" → "milestone_diag_2a"` (positive)
+
+[issue line 39](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:39) re-titles the historical validation block from `Validation evidence for the current wave:` to `Validation evidence for milestone_diag_2a:`. The bullet inside the block already names the `milestone_diag_2a` branch, so the new heading matches. No phantom "current wave" label remains, which makes the document self-consistent now that three waves have validation blocks.
+
+## Out-of-scope drift check (negative findings — *good*)
+
+- `crates/sifr_hir/` — untouched.
+- `LoweringError` / `LoweringResult` / `LoweringOutcome` — untouched.
+- `CompilePhase::TypeCheck` enum variant and its `Display` arm at [diagnostics.rs:36, 228](../crates/sifr_driver/src/diagnostics.rs:36) — retained; the deferral note in the issue and the in-code transitional comment are the audit trail for keeping it.
+- The TypeCheck fallback `"SIFR-TYPE-0001"` at [diagnostics.rs:137](../crates/sifr_driver/src/diagnostics.rs:137) — still in place, as the slicing decision requires.
+- `compile_errors_to_diagnostics` and `apply_diagnostic_recovery_limits` signatures — unchanged.
+- 91 fail fixtures and the `decimal_invalid_literal` baselines — untouched. The transitional `"SIFR-TYPE-0001"` they rely on still routes through the bridge.
+- Help-aware compact renderer in `main.rs` ([main.rs:302-417](../crates/sifr/src/main.rs:302)) — unchanged. The new presentation-layer compact renderer is parallel infrastructure for slice 2 wiring.
+- The legacy CLI's `SIFR-PARSE-` / `SIFR-TYPE-` / `SIFR-CODEGEN-` / `SIFR-BUILD-` prefix sniffer at [main.rs:374-385](../crates/sifr/src/main.rs:374) — unchanged. Pass-2 N6 explicitly out of scope.
+
+## Behavioral / correctness check
+
+I traced every site that this slice changes from a struct literal to `with_code`:
+
+- [build/entrypoint.rs:163-170, 207-211, 214-221](../crates/sifr_driver/src/build/entrypoint.rs:163) — three sites; all carry `BUILD_MATERIALIZATION_FAILURE` or `INTERNAL_COMPILER_PANIC`.
+- [build/materialize.rs:115, 124, 144-158](../crates/sifr_driver/src/build/materialize.rs:115) — split helpers (`build_error` → `BUILD_MATERIALIZATION_FAILURE`, `cargo_build_error` → `BUILD_RUSTC_OR_CARGO_FAILURE`) preserved from pass 2.
+- [build/workspace.rs:30-44, 124-130, 163-170, 210-217, 294-307](../crates/sifr_driver/src/build/workspace.rs:30) — 6 build-error literals replaced with codes (`BUILD_TEMP_WORKSPACE_FAILURE`, `BUILD_ARTIFACT_MISSING`, `BUILD_MATERIALIZATION_FAILURE`).
+- [diagnostics.rs:260-266](../crates/sifr_driver/src/diagnostics.rs:260) — `run_codegen_with_boundary` pairs `Codegen` + `INTERNAL_COMPILER_PANIC` (✓ correct).
+- [frontend/api.rs:21-44](../crates/sifr_driver/src/frontend/api.rs:21) — both Ruff parse paths pair `Parse` + `PARSE_EXPECTED_TOKEN_OR_RECOVERY`.
+- [frontend/module_lowering.rs:25-44](../crates/sifr_driver/src/frontend/module_lowering.rs:25) — uses `CompileError::new(...)` (no code) by design — this is the inert forwarder for HIR lowering errors. Slice-2 work.
+- [project/compile_order.rs:189-195](../crates/sifr_driver/src/project/compile_order.rs:189) — `Build` + `WORKSPACE_IMPORT_CYCLE` (was `TypeCheck` + retired bucket).
+- [project/discovery.rs:194-225, 393-426](../crates/sifr_driver/src/project/discovery.rs:194) — typed dispatch on `ResolutionFailureKind`, parse failures re-coded.
+- [project/frontend.rs:25-32](../crates/sifr_driver/src/project/frontend.rs:25) — `Build` + `INTERNAL_COMPILER_PANIC` for unparsed-module invariant.
+- [stdlib/bootstrap.rs:30-77, 195-209](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) — parse failures and lowering errors paired with `STDLIB_BOOTSTRAP_FAILURE`; codegen-panic forwarder preserves `INTERNAL_COMPILER_PANIC` from `run_codegen_with_boundary`.
+- [stdlib/cache.rs:50-58](../crates/sifr_driver/src/stdlib/cache.rs:50) — synthetic test uses `CompileError::new(...)` (no code) since the test exercises the cache, not the bridge. Correct.
+- [test_runner/execution.rs:39-138](../crates/sifr_driver/src/test_runner/execution.rs:39) — eight `Build` literals coded (`BUILD_MATERIALIZATION_FAILURE`, `BUILD_CARGO_MANIFEST_FAILURE`, `BUILD_RUSTC_OR_CARGO_FAILURE`).
+- [test_runner/orchestrator.rs:88-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:88) — invariant violation gets `INTERNAL_COMPILER_PANIC`; HIR-error forwarder retains `code: error.code` (inert today, ready for slice 2).
+- [tests/diagnostics.rs:7-85](../crates/sifr_driver/src/tests/diagnostics.rs:7) — three positive code-stability tests rewritten to active codes (`SIFR-PARSE-0002`, `SIFR-TYPE-0002`, `SIFR-CODEGEN-0002`, `SIFR-BUILD-0003`). New negative test `test_workspace_codes_do_not_derive_from_message_prefixes` proves the message-prefix workspace inference is gone — emits a workspace-shaped message but with `BUILD_TEMP_WORKSPACE_FAILURE`, asserts `SIFR-BUILD-0003` wins. Excellent regression guard.
+- [workspace/mod.rs:120-204](../crates/sifr_driver/src/workspace/mod.rs:120) — typed `SourceRootErrorKind` enum from pass 2 retained; manifest-parse error coded with `WORKSPACE_MALFORMED_MANIFEST`.
+
+I did not find any path where a previously-coded site has been silently downgraded to `CompileError::new` in this follow-up; every site that has access to a meaningful `DiagnosticCode` uses `with_code`, and every site that does not (HIR lowering forwarder, single sentinel test) uses `new` with a comment.
+
+## Validation
+
+The implementer's reported run is the right scope:
+
+- `cargo fmt --check`
+- `python3 scripts/check_diagnostic_schema_sync.py`
+- `python3 scripts/check_diagnostic_docs_sync.py`
+- `cargo test -p sifr_diagnostics`
+- `cargo test -p sifr_driver diagnostics`
+- `cargo test -p sifr --no-run`
+- `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings`
+- `scripts/run_all_tests.sh --profile quick` — `report_signature=e1bf653aaa770517`, `wall_time=79.70s`
+
+The signature matches the published baseline for the branch and is consistent with the value reported on `milestone_diag_2b`. No baseline regeneration is required because the renderer is not yet wired into the CLI; the JSON/compact outputs still come from `compile_errors_to_diagnostics` and the workspace fixtures continue to assert the active workspace codes.
+
+Pre-PR I would still verify that the workspace verification fixtures (`workspace_unresolved_import`, `workspace_ambiguous_import`, `workspace_malformed_manifest`, `workspace_namespace_collision`) match — but `scripts/run_all_tests.sh --profile quick` covers them, so the green run is sufficient evidence.
+
+## Sequencing recommendations carried forward to slice 2
+
+These are unchanged from pass 2's recommendations and should land in slice 2:
+
+1. Repoint the three remaining bridge fallbacks (`Parse → PARSE_EXPECTED_TOKEN_OR_RECOVERY`, `Codegen → CODEGEN_BACKEND_FAILURE`, `Build → BUILD_MATERIALIZATION_FAILURE`) and **delete** `TypeCheck => SIFR-TYPE-0001` once HIR `LoweringError` carries codes. Re-key the affected `decimal_*` and 80+ e2e fail fixtures in the same slice.
+2. Migrate HIR `LoweringError` to carry a `DiagnosticCode`. Then the inert `code: error.code` forward in [orchestrator.rs:113-115](../crates/sifr_driver/src/test_runner/orchestrator.rs:113) and the `CompileError::new(...)` site at [module_lowering.rs:29](../crates/sifr_driver/src/frontend/module_lowering.rs:29) become live and can be migrated to `with_code` directly.
+3. Reconsider the parse-classification TODOs at [stdlib/bootstrap.rs:30, 48](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) — either delete (if `STDLIB_BOOTSTRAP_FAILURE` is the canonical identity) or change the marker text.
+4. Optionally generalize `is_internal_compile_error` (O4) to recognize any `SIFR-INTERNAL-*` family code, anticipating future internal-error families.
+
+## Summary
+
+Pass 3 confirms the slice is mergeable. The two pass-2 gating items are in place: the deferral is recorded in [issues/ad-hoc-…md:34-35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34) with explicit slice-2 ownership, and the transitional comment at [diagnostics.rs:129-134](../crates/sifr_driver/src/diagnostics.rs:129) names the owning slice. The implementer additionally landed N2-N5 polish and the R5 TODO markers, which makes the slice substantially cleaner than the pass-2 baseline. New observations O1-O5 are cosmetic or deferred-by-design; none block this PR. Validation evidence is the right scope and signature matches.


### PR DESCRIPTION
## Summary

- Add canonical `sifr_diagnostics` presentation helpers for human, compact, and JSON output over rendered diagnostic envelopes.
- Carry explicit `DiagnosticCode` through workspace/build/project/test-runner construction sites touched by this slice, removing workspace message-prefix code inference.
- Keep the legacy phase bridge only as a documented slice-1 deferral; `TypeCheck => SIFR-TYPE-0001` deletion and fixture re-keying move to diag_4a slice 2 with HIR diagnostic-code transport.
- Record Claude review rounds and validation evidence in the phase issue.

## Validation

- `cargo fmt --check`
- `python3 scripts/check_diagnostic_schema_sync.py`
- `python3 scripts/check_diagnostic_docs_sync.py`
- `cargo test -p sifr_diagnostics`
- `cargo test -p sifr_driver diagnostics`
- `cargo test -p sifr --no-run`
- `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=79.70s`)

## Reviews

- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md`
