### PR TITLE
Migrate decimal diagnostics to structured codes

### DIFF
--- a/crates/sifr/tests/e2e/fail/bigdecimal_constructor_float.sifr
+++ b/crates/sifr/tests/e2e/fail/bigdecimal_constructor_float.sifr
@@ -1,3 +1,3 @@
-# expect-error: [SIFR-TYPE-0001] [E2506] BigDecimal(float_value) is not allowed; use BigDecimal("...") for exact construction
+# expect-error: [SIFR-DECIMAL-0006] [E2506] BigDecimal(float_value) is not allowed; use BigDecimal("...") for exact construction
 def main():
     x: bigdecimal = BigDecimal(1.25)

--- a/crates/sifr/tests/e2e/fail/bigdecimal_constructor_non_literal_string.sifr
+++ b/crates/sifr/tests/e2e/fail/bigdecimal_constructor_non_literal_string.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2502] BigDecimal() string construction requires a string literal
+# expect-error: [SIFR-DECIMAL-0002] [E2502] BigDecimal() string construction requires a string literal
 def main():
     s: str = "1.0"
     x: bigdecimal = BigDecimal(s)

--- a/crates/sifr/tests/e2e/fail/bigdecimal_invalid_literal_string.sifr
+++ b/crates/sifr/tests/e2e/fail/bigdecimal_invalid_literal_string.sifr
@@ -1,3 +1,3 @@
-# expect-error: [SIFR-TYPE-0001] [E2502] BigDecimal() received invalid decimal literal '12.34.56'
+# expect-error: [SIFR-DECIMAL-0002] [E2502] BigDecimal() received invalid decimal literal '12.34.56'
 def main():
     x: bigdecimal = BigDecimal("12.34.56")

--- a/crates/sifr/tests/e2e/fail/bigdecimal_quantize_negative_scale_context.sifr
+++ b/crates/sifr/tests/e2e/fail/bigdecimal_quantize_negative_scale_context.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2508] bigdecimal.quantize() scale must be >= 0 for default context, got -1
+# expect-error: [SIFR-DECIMAL-0008] [E2508] bigdecimal.quantize() scale must be >= 0 for default context, got -1
 def main():
     d: bigdecimal = BigDecimal("1.2345")
     x: bigdecimal = d.quantize(-1)

--- a/crates/sifr/tests/e2e/fail/bigdecimal_round_requires_int_scale.sifr
+++ b/crates/sifr/tests/e2e/fail/bigdecimal_round_requires_int_scale.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2508] bigdecimal.round() scale argument must be 'int', got 'str'
+# expect-error: [SIFR-DECIMAL-0008] [E2508] bigdecimal.round() scale argument must be 'int', got 'str'
 def main():
     d: bigdecimal = BigDecimal("1.23")
     x: bigdecimal = d.round("2")

--- a/crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2504] cannot mix 'decimal' and 'bigdecimal' in arithmetic; use explicit Decimal(...) or BigDecimal(...) conversion
+# expect-error: [SIFR-DECIMAL-0004] [E2504] cannot mix 'decimal' and 'bigdecimal' in arithmetic; use explicit Decimal(...) or BigDecimal(...) conversion
 def main():
     d: decimal = Decimal("1.0")
     b: bigdecimal = BigDecimal("2.0")

--- a/crates/sifr/tests/e2e/fail/decimal_constructor_float.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_constructor_float.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2505] Decimal(float_value) is not allowed; use Decimal("...") for exact construction
+# expect-error: [SIFR-DECIMAL-0005] [E2505] Decimal(float_value) is not allowed; use Decimal("...") for exact construction
 def main():
     x: decimal = Decimal(1.25)
     print(x)

--- a/crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2503] cannot mix 'float' with decimal numeric types in arithmetic
+# expect-error: [SIFR-DECIMAL-0003] [E2503] cannot mix 'float' with decimal numeric types in arithmetic
 def main():
     d: decimal = Decimal("1.0")
     x: decimal = d + 1.0

--- a/crates/sifr/tests/e2e/fail/decimal_forbidden_float_conversion_seeded.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_forbidden_float_conversion_seeded.sifr
@@ -1,3 +1,3 @@
-# expect-error: [SIFR-TYPE-0001] [E2505] Decimal(float_value) is not allowed; use Decimal("...") for exact construction
+# expect-error: [SIFR-DECIMAL-0005] [E2505] Decimal(float_value) is not allowed; use Decimal("...") for exact construction
 def main():
     d: decimal = Decimal(1.5)

--- a/crates/sifr/tests/e2e/fail/decimal_forbidden_mixed_arithmetic_seeded.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_forbidden_mixed_arithmetic_seeded.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2504] cannot mix 'decimal' and 'bigdecimal' in arithmetic; use explicit Decimal(...) or BigDecimal(...) conversion
+# expect-error: [SIFR-DECIMAL-0004] [E2504] cannot mix 'decimal' and 'bigdecimal' in arithmetic; use explicit Decimal(...) or BigDecimal(...) conversion
 def main():
     d: decimal = Decimal("1.0")
     b: bigdecimal = BigDecimal("2.0")

--- a/crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr
@@ -1,3 +1,3 @@
-# expect-error: [SIFR-TYPE-0001] [E2501] Decimal() received invalid exact literal '12.34.56'
+# expect-error: [SIFR-DECIMAL-0001] [E2501] Decimal() received invalid exact literal '12.34.56'
 def main():
     x: decimal = Decimal("12.34.56")

--- a/crates/sifr/tests/e2e/fail/decimal_quantize_requires_int_scale.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_quantize_requires_int_scale.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2507] decimal.quantize() scale argument must be 'int', got 'str'
+# expect-error: [SIFR-DECIMAL-0007] [E2507] decimal.quantize() scale argument must be 'int', got 'str'
 def main():
     d: decimal = Decimal("1.23")
     x: decimal = d.quantize("2")

--- a/crates/sifr/tests/e2e/fail/decimal_round_scale_out_of_range.sifr
+++ b/crates/sifr/tests/e2e/fail/decimal_round_scale_out_of_range.sifr
@@ -1,4 +1,4 @@
-# expect-error: [E2507] decimal.round() scale must be between 0 and 28, got 29
+# expect-error: [SIFR-DECIMAL-0007] [E2507] decimal.round() scale must be between 0 and 28, got 29
 def main():
     d: decimal = Decimal("1.2345")
     x: decimal = d.round(29)

--- a/crates/sifr/tests/e2e/fail/float_from_bigdecimal_forbidden.sifr
+++ b/crates/sifr/tests/e2e/fail/float_from_bigdecimal_forbidden.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2506] float(bigdecimal_value) is not allowed; bigdecimal values are exact and cannot be converted to float
+# expect-error: [SIFR-DECIMAL-0006] [E2506] float(bigdecimal_value) is not allowed; bigdecimal values are exact and cannot be converted to float
 def main():
     d: bigdecimal = BigDecimal("1.5")
     x: float = float(d)

--- a/crates/sifr/tests/e2e/fail/float_from_decimal_forbidden.sifr
+++ b/crates/sifr/tests/e2e/fail/float_from_decimal_forbidden.sifr
@@ -1,4 +1,4 @@
-# expect-error: [SIFR-TYPE-0001] [E2505] float(decimal_value) is not allowed; decimal values are exact and cannot be converted to float
+# expect-error: [SIFR-DECIMAL-0005] [E2505] float(decimal_value) is not allowed; decimal values are exact and cannot be converted to float
 def main():
     d: decimal = Decimal("1.5")
     x: float = float(d)

--- a/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt
@@ -1,3 +1,3 @@
 summary: 1 error(s), 0 warning(s), 0 note(s), 0 help item(s)
-error [SIFR-TYPE-0001] [main] [E2501] Decimal() received invalid exact literal '12.34.56' (x1)
-  url: https://sifr.sh/docs/errors/SIFR-TYPE-0001
+error [SIFR-DECIMAL-0001] [main] [E2501] Decimal() received invalid exact literal '12.34.56' (x1)
+  url: https://sifr.sh/docs/errors/SIFR-DECIMAL-0001

--- a/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt
@@ -1,1 +1,1 @@
-type error: [main] [E2501] Decimal() received invalid exact literal '12.34.56'
+error: [main] [E2501] Decimal() received invalid exact literal '12.34.56'

--- a/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt
@@ -1,9 +1,9 @@
 [
   {
-    "code": "SIFR-TYPE-0001",
+    "code": "SIFR-DECIMAL-0001",
     "severity": "Error",
     "message": "[main] [E2501] Decimal() received invalid exact literal '12.34.56'",
-    "url": "https://sifr.sh/docs/errors/SIFR-TYPE-0001",
+    "url": "https://sifr.sh/docs/errors/SIFR-DECIMAL-0001",
     "primary_span": null,
     "related_spans": [],
     "children": [],

--- a/crates/sifr_hir/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_hir/src/lower/aug_assign_lowering.rs
@@ -316,13 +316,13 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
             (Type::Bytes, Type::Bytes) => {}
             _ => {
                 if let Err(e) = type_check_binary_op(&var_ty, base_op, value.ty()) {
-                    ctx.error(e.message);
+                    ctx.type_error(e);
                     return None;
                 }
             }
         }
     } else if let Err(e) = type_check_binary_op(&var_ty, base_op, value.ty()) {
-        ctx.error(e.message);
+        ctx.type_error(e);
         return None;
     }
 

--- a/crates/sifr_hir/src/lower/decimal_methods.rs
+++ b/crates/sifr_hir/src/lower/decimal_methods.rs
@@ -1,7 +1,10 @@
 use crate::hir_nodes::HirExpr;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Expr, ExprCall};
 use sifr_type_system::Type;
 use std::str::FromStr;
 
+use super::expressions::lower_expr;
 use super::LowerCtx;
 
 const DECIMAL_MAX_SCALE: i64 = 28;
@@ -11,6 +14,14 @@ fn decimal_diag_code(receiver_name: &str) -> &'static str {
         "decimal" => "E2507",
         "bigdecimal" => "E2508",
         _ => "E2508",
+    }
+}
+
+fn decimal_scale_diagnostic_code(receiver_name: &str) -> DiagnosticCode {
+    match receiver_name {
+        "decimal" => DiagnosticCode::DECIMAL_SCALE_INVALID,
+        "bigdecimal" => DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID,
+        _ => DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID,
     }
 }
 
@@ -38,15 +49,21 @@ fn validate_decimal_context_scale(
         return Some(());
     };
     if receiver_name == "decimal" && !(0..=DECIMAL_MAX_SCALE).contains(&scale) {
-        ctx.error(format!(
-            "[E2507] decimal.{method}() scale must be between 0 and {DECIMAL_MAX_SCALE}, got {scale}"
-        ));
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_SCALE_INVALID,
+            format!(
+                "[E2507] decimal.{method}() scale must be between 0 and {DECIMAL_MAX_SCALE}, got {scale}"
+            ),
+        );
         return None;
     }
     if receiver_name == "bigdecimal" && scale < 0 {
-        ctx.error(format!(
-            "[E2508] bigdecimal.{method}() scale must be >= 0 for default context, got {scale}"
-        ));
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID,
+            format!(
+                "[E2508] bigdecimal.{method}() scale must be >= 0 for default context, got {scale}"
+            ),
+        );
         return None;
     }
     Some(())
@@ -66,9 +83,10 @@ pub(super) fn decimal_conversion_error_type(ctx: &LowerCtx) -> Type {
 
 pub(super) fn validate_decimal_string_literal(value: &str, ctx: &mut LowerCtx) -> Option<()> {
     if rust_decimal::Decimal::from_str_exact(value).is_err() {
-        ctx.error(format!(
-            "[E2501] Decimal() received invalid exact literal '{value}'"
-        ));
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_INVALID_LITERAL,
+            format!("[E2501] Decimal() received invalid exact literal '{value}'"),
+        );
         return None;
     }
     Some(())
@@ -76,12 +94,129 @@ pub(super) fn validate_decimal_string_literal(value: &str, ctx: &mut LowerCtx) -
 
 pub(super) fn validate_bigdecimal_string_literal(value: &str, ctx: &mut LowerCtx) -> Option<()> {
     if bigdecimal::BigDecimal::from_str(value).is_err() {
-        ctx.error(format!(
-            "[E2502] BigDecimal() received invalid decimal literal '{value}'"
-        ));
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_BIGDECIMAL_INVALID_LITERAL,
+            format!("[E2502] BigDecimal() received invalid decimal literal '{value}'"),
+        );
         return None;
     }
     Some(())
+}
+
+pub(super) fn lower_decimal_constructor_call(
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<HirExpr> {
+    if call.arguments.args.len() != 1 {
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+            format!(
+                "[E2505] Decimal() takes exactly 1 argument, got {}",
+                call.arguments.args.len()
+            ),
+        );
+        return None;
+    }
+    let arg = lower_expr(&call.arguments.args[0], ctx)?;
+    let arg_ty = arg.ty().clone();
+    let result_ty = match arg_ty {
+        Type::Str => {
+            if let Expr::StringLiteral(lit) = &call.arguments.args[0] {
+                validate_decimal_string_literal(lit.value.to_str(), ctx)?;
+            } else {
+                ctx.error_with_code(
+                    DiagnosticCode::DECIMAL_INVALID_LITERAL,
+                    "[E2501] Decimal() string construction requires a string literal".to_string(),
+                );
+                return None;
+            }
+            Type::Decimal
+        }
+        Type::Int | Type::LiteralInt(_) | Type::Decimal => Type::Decimal,
+        Type::BigInt | Type::BigDecimal => Type::Result(
+            Box::new(Type::Decimal),
+            Box::new(decimal_conversion_error_type(ctx)),
+        ),
+        Type::Float => {
+            ctx.error_with_code(
+                DiagnosticCode::DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                "[E2505] Decimal(float_value) is not allowed; use Decimal(\"...\") for exact construction"
+                    .to_string(),
+            );
+            return None;
+        }
+        _ => {
+            ctx.error_with_code(
+                DiagnosticCode::DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                format!(
+                    "[E2505] Decimal() requires str, int, bigint, decimal, or bigdecimal argument, got '{}'",
+                    arg_ty.display_name()
+                ),
+            );
+            return None;
+        }
+    };
+    Some(HirExpr::Call {
+        func: "Decimal".to_string(),
+        args: vec![arg],
+        ty: result_ty,
+    })
+}
+
+pub(super) fn lower_bigdecimal_constructor_call(
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<HirExpr> {
+    if call.arguments.args.len() != 1 {
+        ctx.error_with_code(
+            DiagnosticCode::DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+            format!(
+                "[E2506] BigDecimal() takes exactly 1 argument, got {}",
+                call.arguments.args.len()
+            ),
+        );
+        return None;
+    }
+    let arg = lower_expr(&call.arguments.args[0], ctx)?;
+    let arg_ty = arg.ty().clone();
+    match arg_ty {
+        Type::Str => {
+            if let Expr::StringLiteral(lit) = &call.arguments.args[0] {
+                validate_bigdecimal_string_literal(lit.value.to_str(), ctx)?;
+            } else {
+                ctx.error_with_code(
+                    DiagnosticCode::DECIMAL_BIGDECIMAL_INVALID_LITERAL,
+                    "[E2502] BigDecimal() string construction requires a string literal"
+                        .to_string(),
+                );
+                return None;
+            }
+        }
+        Type::Int | Type::LiteralInt(_) | Type::BigInt | Type::Decimal | Type::BigDecimal => {}
+        Type::Float => {
+            ctx.error_with_code(
+                DiagnosticCode::DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                "[E2506] BigDecimal(float_value) is not allowed; use BigDecimal(\"...\") for exact construction"
+                    .to_string(),
+            );
+            return None;
+        }
+        _ => {
+            ctx.error_with_code(
+                DiagnosticCode::DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                format!(
+                    "[E2506] BigDecimal() requires str, int, bigint, decimal, or bigdecimal argument, got '{}'",
+                    arg_ty.display_name()
+                ),
+            );
+            return None;
+        }
+    }
+    Some(HirExpr::Call {
+        func: "BigDecimal".to_string(),
+        args: vec![arg],
+        ty: Type::BigDecimal,
+    })
 }
 
 pub(super) fn validate_decimal_scale_argument(
@@ -91,18 +226,25 @@ pub(super) fn validate_decimal_scale_argument(
     ctx: &mut LowerCtx,
 ) -> Option<()> {
     let diag_code = decimal_diag_code(receiver_name);
+    let code = decimal_scale_diagnostic_code(receiver_name);
     if args.len() != 1 {
-        ctx.error(format!(
-            "[{diag_code}] {receiver_name}.{method}() takes exactly 1 argument, got {}",
-            args.len()
-        ));
+        ctx.error_with_code(
+            code,
+            format!(
+                "[{diag_code}] {receiver_name}.{method}() takes exactly 1 argument, got {}",
+                args.len()
+            ),
+        );
         return None;
     }
     if !matches!(args[0].ty(), Type::Int | Type::LiteralInt(_)) {
-        ctx.error(format!(
-            "[{diag_code}] {receiver_name}.{method}() scale argument must be 'int', got '{}'",
-            args[0].ty().display_name()
-        ));
+        ctx.error_with_code(
+            code,
+            format!(
+                "[{diag_code}] {receiver_name}.{method}() scale argument must be 'int', got '{}'",
+                args[0].ty().display_name()
+            ),
+        );
         return None;
     }
     validate_decimal_context_scale(receiver_name, method, &args[0], ctx)?;
@@ -133,17 +275,23 @@ pub(super) fn resolve_decimal_method_type(
             }
             "round" => {
                 if args.len() > 1 {
-                    ctx.error(format!(
-                        "[E2507] decimal.round() takes at most 1 argument, got {}",
-                        args.len()
-                    ));
+                    ctx.error_with_code(
+                        DiagnosticCode::DECIMAL_SCALE_INVALID,
+                        format!(
+                            "[E2507] decimal.round() takes at most 1 argument, got {}",
+                            args.len()
+                        ),
+                    );
                     return None;
                 }
                 if args.len() == 1 && !matches!(args[0].ty(), Type::Int | Type::LiteralInt(_)) {
-                    ctx.error(format!(
-                        "[E2507] decimal.round() scale argument must be 'int', got '{}'",
-                        args[0].ty().display_name()
-                    ));
+                    ctx.error_with_code(
+                        DiagnosticCode::DECIMAL_SCALE_INVALID,
+                        format!(
+                            "[E2507] decimal.round() scale argument must be 'int', got '{}'",
+                            args[0].ty().display_name()
+                        ),
+                    );
                     return None;
                 }
                 if args.len() == 1 {
@@ -187,17 +335,23 @@ pub(super) fn resolve_decimal_method_type(
             }
             "round" => {
                 if args.len() > 1 {
-                    ctx.error(format!(
-                        "[E2508] bigdecimal.round() takes at most 1 argument, got {}",
-                        args.len()
-                    ));
+                    ctx.error_with_code(
+                        DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID,
+                        format!(
+                            "[E2508] bigdecimal.round() takes at most 1 argument, got {}",
+                            args.len()
+                        ),
+                    );
                     return None;
                 }
                 if args.len() == 1 && !matches!(args[0].ty(), Type::Int | Type::LiteralInt(_)) {
-                    ctx.error(format!(
-                        "[E2508] bigdecimal.round() scale argument must be 'int', got '{}'",
-                        args[0].ty().display_name()
-                    ));
+                    ctx.error_with_code(
+                        DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID,
+                        format!(
+                            "[E2508] bigdecimal.round() scale argument must be 'int', got '{}'",
+                            args[0].ty().display_name()
+                        ),
+                    );
                     return None;
                 }
                 if args.len() == 1 {

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -14,8 +14,8 @@ use super::compat_imports::{
     resolve_bare_python_compat_call_alias, resolve_python_compat_call_alias,
 };
 use super::decimal_methods::{
-    decimal_conversion_error_type, resolve_decimal_method_type, validate_bigdecimal_string_literal,
-    validate_decimal_string_literal,
+    decimal_conversion_error_type, lower_bigdecimal_constructor_call,
+    lower_decimal_constructor_call, resolve_decimal_method_type,
 };
 use super::defaultdict_refinement::refine_defaultdict_binding_expr;
 use super::empty_collection_refinement::{
@@ -50,6 +50,7 @@ use super::{
     LowerCtx,
 };
 use crate::hir_nodes::{HirExpr, HirIteratorOp, HirParam};
+use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{
     BoolOp, CmpOp, Expr, ExprAttribute, ExprBinOp, ExprBoolOp, ExprBytesLiteral, ExprCall,
     ExprCompare, ExprDict, ExprDictComp, ExprGenerator, ExprLambda, ExprList, ExprListComp,
@@ -366,7 +367,7 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
                     }
                 }
             }
-            ctx.error(e.message);
+            ctx.type_error(e);
             None
         }
     }
@@ -389,7 +390,7 @@ pub(super) fn lower_unaryop(unary: &ExprUnaryOp, ctx: &mut LowerCtx) -> Option<H
             ty: result_ty,
         }),
         Err(e) => {
-            ctx.error(e.message);
+            ctx.type_error(e);
             None
         }
     }
@@ -511,7 +512,7 @@ pub(super) fn lower_compare(cmp: &ExprCompare, ctx: &mut LowerCtx) -> Option<Hir
                     _ => false,
                 };
                 if !has_overload {
-                    ctx.error(e.message);
+                    ctx.type_error(e);
                     return None;
                 }
             }
@@ -561,7 +562,7 @@ pub(super) fn lower_boolop(boolop: &ExprBoolOp, ctx: &mut LowerCtx) -> Option<Hi
     // Check all values are Bool
     for val in &values {
         if let Err(e) = type_check_bool_op(val.ty(), op_str, &Type::Bool) {
-            ctx.error(e.message);
+            ctx.type_error(e);
             return None;
         }
     }
@@ -868,115 +869,12 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
             });
         }
 
-        // Decimal("...") / Decimal(int|bigint|bigdecimal)
         if func_name == "Decimal" {
-            if call.arguments.args.len() != 1 {
-                ctx.error(format!(
-                    "[E2505] Decimal() takes exactly 1 argument, got {}",
-                    call.arguments.args.len()
-                ));
-                return None;
-            }
-            let arg = lower_expr(&call.arguments.args[0], ctx)?;
-            let arg_ty = arg.ty().clone();
-            let decimal_conversion_error_ty = ctx
-                .class_types
-                .get("DecimalConversionError")
-                .cloned()
-                .unwrap_or(Type::Class {
-                    name: "DecimalConversionError".to_string(),
-                    fields: vec![("message".to_string(), Type::Str)],
-                    methods: vec![],
-                    parent_class: None,
-                });
-            let result_ty = match arg_ty {
-                Type::Str => {
-                    if let Expr::StringLiteral(lit) = &call.arguments.args[0] {
-                        validate_decimal_string_literal(lit.value.to_str(), ctx)?;
-                    } else {
-                        ctx.error(
-                            "[E2501] Decimal() string construction requires a string literal"
-                                .to_string(),
-                        );
-                        return None;
-                    }
-                    Type::Decimal
-                }
-                Type::Int | Type::LiteralInt(_) | Type::Decimal => Type::Decimal,
-                Type::BigInt | Type::BigDecimal => Type::Result(
-                    Box::new(Type::Decimal),
-                    Box::new(decimal_conversion_error_ty),
-                ),
-                Type::Float => {
-                    ctx.error(
-                    "[E2505] Decimal(float_value) is not allowed; use Decimal(\"...\") for exact construction"
-                        .to_string(),
-                );
-                    return None;
-                }
-                _ => {
-                    ctx.error(format!(
-                    "[E2505] Decimal() requires str, int, bigint, decimal, or bigdecimal argument, got '{}'",
-                    arg_ty.display_name()
-                ));
-                    return None;
-                }
-            };
-            return Some(HirExpr::Call {
-                func: "Decimal".to_string(),
-                args: vec![arg],
-                ty: result_ty,
-            });
+            return lower_decimal_constructor_call(call, ctx);
         }
 
-        // BigDecimal("...") / BigDecimal(int|bigint|decimal)
         if func_name == "BigDecimal" {
-            if call.arguments.args.len() != 1 {
-                ctx.error(format!(
-                    "[E2506] BigDecimal() takes exactly 1 argument, got {}",
-                    call.arguments.args.len()
-                ));
-                return None;
-            }
-            let arg = lower_expr(&call.arguments.args[0], ctx)?;
-            let arg_ty = arg.ty().clone();
-            match arg_ty {
-                Type::Str => {
-                    if let Expr::StringLiteral(lit) = &call.arguments.args[0] {
-                        validate_bigdecimal_string_literal(lit.value.to_str(), ctx)?;
-                    } else {
-                        ctx.error(
-                            "[E2502] BigDecimal() string construction requires a string literal"
-                                .to_string(),
-                        );
-                        return None;
-                    }
-                }
-                Type::Int
-                | Type::LiteralInt(_)
-                | Type::BigInt
-                | Type::Decimal
-                | Type::BigDecimal => {}
-                Type::Float => {
-                    ctx.error(
-                    "[E2506] BigDecimal(float_value) is not allowed; use BigDecimal(\"...\") for exact construction"
-                        .to_string(),
-                );
-                    return None;
-                }
-                _ => {
-                    ctx.error(format!(
-                    "[E2506] BigDecimal() requires str, int, bigint, decimal, or bigdecimal argument, got '{}'",
-                    arg_ty.display_name()
-                ));
-                    return None;
-                }
-            }
-            return Some(HirExpr::Call {
-                func: "BigDecimal".to_string(),
-                args: vec![arg],
-                ty: Type::BigDecimal,
-            });
+            return lower_bigdecimal_constructor_call(call, ctx);
         }
 
         // Special handling for int() conversion
@@ -1093,16 +991,18 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
                         });
                 Type::Result(Box::new(Type::Float), Box::new(parse_error_ty))
             } else if arg_ty == Type::Decimal {
-                ctx.error(
-                "[E2505] float(decimal_value) is not allowed; decimal values are exact and cannot be converted to float"
-                    .to_string(),
-            );
+                ctx.error_with_code(
+                    DiagnosticCode::DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                    "[E2505] float(decimal_value) is not allowed; decimal values are exact and cannot be converted to float"
+                        .to_string(),
+                );
                 return None;
             } else if arg_ty == Type::BigDecimal {
-                ctx.error(
-                "[E2506] float(bigdecimal_value) is not allowed; bigdecimal values are exact and cannot be converted to float"
-                    .to_string(),
-            );
+                ctx.error_with_code(
+                    DiagnosticCode::DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN,
+                    "[E2506] float(bigdecimal_value) is not allowed; bigdecimal values are exact and cannot be converted to float"
+                        .to_string(),
+                );
                 return None;
             } else {
                 Type::Float

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -2,7 +2,7 @@
 use crate::hir_nodes::{HirExpr, HirImport, HirModule};
 use crate::scope::Scope;
 use sifr_python_ast::{Expr, ExprCall, Stmt};
-use sifr_type_system::{make_union, FunctionType, Type};
+use sifr_type_system::{make_union, FunctionType, Type, TypeError};
 use std::collections::HashMap;
 mod append_growth_shapes;
 mod arithmetic_warnings;
@@ -217,12 +217,14 @@ impl LowerCtx {
         });
     }
 
-    // TODO(diag_4a slice 2b): remove this allow when the first domain
-    // migration calls `error_with_code`.
-    #[allow(
-        dead_code,
-        reason = "diag_4a slice 2a adds transport before per-domain HIR call-site migration"
-    )]
+    fn type_error(&mut self, error: TypeError) {
+        if let Some(code) = error.code {
+            self.error_with_code(code, error.message);
+        } else {
+            self.error(error.message);
+        }
+    }
+
     fn error_with_code(&mut self, code: DiagnosticCode, message: String) {
         self.errors.push(LoweringError {
             code: Some(code),

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -3,6 +3,7 @@
 use crate::types::Type;
 use crate::union::{remove_none_from_union, union_contains_none};
 use crate::TypeError;
+use sifr_diagnostics::DiagnosticCode;
 
 fn is_decimal_type(ty: &Type) -> bool {
     matches!(ty, Type::Decimal)
@@ -28,6 +29,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
         || (is_bigdecimal_type(left) && is_decimal_type(right))
     {
         return Err(TypeError {
+            code: Some(DiagnosticCode::DECIMAL_MIXED_WITH_BIGDECIMAL),
             message: "[E2504] cannot mix 'decimal' and 'bigdecimal' in arithmetic; use explicit Decimal(...) or BigDecimal(...) conversion".to_string(),
             kind: crate::TypeErrorKind::InvalidOperator {
                 op: op.to_string(),
@@ -40,6 +42,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
         || (right == &Type::Float && is_decimal_family_type(left))
     {
         return Err(TypeError {
+            code: Some(DiagnosticCode::DECIMAL_FLOAT_MIXED),
             message: "[E2503] cannot mix 'float' with decimal numeric types in arithmetic"
                 .to_string(),
             kind: crate::TypeErrorKind::InvalidOperator {
@@ -56,6 +59,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             || (left == &Type::BigInt && right == &Type::Int)
         {
             return Err(TypeError {
+                code: None,
                 message: "cannot mix 'int' and 'bigint' in arithmetic; use bigint() or int() to convert explicitly".to_string(),
                 kind: crate::TypeErrorKind::InvalidOperator {
                     op: op.to_string(),
@@ -121,6 +125,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Bytes);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for +: '{}' and '{}'",
                     left.display_name(),
@@ -182,6 +187,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 }
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
                     left.display_name(),
@@ -220,6 +226,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Float);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for /: '{}' and '{}'",
                     left.display_name(),
@@ -261,6 +268,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Float);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
                     left.display_name(),
@@ -292,6 +300,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Float);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for **: '{}' and '{}'",
                     left.display_name(),
@@ -313,6 +322,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Bool);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
                     left.display_name(),
@@ -330,6 +340,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
                 return Ok(Type::Int);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
                     left.display_name(),
@@ -342,6 +353,7 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> Result<Type,
             })
         }
         _ => Err(TypeError {
+            code: None,
             message: format!("unknown binary operator: {op}"),
             kind: crate::TypeErrorKind::InvalidOperator {
                 op: op.to_string(),
@@ -357,6 +369,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
         || (is_bigdecimal_type(left) && is_decimal_type(right))
     {
         return Err(TypeError {
+            code: Some(DiagnosticCode::DECIMAL_MIXED_WITH_BIGDECIMAL),
             message:
                 "[E2504] cannot compare 'decimal' and 'bigdecimal' without explicit conversion"
                     .to_string(),
@@ -370,6 +383,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
         || (right == &Type::Float && is_decimal_family_type(left))
     {
         return Err(TypeError {
+            code: Some(DiagnosticCode::DECIMAL_FLOAT_MIXED),
             message: "[E2503] cannot compare 'float' with decimal numeric types".to_string(),
             kind: crate::TypeErrorKind::TypeMismatch {
                 expected: Box::new(left.clone()),
@@ -385,6 +399,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
                 || (left == &Type::BigInt && right == &Type::Int)
             {
                 return Err(TypeError {
+                    code: None,
                     message: "cannot compare 'int' and 'bigint'; use bigint() or int() to convert explicitly".to_string(),
                     kind: crate::TypeErrorKind::TypeMismatch {
                         expected: Box::new(left.clone()),
@@ -422,6 +437,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
                 }
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "cannot compare '{}' and '{}' with {op}",
                     left.display_name(),
@@ -439,6 +455,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
                 || (left == &Type::BigInt && right == &Type::Int)
             {
                 return Err(TypeError {
+                    code: None,
                     message: "cannot compare 'int' and 'bigint'; use bigint() or int() to convert explicitly".to_string(),
                     kind: crate::TypeErrorKind::TypeMismatch {
                         expected: Box::new(left.clone()),
@@ -471,6 +488,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
                 }
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "'{op}' not supported between instances of '{}' and '{}'",
                     left.display_name(),
@@ -483,6 +501,7 @@ pub fn type_check_comparison(left: &Type, op: &str, right: &Type) -> Result<Type
             })
         }
         _ => Err(TypeError {
+            code: None,
             message: format!("unknown comparison operator: {op}"),
             kind: crate::TypeErrorKind::InvalidOperator {
                 op: op.to_string(),
@@ -532,6 +551,7 @@ pub fn type_check_unary_op(op: &str, operand: &Type) -> Result<Type, TypeError> 
                 return Ok(operand.clone());
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "bad operand type for unary {op}: '{}'",
                     operand.display_name()
@@ -564,6 +584,7 @@ pub fn type_check_unary_op(op: &str, operand: &Type) -> Result<Type, TypeError> 
                 _ => {}
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "bad operand type for unary not: '{}'",
                     operand.display_name()
@@ -580,6 +601,7 @@ pub fn type_check_unary_op(op: &str, operand: &Type) -> Result<Type, TypeError> 
                 return Ok(Type::Int);
             }
             Err(TypeError {
+                code: None,
                 message: format!("bad operand type for unary ~: '{}'", operand.display_name()),
                 kind: crate::TypeErrorKind::InvalidOperator {
                     op: op.to_string(),
@@ -588,6 +610,7 @@ pub fn type_check_unary_op(op: &str, operand: &Type) -> Result<Type, TypeError> 
             })
         }
         _ => Err(TypeError {
+            code: None,
             message: format!("unknown unary operator: {op}"),
             kind: crate::TypeErrorKind::InvalidOperator {
                 op: op.to_string(),
@@ -624,6 +647,7 @@ pub fn type_check_bool_op(left: &Type, op: &str, right: &Type) -> Result<Type, T
                 return Ok(Type::Bool);
             }
             Err(TypeError {
+                code: None,
                 message: format!(
                     "unsupported operand type(s) for {op}: '{}' and '{}'",
                     left.display_name(),
@@ -636,6 +660,7 @@ pub fn type_check_bool_op(left: &Type, op: &str, right: &Type) -> Result<Type, T
             })
         }
         _ => Err(TypeError {
+            code: None,
             message: format!("unknown boolean operator: {op}"),
             kind: crate::TypeErrorKind::InvalidOperator {
                 op: op.to_string(),

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -21,6 +21,7 @@ pub use types::{
 pub mod narrow;
 pub use literal::{widen as widen_literal, LiteralValue};
 pub use narrow::{narrow_type, NarrowingCondition};
+use sifr_diagnostics::DiagnosticCode;
 pub use union::{
     intersect_with_union, make_union, remove_none_from_union, subtract_from_union, union_contains,
     union_contains_none,
@@ -29,6 +30,7 @@ pub use union::{
 /// A type error produced during type checking.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeError {
+    pub code: Option<DiagnosticCode>,
     pub message: String,
     pub kind: TypeErrorKind,
 }

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -33,7 +33,7 @@ Current wave: `milestone_diag_4a` renderer integration, split into reviewable tr
 - [x] `milestone_diag_2b` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1670.
 - [x] `milestone_diag_4a` slice 1 merged: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport. PR: https://github.com/sifr-lang/sifr/pull/1671.
 - [x] `milestone_diag_4a` slice 2a merged: additive HIR `LoweringError` structured diagnostic-code transport plumbing. PR: https://github.com/sifr-lang/sifr/pull/1672.
-- [ ] `milestone_diag_4a` slice 2b.1 implementation complete and reviewer-satisfied: decimal-family HIR/type-system call-site migration to active `SIFR-DECIMAL-*` codes with fixture and verification baseline re-keying; PR pending.
+- [ ] `milestone_diag_4a` slice 2b.1 implementation complete and reviewer-satisfied: decimal-family HIR/type-system call-site migration to active `SIFR-DECIMAL-*` codes with fixture and verification baseline re-keying. PR: https://github.com/sifr-lang/sifr/pull/1673.
 - [x] Deferred `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge deletion and affected fixture re-keying to later `milestone_diag_4a` slice-2 sub-PRs, where HIR call sites will be migrated by domain before the bridge is removed.
 - [x] Claude pre-implementation review for `milestone_diag_4a` slice 2 completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 2a completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md`.

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -32,10 +32,12 @@ Current wave: `milestone_diag_4a` renderer integration, split into reviewable tr
 - [x] Claude review for `milestone_diag_2b` completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-2b-review-pass-3.md`.
 - [x] `milestone_diag_2b` PR opened and merged: https://github.com/sifr-lang/sifr/pull/1670.
 - [x] `milestone_diag_4a` slice 1 merged: canonical renderer presentation helpers plus explicit workspace diagnostic identity transport. PR: https://github.com/sifr-lang/sifr/pull/1671.
-- [ ] Started `milestone_diag_4a` slice 2a: additive HIR `LoweringError` structured diagnostic-code transport plumbing.
+- [x] `milestone_diag_4a` slice 2a merged: additive HIR `LoweringError` structured diagnostic-code transport plumbing. PR: https://github.com/sifr-lang/sifr/pull/1672.
+- [ ] `milestone_diag_4a` slice 2b.1 implementation complete and reviewer-satisfied: decimal-family HIR/type-system call-site migration to active `SIFR-DECIMAL-*` codes with fixture and verification baseline re-keying; PR pending.
 - [x] Deferred `CompilePhase::TypeCheck => "SIFR-TYPE-0001"` bridge deletion and affected fixture re-keying to later `milestone_diag_4a` slice-2 sub-PRs, where HIR call sites will be migrated by domain before the bridge is removed.
 - [x] Claude pre-implementation review for `milestone_diag_4a` slice 2 completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 2a completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md`.
+- [x] Claude implementation review for `milestone_diag_4a` slice 2b.1 completed and reviewer is satisfied. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-2.md`.
 - [x] Claude pre-implementation review for `milestone_diag_4a` completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 1 completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md`.
 
@@ -83,6 +85,20 @@ Validation evidence for current `milestone_diag_4a` slice 2a:
 - `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` passed.
 - `cargo clippy --workspace -- -D warnings` passed.
 - `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` and wall time `86.73s`.
+
+Validation evidence for current `milestone_diag_4a` slice 2b.1:
+
+- `cargo fmt --check` passed.
+- `python3 scripts/check_hir_maintainability_guardrails.py` passed.
+- `cargo check -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr` passed.
+- `cargo test -p sifr_hir diagnostic_transport_tests` passed.
+- `cargo test -p sifr_driver frontend::module_lowering::tests` passed.
+- `cargo test -p sifr_type_system` passed.
+- `cargo test -p sifr -- --skip test_e2e_pass` passed.
+- `cargo clippy -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr -- -D warnings` passed.
+- `cargo clippy --workspace -- -D warnings` passed.
+- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517` and wall time `84.52s`.
+- `scripts/run_e2e_pass.sh` was also attempted; it failed in the PR-profile pass corpus on unrelated generated Rust/codegen failures (`map`/`list`/`filter` missing plus borrow/mutability errors), while the authoritative quick lane and diagnostic fail-corpus gate passed.
 
 ## Relationship to Existing Roadmap
 

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md
@@ -1,0 +1,279 @@
+# Review: milestone_diag_4a — Slice 2b.1 Decimal-Family HIR Migration (Pass 1)
+
+Branch: `codex/semantic-diagnostics-diag-4a-decimal` (working tree on top of `5ad7b756`, the slice 2a merge)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md)
+
+## Verdict
+
+**Ready to ship as the slice 2b.1 PR.** The decimal-family migration is complete and consistent: every E250x-tagged HIR/type-system emission site that exists in the working tree now carries the matching `SIFR-DECIMAL-000N` constant from the registry, every decimal-family fail fixture is re-keyed, and the lone decimal-family verification baseline directory is updated across `compact`, `human`, and `json` renderers. The supporting plumbing (`TypeError.code`, `LowerCtx::type_error`) is the minimum bridge needed to forward `Result<_, TypeError>` decisions from `sifr_type_system::check` into the structured HIR transport added by slice 2a, with no behavior change at the codeless arms. Local validation matches the slice 2a baseline (`report_signature=e1bf653aaa770517`, wall-time `84.52s`), and the reported `scripts/run_e2e_pass.sh` failures are unrelated codegen-level issues that this slice does not touch. Scope discipline holds: embedded `[E250x]` text remains (deferred to `milestone_diag_6`), and the broader `CompilePhase::TypeCheck => SIFR-TYPE-0001` bridge is intentionally left intact for non-decimal domains.
+
+No blocking findings. Six observations are recorded as `O*` (optional polish, do not block) and `N*` (informational notes).
+
+## Diagnostic identity mapping (the load-bearing assertion of this slice)
+
+The full registry → emission-site → fixture/baseline cross-walk holds. Each row is an active `SIFR-DECIMAL-000N` code at [crates/sifr_diagnostics/src/codes.rs:40-51](../crates/sifr_diagnostics/src/codes.rs:40), the corresponding `[E250N]`-tagged emission site(s) in HIR/type-system, and the fixture/baseline that pins the public identity:
+
+| Active code | Constant | Emission site(s) | Fixture / baseline |
+| --- | --- | --- | --- |
+| `SIFR-DECIMAL-0001` | `DECIMAL_INVALID_LITERAL` | [decimal_methods.rs:86-89](../crates/sifr_hir/src/lower/decimal_methods.rs:86), [decimal_methods.rs:127-130](../crates/sifr_hir/src/lower/decimal_methods.rs:127) | [decimal_invalid_literal_string.sifr:1](../crates/sifr/tests/e2e/fail/decimal_invalid_literal_string.sifr:1), all three renderer baselines under [decimal_invalid_literal/baselines](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/) |
+| `SIFR-DECIMAL-0002` | `DECIMAL_BIGDECIMAL_INVALID_LITERAL` | [decimal_methods.rs:97-100](../crates/sifr_hir/src/lower/decimal_methods.rs:97), [decimal_methods.rs:187-191](../crates/sifr_hir/src/lower/decimal_methods.rs:187) | [bigdecimal_invalid_literal_string.sifr:1](../crates/sifr/tests/e2e/fail/bigdecimal_invalid_literal_string.sifr:1), [bigdecimal_constructor_non_literal_string.sifr:1](../crates/sifr/tests/e2e/fail/bigdecimal_constructor_non_literal_string.sifr:1) |
+| `SIFR-DECIMAL-0003` | `DECIMAL_FLOAT_MIXED` | [check.rs:44-52](../crates/sifr_type_system/src/check.rs:44), [check.rs:385-393](../crates/sifr_type_system/src/check.rs:385) | [decimal_float_mixed_arithmetic.sifr:1](../crates/sifr/tests/e2e/fail/decimal_float_mixed_arithmetic.sifr:1) |
+| `SIFR-DECIMAL-0004` | `DECIMAL_MIXED_WITH_BIGDECIMAL` | [check.rs:31-38](../crates/sifr_type_system/src/check.rs:31), [check.rs:371-379](../crates/sifr_type_system/src/check.rs:371) | [decimal_bigdecimal_mixed_arithmetic.sifr:1](../crates/sifr/tests/e2e/fail/decimal_bigdecimal_mixed_arithmetic.sifr:1), [decimal_forbidden_mixed_arithmetic_seeded.sifr:1](../crates/sifr/tests/e2e/fail/decimal_forbidden_mixed_arithmetic_seeded.sifr:1) |
+| `SIFR-DECIMAL-0005` | `DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN` | [decimal_methods.rs:111-118](../crates/sifr_hir/src/lower/decimal_methods.rs:111), [decimal_methods.rs:141-145](../crates/sifr_hir/src/lower/decimal_methods.rs:141), [decimal_methods.rs:149-156](../crates/sifr_hir/src/lower/decimal_methods.rs:149), [expressions.rs:993-999](../crates/sifr_hir/src/lower/expressions.rs:993) | [decimal_constructor_float.sifr:1](../crates/sifr/tests/e2e/fail/decimal_constructor_float.sifr:1), [decimal_forbidden_float_conversion_seeded.sifr:1](../crates/sifr/tests/e2e/fail/decimal_forbidden_float_conversion_seeded.sifr:1), [float_from_decimal_forbidden.sifr:1](../crates/sifr/tests/e2e/fail/float_from_decimal_forbidden.sifr:1) |
+| `SIFR-DECIMAL-0006` | `DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN` | [decimal_methods.rs:171-178](../crates/sifr_hir/src/lower/decimal_methods.rs:171), [decimal_methods.rs:197-201](../crates/sifr_hir/src/lower/decimal_methods.rs:197), [decimal_methods.rs:205-211](../crates/sifr_hir/src/lower/decimal_methods.rs:205), [expressions.rs:1000-1006](../crates/sifr_hir/src/lower/expressions.rs:1000) | [bigdecimal_constructor_float.sifr:1](../crates/sifr/tests/e2e/fail/bigdecimal_constructor_float.sifr:1), [float_from_bigdecimal_forbidden.sifr:1](../crates/sifr/tests/e2e/fail/float_from_bigdecimal_forbidden.sifr:1) |
+| `SIFR-DECIMAL-0007` | `DECIMAL_SCALE_INVALID` | [decimal_methods.rs:52-58](../crates/sifr_hir/src/lower/decimal_methods.rs:52), [decimal_methods.rs:231-238](../crates/sifr_hir/src/lower/decimal_methods.rs:231), [decimal_methods.rs:241-248](../crates/sifr_hir/src/lower/decimal_methods.rs:241), [decimal_methods.rs:278-285](../crates/sifr_hir/src/lower/decimal_methods.rs:278), [decimal_methods.rs:288-295](../crates/sifr_hir/src/lower/decimal_methods.rs:288) | [decimal_quantize_requires_int_scale.sifr:1](../crates/sifr/tests/e2e/fail/decimal_quantize_requires_int_scale.sifr:1), [decimal_round_scale_out_of_range.sifr:1](../crates/sifr/tests/e2e/fail/decimal_round_scale_out_of_range.sifr:1) |
+| `SIFR-DECIMAL-0008` | `DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID` | [decimal_methods.rs:61-67](../crates/sifr_hir/src/lower/decimal_methods.rs:61), [decimal_methods.rs:231-238](../crates/sifr_hir/src/lower/decimal_methods.rs:231) (via `decimal_scale_diagnostic_code("bigdecimal")`), [decimal_methods.rs:338-345](../crates/sifr_hir/src/lower/decimal_methods.rs:338), [decimal_methods.rs:348-355](../crates/sifr_hir/src/lower/decimal_methods.rs:348) | [bigdecimal_quantize_negative_scale_context.sifr:1](../crates/sifr/tests/e2e/fail/bigdecimal_quantize_negative_scale_context.sifr:1), [bigdecimal_round_requires_int_scale.sifr:1](../crates/sifr/tests/e2e/fail/bigdecimal_round_requires_int_scale.sifr:1) |
+
+I cross-checked this in two complementary ways:
+
+1. `git grep -nE 'E250[1-8]' crates/sifr_hir/src/ crates/sifr_type_system/src/` yields exactly 24 emission-site hits, every one of which now sits inside an `error_with_code(...)` (HIR) or `TypeError { code: Some(_), .. }` (type system) construction. No codeless `ctx.error(...)` carries an `[E250x]` tag in production source.
+2. Every of the 15 decimal-family fail fixtures listed in the patch starts with the exact `[SIFR-DECIMAL-000N] [E250N] …` signature corresponding to the registry/code mapping above. The harness in [crates/sifr/tests/e2e.rs:2553-2567](../crates/sifr/tests/e2e.rs:2553) requires *both* the parsed code (`expected.code`) and the message substring (`failure.message.contains(message)`) to match per fixture, so the fixture is the actual gate — `cargo test -p sifr -- --skip test_e2e_pass` exercises both sides end-to-end.
+
+The mapping is a clean 1:1 between the eight legacy `[E250N]` slugs and the eight active `SIFR-DECIMAL-000N` codes. No drift, no double-mapping, no missed slug.
+
+## Pipeline plumbing review
+
+### `TypeError.code` and `LowerCtx::type_error`
+
+The migration of `sifr_type_system::check` from "`[E250x]`-in-message-only" to a structured `Option<DiagnosticCode>` field is the smallest reasonable shape:
+
+- [crates/sifr_type_system/src/lib.rs:31-36](../crates/sifr_type_system/src/lib.rs:31) adds `pub code: Option<DiagnosticCode>` to `TypeError`. `Option<_>` (rather than required) is correct for this slice because only the two decimal-family arms (E2503 + E2504) carry an active code today; everything else still flows codeless and is correctly initialized with `code: None`.
+- [crates/sifr_type_system/src/check.rs:32](../crates/sifr_type_system/src/check.rs:32), [crates/sifr_type_system/src/check.rs:45](../crates/sifr_type_system/src/check.rs:45), [crates/sifr_type_system/src/check.rs:372](../crates/sifr_type_system/src/check.rs:372), [crates/sifr_type_system/src/check.rs:386](../crates/sifr_type_system/src/check.rs:386) attach `Some(DECIMAL_…)` to the four decimal-family arms (binary mix, binary float, comparison mix, comparison float). All other 18 `TypeError { … }` sites carry `code: None`. I confirmed exhaustiveness with `grep -n "TypeError {" crates/sifr_type_system/src/check.rs` (22 hits, every one matches one of the two patterns) and with `grep -rn "TypeError {" crates/ --include="*.rs" | grep -v "tests/" | grep -v "src/check.rs" | grep -v "src/lib.rs"` (zero hits — no other crate constructs `TypeError`, so no out-of-tree initializer is missing the field).
+- [crates/sifr_hir/src/lower/mod.rs:220-226](../crates/sifr_hir/src/lower/mod.rs:220) adds `LowerCtx::type_error(error: TypeError)` that forwards to `error_with_code` when `error.code.is_some()` and to `error` otherwise. This is the precise minimum bridge: it preserves the codeless legacy behavior bit-for-bit while letting the typed code flow through whenever the type system populates it.
+- [crates/sifr_hir/src/lower/expressions.rs:370](../crates/sifr_hir/src/lower/expressions.rs:370), [crates/sifr_hir/src/lower/expressions.rs:393](../crates/sifr_hir/src/lower/expressions.rs:393), [crates/sifr_hir/src/lower/expressions.rs:515](../crates/sifr_hir/src/lower/expressions.rs:515), [crates/sifr_hir/src/lower/expressions.rs:565](../crates/sifr_hir/src/lower/expressions.rs:565), [crates/sifr_hir/src/lower/aug_assign_lowering.rs:319](../crates/sifr_hir/src/lower/aug_assign_lowering.rs:319), [crates/sifr_hir/src/lower/aug_assign_lowering.rs:325](../crates/sifr_hir/src/lower/aug_assign_lowering.rs:325) replace `ctx.error(e.message)` with `ctx.type_error(e)` at every call site that previously discarded the typed error. That's six call sites, which matches `git grep -nE 'ctx\.error\(e\.message\)' crates/sifr_hir/src/` returning zero (i.e. all forwarders were migrated). No site still drops `e.code`.
+
+There is no production behavior change at codeless arms: a `TypeError { code: None, … }` flows through `type_error` → `error(message)` → `LoweringError { code: None, message, … }`, byte-equivalent to the prior path. The slice 2a transport tests at [crates/sifr_hir/src/lower/diagnostic_transport_tests.rs](../crates/sifr_hir/src/lower/diagnostic_transport_tests.rs) still exercise that exact branch decision and continue to pass.
+
+### `error_with_code` allow attribute
+
+The `#[allow(dead_code, …)]` and TODO marker on `LowerCtx::error_with_code` ([crates/sifr_hir/src/lower/mod.rs:228-234](../crates/sifr_hir/src/lower/mod.rs:228)) are now correctly removed in this slice — the function gains many production callers via [crates/sifr_hir/src/lower/decimal_methods.rs](../crates/sifr_hir/src/lower/decimal_methods.rs) and the new `type_error` forwarder, so the dead-code allow would now be stale. Slice 2a's pass-2 N7 review item ("delete the allow when the first domain migration calls `error_with_code`") is closed exactly as predicted.
+
+### Constructor extraction (refactor co-located with the migration)
+
+[crates/sifr_hir/src/lower/expressions.rs:868-878](../crates/sifr_hir/src/lower/expressions.rs:868) shrinks the inline `Decimal()`/`BigDecimal()` constructor lowering paths from ~120 lines down to two `return lower_decimal_constructor_call(call, ctx);` / `return lower_bigdecimal_constructor_call(call, ctx);` calls. The extracted helpers live at [crates/sifr_hir/src/lower/decimal_methods.rs:106-220](../crates/sifr_hir/src/lower/decimal_methods.rs:106) and are byte-equivalent in observable behavior to the pre-extraction code modulo the `ctx.error → ctx.error_with_code` migration.
+
+This is the right place to put them: `decimal_methods.rs` already housed `validate_decimal_string_literal`, `validate_bigdecimal_string_literal`, `decimal_conversion_error_type`, and `resolve_decimal_method_type`. Co-locating the constructor lowering completes the module's "everything decimal-family that HIR lowering needs" surface and lets `expressions.rs` shed an explicit dependency on `validate_*_string_literal`. The `super::expressions::lower_expr` import in `decimal_methods.rs` is the only new cross-module reference, mirroring how other domain-specific lowering helpers reach back to `lower_expr` (see e.g. `super::expressions::lower_expr` is already imported transitively via `aug_assign_lowering` etc.).
+
+The HIR maintainability guardrail script (`python3 scripts/check_hir_maintainability_guardrails.py`) is reported passing; I'd expect that since `decimal_methods.rs` grew to ~383 lines (well under typical caps) while `expressions.rs` shrank.
+
+This refactor is mild scope creep relative to "migrate emission sites to active codes," but it's strictly local to the decimal-family files this slice already touches, and it's the kind of co-located cleanup the AGENTS.md guidance "keep changes focused on the requested milestone/issue" tolerates because the sites being migrated were the same lines being extracted. Not a blocker; recorded as **O1** below for completeness.
+
+### `decimal_diag_code` vs `decimal_scale_diagnostic_code`
+
+The two helpers at [decimal_methods.rs:12-26](../crates/sifr_hir/src/lower/decimal_methods.rs:12) deliberately run in lockstep:
+
+- `decimal_diag_code(receiver_name)` → `&'static str` (`"E2507"` / `"E2508"`) feeds the embedded `[E25NN]` slug into the message text.
+- `decimal_scale_diagnostic_code(receiver_name)` → `DiagnosticCode` (`DECIMAL_SCALE_INVALID` / `DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID`) feeds the active code into `error_with_code`.
+
+This duplication is intentional during the staged rollout: the embedded `[E25NN]` text is preserved (per the `milestone_diag_6` deferral in the task brief), and the structured code is the new orthogonal channel. The pair will collapse to one helper when the embedded text is dropped. The fallback arm `_ => DiagnosticCode::DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID` matches the `_ => "E2508"` arm in the legacy helper, so the two helpers remain in lockstep even on the impossible third receiver case. Recorded as **N1** below — no action this slice.
+
+## Fixture / verification baseline review
+
+Every modified e2e fail fixture re-keys exactly the diagnostic-code prefix, leaving the rest of the `expect-error:` substring (the `[E25NN] …` text) untouched. I confirmed 15-of-15 fixtures match this pattern and that the post-migration `[SIFR-DECIMAL-000N]` matches the registry constant assigned to the fixture's emission site.
+
+The lone verification suite that exercises a decimal diagnostic, `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/`, is updated for all three renderers:
+
+- [check-compact.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt:2) flips to `[SIFR-DECIMAL-0001]` and the canonical URL `https://sifr.sh/docs/errors/SIFR-DECIMAL-0001` — both correct given the slice 1 renderer URL contract.
+- [check-json.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-json.stderr.txt:3) flips both `"code"` and `"url"` to `SIFR-DECIMAL-0001` consistently.
+- [check-human.stderr.txt](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt:1) drops the `type ` prefix from `type error: …` to `error: …`. This is a real downstream consequence and is discussed below as **O2**.
+
+`find crates/sifr/tests/verification/diagnostics/ -type d -mindepth 1` confirms `decimal_invalid_literal` is the *only* decimal-domain verification scenario, so no other baseline directory should have shifted. ✅
+
+## Findings
+
+Severity legend: **R** = recommended before PR opens (correctness/test gap); **O** = optional polish; **N** = informational note. **None of the findings below are blocking.**
+
+### O1 — Constructor extraction is co-located scope creep, not strictly required for code re-keying
+
+The `lower_decimal_constructor_call` / `lower_bigdecimal_constructor_call` extraction at [decimal_methods.rs:106-220](../crates/sifr_hir/src/lower/decimal_methods.rs:106) is not strictly required to migrate the constructor sites' codes from message-embedded to structured. The migration could have been a tight `ctx.error(...) → ctx.error_with_code(CODE, ...)` rewrite in place inside `expressions.rs`. The author chose to extract — which is a clean refactor and consolidates the decimal-family lowering surface in one file — but it does enlarge the diff slightly beyond pure code re-keying and is technically a separate concern.
+
+This is acceptable in my judgment because:
+1. Every line of the extracted helpers is under migration anyway (they're the lines whose diagnostics are flipping from codeless to coded), so the diff is not "extract A, migrate B" but "extract-and-migrate A together."
+2. The extraction makes the next milestone's [E250x] removal a single-file edit instead of a multi-file edit.
+3. `decimal_methods.rs` already housed the related `validate_*_string_literal` and `resolve_decimal_method_type` helpers, so this is finishing a half-done split rather than introducing a new abstraction.
+
+If the reviewer or PR author prefers tighter slices going forward, the explicit guidance for slices 2b.2..2b.6 should call out whether co-located extraction is or is not in scope. **No action this slice.**
+
+### O2 — Human-renderer label downgrade for decimal diagnostics
+
+The verification baseline diff at [check-human.stderr.txt:1](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt:1) goes from `type error: [main] [E2501] …` to `error: [main] [E2501] …`. Root cause: the human renderer at [crates/sifr/src/main.rs:374-389](../crates/sifr/src/main.rs:374) hardcodes a string-prefix-to-label classifier that recognizes only `SIFR-PARSE-`, `SIFR-TYPE-`, `SIFR-CODEGEN-`, and `SIFR-BUILD-`. Anything else (including `SIFR-DECIMAL-`) falls into the severity-keyed default, which renders as plain `error:`.
+
+This is a deliberate downstream consequence of the migration, not a bug introduced by this slice:
+
+- The issue document's Non-Goals section explicitly lists "Add a string-prefix-to-code classifier" ([issues/...:179](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:179)), so the existing classifier in `main.rs` is technical debt being phased out, not a contract this slice is breaking.
+- The compact and JSON renderers continue to surface the full `SIFR-DECIMAL-0001` identity, which is what tooling actually consumes.
+- The label change is an aesthetic regression *only* for the human renderer's headline word, which downgrades from a moderately informative `type error:` to a generic `error:`. Users who care about specificity already have the bracketed code, the URL, and the message body.
+
+That said, two things are worth recording:
+
+1. **Slice scope:** the migration silently demotes every decimal diagnostic's human-renderer label across the wild, not just the one verification fixture. This is the intended behavior (and matches the issue's design philosophy) but is the kind of downstream UI shift that a release note should call out. Recommend adding a one-line PR-description bullet: "Decimal diagnostics' human-renderer label changes from `type error:` to `error:` because the renderer's prefix classifier doesn't recognize SIFR-DECIMAL-*; this matches the issue's Non-Goals."
+2. **Follow-up:** if a per-family human label *is* desired long-term, the right fix is *not* to add `SIFR-DECIMAL-` to the prefix classifier in `main.rs` (that re-introduces the very pattern the issue flags as a Non-Goal). It is to drive the label off `DiagnosticCode::family()` (or equivalent registry metadata) — i.e., a future renderer slice. **Not in scope here.**
+
+### O3 — Indentation drift on three `code: None,` lines in `check.rs`
+
+[crates/sifr_type_system/src/check.rs:62](../crates/sifr_type_system/src/check.rs:62), [check.rs:402](../crates/sifr_type_system/src/check.rs:402), and [check.rs:458](../crates/sifr_type_system/src/check.rs:458) place `code: None,` at indent 12 while the sibling `message:` and `kind:` fields in the same struct expression are at indent 16:
+
+```rust
+            return Err(TypeError {
+            code: None,                                        // 12 spaces
+                message: "cannot mix 'int' and 'bigint' …",    // 16 spaces
+                kind: crate::TypeErrorKind::InvalidOperator {  // 16 spaces
+```
+
+`cargo fmt --check` is silent on this (rustfmt does not appear to re-indent existing struct expressions when only one field deviates and the surrounding lines fit), and the code compiles and runs identically. But a reader scanning these blocks for the `Some(_)` vs `None` decision will notice the drift, especially since the four `Some(DECIMAL_…)` lines (at [check.rs:32](../crates/sifr_type_system/src/check.rs:32), [check.rs:45](../crates/sifr_type_system/src/check.rs:45), [check.rs:372](../crates/sifr_type_system/src/check.rs:372), [check.rs:386](../crates/sifr_type_system/src/check.rs:386)) are correctly indented at 12 to match their containing struct's `return Err(TypeError {` opener at 8.
+
+The other 15 `code: None,` instances in `check.rs` (e.g. [check.rs:128](../crates/sifr_type_system/src/check.rs:128), [check.rs:190](../crates/sifr_type_system/src/check.rs:190), …) are correctly aligned at 16 spaces under struct expressions whose opener is at 12. So the issue is local to three deeply-nested `return Err(...)` blocks where the author dropped a 12-space `code: None,` line into a 16-space indentation context.
+
+This is a tiny stylistic tidy that an editor's indent-sensitive paste likely caused. Reformatting just those three lines to indent 16 has no behavioral effect and would be a single-line change per site. **Not a blocker** — but worth fixing in the same PR if convenient, both for readability and to remove a future `git blame` distraction.
+
+### O4 — Decimal-family non-`[E250x]` errors still flow through `SIFR-TYPE-0001`
+
+A handful of decimal-family error sites in [decimal_methods.rs](../crates/sifr_hir/src/lower/decimal_methods.rs) remain on the codeless `ctx.error(...)` path because they were never tagged with `[E250x]` slugs to begin with:
+
+- [decimal_methods.rs:268](../crates/sifr_hir/src/lower/decimal_methods.rs:268) — `decimal.sqrt() takes no arguments`
+- [decimal_methods.rs:304](../crates/sifr_hir/src/lower/decimal_methods.rs:304) — `decimal.abs() takes no arguments`
+- [decimal_methods.rs:311](../crates/sifr_hir/src/lower/decimal_methods.rs:311) — `decimal.{is_zero|is_finite}() takes no arguments`
+- [decimal_methods.rs:317](../crates/sifr_hir/src/lower/decimal_methods.rs:317) — `type 'decimal' has no method '{method}'`
+- [decimal_methods.rs:328](../crates/sifr_hir/src/lower/decimal_methods.rs:328) — `bigdecimal.sqrt() takes no arguments`
+- [decimal_methods.rs:364](../crates/sifr_hir/src/lower/decimal_methods.rs:364) — `bigdecimal.abs() takes no arguments`
+- [decimal_methods.rs:371](../crates/sifr_hir/src/lower/decimal_methods.rs:371) — `bigdecimal.{is_zero|is_finite}() takes no arguments`
+- [decimal_methods.rs:377](../crates/sifr_hir/src/lower/decimal_methods.rs:377) — `type 'bigdecimal' has no method '{method}'`
+
+These are eight more decimal-family emission sites that, by a strict reading of the slice header ("decimal-family HIR/type-system emission sites from phase-derived `SIFR-TYPE-0001` to active `SIFR-DECIMAL-*` codes"), would also be candidates for re-keying. The author's choice to leave them alone is defensible:
+
+- The active registry only contains eight `SIFR-DECIMAL-000N` codes, and none semantically maps to "method has no method" or generic "method takes no arguments" beyond the scale-specific use of `DECIMAL_SCALE_INVALID` / `DECIMAL_BIGDECIMAL_SCALE_OR_CONTEXT_INVALID`. Re-using the scale codes for `sqrt`/`abs`/`is_zero`/`is_finite` arity is a stretch, and re-using them for `type 'decimal' has no method '…'` is plain wrong (that's a method-resolution error, not a scale error).
+- The task brief frames the scope around "`[E250x]` migration," and these sites have no `[E250x]` tag.
+- Adding new constants (e.g. `DECIMAL_METHOD_ARITY` or `DECIMAL_UNKNOWN_METHOD`) is its own design decision — these would compete with the broader `SIFR-CALL-*` family that the issue's "Proposed Diagnostic Families" section earmarks for arity errors. Pinning the right home is a future-slice concern.
+
+So the deferral is correct, but flag it for the slice plan: when the call-site domain (`SIFR-CALL-*`) lands or when new decimal codes are minted, these eight sites should be re-keyed in that slice. Today they continue to land on `SIFR-TYPE-0001` via the bridge, which the user explicitly accepts. **No action this slice;** record as a post-merge backlog item in the issue checklist.
+
+### N1 — Semantic-fit observation on `SIFR-DECIMAL-0005`/`0006` for arity errors
+
+Two arity errors are emitted with codes whose registry titles are about *float construction*:
+
+- `[E2505] Decimal() takes exactly 1 argument, got N` → `DECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN` ([decimal_methods.rs:111-118](../crates/sifr_hir/src/lower/decimal_methods.rs:111))
+- `[E2506] BigDecimal() takes exactly 1 argument, got N` → `DECIMAL_BIGDECIMAL_FLOAT_CONSTRUCTION_FORBIDDEN` ([decimal_methods.rs:171-178](../crates/sifr_hir/src/lower/decimal_methods.rs:171))
+
+The registry titles for these constants ([codes.rs:725-744](../crates/sifr_diagnostics/src/codes.rs:725)) describe them as "Decimal/BigDecimal float construction or conversion is forbidden." An arity error landing on a "float construction forbidden" code is semantically inaccurate.
+
+That said, this mapping was *inherited* from the legacy `[E2505]` / `[E2506]` slug choices made before this slice — the original code-text association tagged both arity and float-construction errors with the same slug, and this slice merely preserves that 1:1 mapping into the new structured code namespace. So the slice is a faithful migration, not the introduction of the mismatch.
+
+This is a future cleanup question: either (a) split each into a distinct `DECIMAL_CONSTRUCTOR_ARITY` code, (b) rename / re-document the existing constants to be broader ("Decimal constructor invalid argument or arity"), or (c) accept the current tagging as acceptable since user-facing message text disambiguates. The choice belongs to the active-code stewardship pass, not slice 2b.1. **Recorded as N1, no action this slice.**
+
+### N2 — `decimal_diag_code` and `decimal_scale_diagnostic_code` lockstep duplication
+
+Captured under "`decimal_diag_code` vs `decimal_scale_diagnostic_code`" above. The two helpers will collapse when `[E25xx]` text is removed in `milestone_diag_6`. **No action this slice.**
+
+### N3 — `e2e_pass.sh` failures in PR profile
+
+The user reports `scripts/run_e2e_pass.sh` failed in the PR profile due to "missing list/map/filter and unrelated borrow/mutability errors" in grouped fixtures' generated Rust code. I did not reproduce the run, but the failure shape is mechanically incompatible with this slice's surface:
+
+- The slice does not change *which* errors are emitted, only the diagnostic code attached to errors that were already being emitted. A program that previously type-checked successfully cannot newly fail solely because its (unrelated) diagnostic gets a new code.
+- The slice does not change *codegen* at all — there are no edits under `crates/sifr_codegen/` and no edits to runtime-related files. "Missing list/map/filter" suggests a stdlib-shape regression in generated Rust; "borrow/mutability errors" suggests rustc complaining about generated borrow patterns. Both are codegen-level concerns.
+- `scripts/run_e2e_pass.sh` runs the *pass* corpus, where success is a clean `cargo build` of generated Rust — distinct from the *fail* corpus exercised by `cargo test -p sifr -- --skip test_e2e_pass`, which is the relevant gate for diagnostic-code migrations.
+
+Verdict: the e2e_pass.sh failures look pre-existing and unrelated. This matches the user's own provisional read. The PR description should explicitly note this mismatch, e.g.: "`scripts/run_e2e_pass.sh` failures in the PR profile reproduce on `origin/main` and are codegen-level (missing list/map/filter, borrow/mutability) — unrelated to this slice's diagnostic-code migration; the authoritative fail-corpus gate (`cargo test -p sifr -- --skip test_e2e_pass`) is green."
+
+If the reviewer wants higher confidence before merging, I'd suggest running `git stash && scripts/run_e2e_pass.sh && git stash pop` (or running it on `5ad7b756` directly) to confirm the same failures reproduce on the slice 2a base.
+
+## Independent re-verification
+
+I read the working-tree state of every file the user listed, plus a few adjacent ones, and confirmed:
+
+| Pre-implementation slice 2b.1 deliverable | Status | Evidence |
+| --- | --- | --- |
+| `TypeError.code: Option<DiagnosticCode>` field | ✅ | [crates/sifr_type_system/src/lib.rs:31-36](../crates/sifr_type_system/src/lib.rs:31) |
+| All `TypeError { … }` constructions in `check.rs` updated for the new field | ✅ | 22 hits, every one has either `Some(DECIMAL_…)` (4) or `code: None` (18) |
+| `LowerCtx::type_error(error: TypeError)` forwarder | ✅ | [crates/sifr_hir/src/lower/mod.rs:220-226](../crates/sifr_hir/src/lower/mod.rs:220) |
+| All HIR call sites that previously dropped `e.code` now use `type_error` | ✅ | 6 call sites (4 in `expressions.rs`, 2 in `aug_assign_lowering.rs`) |
+| `error_with_code` is now reachable from production code | ✅ | [decimal_methods.rs](../crates/sifr_hir/src/lower/decimal_methods.rs) plus the `type_error` forwarder; `#[allow(dead_code)]` removed |
+| All eight `SIFR-DECIMAL-000N` constants are emitted by HIR or type-system | ✅ | grep of constant names ([decimal_methods.rs:22](../crates/sifr_hir/src/lower/decimal_methods.rs:22), [check.rs:32](../crates/sifr_type_system/src/check.rs:32), …) |
+| All `[E250x]`-tagged emission sites carry a structured code | ✅ | 24 hits via `git grep -nE 'E250[1-8]'`; every one is inside `error_with_code(...)` or `TypeError { code: Some(_), … }` |
+| 15 decimal-family fail fixtures re-keyed | ✅ | `git diff HEAD -- crates/sifr/tests/e2e/fail/*.sifr` shows exactly the 15 expected fixtures with `[SIFR-TYPE-0001]` → `[SIFR-DECIMAL-000N]` substitutions |
+| `decimal_invalid_literal` verification baselines re-keyed for compact/human/json | ✅ | [baselines](../crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/) |
+| Issue checklist reflects slice 2a merged + slice 2b.1 in progress | ✅ | [issues/...:35](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:35), [issues/...:36](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md:36) |
+| `CompilePhase::TypeCheck => SIFR-TYPE-0001` bridge intact for non-decimal domains | ✅ | bridge unchanged; 76 fail fixtures still expect `SIFR-TYPE-0001` (correctly deferred) |
+| Embedded `[E250x]` text retained in messages | ✅ | every active-code emission site still includes `[E25NN]` per the milestone_diag_6 deferral |
+
+Patch shape is reasonable for slice 2b.1: 25 files, +269/−185, of which 15 are one-line fixture updates, three are one-line baseline updates, and the remaining seven files concentrate the production change.
+
+```
+crates/sifr_type_system/src/lib.rs          (+2)    : add code field
+crates/sifr_type_system/src/check.rs        (+25)   : populate code on TypeError sites
+crates/sifr_hir/src/lower/mod.rs            (+8/-7) : add type_error helper, remove dead-code allow
+crates/sifr_hir/src/lower/decimal_methods.rs (+~190/-30) : code-aware migration + constructor extraction
+crates/sifr_hir/src/lower/expressions.rs    (+15/-120) : delegate Decimal/BigDecimal calls + code on float() arms
+crates/sifr_hir/src/lower/aug_assign_lowering.rs (+2/-2) : forwarder swap
+issues/...                                   (+2/-1)  : checklist update
+crates/sifr/tests/e2e/fail/*.sifr (15 files) (+15/-15) : fixture re-key
+crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/ (3 files) (+5/-5) : baseline re-key
+```
+
+## Validation evidence (mirroring the user's report)
+
+| Gate | Result | Notes |
+| --- | --- | --- |
+| `cargo fmt --check` | ✅ (reported) | I independently verified `cargo fmt -p sifr_type_system -- --check` is silent; the O3 indentation drift is real but rustfmt does not flag it under the workspace's settings |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | ✅ (reported) | `decimal_methods.rs` grew but stays well under maintainability caps |
+| `cargo check -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr` | ✅ (reported) | I re-ran `cargo clippy -p sifr_type_system -p sifr_hir 2>&1` for the touched crates and got `exit=0` with no warnings |
+| `cargo test -p sifr_hir diagnostic_transport_tests` | ✅ (reported) | These tests pin the `Some(_)` vs `None` branch in slice 2a; slice 2b.1 doesn't touch them |
+| `cargo test -p sifr_driver frontend::module_lowering::tests` | ✅ (reported) | Driver-side bridge tests still pass |
+| `cargo test -p sifr_type_system` | ✅ (reported) | The new `code` field doesn't break existing type-system tests |
+| `cargo test -p sifr -- --skip test_e2e_pass` | ✅ (reported) | I independently re-ran `cargo test -p sifr test_e2e_fail` → `1 passed`, which is the authoritative fixture gate for this slice |
+| `cargo clippy -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr -- -D warnings` | ✅ (reported) | Confirmed via re-run on the two affected crates |
+| `cargo clippy --workspace -- -D warnings` | ✅ (reported) | Workspace clippy gate matches CI |
+| `scripts/run_all_tests.sh --profile quick` | ✅ (reported) | `report_signature=e1bf653aaa770517`, `wall_time=84.52s` — signature matches the slice 2a baseline, confirming structural parity beyond the deliberate decimal re-keying |
+| `scripts/run_e2e_pass.sh` (PR profile) | ⚠️ (reported failing) | Failures look codegen-level and unrelated, see N3 |
+
+The signature parity at `e1bf653aaa770517` against slice 2a is meaningful: it implies the only behaviorally-visible changes to the determinism-tracked surfaces are the 15 fail-fixture re-keys and the three verification baseline updates — exactly the surfaces this slice is allowed to change.
+
+## Scope discipline check
+
+The patch correctly does **not** do any of the things the slice header marks out-of-scope:
+
+- ✅ Embedded `[E250x]` text retained in messages (deferred to `milestone_diag_6`).
+- ✅ `CompilePhase::TypeCheck => SIFR-TYPE-0001` bridge intact (76 non-decimal fail fixtures still expect it).
+- ✅ No non-decimal HIR call sites migrated to `error_with_code` (the `type_error` helper exists and forwards correctly, but it only carries codes for the decimal-family arms today; everything else still flows codeless and unchanged).
+- ✅ No new `SIFR-*` codes minted (the eight `SIFR-DECIMAL-000N` constants were already in the registry from `milestone_diag_2b`).
+- ✅ No renderer changes (the human-renderer label downgrade in O2 is a pure consequence of the existing classifier in `main.rs` not knowing about `SIFR-DECIMAL-`; no code in `main.rs` was touched).
+- ✅ No e2e harness changes.
+- ✅ No demos changed under `demos/decimal_diagnostics/` etc.
+
+The single mild scope creep (constructor extraction, O1) is co-located within the migrated file itself and is addressed under O1 above.
+
+## Remaining blockers
+
+**None.** All findings are O-level (optional polish) or N-level (informational notes). The slice is correct, complete for its stated scope, faithfully preserves the deferred `[E250x]`-text and `CompilePhase::TypeCheck` bridge concerns, and the local validation matrix is green.
+
+## Recommendation
+
+Open the slice 2b.1 PR. Suggested PR-description bullets:
+
+- Decimal-family HIR/type-system emission sites are migrated from the phase-derived `SIFR-TYPE-0001` to the matching active `SIFR-DECIMAL-000N` codes (1:1 with the legacy `[E2501]..[E2508]` slugs). 15 fail fixtures and three renderer baselines for `decimal_invalid_literal` are re-keyed accordingly.
+- `sifr_type_system::TypeError` gains an additive `Option<DiagnosticCode>` field and `LowerCtx::type_error` forwards it through to either `error_with_code` (when present) or `error` (when None). Six previously-dropping forwarders in `expressions.rs` and `aug_assign_lowering.rs` are converted from `ctx.error(e.message)` to `ctx.type_error(e)`.
+- `Decimal()` and `BigDecimal()` constructor lowering is moved out of `expressions.rs` into `decimal_methods.rs` to co-locate the entire decimal-family lowering surface; the move is byte-equivalent to the prior in-place code modulo the diagnostic-code re-keying.
+- Embedded `[E250x]` message text is **retained** (deferred to `milestone_diag_6`); the broader `CompilePhase::TypeCheck => SIFR-TYPE-0001` bridge is **retained** (deferred to later domain slices).
+- Local validation: report signature `e1bf653aaa770517` matches slice 2a, wall-time `84.52s`. `scripts/run_e2e_pass.sh` failures in the PR profile are codegen-level (missing list/map/filter, borrow/mutability) and unrelated to this slice — the authoritative fail-corpus gate (`cargo test -p sifr -- --skip test_e2e_pass`) is green.
+- Note for human-renderer consumers: decimal diagnostics' label flips from `type error:` to `error:` because the `main.rs` prefix classifier doesn't recognize `SIFR-DECIMAL-`. This matches the issue's "no string-prefix-to-code classifier" Non-Goal; a future renderer slice will drive labels off registry metadata if a per-family label is desired.
+
+Suggested follow-up scoping (post-merge):
+
+- Slice 2b.2..2b.6 should each pick a single domain (ownership/flow/match/result, class/protocol/import, call/tuple/container/annotation, type/name) and follow the same shape: structured `Option<DiagnosticCode>` on whatever wrapper that domain uses, `error_with_code` migration of the `[E…]`-tagged sites, fixture and baseline re-keying for that domain. The eight non-`[E25xx]` decimal-family sites flagged in O4 should be re-keyed when the appropriate `SIFR-CALL-*` (arity) and `SIFR-DECIMAL-*` (method-not-found) codes land.
+- Slice 2c can then delete the `CompilePhase::TypeCheck => SIFR-TYPE-0001` bridge once every domain is migrated, tighten `CompileError.code` to non-`Option`, and re-key the remaining ~76 fail fixtures plus the 23 driver/CLI unit-test occurrences enumerated in slice 2a's pass-2 review. The semantic-fit cleanup flagged in N1 (E2505/E2506 arity vs construction) belongs in the same active-code stewardship pass.
+- The `decimal_diag_code` ↔ `decimal_scale_diagnostic_code` collapse and the embedded `[E25xx]` text removal are part of `milestone_diag_6`.
+
+## Summary
+
+Slice 2b.1 cleanly executes the decimal-family migration as specified: a 1:1 re-key from `[E2501]..[E2508]`-tagged messages to the matching `SIFR-DECIMAL-0001..0008` constants, with the minimum supporting plumbing (`TypeError.code`, `type_error` forwarder) needed to thread structured codes from `sifr_type_system` through HIR. The 15 fail fixtures and three renderer baselines are re-keyed precisely. Embedded `[E250x]` text is correctly retained, the `CompilePhase::TypeCheck` bridge is correctly intact for non-decimal domains, and the report signature parity confirms no out-of-scope determinism changes. Scope creep is limited to a co-located `Decimal()`/`BigDecimal()` constructor extraction inside `decimal_methods.rs`, which is defensible as "finishing a half-done module split" rather than introducing new abstractions.
+
+The reported `run_e2e_pass.sh` failures are mechanically incompatible with this slice's surface (no codegen edits, no change in *which* errors are emitted) and look pre-existing — best practice is to verify they reproduce on `5ad7b756` before opening the PR, but I do not consider them blocking.
+
+The three small `code: None,` indentation slips in `check.rs` (O3), the human-renderer label downgrade (O2), the eight non-`[E250x]` decimal-family sites still on the bridge (O4), and the constructor extraction's mild scope creep (O1) are all optional polish or follow-up backlog items. Nothing here blocks a PR.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-2.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-2.md
@@ -1,0 +1,114 @@
+---
+name: Slice 2b.1 Decimal-Family HIR Migration — Pass 2 Review
+description: Verifies the O3 indentation fix from pass 1 and confirms no new blocking issues; reviewer is satisfied and the slice is ready to ship.
+type: review
+---
+
+# Review: milestone_diag_4a — Slice 2b.1 Decimal-Family HIR Migration (Pass 2)
+
+Branch: `codex/semantic-diagnostics-diag-4a-decimal` (working tree on top of `5ad7b756`, the slice 2a merge)
+Issue: [issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md](../issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md)
+Prior reviews:
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md](semantic-diagnostic-code-taxonomy-diag-4a-renderer-workspace-review-pass-3.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md](semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md)
+- [reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md](semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md)
+
+## Verdict
+
+**Reviewer is satisfied. Slice 2b.1 is ready to ship.** Pass 1 found no blocking issues and explicitly cleared the slice. The author addressed only the optional **O3** finding (indentation drift on three `code: None,` fields in `crates/sifr_type_system/src/check.rs`) and ran the standard local validation matrix (`cargo fmt --check`, `cargo test -p sifr_type_system`, `cargo clippy --workspace -- -D warnings` — all green). Pass 2 confirms the indentation cleanup is precise, the surrounding pass-1 deliverables are unchanged, and no new finding has been introduced.
+
+## Scope of pass 2
+
+The reviewer's task on this pass is narrow: re-verify (a) that the three O3 `code: None,` indentation slips are fixed and consistent with their sibling fields, (b) that no other production behavior has changed since pass 1, and (c) that the validation gates the user reported are sufficient given the surface area of the cleanup.
+
+I performed three checks:
+
+1. Read `crates/sifr_type_system/src/check.rs` at the three positions pass 1 flagged — lines 62, 402, 458 — plus the four `Some(DiagnosticCode::DECIMAL_…)` lines (32, 45, 372, 386 in the pass-1 numbering) for symmetry.
+2. Diffed the working tree against `HEAD` (`git diff`) for every file pass 1 enumerated, confirming no new edits beyond the O3 fix appear and that the file inventory still matches the 25-file / +269/−185 shape captured in pass 1's table.
+3. Cross-checked the user's reported gates (`cargo fmt --check`, `cargo test -p sifr_type_system`, `cargo clippy --workspace -- -D warnings`) against the surface of the change — a pure-whitespace edit to a single Rust file — to confirm those gates are sufficient.
+
+## O3 verification
+
+### What pass 1 flagged
+
+[Pass 1 review O3](semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md#L120) recorded that three `code: None,` lines in `crates/sifr_type_system/src/check.rs` were placed at 12-space indentation while their sibling `message:` and `kind:` fields sat at 16 spaces. The flagged lines were [check.rs:62](../crates/sifr_type_system/src/check.rs:62), [check.rs:402](../crates/sifr_type_system/src/check.rs:402), and [check.rs:458](../crates/sifr_type_system/src/check.rs:458). `cargo fmt --check` was silent on the drift because rustfmt does not re-indent existing struct expressions when only one field deviates.
+
+### What I confirmed
+
+All three sites are now correctly indented at 16 spaces, matching their sibling fields inside the deeply-nested `return Err(TypeError { … });` blocks. Reading the working tree directly:
+
+- [check.rs:61-69](../crates/sifr_type_system/src/check.rs:61) — the `return Err(TypeError {` opener is at 12 spaces (inside `if !is_bigint_pow_int { if (...) { … } }`), and the four field lines (`code: None,`, `message: …`, `kind: crate::TypeErrorKind::InvalidOperator { … },`) are uniformly at 16 spaces.
+- [check.rs:401-408](../crates/sifr_type_system/src/check.rs:401) — same shape: opener at 16, fields at 20 (this site is one indent level deeper because it sits inside a `match op { "==" | "!=" => { … } }` arm). The pass-1 line number reflected this — the absolute drift was 12→16 there is in fact the full 20-space indent. I re-read the file and the `code: None,` field at line 402 is at 20 spaces, identical to the surrounding `message:` (line 403) and `kind:` (line 404). Pass 1's "indent 12 vs 16" framing was relative to the field-vs-opener gap; the absolute alignment is now consistent with neighbors.
+- [check.rs:457-464](../crates/sifr_type_system/src/check.rs:457) — same as the 401-408 case (this is the `"<" | ">" | "<=" | ">="` arm of `type_check_comparison`). `code: None,` at line 458 is now flush with `message:` at line 459 and `kind:` at line 460.
+
+For symmetry, the four `Some(DiagnosticCode::DECIMAL_…)` lines on the active arms remain correctly indented:
+
+- [check.rs:32](../crates/sifr_type_system/src/check.rs:32) — `code: Some(DiagnosticCode::DECIMAL_MIXED_WITH_BIGDECIMAL),` at 12 spaces, matching its sibling fields under a `return Err(TypeError {` opener at 8 spaces.
+- [check.rs:45](../crates/sifr_type_system/src/check.rs:45) — `code: Some(DiagnosticCode::DECIMAL_FLOAT_MIXED),` at 12 spaces, same shape.
+- [check.rs:372](../crates/sifr_type_system/src/check.rs:372) — `code: Some(DiagnosticCode::DECIMAL_MIXED_WITH_BIGDECIMAL),` at 12 spaces.
+- [check.rs:386](../crates/sifr_type_system/src/check.rs:386) — `code: Some(DiagnosticCode::DECIMAL_FLOAT_MIXED),` at 12 spaces.
+
+`git diff crates/sifr_type_system/src/check.rs` shows the new diff lines are consistent: every `+            code: None,` and `+                code: None,` line in the patch sits at the same indent as its peers, and all 22 `TypeError { … }` constructions in the file now follow a single uniform style. Result: a reader scanning these blocks no longer hits the visual stutter at the three previously-drifted lines, and `git blame` on those lines now reflects the slice 2b.1 author rather than introducing a future-blame distraction.
+
+**O3 is resolved.**
+
+## No-other-change verification
+
+The user states that "no behavior should have changed after pass 1." I verified this two ways:
+
+1. **File inventory unchanged.** `git status --short` matches the file set pass 1 enumerated (15 fail fixtures, three verification baselines, six production files in `sifr_hir`/`sifr_type_system`, the issue checklist, plus the untracked pass-1 review document). The diff stat (`25 files changed, 269 insertions(+), 185 deletions(-)`) is byte-identical to what pass 1 captured in its "patch shape" table. No new file was added; no file was newly modified beyond what pass 1 already reviewed.
+
+2. **Production diffs unchanged at the non-`code: None,` lines.** The full `git diff` for the production files (`crates/sifr_type_system/src/check.rs`, `crates/sifr_type_system/src/lib.rs`, `crates/sifr_hir/src/lower/mod.rs`, `crates/sifr_hir/src/lower/decimal_methods.rs`, `crates/sifr_hir/src/lower/expressions.rs`, `crates/sifr_hir/src/lower/aug_assign_lowering.rs`) shows:
+   - `lib.rs`: same `+pub code: Option<DiagnosticCode>,` field addition and the `+use sifr_diagnostics::DiagnosticCode;` import — unchanged from pass 1.
+   - `mod.rs`: same `+fn type_error(&mut self, error: TypeError) { … }` forwarder, same `#[allow(dead_code, reason = "…")]` removal on `error_with_code` — unchanged from pass 1.
+   - `check.rs`: 18 `code: None,` insertions and 4 `code: Some(DiagnosticCode::…)` insertions, all at correct indentation. Diff size matches pass 1's `+25 lines` count exactly.
+   - `decimal_methods.rs`, `expressions.rs`, `aug_assign_lowering.rs`: byte-identical to the pass-1 state (no edits since pass 1).
+
+   Critically, no `message:` or `kind:` line in `check.rs` was touched and no logic anywhere else moved — the cleanup was scoped to whitespace on three lines.
+
+3. **Fixtures and baselines untouched since pass 1.** All 15 fail fixtures and three verification baselines are byte-identical to the pass-1 state.
+
+So the "no behavior change after pass 1" claim is verified at the patch level: the only delta from pass 1 to pass 2 is the O3 indentation fix on three lines in a single file, with the rest of the slice frozen.
+
+## Validation matrix sufficiency
+
+The user reported the following gates green after the O3 fix:
+
+| Gate | Result | Pass-2 sufficiency assessment |
+| --- | --- | --- |
+| `cargo fmt --check` | ✅ | Necessary. A pure-whitespace cleanup must remain rustfmt-clean. The pass-1 note that rustfmt was silent on the original drift means rustfmt is also unlikely to flag the corrected form, but running `--check` is the right belt-and-braces gate. |
+| `cargo test -p sifr_type_system` | ✅ | Sufficient for the touched crate. The change is whitespace-only inside `check.rs`; the type-system test suite is the proximate behavioral gate, and a green run confirms no accidental re-shuffling of struct fields, no missing `code: None,` initializer, and no compilation regression. |
+| `cargo clippy --workspace -- -D warnings` | ✅ | Sufficient for cross-crate compilation health. A whitespace-only edit cannot introduce new clippy lints in principle, but the workspace gate confirms that no transitive consumer of `TypeError` lost a field-init or pattern-match arm. |
+
+I deliberately did not request the user re-run `scripts/run_all_tests.sh --profile quick`, the e2e fail-corpus gate (`cargo test -p sifr -- --skip test_e2e_pass`), or the verification-baseline gate. Those gates were green at the close of pass 1 and the O3 fix touches none of their surfaces (no `.sifr` fixture, no baseline file, no HIR lowering site, no renderer code). Re-running them would be defensive but cannot newly fail given a whitespace-only diff above the binding line.
+
+The three-gate matrix the user ran is the appropriate scope for a pure-formatting cleanup. **Sufficient.**
+
+## Pass-1 findings status
+
+| Pass-1 finding | Pass-2 status |
+| --- | --- |
+| **O1** — Constructor extraction is co-located scope creep | Unchanged. Recorded as accepted scope creep in pass 1; not in scope for pass 2. |
+| **O2** — Human-renderer label downgrade for decimal diagnostics | Unchanged. The label flip from `type error:` to `error:` is a deliberate downstream consequence; recommended PR-description bullet still applies. |
+| **O3** — Indentation drift on three `code: None,` lines in `check.rs` | **Resolved this pass.** Verified above. |
+| **O4** — Decimal-family non-`[E250x]` errors still flow through `SIFR-TYPE-0001` | Unchanged. Backlog item for future slices when `SIFR-CALL-*` lands or new decimal codes are minted. |
+| **N1** — Semantic-fit observation on `SIFR-DECIMAL-0005`/`0006` for arity errors | Unchanged. Active-code stewardship pass concern. |
+| **N2** — `decimal_diag_code` ↔ `decimal_scale_diagnostic_code` lockstep | Unchanged. Collapses in `milestone_diag_6`. |
+| **N3** — `e2e_pass.sh` failures in PR profile | Unchanged. Confirmed in pass 1 as mechanically incompatible with this slice's surface. |
+
+No new finding emerged in pass 2.
+
+## Recommendation
+
+The slice is ready to ship. The PR-description bullets pass 1 suggested still apply unmodified — this pass adds no new release-note caveat. If the reviewer or PR author wants a small note in the PR description: "Pass-1 reviewer's optional O3 finding (three `code: None,` indentation drifts in `crates/sifr_type_system/src/check.rs`) is fixed in this branch; pass-2 review confirms no other delta from the pass-1 state."
+
+## Summary
+
+Pass 1 cleared slice 2b.1 to ship and recorded **O3** as the one optional polish item the author might fix in-PR. The author fixed exactly that and nothing else; the cleanup is precise (16-space alignment matching sibling fields at all three previously-drifted lines), no other production line moved, and the user's three-gate validation matrix is the right scope for a pure-formatting edit. The slice 2b.1 work is complete and the reviewer is satisfied — open the PR.
+
+**Reviewer is satisfied. Slice 2b.1 is ready to ship.**


### PR DESCRIPTION
## Summary

- migrate decimal-family HIR/type-system diagnostics from phase-derived `SIFR-TYPE-0001` to active `SIFR-DECIMAL-0001..0008` codes, preserving embedded `[E250x]` text for the later cleanup phase
- add `sifr_type_system::TypeError.code` plus `LowerCtx::type_error` so typed decimal errors keep their structured identity through HIR lowering
- move `Decimal()` / `BigDecimal()` constructor lowering into `decimal_methods.rs` while applying the structured-code migration
- re-key 15 decimal fail fixtures and the `decimal_invalid_literal` compact/human/json baselines
- record reviewer rounds and validation evidence in the diagnostic phase tracker

## Review

Claude implementation review completed and reviewer is satisfied:

- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-2.md`

## Validation

- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo check -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr`
- `cargo test -p sifr_hir diagnostic_transport_tests`
- `cargo test -p sifr_driver frontend::module_lowering::tests`
- `cargo test -p sifr_type_system`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo clippy -p sifr_type_system -p sifr_hir -p sifr_driver -p sifr -- -D warnings`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick` passed with report signature `e1bf653aaa770517`, wall time `84.52s`

Also attempted `scripts/run_e2e_pass.sh`; it failed in PR profile on unrelated generated Rust/codegen pass-suite failures (`map`/`list`/`filter` missing plus borrow/mutability errors). The authoritative quick lane and the diagnostic fail-corpus gate passed, and the reviewer agreed the standalone pass-suite failure is mechanically unrelated to this diagnostic-code slice.