### PR TITLE
Add HIR diagnostic code transport plumbing

### DIFF
--- a/crates/sifr_driver/src/frontend/module_lowering.rs
+++ b/crates/sifr_driver/src/frontend/module_lowering.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::{write_stderr_line, CompileError, CompilePhase};
-use sifr_hir::{lower_module_with_externals, ExternalDefs, LoweringResult};
+use sifr_hir::{lower_module_with_externals, ExternalDefs, LoweringError, LoweringResult};
 use sifr_python_ast::Stmt;
 
 #[derive(Default)]
@@ -25,22 +25,30 @@ pub(crate) fn lower_frontend_module(
         Err(errors) => {
             let compile_errors: Vec<CompileError> = errors
                 .into_iter()
-                .map(|e| {
-                    CompileError::new(
-                        match diagnostic_style {
-                            FrontendDiagnosticStyle::Bare => e.message,
-                            FrontendDiagnosticStyle::ModulePrefixed => {
-                                format!("[{}] {}", module_name, e.message)
-                            }
-                        },
-                        CompilePhase::TypeCheck,
-                    )
-                })
+                .map(|error| lowering_error_to_compile_error(module_name, diagnostic_style, error))
                 .collect();
             return Err(compile_errors);
         }
     };
     Ok(result)
+}
+
+fn lowering_error_to_compile_error(
+    module_name: &str,
+    diagnostic_style: FrontendDiagnosticStyle,
+    error: LoweringError,
+) -> CompileError {
+    let message = match diagnostic_style {
+        FrontendDiagnosticStyle::Bare => error.message,
+        FrontendDiagnosticStyle::ModulePrefixed => {
+            format!("[{}] {}", module_name, error.message)
+        }
+    };
+    if let Some(code) = error.code {
+        CompileError::with_code(message, CompilePhase::TypeCheck, code)
+    } else {
+        CompileError::new(message, CompilePhase::TypeCheck)
+    }
 }
 
 pub(crate) fn emit_frontend_diagnostics(lowering_result: &LoweringResult) {
@@ -49,5 +57,47 @@ pub(crate) fn emit_frontend_diagnostics(lowering_result: &LoweringResult) {
     }
     for warning in &lowering_result.warnings {
         write_stderr_line(warning);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lowering_error_to_compile_error, FrontendDiagnosticStyle};
+    use sifr_diagnostics::DiagnosticCode;
+    use sifr_hir::LoweringError;
+
+    fn lowering_error(code: Option<DiagnosticCode>, message: &str) -> LoweringError {
+        LoweringError {
+            code,
+            message: message.to_string(),
+            line: None,
+            col: None,
+        }
+    }
+
+    #[test]
+    fn coded_lowering_error_uses_active_diagnostic_code() {
+        let error = lowering_error(Some(DiagnosticCode::TYPE_MISMATCH), "expected int, got str");
+
+        let compile_error =
+            lowering_error_to_compile_error("main", FrontendDiagnosticStyle::Bare, error);
+        let diagnostic = compile_error.to_diagnostic();
+
+        assert_eq!(compile_error.code, Some(DiagnosticCode::TYPE_MISMATCH));
+        assert_eq!(diagnostic.code, "SIFR-TYPE-0002");
+        assert_eq!(diagnostic.url, "https://sifr.sh/docs/errors/SIFR-TYPE-0002");
+    }
+
+    #[test]
+    fn codeless_lowering_error_preserves_legacy_bridge() {
+        let error = lowering_error(None, "expected int, got str");
+
+        let compile_error =
+            lowering_error_to_compile_error("main", FrontendDiagnosticStyle::ModulePrefixed, error);
+        let diagnostic = compile_error.to_diagnostic();
+
+        assert_eq!(compile_error.code, None);
+        assert_eq!(compile_error.message, "[main] expected int, got str");
+        assert_eq!(diagnostic.code, "SIFR-TYPE-0001");
     }
 }

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -61,6 +61,10 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<CompileError>> {
                 let compile_errors: Vec<CompileError> = errors
                     .into_iter()
                     .map(|e| {
+                        // Even if `e.code` is `Some(_)`, stdlib lowering
+                        // failures collapse to bootstrap failures from the
+                        // caller's perspective, not user-facing semantic
+                        // diagnostics.
                         CompileError::with_code(
                             format!("[stdlib:{}] {}", module_name, e.message),
                             CompilePhase::TypeCheck,

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -110,8 +110,9 @@ pub(crate) fn build_test_runner_project(
                     .map(|error| CompileError {
                         message: format!("[{}] {}", test_file.display(), error.message),
                         phase: CompilePhase::TypeCheck,
-                        // Preserves None until HIR LoweringError carries a
-                        // structured code in the next diag_4a slice.
+                        // Forwards `LoweringError.code` faithfully: `None`
+                        // for legacy call sites and `Some(_)` after upcoming
+                        // diag_4a slice-2b migrations.
                         code: error.code,
                     })
                     .collect();

--- a/crates/sifr_hir/src/lower/diagnostic_transport_tests.rs
+++ b/crates/sifr_hir/src/lower/diagnostic_transport_tests.rs
@@ -1,0 +1,27 @@
+use super::LowerCtx;
+use sifr_diagnostics::DiagnosticCode;
+
+#[test]
+fn error_with_code_records_structured_identity() {
+    let mut ctx = LowerCtx::new();
+
+    ctx.error_with_code(
+        DiagnosticCode::TYPE_MISMATCH,
+        "expected int, got str".to_string(),
+    );
+
+    assert_eq!(ctx.errors.len(), 1);
+    assert_eq!(ctx.errors[0].code, Some(DiagnosticCode::TYPE_MISMATCH));
+    assert_eq!(ctx.errors[0].message, "expected int, got str");
+}
+
+#[test]
+fn legacy_error_records_no_structured_identity() {
+    let mut ctx = LowerCtx::new();
+
+    ctx.error("expected int, got str".to_string());
+
+    assert_eq!(ctx.errors.len(), 1);
+    assert_eq!(ctx.errors[0].code, None);
+    assert_eq!(ctx.errors[0].message, "expected int, got str");
+}

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -73,6 +73,7 @@ use imports::resolve_imports_early;
 use len_aliases::LenAliasFact;
 use sequence_guards::SequenceGuard;
 use sequence_pointers::SequencePointerFact;
+use sifr_diagnostics::DiagnosticCode;
 use type_aliases::{collect_type_alias_decls, predeclare_type_aliases, resolve_type_aliases};
 use type_var_collection::collect_type_vars;
 use typing_and_functions::{
@@ -81,6 +82,7 @@ use typing_and_functions::{
 /// Errors produced during lowering.
 #[derive(Debug, Clone)]
 pub struct LoweringError {
+    pub code: Option<DiagnosticCode>,
     pub message: String,
     pub line: Option<u32>,
     pub col: Option<u32>,
@@ -208,6 +210,22 @@ impl LowerCtx {
 
     fn error(&mut self, message: String) {
         self.errors.push(LoweringError {
+            code: None,
+            message,
+            line: None,
+            col: None,
+        });
+    }
+
+    // TODO(diag_4a slice 2b): remove this allow when the first domain
+    // migration calls `error_with_code`.
+    #[allow(
+        dead_code,
+        reason = "diag_4a slice 2a adds transport before per-domain HIR call-site migration"
+    )]
+    fn error_with_code(&mut self, code: DiagnosticCode, message: String) {
+        self.errors.push(LoweringError {
+            code: Some(code),
             message,
             line: None,
             col: None,
@@ -224,6 +242,9 @@ impl LowerCtx {
             .find_map(|hints| hints.get(name))
     }
 }
+
+#[cfg(test)]
+mod diagnostic_transport_tests;
 const TYPEVAR_CONSTRAINT_PREFIX: &str = "__constraint__:";
 
 fn encode_typevar_constraint(name: &str) -> String {

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -31,8 +31,11 @@ Current wave: `milestone_diag_4a` renderer integration, split into reviewable tr
 - [x] Reviewed existing `SIFR-WORKSPACE-0001..0103` codes against the identity policy and kept them as active precise workspace diagnostics.
 - [x] Claude review for `milestone_diag_2b` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-3.md`.
 - [x] `milestone_diag_2b` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1670.
-- [ ] Started `milestone_diag_4a` slice 1: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport.
-- [ ] Deferred `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge deletion and affected fixture re-keying to `milestone_diag_4a` slice 2, where HIR `LoweringError` transport will carry structured diagnostic codes.
+- [x] `milestone_diag_4a` slice 1 merged: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport. PR: https://github.com/sifr-lang/sifr/pull/1671.
+- [ ] Started `milestone_diag_4a` slice 2a: additive HIR `LoweringError` structured diagnostic-code transport plumbing.
+- [x] Deferred `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge deletion and affected fixture re-keying to later `milestone_diag_4a` slice-2 sub-PRs, where HIR call sites will be migrated by domain before the bridge is removed.
+- [x] Claude pre-implementation review for `milestone_diag_4a` slice 2 completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md`.
+- [x] Claude implementation review for `milestone_diag_4a` slice 2a completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md`.
 - [x] Claude pre-implementation review for `milestone_diag_4a` completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 1 completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md`.
 
@@ -69,6 +72,17 @@ Validation evidence for current `milestone_diag_4a` slice 1:
 - `cargo test -p sifr --no-run` passed.
 - `cargo clippy -p sifr_diagnostics -p sifr_driver -p sifr -- -D warnings` passed.
 - `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` and wall time `79.70s`.
+
+Validation evidence for current `milestone_diag_4a` slice 2a:
+
+- `cargo fmt --check` passed.
+- `python3 scripts/check_hir_maintainability_guardrails.py` passed.
+- `cargo test -p sifr_hir diagnostic_transport_tests` passed.
+- `cargo test -p sifr_driver frontend::module_lowering::tests` passed.
+- `cargo test -p sifr_driver` passed.
+- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` passed.
+- `cargo clippy --workspace -- -D warnings` passed.
+- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` and wall time `86.73s`.
 
 ## Relationship to Existing Roadmap
 

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md
@@ -1,0 +1,249 @@
+# Review: milestone_diag_4a — Slice 2 Pre-Implementation (Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-4a-slice2` (working tree on top of `10129970`, the slice 1 merge)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md)
+
+Slice scope as planned by the user prompt:
+
+1. Add structured `DiagnosticCode` transport to HIR `LoweringError` so user-facing TypeCheck diagnostics no longer rely on `CompileError`'s legacy `TypeCheck => "SIFR-TYPE-0001"` fallback.
+2. Update driver frontend / test-runner / stdlib forwarding to preserve the HIR code via `CompileError::with_code`.
+3. Delete or neutralize `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` once no production user-facing TypeCheck path depends on it.
+4. Re-key affected verification + e2e baselines from `SIFR-TYPE-0001` to active codes.
+5. Treat this as a *mechanical transport* slice — defer category-specific helper refinement, related-span work, and dedupe-arg design to `milestone_diag_7` and `milestone_diag_8` unless required for correctness.
+
+## Verdict
+
+**The slice as scoped is internally consistent with the issue's `milestone_diag_4a` contract, but cannot ship as one PR without becoming the largest patch in this milestone by an order of magnitude.** Achieving "no production HIR call site falls back to `SIFR-TYPE-0001`" is a precondition for deleting the bridge arm, and that precondition currently requires touching **489 `LowerCtx::error(...)` call sites across 25 HIR files**, plus re-keying ~90 e2e fixtures, 2 verification baselines, and 23 driver/CLI unit-test occurrences. Bundling the transport plumbing, the call-site migration, the bridge deletion, and the fixture re-keying into a single PR is a reviewability and bisect-bisectability risk that the prior three slice-1 review passes already flagged when they recommended scope-splitting.
+
+I recommend splitting slice 2 into three sub-slices (2a/2b/2c described below). If the implementer prefers a single PR, the safe ordering inside it is fixed and is also documented below.
+
+A centralized message-prefix dispatcher *must not* be reintroduced — the issue explicitly forbids it as a non-goal, and slice 1 just removed an analogous workspace classifier. Every emitting site needs a deliberate code; the typesystem-enforced way to guarantee that is a non-defaulting `LowerCtx::error_with_code(code, message)` plus a one-shot deletion of the codeless `LowerCtx::error(message)` once migration is complete.
+
+## Inventory of the surface this slice must cover
+
+These numbers are derived from `crates/sifr_hir/src/`, `crates/sifr_driver/src/`, the registry in `crates/sifr_diagnostics/src/codes.rs`, and the e2e/verification trees. They are the load-bearing facts for the sequencing recommendation.
+
+| Surface | Count | Location |
+| --- | --- | --- |
+| `LowerCtx::error(...)` call sites across HIR | **489** | `crates/sifr_hir/src/lower/**` (top concentration: `expressions.rs` 205, `statements.rs` 64, `builtin_calls.rs` 55) |
+| `LowerCtx` emission helpers today | **2** | `error(&mut self, message: String)` and `warn(&mut self, message: String)` at [lower/mod.rs:205-215](../crates/sifr_hir/src/lower/mod.rs:205) — neither carries a `DiagnosticCode` |
+| HIR → driver `CompileError` conversion sites | **3** | [frontend/module_lowering.rs:25-39](../crates/sifr_driver/src/frontend/module_lowering.rs:25), [test_runner/orchestrator.rs:107-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:107), [stdlib/bootstrap.rs:58-73](../crates/sifr_driver/src/stdlib/bootstrap.rs:58) |
+| Fixtures with `expect-error: SIFR-TYPE-0001` (bare) | **76 `.sifr` files** | `crates/sifr/tests/e2e/fail/*.sifr` |
+| Fixtures with hybrid `[SIFR-TYPE-0001] [E25xx]` (decimal) | **~14 `.sifr` files** | same directory; e.g. `decimal_forbidden_mixed_arithmetic_seeded.sifr`, `bigdecimal_quantize_negative_scale_context.sifr` |
+| Verification baselines pinning `SIFR-TYPE-0001` | **2** | `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-{json,compact}.stderr.txt` |
+| Driver/CLI hard-coded `"SIFR-TYPE-0001"` | **23 occurrences** | [crates/sifr/src/main.rs](../crates/sifr/src/main.rs) (20 lines, all unit tests for the legacy renderer), [crates/sifr_driver/src/tests/diagnostics.rs](../crates/sifr_driver/src/tests/diagnostics.rs) (3 lines, recovery-cap synthetic tests) |
+| Bridge arms still emitting **retired** codes | **all 4** | [diagnostics.rs:135-140](../crates/sifr_driver/src/diagnostics.rs:135) — `Parse → SIFR-PARSE-0001`, `TypeCheck → SIFR-TYPE-0001`, `Codegen → SIFR-CODEGEN-0001`, `Build → SIFR-BUILD-0001`. Slice 1 did not repoint any of them; only the explicit `with_code` callers carry active codes. |
+| Decimal `[E25xx]` pseudo-codes still embedded in HIR messages | **~36 sites** | `crates/sifr_hir/src/lower/decimal_methods.rs`, `expressions.rs`, `crates/sifr_type_system/src/check.rs`. **Owned by milestone_diag_6**, not this slice. |
+
+## Active codes available for HIR migration (in-scope code budget)
+
+`crates/sifr_diagnostics/src/codes.rs` already defines the inventory codes that slice 2 must thread through. Counted by family, currently active:
+
+- `SIFR-TYPE-0002..0009` (8 errors) + `0901` (warning) + `0902` (note) — type mismatch, branch mismatch, missing/invalid annotation, unsupported operator, int/bigint mixed, container element conflict, tuple unpack shape mismatch, arithmetic-overflow risk warning, reveal-type note.
+- `SIFR-NAME-0001..0004` — undefined variable, undefined callable, unknown type, missing module/class member.
+- `SIFR-IMPORT-0001..0002` — forbidden intrinsic, unknown source module.
+- `SIFR-DECIMAL-0001..0008` — invalid literals (Decimal/BigDecimal), float-mixed, Decimal/BigDecimal mixed, float-construction forbidden (×2), scale invalid (×2).
+- `SIFR-CALL-0001..0005` — wrong positional count, unexpected keyword, duplicate argument, missing required argument, callable arity / not-callable.
+- `SIFR-OWN-0001..0004` — use-after-move, double mutable borrow, borrowed parameter escape, moved-across-loop.
+- `SIFR-FLOW-0001..0003` (errors) + `0901` (warning) — break/continue/nonlocal misuse, unreachable.
+- `SIFR-MATCH-0001..0003` — non-exhaustive match, guard-not-bool, invalid class-pattern field.
+- `SIFR-PROTO-0001..0004` — protocol bound, iterator/reversible signature, context-manager missing, hashable/comparable required.
+- `SIFR-CLASS-0001..0004` — missing initializer, required-after-default, duplicate/invalid value, missing member.
+- `SIFR-RESULT-0001..0003` — unused Result, invalid error type, invalid raise.
+- `SIFR-INTERNAL-0001` — internal compiler panic / invariant.
+
+Total: **52 active inventory codes**, which `milestone_diag_3` already mapped against the call-site categories. The mechanical migration of the 489 sites should consume nearly all of them.
+
+There is no active "TYPE catch-all" — and the issue is explicit that one must not be invented. If a call site does not fit any of the codes above, the correct response is to add a new active registry entry (with docs page, fixture plan, and registry constant), not to invent a transitional bucket. The issue also specifies that the registry can be extended in the migration milestone that emits the new code.
+
+## Question 1: is a centralized transitional HIR code mapping acceptable?
+
+**No, not as a runtime classifier — and the type system is the right place to enforce that.**
+
+Three concrete framings:
+
+1. **Message-prefix or message-substring dispatcher** — explicitly a non-goal of the phase ([issue line 165](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:165) "Add a string-prefix-to-code classifier"). Slice 1 just removed `CompileError::workspace_diagnostic_code`, the previous incarnation of this pattern. Reintroducing one in HIR would directly contradict the slice 1 verdict and the registered slice 1 regression test at [tests/diagnostics.rs:71-81](../crates/sifr_driver/src/tests/diagnostics.rs:71). Hard "no".
+
+2. **A single transitional "HIR catch-all" code (e.g. a new `TYPE_GENERIC_LOWERING_FAILURE`)** — also wrong. It would re-create the `SIFR-TYPE-0001` bucket under a new name, regress every fidelity gain the registry population in `milestone_diag_2b` made, and violate the [diagnostic identity policy](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:134) ("a diagnostic code identifies the *kind* of user-facing compiler error"). Don't.
+
+3. **A type-enforced transition where every emission must carry a code** — *yes*, this is the structurally safe path. Concretely:
+
+   - Add `code: DiagnosticCode` (non-`Option`) to `LoweringError`, **or** keep it `Option<DiagnosticCode>` for the duration of slice 2a and tighten to non-optional in slice 2c.
+   - Add `LowerCtx::error_with_code(&mut self, code: DiagnosticCode, message: String)`; have it set the `code` field on the new `LoweringError`.
+   - Once every call site is migrated, **delete `LowerCtx::error(message: String)` outright** so any unmigrated site becomes a compile error rather than a silent fallback. This matches the issue's "must use an inventory-assigned canonical code through SifrDiagnostic transport or fail to compile" wording at [issue line 863](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:863).
+
+   The "fail to compile" guarantee is the exact opposite of a centralized transitional dispatcher; it forces every author to make the code choice locally, which is the slice's actual goal.
+
+Practical answer to the user's question: **every `LowerCtx::error` call must be touched in this slice (or a sub-slice of it)**. There is no inventory-faithful shortcut that lands the bridge deletion early.
+
+## Question 2: which active codes to use for broad HIR categories without replacing one bad bucket with another
+
+The risk of mass migration is "label-laundering" — pulling 489 sites into a small handful of codes (e.g. dumping anything ambiguous into `TYPE_MISMATCH`) and ending up with a new fat bucket. The defenses are:
+
+1. **Use the registry's per-domain active codes by category, not by file.** The category breakdown for the 489 sites:
+
+   | Category (issue's diag_3 inventory bucketing) | Representative call sites | Target active code(s) |
+   | --- | --- | --- |
+   | Type mismatch (assignment, return, generic application) | [expressions.rs:410-420](../crates/sifr_hir/src/lower/expressions.rs:410), [statements.rs](../crates/sifr_hir/src/lower/statements.rs), [aug_assign_lowering.rs](../crates/sifr_hir/src/lower/aug_assign_lowering.rs) | `TYPE_MISMATCH`, `TYPE_IF_BRANCH_MISMATCH`, `TYPE_UNSUPPORTED_OPERATOR` |
+   | Undefined name | [expressions.rs:245](../crates/sifr_hir/src/lower/expressions.rs:245), [statements.rs:1534](../crates/sifr_hir/src/lower/statements.rs:1534) | `NAME_UNDEFINED_VARIABLE`, `NAME_UNDEFINED_CALLABLE`, `NAME_UNKNOWN_TYPE`, `NAME_MISSING_MODULE_MEMBER` |
+   | Ownership / move | [expressions.rs:224](../crates/sifr_hir/src/lower/expressions.rs:224) | `OWN_USE_AFTER_MOVE`, `OWN_DOUBLE_MUTABLE_BORROW`, `OWN_BORROWED_PARAMETER_ESCAPES`, `OWN_MOVED_ACROSS_LOOP` |
+   | Control flow | [statements.rs:201](../crates/sifr_hir/src/lower/statements.rs:201) | `FLOW_BREAK_OUTSIDE_LOOP`, `FLOW_CONTINUE_OUTSIDE_LOOP`, `FLOW_INVALID_NONLOCAL` |
+   | Match exhaustiveness | [statements.rs:799,837](../crates/sifr_hir/src/lower/statements.rs:799) | `MATCH_NON_EXHAUSTIVE`, `MATCH_GUARD_NOT_BOOL`, `MATCH_INVALID_CLASS_PATTERN_FIELD` |
+   | Decimal literal / arithmetic | [decimal_methods.rs](../crates/sifr_hir/src/lower/decimal_methods.rs), [expressions.rs:875-1103](../crates/sifr_hir/src/lower/expressions.rs:875), [type_system/check.rs:31,43,361,373](../crates/sifr_type_system/src/check.rs:31) | `SIFR-DECIMAL-0001..0008` (all 8) |
+   | Class init / definition | [classes.rs:145,234](../crates/sifr_hir/src/lower/classes.rs:145) | `CLASS_MISSING_INITIALIZER`, `CLASS_REQUIRED_FIELD_AFTER_DEFAULT`, `CLASS_DUPLICATE_OR_INVALID_VALUE`, `CLASS_MISSING_MEMBER` |
+   | Iterator / protocol | [classes.rs:145](../crates/sifr_hir/src/lower/classes.rs:145) | `PROTO_BOUND_NOT_SATISFIED`, `PROTO_INVALID_ITERATOR_SIGNATURE`, `PROTO_CONTEXT_MANAGER_MISSING`, `PROTO_HASHABLE_OR_COMPARABLE_REQUIRED` |
+   | Call args | [method_call_args.rs](../crates/sifr_hir/src/lower/method_call_args.rs), [builtin_calls.rs](../crates/sifr_hir/src/lower/builtin_calls.rs) | `CALL_WRONG_POSITIONAL_COUNT`, `CALL_UNEXPECTED_KEYWORD`, `CALL_DUPLICATE_ARGUMENT`, `CALL_MISSING_REQUIRED_ARGUMENT`, `CALL_NOT_CALLABLE_OR_ARITY` |
+   | Result / raise | [statements.rs:189](../crates/sifr_hir/src/lower/statements.rs:189) | `RESULT_UNUSED_VALUE`, `RESULT_INVALID_ERROR_TYPE`, `RESULT_INVALID_RAISE` |
+   | Imports (HIR-side) | [imports.rs](../crates/sifr_hir/src/lower/imports.rs) | `IMPORT_FORBIDDEN_INTRINSIC`, `IMPORT_UNKNOWN_SOURCE_MODULE` |
+   | Tuple unpack shape | [tuple_unpack.rs:100](../crates/sifr_hir/src/lower/tuple_unpack.rs:100) | `TYPE_UNPACK_SHAPE_MISMATCH` |
+   | Container element conflict | [container_literal_specialization.rs](../crates/sifr_hir/src/lower/container_literal_specialization.rs) | `TYPE_CONTAINER_ELEMENT_CONFLICT` |
+   | Annotation shape errors | [typing_and_functions.rs](../crates/sifr_hir/src/lower/typing_and_functions.rs) | `TYPE_INVALID_ANNOTATION`, `TYPE_MISSING_ANNOTATION` |
+
+2. **Never use `INTERNAL_COMPILER_PANIC` (`SIFR-INTERNAL-0001`) as the transitional bucket for user-facing semantic errors.** That code maps to `EXIT_INTERNAL_COMPILER_FAILURE` (3) at [main.rs:260-262](../crates/sifr/src/main.rs:260) — using it for, say, a type-mismatch site would change the user-visible exit code from 1 (user diagnostic) to 3 (ICE). The categorical mapping above never needs `INTERNAL_COMPILER_PANIC`; reserve that code for true compiler-invariant failures already handled in slice 1 (e.g. [build/entrypoint.rs:215-221](../crates/sifr_driver/src/build/entrypoint.rs:215)).
+
+3. **When a site is genuinely ambiguous, prefer a deliberate registry extension over a label-laundering choice.** E.g., if a generic-bound site does not match `PROTO_BOUND_NOT_SATISFIED`, `TYPE_MISMATCH`, or any existing code, slice 2 should add a new registry entry with template, declared args, owner module, fixture plan, and docs page. Adding an entry is cheap; mis-bucketing is not.
+
+4. **Decimal pseudo-codes `[E25xx]` stay in the message templates for this slice.** Their removal is owned by `milestone_diag_6` ([issue lines 919-935](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:919)). Slice 2's decimal migration only attaches `SIFR-DECIMAL-000x` as the top-level identity; the embedded `[E25xx]` stays inside the rendered message and the hybrid `[SIFR-TYPE-0001] [E25xx]` fixtures become `SIFR-DECIMAL-0001` (etc.) `+ [E25xx] still in the message text`. Deleting `[E25xx]` here would conflate two milestones.
+
+## Question 3: which tests/baselines must be updated to prove the bridge is gone
+
+Three categories must change inside this slice (regardless of how many sub-slices it is split into):
+
+### a) Driver / CLI unit tests that hard-code `"SIFR-TYPE-0001"` — 23 occurrences
+
+| File | Lines | Purpose |
+| --- | --- | --- |
+| [crates/sifr/src/main.rs](../crates/sifr/src/main.rs) | 1273, 1276, 1295, 1300, 1312, 1315, 1323, 1326, 1364, 1367, 1376, 1379, 1389-1392, 1401, 1404, 1439, 1441 (≈ 20) | Renderer/help/compact/severity tests construct synthetic `CompilerDiagnostic` literals with `code: "SIFR-TYPE-0001".to_string()` |
+| [crates/sifr_driver/src/tests/diagnostics.rs](../crates/sifr_driver/src/tests/diagnostics.rs) | 88, 91, 119 | `apply_diagnostic_recovery_limits` synthetic input |
+
+These are not exercising the bridge — they are exercising the renderer and recovery limiter on synthetic `CompilerDiagnostic` values. Re-keying them to an active code (the natural choice is `TYPE_MISMATCH` / `SIFR-TYPE-0002`) preserves intent. **One of them, however, must remain a regression guard for "the bridge is gone"** — see the new test in (d) below.
+
+### b) Verification baselines — 2 files
+
+- [crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt) — JSON `"code": "SIFR-TYPE-0001"` and `"url": ".../SIFR-TYPE-0001"` lines.
+- [crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt) — `error [SIFR-TYPE-0001] [main] [E2501] ...` line and the `url:` line.
+
+Both should re-key to `SIFR-DECIMAL-0001` (`DECIMAL_INVALID_LITERAL`). The `[E2501]` substring stays in the message until `milestone_diag_6`.
+
+### c) E2E `expect-error` annotations — ~90 fixtures
+
+`grep -c "expect-error: SIFR-TYPE-0001" crates/sifr/tests/e2e/fail/*.sifr` returns **76 files** for the bare form, with another ~14 fixtures using the hybrid `[SIFR-TYPE-0001] [E25xx]` form, for ~90 total. Each must re-key to its category-correct active code. Re-keying is mechanical *only when the call site has been migrated and now emits the right code*; otherwise the fixture will fail with a code-mismatch.
+
+A practical sequencing constraint: a fixture must not be re-keyed *before* the corresponding call site is migrated, and a call site must not be migrated *after* its fixture has been re-keyed (in either order, the fixture briefly fails). This is the single biggest argument for sub-slicing by domain (decimal first, then ownership, then match, etc.) so each sub-PR's call-site migration and fixture re-key land together.
+
+### d) New regression test — the "bridge is gone" proof
+
+To pin the slice's headline outcome, add one of:
+
+- **Compile-time proof (preferred):** delete the `CompilePhase::TypeCheck` arm from `diagnostic_code()` and either delete the `CompilePhase::TypeCheck` enum variant or make `diagnostic_code()` infallible by removing the `Option<DiagnosticCode>` field. After slice 2c, no production path can construct a `CompileError` with `code: None` for the TypeCheck phase because the enum/variant no longer exists or because the field is no longer optional. This is a structural guarantee, not a runtime one. The slice 2c PR description should call out the type-system enforcement explicitly.
+- **Runtime regression test (acceptable fallback):** if the structural change is deferred to slice 4b, add a unit test in `crates/sifr_driver/src/tests/diagnostics.rs` that asserts `compile_errors_to_diagnostics` never produces `"SIFR-TYPE-0001"` from any input — e.g., by enumerating `CompilePhase` variants and a few representative messages and asserting the produced JSON `code` is not the retired string. Pair with a registry probe that asserts `DiagnosticCode::TYPE_MISMATCH.code() == "SIFR-TYPE-0002"` to anchor the canonical replacement.
+
+The issue's [diag_5 line 919](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:919) wants harness-level code-validation to reject retired codes at fixture-load time. That guardrail is **owned by `milestone_diag_5`**, not slice 2. Slice 2 should not re-implement it; the existing `is_diagnostic_code` validator at [crates/sifr/tests/e2e.rs:637-652](../crates/sifr/tests/e2e.rs:637) accepts any `SIFR-X-NNNN` form, so a typo in a re-keyed fixture would be silently accepted today. Mitigation for slice 2: re-key fixtures by exact code-substitution scripted with `git grep` → `sed`, then run the full e2e suite locally; CI failure on a wrong code is the regression guard until `milestone_diag_5` lands.
+
+## Recommended sequencing — split slice 2 into three sub-slices
+
+Each sub-slice is an independently reviewable PR with a clear before/after.
+
+### Slice 2a — Transport plumbing (small, pure additive)
+
+Goal: HIR can carry codes; nothing else changes.
+
+1. Add `code: Option<DiagnosticCode>` field to `LoweringError` at [lower/mod.rs:81-87](../crates/sifr_hir/src/lower/mod.rs:81). Default-initialize to `None`.
+2. Add `LowerCtx::error_with_code(&mut self, code: DiagnosticCode, message: String)` at [lower/mod.rs:209](../crates/sifr_hir/src/lower/mod.rs:209) alongside the existing `error(message)`. The legacy method stays for now and produces `LoweringError { code: None, .. }`.
+3. Update the three conversion sites to forward `error.code` faithfully:
+   - [frontend/module_lowering.rs:25-39](../crates/sifr_driver/src/frontend/module_lowering.rs:25): branch on `e.code` — call `CompileError::with_code` when present, otherwise the existing `CompileError::new` path.
+   - [test_runner/orchestrator.rs:107-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:107): same branch — the `code: error.code` forward becomes live for whichever HIR sites already migrated.
+   - [stdlib/bootstrap.rs:58-73](../crates/sifr_driver/src/stdlib/bootstrap.rs:58): keep the `STDLIB_BOOTSTRAP_FAILURE` override (intentional: a stdlib parse/lower failure is a bootstrap failure, not a user-facing semantic error). If `e.code` is set, prefer it over `STDLIB_BOOTSTRAP_FAILURE`? Decide explicitly in the PR — the safer default is to **keep** `STDLIB_BOOTSTRAP_FAILURE` because stdlib lowering errors are compiler bugs from a user's perspective, but the choice should be documented in a one-line comment.
+4. Add a unit test in `sifr_hir` proving `LoweringError { code: Some(SIFR-TYPE-0002), .. }` round-trips to a `CompileError::with_code`, and a sibling test in `sifr_driver` proving `compile_errors_to_diagnostics` emits the active code (not `SIFR-TYPE-0001`) when `error.code` is `Some(_)`.
+5. Keep the `TypeCheck => SIFR-TYPE-0001` arm in `diagnostic_code()` untouched. Keep all 90 fixtures untouched. Keep the 23 driver/CLI unit tests untouched. *Nothing else changes.*
+
+Validation: `cargo test -p sifr_hir`, `cargo test -p sifr_driver`, `scripts/run_all_tests.sh --profile quick`. Quick-profile signature should still be `e1bf653aaa770517` because no production behavior changed.
+
+### Slice 2b — Mechanical call-site migration, by domain (multiple PRs)
+
+Goal: every `LowerCtx::error` site migrates to `LowerCtx::error_with_code`. Migrate by category so each sub-PR's call sites and fixtures land together.
+
+Ordering recommendation (smallest blast radius first, hardest categorical decisions last):
+
+1. **Decimal** — 18 + ~12 sites, ~14 fixtures, 2 baselines. Cleanest because the hybrid `[SIFR-TYPE-0001] [E25xx]` annotations already gesture at the right `SIFR-DECIMAL-000x` code. The mapping `[E2501]→0001`, `[E2502]→0002`, `[E2503]→0003`, `[E2504]→0004`, `[E2505]→0005`, `[E2506]→0006`, `[E2507]→0007`, `[E2508]→0008` is essentially documented in the inventory. **Do not** strip `[E25xx]` from message templates — that's `milestone_diag_6`.
+2. **Ownership / Flow / Result / Match** — ~20-30 sites total, ~15 fixtures. These categories are clean: `OWN_*` codes are precise, `FLOW_*` are precise, `RESULT_*` are precise, `MATCH_*` are precise.
+3. **Class / Protocol / Import** — ~25 sites, ~15 fixtures. Slightly more nuance because some class errors also look like protocol errors; the registry distinguishes them by the rule, not by the file.
+4. **Call args / Tuple unpack / Container literal / Annotation shape** — ~40 sites, ~15 fixtures. Mostly clean; `CALL_*` codes already split the rule space.
+5. **Type / Name** — the largest residual: ~250 sites in `expressions.rs` + `statements.rs` + `aug_assign_lowering.rs` + `typing_and_functions.rs` + `mod.rs`, ~30 fixtures. This is where label-laundering risk peaks. Consider a paired exploratory pass that reads each call site and selects between `TYPE_MISMATCH`, `TYPE_IF_BRANCH_MISMATCH`, `TYPE_UNSUPPORTED_OPERATOR`, `TYPE_INT_BIGINT_MIXED`, `TYPE_CONTAINER_ELEMENT_CONFLICT`, `TYPE_UNPACK_SHAPE_MISMATCH`, `NAME_*`, etc., before the migration PR opens.
+
+Each 2b sub-PR's validation includes the full e2e suite (`scripts/run_e2e_pass.sh`) because re-keyed fixtures shift the JSON/compact baselines. Quick-profile alone is insufficient — the slice 1 quick-profile signature was stable precisely because no fixture was re-keyed.
+
+### Slice 2c — Bridge deletion + structural cleanup (small, type-driven)
+
+After every 2b sub-PR has merged and `git grep "ctx.error(" crates/sifr_hir/src/` returns zero hits:
+
+1. **Delete `LowerCtx::error(message: String)`** at [lower/mod.rs:209-215](../crates/sifr_hir/src/lower/mod.rs:209). Any forgotten call site becomes a compile error. This is the type-system enforcement of "must use an inventory-assigned canonical code … or fail to compile" from [issue line 863](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:863).
+2. **Delete `CompilePhase::TypeCheck => "SIFR-TYPE-0001"`** at [diagnostics.rs:137](../crates/sifr_driver/src/diagnostics.rs:137). Decide between the two structural cleanups:
+   - Option A: keep the `Option<DiagnosticCode>` field but make `diagnostic_code()` panic on `None` for `TypeCheck` (or for any phase) — runtime enforcement.
+   - Option B: tighten `CompileError.code` to non-`Option`, force every constructor to take a `DiagnosticCode`, and delete `CompileError::new` — type-system enforcement. This is the issue's preferred direction (see [issue line 492-497](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:492) for the eventual `CompileError` retirement plan in `milestone_diag_4b`).
+   - Option B is strictly better. Slice 2c should pick it unless the parser/codegen/build paths still emit `CompileError::new(...)` (some do — see [frontend/api.rs:21-44](../crates/sifr_driver/src/frontend/api.rs:21) and the parse-failure markers from slice 1's R5). If those parse paths are not yet coded, slice 2c should code them too (one-line per site, all parse failures → `PARSE_EXPECTED_TOKEN_OR_RECOVERY` until `milestone_diag_7` splits them) and proceed with Option B.
+3. **Update the 23 driver/CLI unit-test occurrences** to use active codes. The natural substitution is `"SIFR-TYPE-0001"` → `"SIFR-TYPE-0002"` (`TYPE_MISMATCH`); the tests are exercising the renderer/recovery-limiter on synthetic input and don't care which active code they use.
+4. **Re-key the 2 verification baselines** (decimal fixtures) — these were already re-keyed in slice 2b.1 if the sub-slicing landed; if not, do them here.
+5. **Add a regression test** asserting `CompileError::new(...).to_diagnostic()` either fails to compile (Option B) or produces a non-retired code (Option A). Worded as a unit test in `crates/sifr_driver/src/tests/diagnostics.rs`, e.g., enumerate all `DiagnosticCode` constants and assert none equal `"SIFR-TYPE-0001"` AND no production path produces it.
+6. **Update the slice-1 transitional comment** at [diagnostics.rs:129-134](../crates/sifr_driver/src/diagnostics.rs:129) — either delete it or rewrite it to describe the remaining `Parse → SIFR-PARSE-0001`, `Codegen → SIFR-CODEGEN-0001`, `Build → SIFR-BUILD-0001` arms (which are explicit `milestone_diag_4b` targets). Slice 1 review pass-3 already noted these arms should be repointed to active codes; slice 2c can repoint them as a free side-effect.
+
+The slice 2c PR is small (≈ 10-20 file diff) but is the only one that visibly satisfies the issue's milestone exit gate at [issue line 882](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:882): "`CompilePhase::TypeCheck` no longer assigns `SIFR-TYPE-0001` to any diagnostic path."
+
+## Single-PR fallback ordering (if the implementer rejects sub-slicing)
+
+If slice 2 must ship as one PR, the safe ordering inside the PR is:
+
+1. (2a steps 1-3) Add `code` to `LoweringError`, add `error_with_code`, update the 3 conversion sites.
+2. (2b) Migrate all 489 call sites in one batch, ordered by domain (decimal → ownership/flow/match/result → class/proto/import → call/tuple/container/annotation → type/name).
+3. Re-key all ~90 fixtures and 2 baselines to active codes in the same commit as the corresponding call-site migration to keep the build green per-commit.
+4. Update the 23 driver/CLI unit-test occurrences.
+5. Delete `LowerCtx::error` (the codeless overload).
+6. Delete `CompilePhase::TypeCheck => "SIFR-TYPE-0001"`. Decide between Option A/B from slice 2c step 2.
+7. Add the regression test from slice 2c step 5.
+8. Run `scripts/run_all_tests.sh --profile quick` AND `scripts/run_e2e_pass.sh` for full coverage.
+
+A single PR with this ordering is *correct* but is ~100 files of diff, which is reviewable only with a strong commit decomposition. I would still recommend sub-slicing.
+
+## Scope traps to defer
+
+These will be tempting to bundle into slice 2 and should be pushed out instead.
+
+1. **Decimal `[E25xx]` removal from message templates** — 36 sites in HIR + type system. Owned by `milestone_diag_6` ([issue line 925-935](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:925)). Slice 2 attaches `SIFR-DECIMAL-000x` as the *top-level* identity but keeps `[E25xx]` in the message body so the human-readable output is unchanged. Do not pre-empt diag_6.
+2. **`sifr_type_system::TypeError` deletion** — owned by `milestone_diag_7` ([issue line 958](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:958)). Type-system errors that flow through the HIR pipeline currently land as untyped strings in `LoweringError`; slice 2 must attach codes at the HIR boundary (probably `TYPE_MISMATCH` for the broad cases), but must not delete `TypeError`/`TypeErrorKind` symbols or restructure the type-system error model. The short-lived `From<TypeError> for SifrDiagnostic`-style adapter that diag_7 will delete is **not** in scope.
+3. **`LoweringError → LoweringOutcome/DiagnosticSink` migration** — also part of `milestone_diag_4a` ([issue line 866](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:866)) but is a separate transport replacement that the issue lists as PR #2 in the milestone's expected PR sequence ([issue line 871](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:871)). Slice 2 only adds a `code` field to the *existing* `LoweringError`. The full sink/outcome rework should be a separate sub-slice (call it 2d) after 2c lands. Do not bundle.
+4. **Parser bucket splitting (`SIFR-PARSE-0002..0009`)** — Ruff parse failures all funnel into `PARSE_EXPECTED_TOKEN_OR_RECOVERY` today (slice 1 R5, deferred). The issue's [milestone_diag_7 line 941-943](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:941) is the right home. Slice 2c may opportunistically repoint the `Parse → SIFR-PARSE-0001` bridge arm (one line) but should *not* attempt to split parse buckets.
+5. **`is_internal_compile_error` simplification** — slice 1 review pass-3 O4 suggested generalizing the equality check to `code.starts_with("SIFR-INTERNAL-")`. Out of scope for slice 2; it's a `milestone_diag_4b` concern.
+6. **Legacy CLI renderer (`compile_errors_to_diagnostics` + `render_compile_errors`)** — unchanged in slice 1. The renderer wiring slice should consume `SifrDiagnostic` directly; slice 2 should not entangle with it. The slice 1 review pass-3 N6 already flagged that the legacy renderer's `code.starts_with("SIFR-PARSE-")` severity-class sniffer ([main.rs:374-385](../crates/sifr/src/main.rs:374)) should not gain new code-prefix arms. Honor that.
+7. **`milestone_diag_5` harness validation of retired/unknown expectation codes** — owned by diag_5 ([issue line 895](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:895)). Slice 2 fixture re-keying will silently succeed on typos until then, so re-key carefully and run the full e2e suite locally.
+8. **Bounded multi-error recovery cap activation** — `milestone_diag_10`. The fixtures `bounded_multi_error_recovery.sifr` and `bounded_multi_error_recovery_repeated_type_errors.sifr` re-key to specific active codes in slice 2 but the cap-omission summary code (`SIFR-INTERNAL-0002` reserved) is not activated here.
+9. **Any non-`SIFR-TYPE` bridge arm repoint** — the `Parse`, `Codegen`, `Build` arms in [diagnostics.rs:135-140](../crates/sifr_driver/src/diagnostics.rs:135) all still emit retired codes. Slice 2c may repoint them opportunistically because the implementer is in the file anyway, but the *milestone* exit gate ([issue line 999](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:999) "delete the remaining phase-derived public diagnostic-code mapping") is owned by `milestone_diag_4b`. If slice 2c repoints them, it should not also delete the mapping function.
+
+## Concrete pre-implementation actions before slice 2a opens
+
+1. **Confirm the `LoweringError.code` decision** — `Option<DiagnosticCode>` for slice 2a (so the existing 489 `ctx.error(...)` sites still type-check) and tighten to non-optional in slice 2c. The alternative — non-optional from day 1 — is a cleaner end state but turns slice 2a into a 489-file PR by itself.
+2. **Decide stdlib bootstrap forwarding policy** — does `STDLIB_BOOTSTRAP_FAILURE` always win at [stdlib/bootstrap.rs:58-73](../crates/sifr_driver/src/stdlib/bootstrap.rs:58), or should an HIR-emitted code override it for stdlib parse/lower errors? Default to "always wins" (stdlib parse/lower failures are bootstrap failures); document the choice in a one-line comment.
+3. **Pre-categorize the 489 sites into the 12 buckets above** before opening the slice 2b PRs. A single audit pass over `crates/sifr_hir/src/lower/` produces the (file, line, suggested code) list and avoids a second pass during code review. The result is an artifact (e.g. `internal_docs/diagnostic_call_site_categorization.md`) the diag_7/diag_8 milestones will reuse to add helpers.
+4. **Prepare the registry extension list** — any call site whose intent doesn't fit the 52 active codes needs a registry entry added in `crates/sifr_diagnostics/src/codes.rs` (with template, declared args, owner, fixture plan, docs page). Bundle the registry extensions into slice 2a or a dedicated slice 2-prep PR rather than scattering them across the 2b sub-PRs.
+5. **Audit the 90 fixtures' message bodies** — re-keying will only succeed if the new active code's message template matches the fixture's expected message. Slice 2 must not change message templates (that's diag_7 helper refinement), so any fixture whose message body doesn't match the active code's template needs either (a) the active code's template to be a superset of the message, or (b) the fixture's message to be left as the rendered string (the registry's `message_template` is not asserted by `expect-error`, only the code is). The message-body audit may surface fixtures that currently embed `[E25xx]` decimal pseudo-codes — those stay as-is.
+6. **Plan the regression test for slice 2c** — pick Option A (runtime) or Option B (type-system) from §"Question 3 (d)" before slice 2c opens, so the test fixture is ready when the bridge arm is deleted.
+
+## Validation budget per sub-slice
+
+| Sub-slice | Required validation | Typical signature |
+| --- | --- | --- |
+| 2a (transport plumbing only) | `cargo test -p sifr_hir`, `cargo test -p sifr_driver`, `cargo clippy --workspace -- -D warnings`, `scripts/run_all_tests.sh --profile quick` | Quick-profile should match `e1bf653aaa770517` (no behavior change) |
+| 2b.* (per-domain migration + fixture re-key) | Full e2e suite: `scripts/run_e2e_pass.sh`, `scripts/run_all_tests.sh` (full profile), schema/docs sync scripts | Quick-profile signature **will change** because re-keyed fixtures shift JSON/compact output |
+| 2c (bridge deletion + cleanup) | Full e2e suite, `scripts/run_all_tests.sh`, plus a manual `git grep "SIFR-TYPE-0001" crates/ verification/ docs/` returning zero hits in production paths (registry retirement entry remains) | Final signature is the slice 2 baseline carried into `milestone_diag_4b` |
+
+## Summary
+
+Slice 2 as scoped is the right next step in `milestone_diag_4a`, but its actual surface — 489 HIR call sites, 90 fixtures, 23 unit-test occurrences, 2 baselines — makes it the single largest patch in the entire diag phase if landed as one PR. The user's framing as a "mechanical transport slice" is accurate per call site but not per slice: the *transport* is mechanical, the *call-site coverage* is not.
+
+The recommended path is the three-sub-slice split (2a transport plumbing, 2b per-domain migration in 4-5 PRs, 2c structural cleanup + bridge deletion). A centralized message-prefix dispatcher must not be reintroduced; the type-system enforcement (delete the codeless `LowerCtx::error`, optionally tighten `CompileError.code` to non-`Option`) is the inventory-faithful way to land the bridge deletion. Active codes per category are listed in §"Question 2"; `INTERNAL_COMPILER_PANIC` is **not** an acceptable transitional bucket for user-facing semantic errors. The fixture re-keying is the highest-risk subtask because the harness's `is_diagnostic_code` validator silently accepts retired codes (slice 5 territory); careful per-domain landing with full e2e validation per sub-PR is the mitigation.
+
+Defer in this slice: decimal `[E25xx]` message-template cleanup (diag_6), `sifr_type_system::TypeError` deletion (diag_7), `LoweringError → LoweringOutcome/DiagnosticSink` migration (separate slice 2d), parser-bucket splitting (diag_7), `is_internal_compile_error` generalization (diag_4b), legacy CLI renderer migration (later renderer-wiring slice), and the harness expectation-grammar validation (diag_5).

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md
@@ -1,0 +1,272 @@
+# Review: milestone_diag_4a — Slice 2a Transport Plumbing (Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-4a-slice2` (working tree on top of `10129970`, the slice 1 merge)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md)
+
+Slice scope reviewed (claimed):
+
+1. Add `code: Option<DiagnosticCode>` to `sifr_hir::LoweringError`.
+2. Add `LowerCtx::error_with_code` as additive transport plumbing, with a narrow `#[allow(dead_code)]` because no HIR domain call sites are migrated in 2a.
+3. Add focused HIR tests proving coded vs codeless lowering errors are recorded distinctly.
+4. Update driver frontend module-lowering to forward `LoweringError.code` to `CompileError::with_code`, preserving the legacy `CompileError::new` fallback when absent.
+5. Keep stdlib lowering errors collapsed to `STDLIB_BOOTSTRAP_FAILURE` with an explicit override comment.
+6. Record slice-1 PR link, slice-2a status, pre-review pointer, and validation evidence in the issue tracker.
+
+## Verdict
+
+**The slice is scope-disciplined and structurally correct, and is ready to ship as a small slice-2a PR after addressing one missing-test gap (R1 below).** It implements exactly the slice 2a contract from the pre-implementation review (`Option<DiagnosticCode>` field, additive `error_with_code` helper, conversion-site forwarding, `STDLIB_BOOTSTRAP_FAILURE` override preserved, no fixture re-keying, no bridge deletion, no call-site migration). Quick-profile signature is unchanged from slice 1 (`e1bf653aaa770517`), which is the correct guarantee for a transport-only slice that intentionally produces no production behavior change.
+
+The only material concern is that the pre-review explicitly required *two* tests for slice 2a — one in `sifr_hir` and one in `sifr_driver` — and only the `sifr_hir` half landed. The `sifr_driver` half (proving `compile_errors_to_diagnostics` emits the active code rather than the `SIFR-TYPE-0001` legacy bridge when `LoweringError.code` is `Some(_)`) is the test that actually pins the new branch in [crates/sifr_driver/src/frontend/module_lowering.rs:35](../crates/sifr_driver/src/frontend/module_lowering.rs:35) against silent regression. Recommendation: add it before opening the PR.
+
+Everything else is minor polish.
+
+## What was actually delivered (verified by code reading + local rebuild)
+
+| Pre-review slice 2a deliverable | Status | Evidence |
+| --- | --- | --- |
+| `code: Option<DiagnosticCode>` field on `LoweringError` | ✅ | [crates/sifr_hir/src/lower/mod.rs:84-89](../crates/sifr_hir/src/lower/mod.rs:84) |
+| `LowerCtx::error_with_code(code, message)` added alongside legacy `error(message)` | ✅ | [crates/sifr_hir/src/lower/mod.rs:220-231](../crates/sifr_hir/src/lower/mod.rs:220) |
+| Legacy `LowerCtx::error(message)` initialises `code: None` | ✅ | [crates/sifr_hir/src/lower/mod.rs:211-218](../crates/sifr_hir/src/lower/mod.rs:211) |
+| `frontend/module_lowering.rs` branches on `e.code` (Some → `with_code`; None → `new`) | ✅ | [crates/sifr_driver/src/frontend/module_lowering.rs:28-40](../crates/sifr_driver/src/frontend/module_lowering.rs:28) |
+| `stdlib/bootstrap.rs` keeps `STDLIB_BOOTSTRAP_FAILURE` override | ✅ | [crates/sifr_driver/src/stdlib/bootstrap.rs:64-71](../crates/sifr_driver/src/stdlib/bootstrap.rs:64) |
+| `STDLIB_BOOTSTRAP_FAILURE` override has documentation comment | ✅ | same hunk; see R3 below for tightening |
+| HIR test: coded `error_with_code` records `Some(code)` | ✅ | [crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:4-16](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:4) |
+| HIR test: legacy `error` records `None` | ✅ | [crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:18-27](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:18) |
+| `sifr_driver` test: round-trip from `LoweringError { code: Some(_) }` to `CompileError::with_code` ⇒ active code in `to_diagnostic()` | ❌ **missing** | see R1 below |
+| Bridge `CompilePhase::TypeCheck => SIFR-TYPE-0001` left intact | ✅ | [crates/sifr_driver/src/diagnostics.rs:135-140](../crates/sifr_driver/src/diagnostics.rs:135) |
+| 90 fixtures unchanged | ✅ | git diff shows no `crates/sifr/tests/e2e/**` modifications |
+| 23 driver/CLI unit-test occurrences of `SIFR-TYPE-0001` unchanged | ✅ | git diff shows none of those files modified |
+| Pre-implementation review checked-in | ✅ | `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md` is untracked but present |
+| Issue tracker: slice-1 PR link recorded | ✅ | [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34) |
+| Issue tracker: slice-2a status item present | ✅ | [issues/...:35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:35) (unchecked, which is correct for an in-progress slice) |
+| Issue tracker: pre-review pointer | ✅ | [issues/...:37](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:37) |
+| Issue tracker: validation evidence for slice 2a | ✅ | [issues/...:75-82](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:75) |
+| Quick-profile signature unchanged from slice 1 | ✅ | `e1bf653aaa770517` reported, matches slice 1 |
+
+I rebuilt `sifr_hir` in both `dev` and `release` profiles locally (clean build for the latter): both finish without warnings, which confirms the `#[allow(dead_code, reason = "…")]` annotation on `error_with_code` is correctly scoped — without it, a release build would warn (the function has no production caller yet) and clippy would fail the workspace's `-D warnings` gate.
+
+## Answers to the user's review questions
+
+### Q1. Is `Option<DiagnosticCode>` the right additive shape for slice 2a?
+
+**Yes.** It is the only shape that lets slice 2a land as a small additive PR without simultaneously migrating all 489 `LowerCtx::error(...)` call sites. The pre-review ([§"Concrete pre-implementation actions before slice 2a opens", line 228](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md:228)) explicitly recommends `Option` for slice 2a and a tightening to non-`Option` in slice 2c, after every call site is migrated; the implementation matches that recommendation.
+
+The alternative — making `code: DiagnosticCode` non-optional from day one — would force every existing `ctx.error(...)` call site to either pick a code or be temporarily routed through a transitional bucket. Picking a code per site is the correct end state but is the slice 2b workload (489 sites, ~90 fixtures); collapsing into a transitional bucket is exactly the "label-laundering" anti-pattern the issue forbids and which slice 1 just removed. The `Option` shape preserves the correct compile-time behavior of *every existing call site* (they continue to record `code: None`, fall through the bridge arm, and remain `SIFR-TYPE-0001`) while giving 2b sub-PRs a place to plug in active codes one domain at a time.
+
+A subtler reason this is the right shape: with `Option`, the bridge arm in [crates/sifr_driver/src/diagnostics.rs:137](../crates/sifr_driver/src/diagnostics.rs:137) becomes the *exact* signal of "this site has not been migrated yet." Slice 2c's deletion of that arm is then equivalent to the type-system enforcement of "every HIR error carries a code" — which is the issue's [line 863](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:863) "must use an inventory-assigned canonical code … or fail to compile" requirement. The slice plan composes cleanly toward that gate.
+
+### Q2. Is the `#[allow(dead_code)]` allowance on `error_with_code` acceptable as a transitional marker?
+
+**Yes, with caveats.** The allow-attribute is necessary in non-test builds (no production caller exists yet — the function would otherwise trip the workspace's `unused` lints under `-D warnings` for clippy), and the explicit `reason = "diag_4a slice 2a adds transport before per-domain HIR call-site migration"` text makes the transitional intent legible to future readers. I rebuilt `release` locally (no test cfg) and confirmed the function compiles cleanly because of the allow.
+
+Two caveats worth tracking, neither blocking:
+
+- **N7 (auto-removal as a slice-2b reminder).** When the first slice 2b sub-PR migrates a call site to `error_with_code`, the `#[allow(dead_code)]` becomes unnecessary; clippy will warn that the allow is itself unused. The reason text already serves as a passive hint, but a one-line `TODO(diag_4a slice 2b): drop this allow when the first call site migrates` next to the attribute would make the cleanup obligation explicit. Optional polish — not a blocker.
+- **R2 (visibility inconsistency).** `error_with_code` is `pub(super)` while the existing `error` is plain `fn`. The existing `error` is callable from every `lower::*` submodule via Rust's descendant-private access, so plain `fn` is sufficient. Either both should be `pub(super)` or both should be plain `fn`; mixing is a small inconsistency. The minimum-scope and stylistic-parity choice is plain `fn error_with_code`. Not a correctness issue, and the wider visibility does not leak symbols outside the crate (still crate-internal because `LowerCtx` itself is `pub(super)`). Drop `pub(super)` for parity, or accept the wider visibility deliberately.
+
+### Q3. Does module-lowering forwarding preserve behavior for `None` and correctly use active codes for `Some`?
+
+**Yes.** The branch in [crates/sifr_driver/src/frontend/module_lowering.rs:28-40](../crates/sifr_driver/src/frontend/module_lowering.rs:28) is structurally correct:
+
+```rust
+let message = match diagnostic_style {
+    FrontendDiagnosticStyle::Bare => e.message,
+    FrontendDiagnosticStyle::ModulePrefixed => {
+        format!("[{}] {}", module_name, e.message)
+    }
+};
+if let Some(code) = e.code {
+    CompileError::with_code(message, CompilePhase::TypeCheck, code)
+} else {
+    CompileError::new(message, CompilePhase::TypeCheck)
+}
+```
+
+- **None branch** constructs `CompileError::new(...)`, which sets `code: None`. `to_diagnostic()` then falls through to the bridge arm `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` — identical to slice 1 behavior. No fixture, baseline, or driver/CLI test is affected.
+- **Some branch** constructs `CompileError::with_code(_, _, code)`, which sets `code: Some(code)`. `to_diagnostic()` short-circuits at [diagnostics.rs:126-127](../crates/sifr_driver/src/diagnostics.rs:126) and emits `code.code()` — the active inventory string. This is the path that will start carrying production load in slice 2b once HIR call sites migrate to `error_with_code`.
+
+Two transitive checks that this slice gets right by virtue of *not* touching them:
+
+- The test-runner orchestrator path at [crates/sifr_driver/src/test_runner/orchestrator.rs:108-118](../crates/sifr_driver/src/test_runner/orchestrator.rs:108) takes the `Vec<CompileError>` *already produced by* `lower_frontend_module` and re-wraps it; it does not re-classify or strip codes. So whatever code `module_lowering.rs` set is preserved. The pre-review listed this as one of the three forwarding sites; in practice the slice 2a transport plumbing is satisfied without modifying it because the conversion already lives upstream. (See O4 below for a stale-comment nit at this site.)
+- The stdlib path at [crates/sifr_driver/src/stdlib/bootstrap.rs:60-75](../crates/sifr_driver/src/stdlib/bootstrap.rs:60) intentionally collapses to `STDLIB_BOOTSTRAP_FAILURE`; that is the documented override and is the right behavior (see Q4).
+
+### Q4. Is the stdlib bootstrap override documented clearly enough?
+
+**Adequately, but the comment can be tightened.** The current text:
+
+```rust
+// User-facing HIR codes are intentionally collapsed
+// here: stdlib lowering failures are compiler
+// bootstrap failures from the caller's perspective.
+```
+
+This explains the *philosophy* (stdlib is a compiler-internal concern, not a user-facing semantic error). What it does not say explicitly is the *operational* consequence: when slice 2b lands and `e.code` is `Some(SIFR-TYPE-0002)` etc., this site **discards** that code and substitutes `STDLIB_BOOTSTRAP_FAILURE`. A future reader looking at the code will not see `e.code` referenced anywhere in the body, which is the actual signal that the override is happening, but the comment doesn't make the override explicit.
+
+Recommendation (R3, optional polish): tighten to something like:
+
+> Even if `e.code` is `Some(_)`, this collapses to `STDLIB_BOOTSTRAP_FAILURE`: stdlib lowering failures are compiler bootstrap failures from the caller's perspective, not user-facing semantic diagnostics.
+
+The `e.code` mention is the load-bearing piece — it tells a 2b reviewer that this site is a deliberate exception to the "forward HIR code" contract that `lower_frontend_module` follows.
+
+A separate observation: [crates/sifr_driver/src/stdlib/bootstrap.rs:30-31, 48-49](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) already carries `TODO(diag_4a slice 2): classify Ruff parse failures …` markers on the stdlib *parse* failure paths. Those TODOs survive slice 2a unchanged and are correctly scoped (slice 2a does not touch parse classification — that is owned by [milestone_diag_7 line 941-943](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:941) per the pre-review). The stdlib lowering site does not have an analogous TODO because the override is the intended permanent behavior, not a transitional state. Consistent.
+
+### Q5. Is validation sufficient for this no-production-behavior slice?
+
+**Sufficient with one caveat.** The validation budget the pre-review prescribed for slice 2a ([line 239](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md:239)) is exactly:
+
+- `cargo test -p sifr_hir`, `cargo test -p sifr_driver`, `cargo clippy --workspace -- -D warnings`, `scripts/run_all_tests.sh --profile quick`
+- "Quick-profile should match `e1bf653aaa770517` (no behavior change)."
+
+The reported evidence (issue tracker line 75-82) covers:
+
+- `cargo fmt --check` ✅
+- `python3 scripts/check_hir_maintainability_guardrails.py` ✅ (extra, slice-appropriate because the patch adds an HIR test file)
+- `cargo test -p sifr_hir diagnostic_transport_tests` ✅ (subset; see caveat)
+- `cargo test -p sifr_driver` ✅
+- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` ✅ (narrower than the pre-review's `--workspace`; see caveat)
+- `scripts/run_all_tests.sh --profile quick` ✅, signature `e1bf653aaa770517` matches slice 1 — this is the headline evidence that no production behavior changed.
+
+I re-ran `cargo test -p sifr_hir diagnostic_transport_tests`, `cargo test -p sifr_driver`, and `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` locally; all pass. The signature match for `--profile quick` is the single strongest signal for a transport-only slice and is the right gate.
+
+Caveats:
+
+- **The reported `cargo test -p sifr_hir` is filtered to `diagnostic_transport_tests` only.** The user's note about the two unrelated pre-existing HIR assertion failures (`test_empty_dict_literal_conflicting_write_reports_deterministic_error`, `test_empty_list_specialization_optional_append_in_loop_rejects_return_annotation`) explains why a full `cargo test -p sifr_hir` was not the gate. That is acceptable here because (a) those failures reproduce on `origin/main` and are not introduced by this diff, (b) the workspace `--profile quick` lane is the authoritative gate per `AGENTS.md`, and (c) it ran clean. The slice-2a PR description should call this out explicitly so reviewers don't assume the partial filter is hiding new failures: "the two failing HIR tests reproduce on `origin/main` at `<sha>` and are unrelated to this diff; quick-profile is the authoritative gate." Optional but recommended for PR hygiene.
+- **Clippy was run on `-p sifr_hir -p sifr_driver`, not `--workspace`.** That is fine for slice 2a because no other crate changed, but `cargo clippy --workspace -- -D warnings` is cheap and matches the workspace-level lint gate exercised by CI. Recommend running once before opening the PR — should be a no-op given the touched crates, but it is the gate the issue's `AGENTS.md` defaults to.
+
+For a transport-only slice with no fixture or baseline changes, the quick-profile signature match is the load-bearing evidence. Slice 2b PRs will need the full e2e suite (`scripts/run_e2e_pass.sh`) per the pre-review's [§"Validation budget" 2b row](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md:240); slice 2a does not.
+
+## Findings
+
+Severity legend: **R** = recommended before PR opens (test or correctness gap); **O** = optional polish; **N** = note for the PR description or future slice.
+
+### R1. Missing driver-side round-trip test for the new `Some(code)` branch
+
+The pre-review explicitly required ([§"Slice 2a — Transport plumbing", step 4, line 162](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md:162)):
+
+> Add a unit test in `sifr_hir` proving `LoweringError { code: Some(SIFR-TYPE-0002), .. }` round-trips to a `CompileError::with_code`, and a sibling test in `sifr_driver` proving `compile_errors_to_diagnostics` emits the active code (not `SIFR-TYPE-0001`) when `error.code` is `Some(_)`.
+
+The HIR side landed (the two tests in [diagnostic_transport_tests.rs](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs) cover the field-level invariants), but the driver-side counterpart is absent. The HIR tests prove `LowerCtx::error_with_code` populates `LoweringError.code`; they do **not** prove that `lower_frontend_module` correctly forwards that code into a `CompileError::with_code` rather than the legacy `CompileError::new` fallback.
+
+Why this matters concretely: the new branch in [module_lowering.rs:35-39](../crates/sifr_driver/src/frontend/module_lowering.rs:35) is the *only* production code path that this slice changes. Without a unit test exercising both arms (`Some` → `with_code`, `None` → `new`), a future refactor could collapse the branch back to the legacy single-arm form and the whole test suite would still pass — because no migrated HIR call site exists yet to fail integration. The test is cheap (a small synthetic call to `lower_frontend_module` with a hand-crafted source that triggers a known HIR error path is overkill; a more targeted test that constructs a `CompileError` directly from a `LoweringError` is sufficient — but the cleanest version uses the public `lower_frontend_module` entry point).
+
+Recommended shapes (any one suffices):
+
+1. **Targeted unit test in `crates/sifr_driver/src/tests/diagnostics.rs`.** Construct a `CompileError::with_code` with `DiagnosticCode::TYPE_MISMATCH` and assert `to_diagnostic().code == "SIFR-TYPE-0002"` (already covered transitively by `test_compile_errors_to_diagnostics_preserves_order`); and a paired `CompileError::new(_, CompilePhase::TypeCheck)` whose `to_diagnostic().code == "SIFR-TYPE-0001"` (also already covered transitively because the bridge arm is exercised by every legacy site). What is *not* covered today and is the actual missing test is the **`lower_frontend_module` branch decision** — a test that drives a `LoweringError { code: Some(_) }` through `lower_frontend_module` and asserts the resulting `CompileError` carries `code: Some(_)`, plus a sibling `LoweringError { code: None }` case asserting the resulting `CompileError` carries `code: None`. This is a `crates/sifr_driver/src/frontend/module_lowering.rs` `#[cfg(test)]` test or a sibling in `crates/sifr_driver/src/tests/`.
+2. **End-to-end-ish test using a real HIR error site that already exists.** Pick any current `ctx.error(...)` site (still produces `code: None`) and any test source that triggers it; assert the `to_diagnostic().code == "SIFR-TYPE-0001"` (the legacy fallback is alive). For the `Some` arm, *temporarily* call `error_with_code` from within a test-only scaffolding helper. This is heavier than option 1 and probably not worth it for slice 2a.
+
+Option 1 is the smaller, slice-2a-appropriate choice. The literal one-line behavior to pin is "`if let Some(code) = e.code` correctly routes to `with_code`" — anything that mechanically asserts that is sufficient.
+
+### R2. Visibility inconsistency between `error` and `error_with_code`
+
+[crates/sifr_hir/src/lower/mod.rs:211 vs 220-224](../crates/sifr_hir/src/lower/mod.rs:211)
+
+```rust
+fn error(&mut self, message: String) { ... }                         // crate-private + descendant access
+
+#[allow(dead_code, reason = "...")]
+pub(super) fn error_with_code(&mut self, code: DiagnosticCode, message: String) { ... }
+```
+
+`pub(super)` from `lower::mod.rs` widens the visibility to `sifr_hir`'s root module, while `fn error` (no qualifier) is private to `lower` with the usual descendant-access carve-out — that's why every `lower::*` submodule can call `ctx.error(...)`. Both forms reach the same set of slice-2b call sites (which all live under `lower::*`).
+
+Two ways to fix:
+
+- **Drop `pub(super)`** to plain `fn error_with_code` for parity with the existing `error`. This is the minimum-scope choice and matches the existing codebase style. **Recommended.**
+- Keep `pub(super)` and *also* widen `error` to `pub(super)` in a same-PR consistency pass. Bigger blast radius for a stylistic fix; not recommended for slice 2a.
+
+This is a style-and-consistency finding, not a correctness one. The wider visibility does not leak symbols outside the crate (`LowerCtx` is `pub(super)`).
+
+### O3. Stdlib override comment can be tightened
+
+[crates/sifr_driver/src/stdlib/bootstrap.rs:64-66](../crates/sifr_driver/src/stdlib/bootstrap.rs:64)
+
+The current comment explains why stdlib lowering errors collapse to `STDLIB_BOOTSTRAP_FAILURE` (philosophy: stdlib is bootstrap, not user-facing). It does not state explicitly that `e.code` is discarded. When slice 2b lands and HIR call sites start emitting structured codes for stdlib lowering errors, a 2b reviewer reading this site will see no reference to `e.code` at all and may wonder whether the omission is a bug.
+
+Recommended tightening:
+
+> Even if `e.code` is `Some(_)`, this collapses to `STDLIB_BOOTSTRAP_FAILURE`: stdlib lowering failures are compiler bootstrap failures from the caller's perspective, not user-facing semantic diagnostics.
+
+The "Even if `e.code` is `Some(_)`" clause is the load-bearing addition.
+
+Optional. The current comment is already adequate as transitional documentation.
+
+### O4. Stale comment in test_runner/orchestrator.rs
+
+[crates/sifr_driver/src/test_runner/orchestrator.rs:113-115](../crates/sifr_driver/src/test_runner/orchestrator.rs:113)
+
+```rust
+// Preserves None until HIR LoweringError carries a
+// structured code in the next diag_4a slice.
+code: error.code,
+```
+
+This comment was written in slice 1 to document a forward-reference to slice 2. Slice 2a now lands the *plumbing* but no production HIR call site emits a code yet — that is slice 2b. So strictly the comment is still accurate (the field is still typically `None` for production paths), but the phrase "the next diag_4a slice" is now ambiguous: slice 2a *is* the next slice and it did add the plumbing but didn't fill in any active codes. A 2b reviewer reading this might misinterpret it.
+
+Recommended phrasing (optional polish):
+
+> Forwards `LoweringError.code` faithfully — `None` for legacy unmigrated call sites, `Some(_)` once HIR call sites migrate in upcoming slice 2b sub-PRs.
+
+Slice 2a does not need to repaint this comment, but a one-line touch-up here is a low-cost win and keeps the slice-2a PR scope honest about what changed in adjacent files.
+
+### O5. Wall-time variance in `--profile quick`
+
+Slice 1 reported `79.70s`; slice 2a reports `131.56s` for the same `e1bf653aaa770517` signature. The signature match is the load-bearing assertion (no production behavior change); the wall-time delta is environmental (machine load, cold artifact cache, parallel jobs). Worth a one-line PR-description note ("wall-time variance is environmental; signature is the gate") so reviewers don't read the 65% wall-time jump as a regression.
+
+### N6. Issue tracker checkbox state for slice 2a
+
+[issues/...:35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:35) reads:
+
+```
+- [ ] Started `milestone_diag_4a` slice 2a: additive HIR `LoweringError` structured diagnostic-code transport plumbing.
+```
+
+This is the right state for an in-progress slice. Slice 1's bullet at line 34 is `[x]` with merged-PR link; slice 2a should follow the same pattern once merged. Just a note: when the slice 2a PR opens, leave the bullet `[ ]` until merge; on merge, flip to `[x]` and append `PR: https://github.com/sifr-lang/sifr/pull/<n>.` Consistent with the slice-1 bullet style.
+
+The deferred-bridge-deletion bullet at line 36 is now `[x]` with the rationale "deferred to later milestone_diag_4a slice-2 sub-PRs, where HIR call sites will be migrated by domain before the bridge is removed." That is correct framing and matches the pre-review's three-sub-slice plan.
+
+### N7. The `#[allow(dead_code)]` becomes redundant in the first slice 2b sub-PR
+
+When slice 2b's first migration PR (decimal, per the pre-review's recommended ordering) lands, `error_with_code` will gain a production caller and the `#[allow]` will be unused. Clippy's `unused_attributes` will flag it. Slice 2b's first sub-PR should remove the attribute as part of the same diff. A passive `TODO(diag_4a slice 2b): drop this allow when the first call site migrates` next to the attribute would make the obligation explicit; the current `reason = "diag_4a slice 2a adds transport before per-domain HIR call-site migration"` already implies it but is not as actionable. Optional polish; not a blocker.
+
+## Scope discipline check
+
+The slice does **not** do any of the things the pre-review flagged as out-of-scope for slice 2a:
+
+- ✅ No HIR call sites migrated (489 sites untouched).
+- ✅ No fixtures re-keyed (~90 untouched).
+- ✅ No verification baselines re-keyed (2 untouched).
+- ✅ No driver/CLI hard-coded `"SIFR-TYPE-0001"` test occurrences re-keyed (23 untouched).
+- ✅ No bridge arm deleted (`CompilePhase::TypeCheck => "SIFR-TYPE-0001"` still live).
+- ✅ No legacy `CompileError::new` removal.
+- ✅ No `LoweringError → LoweringOutcome/DiagnosticSink` migration (separate slice 2d per pre-review).
+- ✅ No parser bucket splitting (owned by `milestone_diag_7`).
+- ✅ No decimal `[E25xx]` removal from message templates (owned by `milestone_diag_6`; slice 2a only adds the *transport* shape).
+- ✅ No centralized message-prefix dispatcher reintroduced (slice 1's R5 regression-guard test at [crates/sifr_driver/src/tests/diagnostics.rs:71-81](../crates/sifr_driver/src/tests/diagnostics.rs:71) is unchanged).
+
+The patch surface is exactly the four files the pre-review's slice 2a section specified, plus the issue tracker and the new HIR test module. No incidental refactors, no commented-out code, no introduced abstractions. This is the right size for a slice-2a PR (~30-line diff in the production source plus the test module).
+
+## Readiness
+
+The slice is ready to ship as a small slice-2a PR after addressing **R1** (the missing driver-side round-trip test). Without R1, a future change to `lower_frontend_module` could silently regress code-forwarding because no unit test exercises the new branch. R2 (visibility inconsistency) is recommended for stylistic parity but does not affect correctness; O3, O4, O5, N6, N7 are polish.
+
+Suggested PR description bullets:
+
+- Adds `Option<DiagnosticCode>` transport to `sifr_hir::LoweringError`, additive `LowerCtx::error_with_code`, and forwarding in `frontend/module_lowering.rs`. No production HIR call sites migrate yet; that is slice 2b.
+- `STDLIB_BOOTSTRAP_FAILURE` override for stdlib lowering errors is preserved by design; documented inline.
+- Quick-profile signature `e1bf653aaa770517` matches slice 1, confirming no production behavior change.
+- The two pre-existing HIR assertion failures (`test_empty_dict_literal_conflicting_write_reports_deterministic_error`, `test_empty_list_specialization_optional_append_in_loop_rejects_return_annotation`) reproduce on `origin/main` and are not introduced by this diff; the authoritative gate is `scripts/run_all_tests.sh --profile quick`.
+
+Suggested follow-up scoping (re-asserts the pre-review's three-sub-slice plan):
+
+- Slice 2b: per-domain migration of `LowerCtx::error → error_with_code`, ordered decimal → ownership/flow/match/result → class/protocol/import → call/tuple/container/annotation → type/name. Each domain sub-PR re-keys its fixtures and runs the full e2e suite.
+- Slice 2c: delete `LowerCtx::error` (codeless overload) and `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge arm; tighten `CompileError.code` to non-`Option` if parse/codegen/build paths are coded by then; re-key the 2 verification baselines and 23 driver/CLI unit-test occurrences; add the "bridge is gone" regression test.
+
+## Summary
+
+Slice 2a is a tight, scope-disciplined transport-plumbing slice that lands exactly the data-structure changes the pre-implementation review prescribed for sub-slice 2a, with the stdlib override correctly preserved and an explicit dead-code allowance making the additive nature visible. Quick-profile signature parity with slice 1 confirms no production behavior change, which is the correct guarantee for this slice. The single material gap is the absent driver-side round-trip test (R1) for the new `Some(_) → CompileError::with_code` forwarding branch — adding it before the PR opens closes the regression-guard hole and brings the test surface fully in line with the pre-review's spec. Beyond that, R2 (visibility inconsistency), O3 (stdlib comment tightening), O4 (stale orchestrator comment), O5 (wall-time PR note), N6 (issue checkbox flip on merge), and N7 (TODO next to the dead-code allow) are minor polish that the implementer can address inline or defer.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md
@@ -1,0 +1,185 @@
+# Review: milestone_diag_4a — Slice 2a Transport Plumbing (Pass 2)
+
+Branch: `codex/semantic-diagnostics-diag-4a-slice2` (working tree on top of `10129970`, the slice 1 merge)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md)
+
+## Verdict
+
+**Ready to ship as the slice 2a PR.** Every actionable pass-1 finding (R1, R2, O3, O4, N7) is closed by a focused, in-place change. No new findings have surfaced. Quick-profile signature continues to match `e1bf653aaa770517` (slice 1 baseline), which is the correct guarantee for a transport-only slice that intentionally produces no production behavior change. The patch surface stays tight to the slice 2a scope from the pre-implementation review: `Option<DiagnosticCode>` on `LoweringError`, additive `error_with_code` helper, conversion-site forwarding in `lower_frontend_module`, `STDLIB_BOOTSTRAP_FAILURE` override preserved, no fixture re-keying, no bridge deletion, no HIR call-site migration.
+
+## Pass-1 finding closure
+
+Severity legend reused from pass 1: **R** = recommended before PR opens (correctness/test gap); **O** = optional polish; **N** = note.
+
+### R1 — Driver-side round-trip test for the `Some(_) → with_code` branch
+
+**Closed.** Two new tests under `crates/sifr_driver/src/frontend/module_lowering.rs::tests` exercise the production branch decision in `lowering_error_to_compile_error`:
+
+- [`coded_lowering_error_uses_active_diagnostic_code`](../crates/sifr_driver/src/frontend/module_lowering.rs:78) — feeds `LoweringError { code: Some(DiagnosticCode::TYPE_MISMATCH), .. }` through the helper with `FrontendDiagnosticStyle::Bare`, then asserts (a) `compile_error.code == Some(TYPE_MISMATCH)`, (b) `compile_error.to_diagnostic().code == "SIFR-TYPE-0002"`, and (c) the rendered URL is `https://sifr.sh/docs/errors/SIFR-TYPE-0002`. The triple assertion pins both the in-process state and the public-facing identity emitted by `to_diagnostic()`.
+- [`codeless_lowering_error_preserves_legacy_bridge`](../crates/sifr_driver/src/frontend/module_lowering.rs:91) — feeds `LoweringError { code: None, .. }` through the helper with `FrontendDiagnosticStyle::ModulePrefixed`, then asserts (a) `compile_error.code == None`, (b) `compile_error.message == "[main] expected int, got str"` (proving the prefix path was taken), and (c) `compile_error.to_diagnostic().code == "SIFR-TYPE-0001"` (proving the legacy bridge is still alive when no code is attached).
+
+Two design choices in the patch make these tests reliable:
+
+1. **The branch arm is now an extracted helper.** `lower_frontend_module` no longer constructs `CompileError` inline; it calls `lowering_error_to_compile_error(module_name, diagnostic_style, error)` ([crates/sifr_driver/src/frontend/module_lowering.rs:36-52](../crates/sifr_driver/src/frontend/module_lowering.rs:36)). The extraction is purely refactor-grade — the body is byte-equivalent to the previous inline expression — but it isolates the branch decision into a small pure function the unit tests can call without standing up an AST or a real lowering pipeline. This is a reasonable substitute for the pass-1 R1 wording "drive a `LoweringError { code: Some(_) }` through `lower_frontend_module`": the branch decision *is* `lowering_error_to_compile_error`, so testing it directly proves the only behavior that slice 2a actually changes.
+2. **Both arms exercise complementary diagnostic styles.** Test 1 uses `Bare`; test 2 uses `ModulePrefixed`. Together they prove the formatting branch and the code-forwarding branch are independent — a future refactor that, for example, accidentally moved code-forwarding under one style would fail one of the two tests.
+
+The pass-1 R1 concern was that *no* test pinned the new branch in [crates/sifr_driver/src/frontend/module_lowering.rs:47-51](../crates/sifr_driver/src/frontend/module_lowering.rs:47) against silent regression. After this patch, both arms (`Some` and `None`) are pinned, the rendered code string is asserted (so a future change to the `code.code()` mapping would surface here too), and both diagnostic styles are exercised. R1 is fully closed.
+
+A minor stylistic observation that is *not* a finding: the test helper `lowering_error(code, message)` ([module_lowering.rs:69-76](../crates/sifr_driver/src/frontend/module_lowering.rs:69)) constructs `LoweringError` via the public field syntax. This works because `LoweringError`'s fields are `pub` ([crates/sifr_hir/src/lower/mod.rs:84-89](../crates/sifr_hir/src/lower/mod.rs:84)). That is also true for the `lib.rs` re-export at [crates/sifr_hir/src/lib.rs:19](../crates/sifr_hir/src/lib.rs:19). No encapsulation is being violated.
+
+### R2 — Visibility inconsistency between `error` and `error_with_code`
+
+**Closed.** [crates/sifr_hir/src/lower/mod.rs:226](../crates/sifr_hir/src/lower/mod.rs:226) now reads `fn error_with_code(&mut self, code: DiagnosticCode, message: String)` (plain `fn`, no `pub(super)`). This matches the existing `fn error(&mut self, message: String)` at [crates/sifr_hir/src/lower/mod.rs:211](../crates/sifr_hir/src/lower/mod.rs:211).
+
+I verified that the descendant-private access still works for the new test module: `crates/sifr_hir/src/lower/diagnostic_transport_tests.rs` is declared as `mod diagnostic_transport_tests;` at [crates/sifr_hir/src/lower/mod.rs:247](../crates/sifr_hir/src/lower/mod.rs:247) and uses `super::LowerCtx`, so it sees the private `error_with_code` method via the standard parent-private/descendant-access carve-out. The wider `pub(super)` was unnecessary and is now correctly dropped.
+
+### O3 — Stdlib override comment tightening
+
+**Closed.** [crates/sifr_driver/src/stdlib/bootstrap.rs:64-67](../crates/sifr_driver/src/stdlib/bootstrap.rs:64) now reads:
+
+```rust
+// Even if `e.code` is `Some(_)`, stdlib lowering
+// failures collapse to bootstrap failures from the
+// caller's perspective, not user-facing semantic
+// diagnostics.
+```
+
+The "Even if `e.code` is `Some(_)`" clause is the load-bearing addition that pass-1 O3 specifically called for: it makes the override visible to a future slice 2b reviewer who would otherwise see `e.code` referenced nowhere in the body and wonder whether the omission is a bug. The comment now explains *both* the philosophy (stdlib is bootstrap, not user-facing) and the operational consequence (any HIR-emitted code is intentionally discarded). Good.
+
+### O4 — Stale `next diag_4a slice` comment in test_runner/orchestrator.rs
+
+**Closed.** [crates/sifr_driver/src/test_runner/orchestrator.rs:113-115](../crates/sifr_driver/src/test_runner/orchestrator.rs:113) now reads:
+
+```rust
+// Forwards `LoweringError.code` faithfully: `None`
+// for legacy call sites and `Some(_)` after upcoming
+// diag_4a slice-2b migrations.
+```
+
+The slice-2 ambiguity that pass-1 O4 flagged ("the next diag_4a slice" was unclear once 2a *was* the next slice) is resolved: the new wording explicitly names slice 2b as the migration milestone for active codes, while accurately describing the current behavior (faithful pass-through, with `None` predominating today). This is exactly the rephrasing pass-1 O4 suggested.
+
+### N7 — TODO next to the dead-code allow
+
+**Closed.** [crates/sifr_hir/src/lower/mod.rs:220-225](../crates/sifr_hir/src/lower/mod.rs:220) now carries:
+
+```rust
+// TODO(diag_4a slice 2b): remove this allow when the first domain
+// migration calls `error_with_code`.
+#[allow(
+    dead_code,
+    reason = "diag_4a slice 2a adds transport before per-domain HIR call-site migration"
+)]
+fn error_with_code(&mut self, code: DiagnosticCode, message: String) {
+```
+
+The TODO line names the cleanup obligation explicitly and ties it to the same `(diag_4a slice 2b)` marker used elsewhere in the codebase (e.g. [crates/sifr_driver/src/stdlib/bootstrap.rs:30](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) and [crates/sifr_driver/src/stdlib/bootstrap.rs:48](../crates/sifr_driver/src/stdlib/bootstrap.rs:48)). When the first slice 2b sub-PR migrates a `LowerCtx::error` site to `error_with_code`, the function will gain a production caller and clippy will start warning that the `#[allow]` is unused; the TODO makes it obvious that the attribute should be deleted in the same diff. This matches pass-1 N7 word-for-word.
+
+### Pass-1 findings tracked but not requiring code changes
+
+- **O5 — Wall-time variance.** Pass 1 noted the ~65% wall-time jump (79.70s → 131.56s) and recommended a one-line PR-description note. The validation table now reports `wall_time=86.73s`, which is only ~9% above slice 1 — well within environmental noise. The signature match is unchanged at `e1bf653aaa770517`, which is the load-bearing assertion for a transport-only slice. No PR-description hygiene action is necessary because the wall-time delta is no longer surprising.
+- **N6 — Issue-tracker checkbox state.** [issues/...:35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:35) is correctly `[ ]` for an in-progress slice; the merged-PR pattern from slice 1 ([issues/...:34](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34)) is the right template for the post-merge update. No code change required pre-merge.
+
+## Independent re-verification
+
+I read the working-tree state of every touched file and confirmed:
+
+| Pre-review slice 2a deliverable | Status | Evidence |
+| --- | --- | --- |
+| `code: Option<DiagnosticCode>` field on `LoweringError` | ✅ | [crates/sifr_hir/src/lower/mod.rs:84-89](../crates/sifr_hir/src/lower/mod.rs:84) |
+| `LowerCtx::error_with_code` added alongside legacy `error` (parity-styled `fn`) | ✅ | [crates/sifr_hir/src/lower/mod.rs:226-233](../crates/sifr_hir/src/lower/mod.rs:226) |
+| Legacy `LowerCtx::error(message)` initialises `code: None` | ✅ | [crates/sifr_hir/src/lower/mod.rs:211-218](../crates/sifr_hir/src/lower/mod.rs:211) |
+| `frontend/module_lowering.rs` branches on `error.code` (Some → `with_code`; None → `new`) | ✅ | [crates/sifr_driver/src/frontend/module_lowering.rs:47-51](../crates/sifr_driver/src/frontend/module_lowering.rs:47) (now extracted into `lowering_error_to_compile_error`) |
+| `stdlib/bootstrap.rs` keeps `STDLIB_BOOTSTRAP_FAILURE` override and documents it | ✅ | [crates/sifr_driver/src/stdlib/bootstrap.rs:60-77](../crates/sifr_driver/src/stdlib/bootstrap.rs:60) |
+| `test_runner/orchestrator.rs` forwards `error.code` and the comment is current | ✅ | [crates/sifr_driver/src/test_runner/orchestrator.rs:108-119](../crates/sifr_driver/src/test_runner/orchestrator.rs:108) |
+| HIR test: coded `error_with_code` records `Some(code)` | ✅ | [crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:4-16](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:4) |
+| HIR test: legacy `error` records `None` | ✅ | [crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:18-27](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs:18) |
+| Driver test: `Some(_) → CompileError::with_code → "SIFR-TYPE-0002"` | ✅ | [crates/sifr_driver/src/frontend/module_lowering.rs:78-89](../crates/sifr_driver/src/frontend/module_lowering.rs:78) |
+| Driver test: `None → CompileError::new → "SIFR-TYPE-0001"` (legacy bridge alive) | ✅ | [crates/sifr_driver/src/frontend/module_lowering.rs:91-102](../crates/sifr_driver/src/frontend/module_lowering.rs:91) |
+| Bridge `CompilePhase::TypeCheck => SIFR-TYPE-0001` left intact | ✅ | [crates/sifr_driver/src/diagnostics.rs:135-140](../crates/sifr_driver/src/diagnostics.rs:135) |
+| 90 fixtures unchanged | ✅ | git diff shows no `crates/sifr/tests/e2e/**` modifications |
+| 23 driver/CLI unit-test occurrences of `SIFR-TYPE-0001` unchanged | ✅ | git diff shows none of those files modified |
+| Issue tracker: slice-1 PR link recorded | ✅ | [issues/...:34](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:34) |
+| Issue tracker: slice-2a status item present (correctly `[ ]`) | ✅ | [issues/...:35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:35) |
+| Issue tracker: slice-2 pre-review pointer | ✅ | [issues/...:37](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:37) |
+| Issue tracker: slice-2a in-progress review pointer | ✅ | [issues/...:38](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:38) |
+| Issue tracker: slice 2a validation evidence block | ✅ | [issues/...:76-84](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:76) |
+| Quick-profile signature still `e1bf653aaa770517` | ✅ | reported and matches slice 1 |
+
+Patch shape (`git diff --stat` on the working tree):
+
+```
+crates/sifr_driver/src/frontend/module_lowering.rs   | 74 +++++++++++++++--
+crates/sifr_driver/src/stdlib/bootstrap.rs           |  4 +
+crates/sifr_driver/src/test_runner/orchestrator.rs   |  5 +-
+crates/sifr_hir/src/lower/mod.rs                     | 21 +++++
+issues/ad-hoc-semantic-diagnostic-code-taxonomy-...  | 17 +++-
++ crates/sifr_hir/src/lower/diagnostic_transport_tests.rs  (new, 27 lines)
+```
+
+This is the right size for slice 2a: ~30 production-source lines (additive transport + extraction) plus two small test modules. No incidental refactors, no commented-out code, no introduced abstractions outside the test surface, no new public API on `sifr_hir` or `sifr_driver` beyond the additive transport requested by the pre-review.
+
+## Scope discipline check
+
+The patch still does **not** do any of the things the pre-review flagged as out-of-scope for slice 2a:
+
+- ✅ No HIR call sites migrated (489 sites untouched — `git grep "ctx.error(" crates/sifr_hir/src/lower/` returns the same hit count as slice 1).
+- ✅ No fixtures re-keyed (~90 untouched).
+- ✅ No verification baselines re-keyed (2 untouched).
+- ✅ No driver/CLI hard-coded `"SIFR-TYPE-0001"` test occurrences re-keyed (23 untouched).
+- ✅ No bridge arm deleted (`CompilePhase::TypeCheck => "SIFR-TYPE-0001"` still live at [crates/sifr_driver/src/diagnostics.rs:137](../crates/sifr_driver/src/diagnostics.rs:137)).
+- ✅ No legacy `CompileError::new` removal.
+- ✅ No `LoweringError → LoweringOutcome/DiagnosticSink` migration (separate slice 2d per pre-review).
+- ✅ No parser bucket splitting (owned by `milestone_diag_7`).
+- ✅ No decimal `[E25xx]` removal from message templates (owned by `milestone_diag_6`).
+- ✅ No centralized message-prefix dispatcher reintroduced — the slice 1 R5 regression-guard test at [crates/sifr_driver/src/tests/diagnostics.rs:71-81](../crates/sifr_driver/src/tests/diagnostics.rs:71) is unchanged.
+
+The one structural change pass 2 added is purely refactor-grade: extracting `lowering_error_to_compile_error` from the inline `Err` arm of `lower_frontend_module`. That extraction is a direct precondition of the new R1 tests (an inline closure cannot be reached by a unit test) and the resulting helper is byte-equivalent to the previous inline code path. No behavior change.
+
+## Validation evidence (mirrors the issue tracker, signature is the gate)
+
+| Gate | Result | Notes |
+| --- | --- | --- |
+| `cargo fmt --check` | ✅ | clean |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | ✅ | new HIR test file is small (27 lines); within guardrails |
+| `cargo test -p sifr_hir diagnostic_transport_tests` | ✅ | both new HIR tests pass |
+| `cargo test -p sifr_driver frontend::module_lowering::tests` | ✅ | both new driver tests pass |
+| `cargo test -p sifr_driver` | ✅ | full driver suite green |
+| `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` | ✅ | dead-code allow remains correctly scoped; no other lints surface |
+| `scripts/run_all_tests.sh --profile quick` | ✅ | report signature `e1bf653aaa770517` (matches slice 1), wall time `86.73s` |
+
+The signature parity is the load-bearing evidence for a transport-only slice that intentionally produces no production behavior change. Slice 2b PRs will need the full e2e suite (`scripts/run_e2e_pass.sh`) once HIR call sites start emitting active codes; slice 2a does not.
+
+Two narrowing caveats from pass 1 still apply to the reported gates and remain acceptable:
+
+- `cargo test -p sifr_hir` is filtered to `diagnostic_transport_tests` because of two unrelated pre-existing HIR assertion failures (`test_empty_dict_literal_conflicting_write_reports_deterministic_error`, `test_empty_list_specialization_optional_append_in_loop_rejects_return_annotation`) that reproduce on `origin/main`. The quick-profile signature match is the authoritative gate per `AGENTS.md`. Worth a one-line PR-description note ("two unrelated HIR test failures reproduce on `origin/main`; quick-profile is the authoritative gate") so reviewers don't misread the filter.
+- Clippy was run on `-p sifr_hir -p sifr_driver` rather than `--workspace`. That is fine for this slice because no other crate changed, but `cargo clippy --workspace -- -D warnings` is cheap and matches the workspace-level lint gate that CI will exercise. Recommend running once before opening the PR — should be a no-op given the touched crates, but it is the gate the issue's `AGENTS.md` defaults to. *Not a blocker.*
+
+## Remaining blockers
+
+**None.** All pass-1 R/O/N findings are closed in code or correctly deferred to PR-description hygiene. No new findings have surfaced from re-reading the working tree.
+
+## Recommendation
+
+Open the slice 2a PR. Suggested PR-description bullets (carried forward from pass 1, refreshed):
+
+- Adds `Option<DiagnosticCode>` transport to `sifr_hir::LoweringError`, additive `LowerCtx::error_with_code` (private, parity with `error`), and forwarding in `frontend/module_lowering.rs` via the new `lowering_error_to_compile_error` helper. No production HIR call sites migrate yet; that is slice 2b.
+- `STDLIB_BOOTSTRAP_FAILURE` override for stdlib lowering errors is preserved by design and explicitly documented; an HIR-emitted `Some(_)` code is intentionally discarded at this site.
+- Quick-profile signature `e1bf653aaa770517` matches slice 1, confirming no production behavior change. Wall-time `86.73s` is within environmental noise.
+- Test surface: two HIR-side tests (`error_with_code` writes `Some(code)`, legacy `error` writes `None`) plus two driver-side tests (`Some(_)` arm renders `SIFR-TYPE-0002`, `None` arm renders the bridge `SIFR-TYPE-0001`) pin the new branch decision.
+- Unrelated pre-existing HIR test failures (`test_empty_dict_literal_conflicting_write_reports_deterministic_error`, `test_empty_list_specialization_optional_append_in_loop_rejects_return_annotation`) reproduce on `origin/main` and are not introduced by this diff; quick-profile is the authoritative gate.
+
+Suggested follow-up scoping (re-asserts the pre-review's three-sub-slice plan):
+
+- Slice 2b: per-domain migration of `LowerCtx::error → error_with_code`, ordered decimal → ownership/flow/match/result → class/protocol/import → call/tuple/container/annotation → type/name. Each domain sub-PR re-keys its fixtures and runs the full e2e suite. The first 2b sub-PR also drops the `#[allow(dead_code)]` and the `TODO(diag_4a slice 2b)` marker on `error_with_code` once the function gains a production caller.
+- Slice 2c: delete `LowerCtx::error` (codeless overload) and `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge arm; tighten `CompileError.code` to non-`Option` if parse/codegen/build paths are coded by then; re-key the 2 verification baselines and 23 driver/CLI unit-test occurrences; add the "bridge is gone" regression test.
+
+## Summary
+
+Slice 2a converged in two review passes. The pass-1 R1 gap (missing driver-side round-trip test for the new `Some(_) → with_code` branch) is closed by a clean refactor of the conversion logic into `lowering_error_to_compile_error` plus two paired unit tests that assert both the in-process `CompileError.code` and the rendered `to_diagnostic().code` for both arms, across both diagnostic styles. R2 (visibility), O3 (stdlib comment), O4 (orchestrator comment), and N7 (TODO marker) are all closed in place with the wording pass 1 specifically suggested. Quick-profile signature parity with slice 1 (`e1bf653aaa770517`) confirms no production behavior change, scope discipline holds (no fixture re-keying, no bridge deletion, no call-site migration, no centralized prefix dispatcher), and the patch surface remains small enough for a focused slice-2a PR. No blockers remain.


### PR DESCRIPTION
## Summary

- Add optional `DiagnosticCode` transport to `sifr_hir::LoweringError` and additive `LowerCtx::error_with_code` plumbing for later HIR domain migrations.
- Forward coded HIR lowering errors through driver module lowering with `CompileError::with_code`, while preserving the legacy `SIFR-TYPE-0001` bridge for codeless errors.
- Keep stdlib lowering failures collapsed to `STDLIB_BOOTSTRAP_FAILURE` by design and document that override.
- Record slice 1 merge status, slice 2a review rounds, and validation evidence in the phase issue.

No production HIR call sites migrate in this PR; fixture re-keying and bridge deletion are deferred to the slice-2b/2c PRs recommended by the review.

## Validation

- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr_hir diagnostic_transport_tests`
- `cargo test -p sifr_driver frontend::module_lowering::tests`
- `cargo test -p sifr_driver`
- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=86.73s`)

Note: full `cargo test -p sifr_hir` still has two unrelated HIR assertion failures that reproduce outside this diff; the quick lane is the authoritative local gate.

## Reviews

- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md`
