### PR TITLE
Classify parser diagnostics by Ruff category

### DIFF
--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_diagnostics::{
-    DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
+    ChildSeverity, DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
 };
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build, build_cached_project, build_cached_single_file,
@@ -417,6 +417,13 @@ fn render_diagnostic_stream(
                     }
                 };
                 let _ = writeln!(output, "{label}: {message}", message = diagnostic.message);
+                for child in &diagnostic.children {
+                    let child_label = match child.severity {
+                        ChildSeverity::Note => "note",
+                        ChildSeverity::Help => "help",
+                    };
+                    let _ = writeln!(output, "{child_label}: {}", child.message);
+                }
             }
         }
         DiagnosticFormat::Json => {
@@ -1501,6 +1508,30 @@ mod tests {
         assert_eq!(compact_total, canonical.len());
         assert!(compact_output.contains("error [SIFR-TYPE-0002] distinct diagnostic 43 (x1)"));
         assert!(!compact_output.contains("distinct diagnostic 44"));
+    }
+
+    #[test]
+    fn test_human_diagnostic_format_renders_child_notes() {
+        let mut diagnostic = test_diagnostic(
+            "SIFR-PARSE-0002",
+            Severity::Error,
+            "syntax error: expected expression",
+            None,
+            None,
+        );
+        diagnostic
+            .children
+            .push(sifr_diagnostics::render::RenderedDiagnosticChild {
+                severity: ChildSeverity::Note,
+                message: "while parsing helper".to_string(),
+            });
+
+        let human_output = render_diagnostic_output(&[diagnostic], DiagnosticFormat::Human)
+            .expect("human diagnostics should render");
+        assert_eq!(
+            human_output,
+            "parse error: syntax error: expected expression\nnote: while parsing helper\n"
+        );
     }
 
     #[test]

--- a/crates/sifr/tests/e2e/fail/parser_expected_token.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_expected_token.sifr
@@ -1,0 +1,3 @@
+# expect-error: SIFR-PARSE-0002
+def main(:
+    pass

--- a/crates/sifr/tests/e2e/fail/parser_invalid_call_arguments.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_invalid_call_arguments.sifr
@@ -1,0 +1,3 @@
+# expect-error: SIFR-PARSE-0006
+def main():
+    print(value=1, 2)

--- a/crates/sifr/tests/e2e/fail/parser_invalid_layout.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_invalid_layout.sifr
@@ -1,0 +1,2 @@
+# expect-error: SIFR-PARSE-0004
+    value = 1

--- a/crates/sifr/tests/e2e/fail/parser_invalid_match_pattern.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_invalid_match_pattern.sifr
@@ -1,0 +1,5 @@
+# expect-error: SIFR-PARSE-0008
+def main():
+    match 1:
+        case *value:
+            pass

--- a/crates/sifr/tests/e2e/fail/parser_invalid_target.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_invalid_target.sifr
@@ -1,0 +1,3 @@
+# expect-error: SIFR-PARSE-0005
+def main():
+    1 = 2

--- a/crates/sifr/tests/e2e/fail/parser_malformed_declaration_list.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_malformed_declaration_list.sifr
@@ -1,0 +1,3 @@
+# expect-error: SIFR-PARSE-0007
+def main():
+    global

--- a/crates/sifr/tests/e2e/fail/parser_malformed_string.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_malformed_string.sifr
@@ -1,0 +1,3 @@
+# expect-error: SIFR-PARSE-0003
+def main():
+    value = "unterminated

--- a/crates/sifr/tests/e2e/fail/parser_unsupported_syntax.sifr
+++ b/crates/sifr/tests/e2e/fail/parser_unsupported_syntax.sifr
@@ -1,0 +1,2 @@
+# expect-error: SIFR-PARSE-0009
+lazy import value

--- a/crates/sifr_driver/src/frontend/api.rs
+++ b/crates/sifr_driver/src/frontend/api.rs
@@ -1,11 +1,10 @@
+use super::parse_module_with_diagnostics;
 use crate::build::{compile_single_file_entrypoint_with_metadata, compile_single_file_frontend};
 use crate::diagnostics::{CompileResult, CompileResultFull, RenderedDiagnostic};
 use crate::frontend::module_lowering::emit_frontend_diagnostics;
 use crate::stdlib::StdlibCompiled;
-use sifr_diagnostics::DiagnosticCode;
 use sifr_hir::LoweringResult;
 use sifr_python_ast::Stmt;
-use sifr_python_parser::parse_module;
 
 pub(crate) struct FrontendCompiled {
     pub(crate) stdlib: StdlibCompiled,
@@ -13,32 +12,7 @@ pub(crate) struct FrontendCompiled {
 }
 
 pub fn parse_source(source: &str) -> Result<Vec<Stmt>, Vec<RenderedDiagnostic>> {
-    match parse_module(source) {
-        Ok(parsed) => {
-            if !parsed.has_valid_syntax() {
-                // TODO(diag_4a slice 2): classify Ruff parse failures into
-                // the precise active parse-code buckets.
-                let errors: Vec<RenderedDiagnostic> = parsed
-                    .errors()
-                    .iter()
-                    .map(|e| {
-                        crate::diagnostics::diagnostic_with_code(
-                            format!("{e}"),
-                            DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
-                        )
-                    })
-                    .collect();
-                return Err(errors);
-            }
-            Ok(parsed.into_suite())
-        }
-        // TODO(diag_4a slice 2): classify Ruff parse failures into the
-        // precise active parse-code buckets.
-        Err(e) => Err(vec![crate::diagnostics::diagnostic_with_code(
-            format!("failed to parse: {e}"),
-            DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
-        )]),
-    }
+    parse_module_with_diagnostics(source, None).map(sifr_python_parser::Parsed::into_suite)
 }
 
 fn compile_frontend(source: &str) -> Result<FrontendCompiled, Vec<RenderedDiagnostic>> {

--- a/crates/sifr_driver/src/frontend/mod.rs
+++ b/crates/sifr_driver/src/frontend/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod module_lowering;
+mod parser_diagnostics;
 
 pub use api::{
     check, compile, compile_with_metadata, lower_source, parse_source, type_check_source,
@@ -9,3 +10,4 @@ pub(crate) use api::FrontendCompiled;
 pub(crate) use module_lowering::{
     lower_frontend_module, FrontendDiagnosticStyle, FrontendModuleDiagnostics,
 };
+pub(crate) use parser_diagnostics::parse_module_with_diagnostics;

--- a/crates/sifr_driver/src/frontend/parser_diagnostics.rs
+++ b/crates/sifr_driver/src/frontend/parser_diagnostics.rs
@@ -1,0 +1,362 @@
+use crate::diagnostics::RenderedDiagnostic;
+use sifr_diagnostics::render::RenderedDiagnosticChild;
+use sifr_diagnostics::{ChildSeverity, DiagnosticArg, DiagnosticCode};
+use sifr_python_ast::{ModModule, PythonVersion};
+use sifr_python_parser::{
+    parse_unchecked, InterpolatedStringErrorType, LexicalErrorType, Mode, ParseError,
+    ParseErrorType, ParseOptions, Parsed, UnsupportedSyntaxError,
+};
+use std::collections::BTreeMap;
+
+pub(crate) fn parse_module_with_diagnostics(
+    source: &str,
+    context: Option<&str>,
+) -> Result<Parsed<ModModule>, Vec<RenderedDiagnostic>> {
+    let parsed = parse_unchecked(
+        source,
+        // Sifr owns the latest Python-derived syntax surface pre-1.0; do not
+        // reject syntax only because Ruff's default target is older.
+        ParseOptions::from(Mode::Module).with_target_version(PythonVersion::latest_ty()),
+    );
+    let Some(parsed) = parsed.try_into_module() else {
+        unreachable!("module parse mode must produce a module syntax tree");
+    };
+    if parsed.has_invalid_syntax() {
+        // Grammar errors are primary. Ruff version diagnostics are only useful
+        // after the parser has produced a syntactically valid module.
+        return Err(parsed
+            .errors()
+            .iter()
+            .map(|error| parse_error_diagnostic(error, context))
+            .collect());
+    }
+    if !parsed.unsupported_syntax_errors().is_empty() {
+        return Err(parsed
+            .unsupported_syntax_errors()
+            .iter()
+            .map(|error| unsupported_syntax_diagnostic(error, context))
+            .collect());
+    }
+    Ok(parsed)
+}
+
+fn parse_error_diagnostic(error: &ParseError, context: Option<&str>) -> RenderedDiagnostic {
+    parse_diagnostic(parse_error_details(&error.error), context)
+}
+
+fn unsupported_syntax_diagnostic(
+    error: &UnsupportedSyntaxError,
+    context: Option<&str>,
+) -> RenderedDiagnostic {
+    parse_diagnostic(
+        ParseDiagnosticDetails {
+            code: DiagnosticCode::PARSE_UNSUPPORTED_SYNTAX,
+            template: "unsupported syntax: {syntax_kind}",
+            arg_name: "syntax_kind",
+            arg_value: error.to_string(),
+            parser_category: "unsupported_syntax",
+        },
+        context,
+    )
+}
+
+struct ParseDiagnosticDetails {
+    code: DiagnosticCode,
+    template: &'static str,
+    arg_name: &'static str,
+    arg_value: String,
+    parser_category: &'static str,
+}
+
+fn parse_diagnostic(details: ParseDiagnosticDetails, context: Option<&str>) -> RenderedDiagnostic {
+    let message = render_template(details.template, details.arg_name, &details.arg_value);
+    let mut args = BTreeMap::new();
+    args.insert(
+        details.arg_name.to_string(),
+        DiagnosticArg::String(details.arg_value),
+    );
+    args.insert(
+        "parser_category".to_string(),
+        DiagnosticArg::String(details.parser_category.to_string()),
+    );
+    let children = context
+        .map(|label| RenderedDiagnosticChild {
+            severity: ChildSeverity::Note,
+            message: format!("while parsing {label}"),
+        })
+        .into_iter()
+        .collect();
+    RenderedDiagnostic {
+        code: details.code.code().to_string(),
+        severity: details.code.declared_severity(),
+        message,
+        message_template: details.template.to_string(),
+        args,
+        url: details.code.docs_url(),
+        spans: Vec::new(),
+        children,
+        help: None,
+        suggestions: Vec::new(),
+    }
+}
+
+fn render_template(template: &str, arg_name: &str, arg_value: &str) -> String {
+    template.replace(&format!("{{{arg_name}}}"), arg_value)
+}
+
+fn parse_error_details(error: &ParseErrorType) -> ParseDiagnosticDetails {
+    match error {
+        ParseErrorType::Lexical(reason) => lexical_or_string_details(reason),
+        ParseErrorType::FStringError(reason) => interpolated_string_details("f_string", reason),
+        ParseErrorType::TStringError(reason) => interpolated_string_details("t_string", reason),
+
+        ParseErrorType::UnexpectedIndentation => layout_details("unexpected indentation"),
+        ParseErrorType::SimpleStatementsOnSameLine => {
+            layout_details("simple statements must be separated")
+        }
+        ParseErrorType::SimpleAndCompoundStatementOnSameLine => {
+            layout_details("compound statement shares a line with a simple statement")
+        }
+
+        ParseErrorType::InvalidAssignmentTarget => {
+            invalid_target_details("assignment target", "invalid_assignment_target")
+        }
+        ParseErrorType::InvalidNamedAssignmentTarget => {
+            invalid_target_details("named assignment target", "invalid_named_assignment_target")
+        }
+        ParseErrorType::InvalidAnnotatedAssignmentTarget => invalid_target_details(
+            "annotated assignment target",
+            "invalid_annotated_assignment_target",
+        ),
+        ParseErrorType::InvalidAugmentedAssignmentTarget => invalid_target_details(
+            "augmented assignment target",
+            "invalid_augmented_assignment_target",
+        ),
+        ParseErrorType::InvalidDeleteTarget => {
+            invalid_target_details("delete target", "invalid_delete_target")
+        }
+        ParseErrorType::EmptyDeleteTargets => declaration_list_details("delete statement"),
+        ParseErrorType::InvalidStarredExpressionUsage => {
+            invalid_target_details("starred expression", "invalid_starred_expression")
+        }
+
+        ParseErrorType::DuplicateKeywordArgumentError(name) => invalid_call_details(
+            format!("duplicate keyword argument {name:?}"),
+            "duplicate_keyword_argument",
+        ),
+        ParseErrorType::PositionalAfterKeywordArgument => invalid_call_details(
+            "positional argument after keyword argument",
+            "positional_after_keyword_argument",
+        ),
+        ParseErrorType::PositionalAfterKeywordUnpacking => invalid_call_details(
+            "positional argument after keyword unpacking",
+            "positional_after_keyword_unpacking",
+        ),
+        ParseErrorType::InvalidArgumentUnpackingOrder => invalid_call_details(
+            "iterable unpacking after keyword unpacking",
+            "invalid_argument_unpacking_order",
+        ),
+        ParseErrorType::IterableUnpackingInComprehension => invalid_call_details(
+            "iterable unpacking in comprehension",
+            "iterable_unpacking_in_comprehension",
+        ),
+
+        ParseErrorType::EmptyGlobalNames => declaration_list_details("global statement"),
+        ParseErrorType::EmptyNonlocalNames => declaration_list_details("nonlocal statement"),
+        ParseErrorType::EmptyImportNames => declaration_list_details("import statement"),
+        ParseErrorType::EmptyTypeParams => declaration_list_details("type parameter list"),
+        ParseErrorType::ParamAfterVarKeywordParam => {
+            declaration_list_details("parameter after var-keyword parameter")
+        }
+        ParseErrorType::NonDefaultParamAfterDefaultParam => {
+            declaration_list_details("non-default parameter after default parameter")
+        }
+        ParseErrorType::VarParameterWithDefault => {
+            declaration_list_details("var parameter default")
+        }
+        ParseErrorType::ExpectedKeywordParam => {
+            declaration_list_details("keyword-only parameter list")
+        }
+
+        ParseErrorType::InvalidStarPatternUsage => {
+            invalid_pattern_details("star pattern outside a sequence pattern")
+        }
+        ParseErrorType::ExpectedRealNumber => {
+            invalid_pattern_details("expected real number in complex literal pattern")
+        }
+        ParseErrorType::ExpectedImaginaryNumber => {
+            invalid_pattern_details("expected imaginary number in complex literal pattern")
+        }
+
+        ParseErrorType::UnexpectedTokenAfterAsync(token) => unsupported_details(
+            format!("async statement cannot be followed by {token}"),
+            "unexpected_token_after_async",
+        ),
+        ParseErrorType::UnexpectedIpythonEscapeCommand => unsupported_details(
+            "IPython escape command in module mode",
+            "unexpected_ipython_escape_command",
+        ),
+
+        ParseErrorType::ExpectedToken { expected, found } => expected_details(
+            format!("{expected}; found {found}"),
+            "expected_token_or_recovery",
+        ),
+        ParseErrorType::ExpectedExpression => expected_details("expression", "expected_expression"),
+        ParseErrorType::UnexpectedExpressionToken => {
+            expected_details("expression terminator", "unexpected_expression_token")
+        }
+        ParseErrorType::EmptySlice => expected_details("index or slice expression", "empty_slice"),
+        ParseErrorType::UnparenthesizedNamedExpression => expected_details(
+            "parenthesized named expression",
+            "unparenthesized_named_expression",
+        ),
+        ParseErrorType::UnparenthesizedTupleExpression => expected_details(
+            "parenthesized tuple expression",
+            "unparenthesized_tuple_expression",
+        ),
+        ParseErrorType::UnparenthesizedGeneratorExpression => expected_details(
+            "parenthesized generator expression",
+            "unparenthesized_generator_expression",
+        ),
+        ParseErrorType::InvalidLambdaExpressionUsage => expected_details(
+            "valid lambda expression context",
+            "invalid_lambda_expression_usage",
+        ),
+        ParseErrorType::InvalidYieldExpressionUsage => expected_details(
+            "valid yield expression context",
+            "invalid_yield_expression_usage",
+        ),
+        ParseErrorType::OtherError(message) => {
+            expected_details(recovery_expected(message), "parser_recovery")
+        }
+    }
+}
+
+fn recovery_expected(message: &str) -> String {
+    if let Some(stripped) = message
+        .strip_prefix("Expected ")
+        .or_else(|| message.strip_prefix("expected "))
+    {
+        return stripped.to_string();
+    }
+    format!("recovery: {message}")
+}
+
+fn expected_details(
+    expected: impl Into<String>,
+    parser_category: &'static str,
+) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+        template: "syntax error: expected {expected}",
+        arg_name: "expected",
+        arg_value: expected.into(),
+        parser_category,
+    }
+}
+
+fn lexical_or_string_details(reason: &LexicalErrorType) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_LEXICAL_OR_STRING,
+        template: "lexical error: {reason}",
+        arg_name: "reason",
+        arg_value: reason.to_string(),
+        parser_category: match reason {
+            LexicalErrorType::StringError
+            | LexicalErrorType::UnclosedStringError
+            | LexicalErrorType::UnicodeError
+            | LexicalErrorType::MissingUnicodeLbrace
+            | LexicalErrorType::MissingUnicodeRbrace
+            | LexicalErrorType::FStringError(_)
+            | LexicalErrorType::TStringError(_)
+            | LexicalErrorType::InvalidByteLiteral => "lexical_string",
+            LexicalErrorType::IndentationError => "lexical_indentation",
+            LexicalErrorType::UnrecognizedToken { .. } => "lexical_unrecognized_token",
+            LexicalErrorType::LineContinuationError => "lexical_line_continuation",
+            LexicalErrorType::Eof => "lexical_eof",
+            LexicalErrorType::OtherError(_) => "lexical_other",
+        },
+    }
+}
+
+fn interpolated_string_details(
+    parser_category: &'static str,
+    reason: &InterpolatedStringErrorType,
+) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_LEXICAL_OR_STRING,
+        template: "lexical error: {reason}",
+        arg_name: "reason",
+        arg_value: reason.to_string(),
+        parser_category,
+    }
+}
+
+fn layout_details(reason: impl Into<String>) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_LAYOUT,
+        template: "invalid source layout: {reason}",
+        arg_name: "reason",
+        arg_value: reason.into(),
+        parser_category: "layout",
+    }
+}
+
+fn invalid_target_details(
+    target_kind: impl Into<String>,
+    parser_category: &'static str,
+) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_INVALID_TARGET,
+        template: "invalid target syntax: {target_kind}",
+        arg_name: "target_kind",
+        arg_value: target_kind.into(),
+        parser_category,
+    }
+}
+
+fn invalid_call_details(
+    reason: impl Into<String>,
+    parser_category: &'static str,
+) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_INVALID_CALL_ARGUMENTS,
+        template: "invalid call argument syntax: {reason}",
+        arg_name: "reason",
+        arg_value: reason.into(),
+        parser_category,
+    }
+}
+
+fn declaration_list_details(declaration_kind: impl Into<String>) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_MALFORMED_DECLARATION_LIST,
+        template: "malformed declaration list: {declaration_kind}",
+        arg_name: "declaration_kind",
+        arg_value: declaration_kind.into(),
+        parser_category: "malformed_declaration_list",
+    }
+}
+
+fn invalid_pattern_details(reason: impl Into<String>) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_INVALID_PATTERN,
+        template: "invalid match pattern syntax: {reason}",
+        arg_name: "reason",
+        arg_value: reason.into(),
+        parser_category: "invalid_pattern",
+    }
+}
+
+fn unsupported_details(
+    syntax_kind: impl Into<String>,
+    parser_category: &'static str,
+) -> ParseDiagnosticDetails {
+    ParseDiagnosticDetails {
+        code: DiagnosticCode::PARSE_UNSUPPORTED_SYNTAX,
+        template: "unsupported syntax: {syntax_kind}",
+        arg_name: "syntax_kind",
+        arg_value: syntax_kind.into(),
+        parser_category,
+    }
+}

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -1,8 +1,8 @@
 use crate::diagnostics::RenderedDiagnostic;
+use crate::frontend::parse_module_with_diagnostics;
 use crate::workspace::WorkspaceRoot;
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::Stmt;
-use sifr_python_parser::parse_module;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
@@ -396,34 +396,7 @@ pub(crate) fn parse_import_closure_modules(
             )]
         })?;
         let label = discovery_label(&module_name, &path, diagnostic_style);
-        let parsed = match parse_module(&source) {
-            Ok(parsed) => {
-                if !parsed.has_valid_syntax() {
-                    // TODO(diag_4a slice 2): classify Ruff parse failures
-                    // into the precise active parse-code buckets.
-                    let errors: Vec<RenderedDiagnostic> = parsed
-                        .errors()
-                        .iter()
-                        .map(|e| {
-                            crate::diagnostics::diagnostic_with_code(
-                                format!("[{label}] {e}"),
-                                DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
-                            )
-                        })
-                        .collect();
-                    return Err(errors);
-                }
-                parsed
-            }
-            Err(e) => {
-                // TODO(diag_4a slice 2): classify Ruff parse failures into
-                // the precise active parse-code buckets.
-                return Err(vec![crate::diagnostics::diagnostic_with_code(
-                    format!("[{label}] failed to parse: {e}"),
-                    DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
-                )]);
-            }
-        };
+        let parsed = parse_module_with_diagnostics(&source, Some(&label))?;
         let suite = parsed.into_suite();
         for dependency in collect_import_closure_module_dependencies(&suite) {
             if parsed_names.contains(dependency.as_str()) {

--- a/crates/sifr_driver/src/tests/discovery_and_workspace.rs
+++ b/crates/sifr_driver/src/tests/discovery_and_workspace.rs
@@ -158,10 +158,14 @@ fn test_project_and_test_discovery_parity_reports_reachable_parse_errors() {
             .err()
             .expect("test closure should fail on reachable parse error");
 
-    assert!(project_errors
+    assert!(project_errors.iter().any(|e| e
+        .children
         .iter()
-        .any(|e| e.message.contains("[helper]")));
-    assert!(test_errors.iter().any(|e| e.message.contains("[helper]")));
+        .any(|child| child.message == "while parsing helper")));
+    assert!(test_errors.iter().any(|e| e
+        .children
+        .iter()
+        .any(|child| child.message == "while parsing helper")));
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -271,11 +271,10 @@ fn test_check_project_reports_reachable_parse_errors_in_import_closure() {
 
     let errors = check_project(&dir.join("main.sifr"));
     assert!(
-        errors.iter().any(|e| {
-            e.message.contains("[helper]")
-                && (e.message.contains("failed to parse")
-                    || e.message.contains("Expected a parameter"))
-        }),
+        errors.iter().any(|e| e.code == "SIFR-PARSE-0002"
+            && e.children
+                .iter()
+                .any(|child| child.message == "while parsing helper")),
         "reachable parse errors must still fail check_project: {errors:?}"
     );
 

--- a/crates/sifr_driver/src/tests/single_file_frontend.rs
+++ b/crates/sifr_driver/src/tests/single_file_frontend.rs
@@ -2,7 +2,7 @@ use crate::{
     check, compile, compile_with_metadata, lower_source, parse_source, type_check_source,
     CompileResult, CompileResultFull,
 };
-use sifr_diagnostics::DiagnosticCode;
+use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
 
 #[test]
 fn test_parse_source_returns_suite_for_valid_program() {
@@ -19,6 +19,109 @@ fn test_parse_source_returns_parse_error_for_invalid_program() {
         errors[0].code,
         DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY.code()
     );
+}
+
+#[test]
+fn test_parse_source_classifies_parser_error_categories() {
+    let cases = [
+        (
+            "def main(:\n    pass\n",
+            DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY,
+            "expected",
+            "parser_category",
+        ),
+        (
+            "def main():\n    x = \"unterminated\n",
+            DiagnosticCode::PARSE_LEXICAL_OR_STRING,
+            "reason",
+            "parser_category",
+        ),
+        (
+            "    x = 1\n",
+            DiagnosticCode::PARSE_LAYOUT,
+            "reason",
+            "parser_category",
+        ),
+        (
+            "def main():\n    1 = 2\n",
+            DiagnosticCode::PARSE_INVALID_TARGET,
+            "target_kind",
+            "parser_category",
+        ),
+        (
+            "def main():\n    f(a=1, 2)\n",
+            DiagnosticCode::PARSE_INVALID_CALL_ARGUMENTS,
+            "reason",
+            "parser_category",
+        ),
+        (
+            "def main():\n    global\n",
+            DiagnosticCode::PARSE_MALFORMED_DECLARATION_LIST,
+            "declaration_kind",
+            "parser_category",
+        ),
+        (
+            "def main():\n    match 1:\n        case *x:\n            pass\n",
+            DiagnosticCode::PARSE_INVALID_PATTERN,
+            "reason",
+            "parser_category",
+        ),
+        (
+            "lazy import value\n",
+            DiagnosticCode::PARSE_UNSUPPORTED_SYNTAX,
+            "syntax_kind",
+            "parser_category",
+        ),
+    ];
+
+    for (source, expected_code, message_arg, category_arg) in cases {
+        let errors = parse_source(source).expect_err("invalid source should fail parsing");
+        let diagnostic = errors
+            .iter()
+            .find(|diagnostic| diagnostic.code == expected_code.code())
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected parser code {} in {errors:?}",
+                    expected_code.code()
+                )
+            });
+        assert_eq!(diagnostic.code, expected_code.code(), "{source}");
+        assert_eq!(diagnostic.severity, expected_code.declared_severity());
+        assert!(diagnostic.args.contains_key(message_arg), "{source}");
+        assert!(matches!(
+            diagnostic.args.get(category_arg),
+            Some(DiagnosticArg::String(category)) if !category.is_empty()
+        ));
+        assert_ne!(diagnostic.message_template, "{message}");
+    }
+}
+
+#[test]
+fn test_parse_source_normalizes_parser_recovery_messages() {
+    let expected_prefixed = parse_source("def main(:\n")
+        .expect_err("invalid source should fail parsing")
+        .into_iter()
+        .find(|diagnostic| {
+            diagnostic.code == DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY.code()
+        })
+        .expect("expected parser recovery diagnostic");
+    assert_eq!(
+        expected_prefixed.message,
+        "syntax error: expected a parameter or the end of the parameter list"
+    );
+    assert!(!expected_prefixed.message.contains("expected Expected"));
+
+    let recovery_prefixed = parse_source("def f(mut mut items: list[int]):\n    return items\n")
+        .expect_err("invalid source should fail parsing")
+        .into_iter()
+        .find(|diagnostic| {
+            diagnostic.code == DiagnosticCode::PARSE_EXPECTED_TOKEN_OR_RECOVERY.code()
+                && diagnostic.message.contains("recovery:")
+        })
+        .expect("non-expected recovery payload should be normalized");
+    assert!(recovery_prefixed
+        .message
+        .starts_with("syntax error: expected recovery: "));
 }
 
 #[test]

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -291,25 +291,45 @@ fn test_run_tests_reports_deterministic_parse_error_order() {
     std::fs::write(test_dir.join("test_a_bad.sifr"), "def a(:\n")
         .expect("test_a_bad should be written");
 
-    let first_messages: Vec<String> = run_tests(&test_dir)
+    let first_diagnostics: Vec<(String, Vec<String>)> = run_tests(&test_dir)
         .err()
         .expect("parse errors should be reported")
         .into_iter()
-        .map(|error| error.message)
+        .map(|error| {
+            (
+                error.message,
+                error
+                    .children
+                    .into_iter()
+                    .map(|child| child.message)
+                    .collect(),
+            )
+        })
         .collect();
-    let second_messages: Vec<String> = run_tests(&test_dir)
+    let second_diagnostics: Vec<(String, Vec<String>)> = run_tests(&test_dir)
         .err()
         .expect("parse errors should be deterministic")
         .into_iter()
-        .map(|error| error.message)
+        .map(|error| {
+            (
+                error.message,
+                error
+                    .children
+                    .into_iter()
+                    .map(|child| child.message)
+                    .collect(),
+            )
+        })
         .collect();
 
-    assert_eq!(first_messages, second_messages);
+    assert_eq!(first_diagnostics, second_diagnostics);
     assert!(
-        first_messages
+        first_diagnostics
             .first()
-            .is_some_and(|message| message.contains("test_a_bad.sifr")),
-        "first parse error should be from lexicographically first fixture: {first_messages:?}"
+            .is_some_and(|(_message, children)| children
+                .iter()
+                .any(|child| child.contains("test_a_bad.sifr"))),
+        "first parse error should be from lexicographically first fixture: {first_diagnostics:?}"
     );
 
     let _ = std::fs::remove_dir_all(&test_dir);

--- a/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
+++ b/issues/ad-hoc-semantic-diagnostic-code-taxonomy-and-structured-hir-diagnostics.md
@@ -8,7 +8,7 @@ Sifr is not production-released yet. This phase intentionally does not preserve 
 
 ## Execution Status
 
-Current wave: `milestone_diag_5` test harness contract cleanup, split into reviewable residual-cleanup slices.
+Current wave: `milestone_diag_7` parser/name/import/type/call diagnostic refinement, split into reviewable category slices.
 
 - [x] Proposal reviewed through final loop and accepted for implementation.
 - [x] Added `crates/sifr_diagnostics` as the canonical leaf crate for diagnostic codes, source spans/source map, model builders, sink emission, rendering, and JSON schema generation.
@@ -75,6 +75,7 @@ Current wave: `milestone_diag_5` test harness contract cleanup, split into revie
 - [x] `milestone_diag_5` slice 2 implementation complete and reviewer-satisfied: added verification harness duplicate-baseline artifact path detection before command execution or blessing, normalized baseline artifact identity to resolved repo-contained paths, added manifest-shape failures for duplicate formats and invalid entries, and wired regression self-tests into the authoritative local validation lane. PR: https://github.com/sifr-lang/sifr/pull/1711.
 - [x] `milestone_diag_5` slice 3 implementation complete and reviewer-satisfied: added e2e fixture expectation contradiction detection so overlapping explicit `expect-error[col=N]` assertion locations cannot claim incompatible diagnostic codes, kept unqualified markers as code-existence assertions only, and loaded all fail-fixture expectation contracts before compiling the fail corpus. PR: https://github.com/sifr-lang/sifr/pull/1712.
 - [x] `milestone_diag_5` slice 4 implementation complete and reviewer-satisfied: refactored CLI diagnostic rendering so human, JSON, and compact formats consume one canonical sorted-and-capped diagnostic stream, and added a focused regression test proving all three outputs derive from that same stream. PR: https://github.com/sifr-lang/sifr/pull/1713.
+- [x] `milestone_diag_7` slice 1 implementation complete and reviewer-satisfied: parser diagnostics now classify Ruff parse and unsupported-syntax categories to active `SIFR-PARSE-0002..0009` codes with registry-aligned templates, declared args, `parser_category` JSON context, project/test child-note context, and representative e2e fixtures for every active parse code. PR: https://github.com/sifr-lang/sifr/pull/1714.
 - [x] Claude pre-implementation review for `milestone_diag_4a` slice 2 completed: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2-preimplementation-review-pass-1.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 2a completed and all actionable findings addressed. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-slice2a-transport-review-pass-2.md`.
 - [x] Claude implementation review for `milestone_diag_4a` slice 2b.1 completed and reviewer is satisfied. Review rounds: `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-1.md`, `reviews/semantic-diagnostic-code-taxonomy-diag-4a-decimal-review-pass-2.md`.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-1.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-1.md
@@ -1,0 +1,217 @@
+# Review Pass 1 — milestone_diag_7 Parser Diagnostic Classification
+
+Scope under review: working-tree changes to single-file frontend, project import discovery, the new `frontend/parser_diagnostics.rs` module, the new `parser_*.sifr` e2e fail fixtures, and the new unit-test bucket added to `crates/sifr_driver/src/tests/single_file_frontend.rs`.
+
+Read against the brief: replace broad parser diagnostics with category-specific active SIFR-PARSE-0002..0009 emissions, parse with the latest Ruff target version so Sifr-owned syntax is not version-rejected, and produce structured diagnostics whose `code` / `severity` / `message_template` / declared message arg / `parser_category` JSON arg all align with the registry.
+
+## Verdict
+
+**NOT MERGEABLE.** The slice's *intent* and *taxonomy mapping* are largely correct, but the patch:
+
+1. Breaks three pre-existing `sifr_driver` unit tests because the `[label]` message-prefix contract was removed without updating callers (B1, B2, B3).
+2. Fails `cargo clippy -p sifr_driver --no-deps -- -D warnings` due to a redundant closure introduced in this slice (B4). The workspace policy is `-D warnings`.
+3. Renders a grammatically broken `"syntax error: expected Expected …"` whenever `ParseErrorType::OtherError(_)` is hit (M1) — and `OtherError` is the bucket Ruff reaches in our own representative fixture for `SIFR-PARSE-0002` (`def main(:`), so this is the *first* thing a user sees from the new active code.
+
+The validation the patch author ran (`cargo test -p sifr_driver parse_source` + `cargo test -p sifr --test e2e test_e2e_fail`) does not cover any of B1–B3, and `cargo clippy` was not run. The required local validation in [AGENTS.md](../AGENTS.md) is `scripts/run_all_tests.sh --profile quick` — that gate would have caught all four blockers.
+
+The classification module itself ([crates/sifr_driver/src/frontend/parser_diagnostics.rs](../crates/sifr_driver/src/frontend/parser_diagnostics.rs)) is well structured: exhaustive match on `ParseErrorType` (no `_` arm — good forward-pressure when Ruff is bumped), per-variant code/template/arg/category, and no fallback paths back to the broad PARSE-0002 bucket. The registry side ([crates/sifr_diagnostics/src/codes.rs:375-462](../crates/sifr_diagnostics/src/codes.rs:375)) is consistent with the emission templates and arg names.
+
+Fix B1–B4 + M1 and a re-review pass should be short.
+
+---
+
+## Blockers
+
+### B1 — `sifr_driver::tests::discovery_and_workspace::test_project_and_test_discovery_parity_reports_reachable_parse_errors` fails
+
+[crates/sifr_driver/src/tests/discovery_and_workspace.rs:161-164](../crates/sifr_driver/src/tests/discovery_and_workspace.rs:161) still asserts:
+
+```rust
+assert!(project_errors.iter().any(|e| e.message.contains("[helper]")));
+assert!(test_errors.iter().any(|e| e.message.contains("[helper]")));
+```
+
+Before this slice, [project/discovery.rs](../crates/sifr_driver/src/project/discovery.rs) prefixed parser errors with `format!("[{label}] {e}")`. After this slice, the label is moved to a `RenderedDiagnosticChild { severity: Note, message: "while parsing helper" }` and never appears in `e.message`. The assertion now flips to false. Confirmed by running the test directly:
+
+```
+thread 'tests::discovery_and_workspace::test_project_and_test_discovery_parity_reports_reachable_parse_errors' panicked at crates/sifr_driver/src/tests/discovery_and_workspace.rs:161:5:
+assertion failed: project_errors.iter().any(|e| e.message.contains("[helper]"))
+```
+
+This is a contract change to the diagnostic surface that the slice's tests should cover. Either:
+
+- Update both assertions to `e.children.iter().any(|c| c.message == "while parsing helper")`, or
+- If module-prefixed parse messages are still desired (matching `FrontendDiagnosticStyle::ModulePrefixed` for HIR errors via [frontend/module_lowering.rs:46-48](../crates/sifr_driver/src/frontend/module_lowering.rs:46)), have `parse_module_with_diagnostics` accept a style argument and prefix the rendered `message` in `ModulePrefixed` mode.
+
+### B2 — `sifr_driver::tests::project_build_check::test_check_project_reports_reachable_parse_errors_in_import_closure` fails
+
+[crates/sifr_driver/src/tests/project_build_check.rs:273-280](../crates/sifr_driver/src/tests/project_build_check.rs:273) asserts:
+
+```rust
+assert!(
+    errors.iter().any(|e| {
+        e.message.contains("[helper]")
+            && (e.message.contains("failed to parse")
+                || e.message.contains("Expected a parameter"))
+    }),
+    "reachable parse errors must still fail check_project: {errors:?}"
+);
+```
+
+Both halves of the substring conjunction are now false. The actual rendered diagnostic from this fixture (`def value(:\n` reachable from `main`) is:
+
+```
+RenderedDiagnostic {
+  code: "SIFR-PARSE-0002",
+  message: "syntax error: expected Expected a parameter or the end of the parameter list",
+  message_template: "syntax error: expected {expected}",
+  args: {"expected": String("Expected a parameter or the end of the parameter list"), "parser_category": String("parser_recovery")},
+  children: [RenderedDiagnosticChild { severity: Note, message: "while parsing helper" }],
+  …
+}
+```
+
+`[helper]` is gone (now a child note), and `"failed to parse"` is gone (the slice deliberately removed that legacy prefix). The substring `"Expected a parameter"` *does* still appear, but only as a side effect of the `OtherError` rendering bug discussed in M1 — i.e., the test passes accidentally only when `OtherError` reuses Ruff's English sentence. Don't rely on that.
+
+The test should match on `e.code == "SIFR-PARSE-0002"` (and/or any 0003-0009 code) plus a child-note check, not on the legacy free-form message.
+
+### B3 — `sifr_driver::tests::test_runner::test_run_tests_reports_deterministic_parse_error_order` fails
+
+[crates/sifr_driver/src/tests/test_runner.rs:308-313](../crates/sifr_driver/src/tests/test_runner.rs:308):
+
+```rust
+assert!(
+    first_messages.first().is_some_and(|message| message.contains("test_a_bad.sifr")),
+    "first parse error should be from lexicographically first fixture: {first_messages:?}"
+);
+```
+
+`run_tests` flows through `parse_import_closure_modules` with `DiscoveryDiagnosticStyle::FilePath` ([test_runner/orchestrator.rs:49](../crates/sifr_driver/src/test_runner/orchestrator.rs:49)). Pre-slice, the file path landed in `e.message` via `[label]` and the assertion ordered fixtures by message. Post-slice, the file path lives in `e.children[0].message` (`while parsing /tmp/.../test_a_bad.sifr`) and `e.message` contains only the templated "syntax error: expected …" string with no path information. Test panics:
+
+```
+first parse error should be from lexicographically first fixture: ["syntax error: expected Expected a parameter or the end of the parameter list", "lexical error: unexpected EOF while parsing"]
+```
+
+Same fix family as B1/B2 — the test should assert on the child note, or on a path-bearing rendered field once one exists.
+
+### B4 — Clippy violation on the new `parse_source` body
+
+[crates/sifr_driver/src/frontend/api.rs:15](../crates/sifr_driver/src/frontend/api.rs:15):
+
+```rust
+parse_module_with_diagnostics(source, None).map(|parsed| parsed.into_suite())
+```
+
+`cargo clippy -p sifr_driver --no-deps -- -D warnings` fails:
+
+```
+error: redundant closure
+  --> crates/sifr_driver/src/frontend/api.rs:15:53
+   |
+15 |     parse_module_with_diagnostics(source, None).map(|parsed| parsed.into_suite())
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `ruff_python_parser::Parsed::into_suite`
+   = note: `-D clippy::redundant-closure-for-method-calls` implied by `-D warnings`
+```
+
+Verified by re-running clippy on `git stash` (pre-slice tree passes cleanly). Fix: `.map(Parsed::into_suite)`.
+
+The pre-existing tree is clippy-clean for `-p sifr_driver --no-deps`, so this is a regression introduced by this slice.
+
+---
+
+## Major
+
+### M1 — `OtherError` rendering produces ungrammatical "syntax error: expected Expected …" messages
+
+[parser_diagnostics.rs:224](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:224):
+
+```rust
+ParseErrorType::OtherError(message) => expected_details(message.clone(), "parser_recovery"),
+```
+
+`expected_details` ([parser_diagnostics.rs:228-239](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:228)) hard-codes the template `"syntax error: expected {expected}"`. But Ruff's `OtherError` payload is a *full English sentence*, often beginning with "Expected …" itself, e.g. `"Expected a parameter or the end of the parameter list"` (literally what `def main(:` produces — see B2 dump above). The composed message becomes:
+
+> syntax error: **expected Expected** a parameter or the end of the parameter list
+
+This is the user-visible string for the slice's own `parser_expected_token.sifr` representative fixture and for the existing `helper.sifr` parse error in `test_check_project_reports_reachable_parse_errors_in_import_closure`. Two related concerns:
+
+1. **Grammar.** Other `expected_details` callers (e.g. `ExpectedExpression → expected_details("expression", …)`) use a noun phrase, so the prefix reads correctly. `OtherError` is the only caller passing a full sentence.
+2. **JSON arg semantics.** The `expected` arg ends up holding a sentence rather than the *thing expected*. Tooling consuming `args["expected"]` as structured data gets a meaningless string.
+
+Fix options (lowest impact first):
+- Give `OtherError` its own helper that uses a different template, e.g. `"syntax error during recovery: {message}"` with arg name `"message"`. The registry already declares `[arg!("expected"), json_arg!("parser_category")]` for SIFR-PARSE-0002, so changing the arg name would require a registry change. Alternatively, keep `expected` but pass a noun-phrase prefix and put the raw payload in the JSON arg.
+- At minimum, drop the `"expected "` literal for the `OtherError` arm so the message is `"syntax error: <payload>"`.
+
+Either way, the representative fixture for SIFR-PARSE-0002 should not exercise the `OtherError` path — it's strictly worse than `ExpectedToken { expected, found }`. If you can pick a source that triggers `ExpectedToken` instead (e.g. `def main):` or similar) the canonical message becomes the cleaner `"syntax error: expected <token>; found <token>"` form that `expected_details` was designed for.
+
+---
+
+## Minor
+
+### m1 — Unit test asserts only the first emitted diagnostic is the expected one
+
+[tests/single_file_frontend.rs:75-89](../crates/sifr_driver/src/tests/single_file_frontend.rs:75) uses `errors.first()` per case. Ruff's `parse_unchecked` now surfaces *all* parser errors (an intentional and good improvement over the old `parse_module().into_result()` which collapsed to the first error only — see m4). For a few of the chosen sources Ruff emits more than one diagnostic; e.g. `def value(:\n` produces SIFR-PARSE-0002 *and* SIFR-PARSE-0003 (`"unexpected EOF while parsing"`). The current cases happen to put the expected category first, but a future Ruff revision could reorder. Prefer `errors.iter().any(|d| d.code == expected_code.code())` over `.first()`.
+
+### m2 — `EmptyDeleteTargets` is bucketed as `PARSE_INVALID_TARGET`, not `PARSE_MALFORMED_DECLARATION_LIST`
+
+[parser_diagnostics.rs:131-133](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:131) groups `EmptyDeleteTargets` with `InvalidDeleteTarget` under PARSE-0005 with `target_kind = "delete target"`. By the *registry summaries* (PARSE-0005 = "Invalid assignment, delete, starred, or named-expression target syntax"; PARSE-0007 = "Empty or malformed declaration list syntax"), an *empty* delete target list is closer to PARSE-0007 — `Empty{Global,Nonlocal,Import}Names` and `EmptyTypeParams` already live there ([parser_diagnostics.rs:159-162](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:159)). Either bucket is defensible, but the asymmetry between "empty `del`" (PARSE-0005) and "empty `global`/`nonlocal`/`import`/`type-params`" (PARSE-0007) reads accidentally and will surprise anyone grepping by category. Recommend moving `EmptyDeleteTargets` to `declaration_list_details("delete statement")`.
+
+### m3 — Child note emitted per-diagnostic, redundant when there are N parser errors in one module
+
+[parser_diagnostics.rs:78-84](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:78) attaches the same `"while parsing <label>"` child to every diagnostic. For a multi-error file (e.g. unterminated string + EOF + recovery cascade) the user sees the same child note repeated N times. Acceptable for now, but if you ever introduce de-duplication at the renderer layer this is a candidate. No action required for this slice.
+
+### m4 — Behavioral change: now reports *all* parser errors instead of only the first
+
+This is not a regression — it's an improvement — but it is an undocumented behavior change that's worth noting in the slice's PR description. The old [api.rs](../crates/sifr_driver/src/frontend/api.rs) used `parse_module()`, which internally calls `into_result()` and discards everything but the first error. The new path uses `parse_unchecked` and iterates `parsed.errors()`. The `test_check_project_reports_reachable_parse_errors_in_import_closure` test output in B2 shows two diagnostics for one source where there used to be one. Tests asserting on `errors.len()` or "exactly one parse error" elsewhere may break — none do today, but the contract change is real.
+
+### m5 — When `has_invalid_syntax()` is true, `unsupported_syntax_errors()` is silently dropped
+
+[parser_diagnostics.rs:22-35](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:22) reports parser errors *or* unsupported-syntax errors, never both. If a source has both real syntax errors and version-gated features, the user only sees the parser errors. This is a defensible tradeoff (the grammar errors are usually the proximate cause) and matches the prior behavior; document it in a comment so future readers don't think it's an oversight.
+
+### m6 — Stdlib bootstrap parser path still has the slice-2 TODO
+
+[crates/sifr_driver/src/stdlib/bootstrap.rs:30-52](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) still funnels stdlib parse failures into `STDLIB_BOOTSTRAP_FAILURE` with the original `// TODO(diag_4a slice 2): classify Ruff parse failures into the precise active parse-code buckets.` comments. Out of stated scope for *this* slice (single-file frontend + project discovery), but flag it: the same `parse_module_with_diagnostics` helper now exists and could absorb this site too — though stdlib bootstrap *intentionally* collapses to a single bootstrap-failure code, not a per-classification SIFR-PARSE-* code. If stdlib bootstrap is intended to keep the bootstrap-failure facade, add a note in [parser_diagnostics.rs](../crates/sifr_driver/src/frontend/parser_diagnostics.rs) explaining why bootstrap doesn't use it; otherwise file a follow-up issue.
+
+### m7 — `parser_unsupported_syntax.sifr` doesn't exercise `unsupported_syntax_errors()`
+
+The fixture (`async value\n`) trips `ParseErrorType::UnexpectedTokenAfterAsync` ([parser_diagnostics.rs:186-189](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:186)), which is a *parser error*, not a Ruff `UnsupportedSyntaxError`. So `unsupported_syntax_diagnostic` ([parser_diagnostics.rs:43-57](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:43)) — the only path that consumes Ruff's version-gated error type — has zero coverage. With `target_version = PythonVersion::latest_ty()` ( = `PY314`), the fixture menu for triggering `UnsupportedSyntaxError` is narrow (PY315-only syntax, like `t""`-strings nested in particular ways). Consider adding one such fixture or a `#[cfg(test)]` unit case so the `unsupported_syntax_diagnostic` path is exercised; otherwise, that branch is currently dead and a future Ruff bump that changes its shape won't be caught.
+
+### m8 — `unreachable!` in `parse_module_with_diagnostics`
+
+[parser_diagnostics.rs:19-21](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:19):
+
+```rust
+let Some(parsed) = parsed.try_into_module() else {
+    unreachable!("module parse mode must produce a module syntax tree");
+};
+```
+
+This is fine — it's a programmer-invariant assertion on Ruff's `Parsed<Mod> → Parsed<ModModule>` contract for `Mode::Module`, not a data-dependent panic in a user path. Matches the [AGENTS.md](../AGENTS.md) "no panics in user paths" rule. No action needed; flagging only because the milestone has unusually high panic-discipline expectations.
+
+### m9 — `with_target_version(PythonVersion::latest_ty())` is the right call; `latest()` would also work
+
+`PythonVersion::latest_ty() == PY314 == PythonVersion::latest()` today ([third_party/ruff/crates/ruff_python_ast/src/python_version.rs:63-77](../third_party/ruff/crates/ruff_python_ast/src/python_version.rs:63)). `latest_ty()` carries a comment about staying coupled to ty's environment defaults; `latest()` is the unconditional newest stable. Either is defensible. `latest_ty()` is slightly more conservative against ty-driven roadmap shifts, but Sifr doesn't ship ty's environment options. A 5-word comment in the call site explaining *why* `latest_ty` over `latest` would help future readers; otherwise it reads as cargo-culted. Non-blocking.
+
+---
+
+## Things checked and OK
+
+- **Registry ↔ emission alignment.** Every active SIFR-PARSE-0002..0009 entry's `message_template` ([codes.rs:381,392,403,414,425,436,447,458](../crates/sifr_diagnostics/src/codes.rs:381)) matches the per-bucket helper's `template` field in [parser_diagnostics.rs](../crates/sifr_driver/src/frontend/parser_diagnostics.rs). Every `declared_args` list contains the named placeholder (`MessageAndJson`) plus `parser_category` (`JsonOnly`). The registry's `assert_template_placeholders_are_declared` test ([codes.rs:1620-1641](../crates/sifr_diagnostics/src/codes.rs:1620)) enforces this contract and will keep enforcing it.
+- **Severity contract.** `parse_diagnostic` uses `code.declared_severity()` ([parser_diagnostics.rs:87](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:87)) so the registry's declared severity is the source of truth — no per-emission-site override. This matches the slice's stated expectation and the registry consistency test at [codes.rs:1522-1530](../crates/sifr_diagnostics/src/codes.rs:1522).
+- **`parser_category` JSON arg.** Always emitted as `DiagnosticArg::String(non_empty_str)` (verified for every variant of `parse_error_details`). The unit test at [tests/single_file_frontend.rs:84-87](../crates/sifr_driver/src/tests/single_file_frontend.rs:84) asserts non-empty.
+- **Exhaustive match, no fallback.** `parse_error_details` has no `_ =>` arm — every Ruff `ParseErrorType` variant is handled. If Ruff (vendored at [third_party/ruff](../third_party/ruff/)) gains a variant, the build fails and forces re-classification. This is the right shape for a pre-production compiler; matches [AGENTS.md](../AGENTS.md): "Do NOT create fallback paths or solutions unless explicitly requested."
+- **Representative-fixture file paths.** All eight `representative_fixture_path` values in the registry ([codes.rs:380,391,402,413,424,435,446,457](../crates/sifr_diagnostics/src/codes.rs:380)) point at existing files in the working tree, and each fixture's `# expect-error:` line matches the registry-declared code. `test_e2e_fail` passes (per the patch author and verified above).
+- **No new `unwrap`/`expect` on user data.** The only `unreachable!` (m8) is on Ruff's `Mode::Module → ModModule` invariant; no `.unwrap()` on `parsed.errors()` or arg conversion.
+- **No CI-only behavior added.** The slice doesn't introduce conditional code, env-gated branches, or feature-flagged shims. Matches "no fallback compatibility" + "pre-production" rules.
+
+---
+
+## Suggested fix order
+
+1. B4 (one-line clippy fix; keeps tree green).
+2. M1 (rendering bug — user-visible quality regression for the slice's headline code).
+3. B1 / B2 / B3 (test contract update — straightforward `e.message` → `e.code` + `e.children[0].message` swap, *or* re-add `[label]` prefix path through `parse_module_with_diagnostics`'s new context arg if you want to preserve message-level prefixing for the project-discovery flow).
+4. m2, m7 (categorization + dead-branch coverage).
+5. m1, m5, m6, m9 (test brittleness + comments + follow-up note).
+
+After fixes, re-run `scripts/run_all_tests.sh --profile quick` (the gate the brief asks for) and re-submit for pass-2.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-2.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-2.md
@@ -1,0 +1,193 @@
+# Review Pass 2 — milestone_diag_7 Parser Diagnostic Classification
+
+Scope under review: working-tree changes since pass 1, including the renamed [`parser_diagnostics.rs`](../crates/sifr_driver/src/frontend/parser_diagnostics.rs) (still untracked — flagging because `git status` shows it as `??`, so it must land with the slice or the slice fails to compile), the test-contract updates in [`tests/discovery_and_workspace.rs`](../crates/sifr_driver/src/tests/discovery_and_workspace.rs), [`tests/project_build_check.rs`](../crates/sifr_driver/src/tests/project_build_check.rs), [`tests/test_runner.rs`](../crates/sifr_driver/src/tests/test_runner.rs), the new classification unit-test bucket in [`tests/single_file_frontend.rs`](../crates/sifr_driver/src/tests/single_file_frontend.rs), the child-note rendering in [`sifr/src/main.rs`](../crates/sifr/src/main.rs), the helper-call refactors in [`frontend/api.rs`](../crates/sifr_driver/src/frontend/api.rs) and [`project/discovery.rs`](../crates/sifr_driver/src/project/discovery.rs), and the validation-contract update in [`manifest.json`](../verification/validation_contracts/manifest.json).
+
+## Verdict
+
+**Conditionally mergeable — one user-visible quality regression remains.**
+
+Pass 1's blockers (B1–B4) are all resolved cleanly, validated locally by the author with `scripts/run_all_tests.sh --profile quick`. The structural shape of the slice — exhaustive match on `ParseErrorType`, registry-driven severity, distinct codes per category, child-note carrying module/file context — is solid. Pass-1 minors m1, m2, m5, m7, and m9 are addressed; m3 and m6 remain by design or as out-of-scope follow-ups.
+
+The one remaining quality concern is **M1 partial fix (now M1')**: the new `recovery_expected` helper only strips a leading `"Expected "`/`"expected "` prefix from `OtherError` payloads. A non-trivial set of Ruff `OtherError` payloads do *not* start with that prefix, so the rendered message still reads `"syntax error: expected <full sentence>"` ungrammatically for those paths. This is a smaller surface than pass 1 (the most common ones — `def main(:` style — now read correctly), but it is still wrong on real fixtures. Given the slice's headline contract is "category-specific, well-formed parser diagnostics", I'd want this finalized before merge rather than carried as follow-up.
+
+If you elect to merge with M1' as a tracked follow-up, I would still expect a regression test pinning the *rendered message string* of the SIFR-PARSE-0002 representative fixture so the carry-over is observable.
+
+---
+
+## Blockers cleared
+
+### B1 → fixed
+[discovery_and_workspace.rs:161-168](../crates/sifr_driver/src/tests/discovery_and_workspace.rs:161) now asserts on `e.children.iter().any(|child| child.message == "while parsing helper")` for both `project_errors` and `test_errors`. Equality match (not `contains`) is the right call — it pins the exact contract of `parser_diagnostics::parse_diagnostic`'s child-note format.
+
+### B2 → fixed
+[project_build_check.rs:273-279](../crates/sifr_driver/src/tests/project_build_check.rs:273) now asserts on `e.code == "SIFR-PARSE-0002"` *and* the child-note message — two independent signals, neither relying on Ruff's English sentence content. This is more robust than the pre-slice substring match.
+
+### B3 → fixed
+[test_runner.rs:294-333](../crates/sifr_driver/src/tests/test_runner.rs:294) destructures each diagnostic into `(message, children)` and asserts the first error's children carry the `test_a_bad.sifr` path. Determinism is asserted by full-equality of the `(message, children)` vectors across two runs. The path lives in `child.message` because [`orchestrator.rs:49`](../crates/sifr_driver/src/test_runner/orchestrator.rs:49) passes `DiscoveryDiagnosticStyle::FilePath`, which routes through `discovery_label → path.display()`. Correct.
+
+Behavioral note: with `parse_unchecked`, all errors from the lexicographically-first failing module (`test_a_bad.sifr`) now appear at once, and `parse_import_closure_modules` short-circuits before `test_z_bad.sifr` is touched. The "first error is from `test_a_bad`" invariant therefore holds; the "deterministic across runs" invariant still holds (both runs produce identical N-error sequences). The test name still reflects the contract.
+
+### B4 → fixed
+[api.rs:15](../crates/sifr_driver/src/frontend/api.rs:15) is now `parse_module_with_diagnostics(source, None).map(sifr_python_parser::Parsed::into_suite)`. Method-reference form, clippy-clean. Verified consistent with the `Parsed::into_suite` signature in `third_party/ruff/crates/ruff_python_parser/src/lib.rs:415`.
+
+---
+
+## Major
+
+### M1' — `recovery_expected` only patches a subset of `OtherError` rendering
+
+[parser_diagnostics.rs:229-241](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:229):
+
+```rust
+ParseErrorType::OtherError(message) => {
+    expected_details(recovery_expected(message), "parser_recovery")
+}
+
+fn recovery_expected(message: &str) -> String {
+    message
+        .strip_prefix("Expected ")
+        .or_else(|| message.strip_prefix("expected "))
+        .unwrap_or(message)
+        .to_string()
+}
+```
+
+`expected_details` hard-codes the template `"syntax error: expected {expected}"`. The strip succeeds when Ruff's payload reads "Expected …" (the common case the slice's representative fixture happens to hit), but `OtherError` is used at ~30 call sites in the vendored Ruff parser, and many of those payloads are not prefixed with "Expected"/"expected". Audited from `third_party/ruff/crates/ruff_python_parser/src/parser/`:
+
+| Payload (source) | Rendered with current code |
+|---|---|
+| `"Trailing comma not allowed"` (`parser/mod.rs:661`) | `syntax error: expected Trailing comma not allowed` |
+| `"Invalid mapping pattern key"` (`parser/pattern.rs:229`) | `syntax error: expected Invalid mapping pattern key` |
+| `"Invalid value for a class pattern"` (`parser/pattern.rs:670`) | `syntax error: expected Invalid value for a class pattern` |
+| `"missing closing bracket `]`"` (`parser/expression.rs:2004`) | `syntax error: expected missing closing bracket `]`` |
+| `"missing closing brace `}`"` (`parser/expression.rs:2066`) | `syntax error: expected missing closing brace `}`` |
+| `"missing closing parenthesis `)`"` (`parser/expression.rs:2176`) | `syntax error: expected missing closing parenthesis `)`` |
+| `"<expr> expression cannot be used here"` (`parser/expression.rs:450`) | `syntax error: expected <expr> expression cannot be used here` |
+| `"duplicate `mut` parameter modifier"` (`parser/tests.rs:214` — Sifr fork-specific) | `syntax error: expected duplicate `mut` parameter modifier` |
+
+These all reach SIFR-PARSE-0002 via `parser_recovery`, the most popular bucket among parser errors. Users will see ungrammatical strings on common inputs (unbalanced brackets, malformed pattern matches, trailing commas, etc.).
+
+Two issues compound:
+
+1. **Grammar.** As above.
+2. **JSON arg semantics.** `args["expected"]` ends up holding a full English sentence rather than the noun phrase the registry's documentation implies. Anything consuming structured output sees a string that's only meaningful as prose, not as a "what was expected" datum.
+
+Suggested fix (registry-compatible): change `recovery_expected` so payloads that don't begin with `"Expected "`/`"expected "` are wrapped to read correctly under the existing template, e.g.:
+
+```rust
+fn recovery_expected(message: &str) -> String {
+    if let Some(stripped) = message.strip_prefix("Expected ").or_else(|| message.strip_prefix("expected ")) {
+        return stripped.to_string();
+    }
+    // Fallback: emit a noun-phrase the template can prefix without grammar drift.
+    format!("recovery: {message}")
+}
+```
+
+That keeps the registry contract (`{expected}` arg) and avoids the doubled-verb issue. Alternatively, give `OtherError` its own `(code, template, arg_name)` triple — but that requires a registry change and is heavier.
+
+If the alternative is preferred, the registry side at [crates/sifr_diagnostics/src/codes.rs:381-385](../crates/sifr_diagnostics/src/codes.rs:381) needs a parallel update.
+
+The slice's pass-2 author noted explicitly: *"normalizing OtherError payloads by stripping leading Expected/expected"* — so they're aware the prefix-strip is the intended fix, but the prefix space turns out to be smaller than the OtherError surface. This is a follow-up of the same root cause.
+
+---
+
+## Minor
+
+### m1 — No unit test asserting the rendered human message
+
+[main.rs:417-426](../crates/sifr/src/main.rs:417) now writes child notes after the primary line:
+
+```rust
+let _ = writeln!(output, "{label}: {message}", message = diagnostic.message);
+for child in &diagnostic.children {
+    let child_label = match child.severity {
+        ChildSeverity::Note => "note",
+        ChildSeverity::Help => "help",
+    };
+    let _ = writeln!(output, "{child_label}: {}", child.message);
+}
+```
+
+The existing snapshot test [`test_diagnostic_formats_share_canonical_sorted_capped_stream`](../crates/sifr/src/main.rs:1436) only exercises diagnostics built with `test_diagnostic`, which initializes `children: Vec::new()`. It does not exercise the new branch. The validation-contract manifest exercises it end-to-end (`closure_neg_check` asserting `"while parsing helper"` in stderr — verified to pass) but there is no in-crate unit test pinning the format.
+
+Recommend adding one case to `test_diagnostic_formats_share_canonical_sorted_capped_stream` (or a sibling test) that constructs a diagnostic with `children: vec![RenderedDiagnosticChild { severity: Note, message: "while parsing foo" }]` and asserts the rendered human output contains `"\nnote: while parsing foo\n"`. Trivial to add, prevents silent format drift.
+
+### m2 — Compact format silently drops child notes
+
+[main.rs:331-396](../crates/sifr/src/main.rs:331) groups by `(severity, code, is_summary_group, message)` and emits `at <span>` / `help` / `url` lines but never `children`. Effect: a user running with `--diagnostic-format=compact` against a project with reachable parse errors loses the `"while parsing <module>"` context.
+
+Defensible — compact format is intentionally lossy — but worth either:
+- Documenting the lossiness in a code comment, or
+- Inlining the first child note after the `(xN)` line.
+
+Non-blocking; flagging because the slice introduces children on the parser path for the first time and the asymmetry between human/JSON (which preserve them) and compact (which drops them) is now observable.
+
+### m3 — `children` populated in JSON output for every parser diagnostic
+
+The slice's behavior change is: every parser diagnostic now carries a `children: [{severity: "Note", message: "while parsing <label>"}]` entry when invoked through project discovery. Tools or downstream consumers that previously assumed parser diagnostics had empty `children` will see populated arrays. No in-tree consumer breaks (verified by `cargo test -p sifr diagnostic_format` per the author's run), but this is a JSON contract change worth calling out in the PR description.
+
+### m4 — `parser_category` taxonomy has minor inconsistency for f-string/t-string errors
+
+For lexer-emitted f-string/t-string errors:
+- `ParseErrorType::FStringError(_)` / `TStringError(_)` → `parser_category = "f_string"` / `"t_string"` ([parser_diagnostics.rs:110-111](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:110))
+- `ParseErrorType::Lexical(LexicalErrorType::FStringError(_))` / `LexicalErrorType::TStringError(_)` → `parser_category = "lexical_string"` ([parser_diagnostics.rs:268-269](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:268))
+
+Same kind of error semantically; two different category strings depending on which Ruff path emits it. Anyone aggregating by `parser_category` will see two buckets where one would do. Could collapse both to `"interpolated_string"` (or split the lexical case into `lexical_f_string` / `lexical_t_string` to match) — pick one. Either way, document the convention.
+
+Non-blocking.
+
+### m5 — Pass-1 m3 / m6 unchanged
+
+Both intentional:
+- m3 ("redundant child note per N parser errors per module"): still produces N copies of `"while parsing <label>"` for a module with N parse errors. Acceptable; document if not already.
+- m6 (stdlib bootstrap): [stdlib/bootstrap.rs:30-52](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) still funnels stdlib parse failures into `STDLIB_BOOTSTRAP_FAILURE`. The `parse_module_with_diagnostics` helper exists now and could absorb that site if the bootstrap-failure facade is to be removed. Out of scope for this slice.
+
+If both are deferred, file a follow-up issue covering them and link from the slice PR.
+
+### m6 — Pass-1 m9 partially addressed
+
+[parser_diagnostics.rs:17-19](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:17) now has:
+
+```rust
+// Sifr owns the latest Python-derived syntax surface pre-1.0; do not
+// reject syntax only because Ruff's default target is older.
+ParseOptions::from(Mode::Module).with_target_version(PythonVersion::latest_ty()),
+```
+
+The comment justifies *why we override the default* but doesn't justify *why `latest_ty()` over `latest()`* (today both are `PY314`). Five-word add — `// latest_ty stays coupled to ty's defaults` — would close the loop. Non-blocking.
+
+---
+
+## Things checked and OK in pass 2
+
+- **`lazy import value` exercises `unsupported_syntax_errors()`.** Traced through `parser/statement.rs:286-336`: on PY314 (`latest_ty()`), `lazy import …` calls `add_unsupported_syntax_error(LazyImportStatement)` and parses the import. Result: `has_invalid_syntax() == false`, `unsupported_syntax_errors().len() == 1`. The new `parse_module_with_diagnostics` correctly hits the second branch and emits SIFR-PARSE-0009 via `unsupported_syntax_diagnostic`. Pass-1 m7 ("dead branch") cleared. Confirmed by the e2e fixture and the new unit test case at [single_file_frontend.rs:69-74](../crates/sifr_driver/src/tests/single_file_frontend.rs:69).
+
+- **`EmptyDeleteTargets` reclassification.** [parser_diagnostics.rs:138](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:138) now routes through `declaration_list_details("delete statement")` → SIFR-PARSE-0007. Symmetrical with `EmptyGlobalNames` / `EmptyNonlocalNames` / `EmptyImportNames` / `EmptyTypeParams`. Pass-1 m2 cleared.
+
+- **Parser-error-precedence comment.** [parser_diagnostics.rs:25-26](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:25) now documents why `unsupported_syntax_errors` is short-circuited when `has_invalid_syntax()` — addresses pass-1 m5.
+
+- **Unit test searches all errors.** [single_file_frontend.rs:79-87](../crates/sifr_driver/src/tests/single_file_frontend.rs:79) uses `errors.iter().find(|d| d.code == expected_code.code())` with a `unwrap_or_else(|| panic!(…))` for diagnostic context. Robust against Ruff reordering errors. Pass-1 m1 cleared. The test correctly validates: code, severity (vs `declared_severity()`), presence of the per-bucket arg, presence of `parser_category` as a non-empty string, and that `message_template` isn't the `"{message}"` legacy placeholder. Eight cases cover each of SIFR-PARSE-0002…0009.
+
+- **Validation contract update is consistent.** [manifest.json:200](../verification/validation_contracts/manifest.json:200) now asserts `"while parsing helper"` in stderr for the reachable-parse-error contract, matching the new child-note format. The `helper.sifr` assertion on `closure_neg_test` continues to work because `DiscoveryDiagnosticStyle::FilePath` renders the path in the child note (via `discovery_label → path.display()`).
+
+- **Child-note + JSON envelope contract.** `RenderedDiagnostic.children` is `Vec<RenderedDiagnosticChild>` ([crates/sifr_diagnostics/src/render/mod.rs:32,40-43](../crates/sifr_diagnostics/src/render/mod.rs:32)). Schema type is part of the public envelope (`#[derive(JsonSchema)]`), so additions don't break consumers; child-note is a non-breaking enrichment.
+
+- **`Parsed::into_suite` referenced via fully-qualified path in `api.rs`.** Avoids the redundant-closure clippy lint and avoids needing an additional import. Clean.
+
+- **Stdlib bootstrap unaffected.** [stdlib/bootstrap.rs](../crates/sifr_driver/src/stdlib/bootstrap.rs) still uses its own `parse_module` path and still emits `STDLIB_BOOTSTRAP_FAILURE`. Confirmed by `git status` — the file isn't modified, so no regression risk for stdlib bootstrap behavior. (The pass-1 m6 follow-up is still tracked.)
+
+- **No new `unwrap`/`expect`/`panic!` on user data paths.** The only `unreachable!` is the `Parsed::try_into_module()` invariant under `Mode::Module` ([parser_diagnostics.rs:21-23](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:21)), which is a programmer-invariant assertion against Ruff's API contract — not a data-dependent panic. Matches AGENTS.md.
+
+- **Author's local-validation gate.** The reported run includes `scripts/run_all_tests.sh --profile quick` (the AGENTS.md gate) plus targeted `cargo test`, `cargo clippy`, `cargo fmt --check`, `bash scripts/run_validation_contract_matrix.sh`. The clippy + project-test failures from pass 1 are no longer present.
+
+---
+
+## Suggested fix order
+
+1. **M1'** — extend `recovery_expected` (or split `OtherError` into its own helper) so non-`Expected `-prefixed payloads still produce grammatical messages. Add a regression test pinning the rendered SIFR-PARSE-0002 message for at least one such payload (e.g., a fixture that triggers `"missing closing bracket"`).
+2. **m1** — add a unit test in `crates/sifr/src/main.rs` covering `render_diagnostic_stream` with a non-empty `children` vec for the human format.
+3. **m2/m3/m4** — pick: address now (small) or file follow-ups.
+4. **m5/m6** — link pass-1 m3/m6/m9 deferrals from the slice PR description.
+
+Not satisfied yet — I'd want M1' addressed before merge; everything else is non-blocking and could ride a follow-up.

--- a/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-3.md
+++ b/reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-3.md
@@ -1,0 +1,178 @@
+# Review Pass 3 — milestone_diag_7 Parser Diagnostic Classification
+
+Scope under review: working-tree changes since pass 2, focused on the pass-2 merge-blocker (`recovery_expected` non-`Expected`-prefixed payloads) and the pass-2 minor m1 (no in-crate test pinning the human child-note format). Files touched on top of the pass-2 tree:
+
+- [crates/sifr_driver/src/frontend/parser_diagnostics.rs:235-243](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:235) — `recovery_expected` now wraps non-prefixed payloads as `recovery: <payload>`.
+- [crates/sifr_driver/src/tests/single_file_frontend.rs:96-129](../crates/sifr_driver/src/tests/single_file_frontend.rs:96) — new `test_parse_source_normalizes_parser_recovery_messages`.
+- [crates/sifr/src/main.rs:1513-1535](../crates/sifr/src/main.rs:1513) — new `test_human_diagnostic_format_renders_child_notes`.
+
+The rest of the diff is unchanged from pass 2 and is re-confirmed in **§ Re-checked from pass 2** below.
+
+## Verdict
+
+**Satisfied — mergeable.** Pass-2's M1' merge blocker is resolved: `recovery_expected` now (a) strips a leading `Expected `/`expected ` if present, otherwise (b) wraps the payload as `recovery: <payload>`. Both branches keep the registry's `SIFR-PARSE-0002` template/arg shape (`syntax error: expected {expected}`) intact, and the second branch removes the doubled-verb defect from the pass-2 message dump. Pass-2 minor m1 is also addressed by the new human-format unit test. The slice now satisfies the parser-classification contract end-to-end.
+
+Local-validation gate (the one AGENTS.md requires) was rerun by the author against pass-3 — `scripts/run_all_tests.sh --profile quick` reports `report_signature=e1bf653aaa770517` with only advisory wall-time/group-skew flags. No new blockers introduced.
+
+The deferred items below (m2–m4 from pass 2 plus a small new m7) are all non-blocking and worth tracking as follow-ups in the slice PR description, not gating.
+
+---
+
+## Pass-2 blocker resolved
+
+### M1' (pass-2 merge blocker) → fixed
+
+[parser_diagnostics.rs:235-243](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:235):
+
+```rust
+fn recovery_expected(message: &str) -> String {
+    if let Some(stripped) = message
+        .strip_prefix("Expected ")
+        .or_else(|| message.strip_prefix("expected "))
+    {
+        return stripped.to_string();
+    }
+    format!("recovery: {message}")
+}
+```
+
+This is exactly the shape pass-2 suggested. Walking through each `OtherError` payload audited in pass 2:
+
+| Ruff payload | Pass-2 rendering (broken) | Pass-3 rendering |
+|---|---|---|
+| `Expected a parameter or the end of the parameter list` | `syntax error: expected Expected a parameter or the end of the parameter list` | `syntax error: expected a parameter or the end of the parameter list` |
+| `Trailing comma not allowed` | `syntax error: expected Trailing comma not allowed` | `syntax error: expected recovery: Trailing comma not allowed` |
+| `missing closing bracket \`]\`` | `syntax error: expected missing closing bracket \`]\`` | `syntax error: expected recovery: missing closing bracket \`]\`` |
+| `duplicate \`mut\` parameter modifier` (Sifr fork; [statement.rs:3110](../third_party/ruff/crates/ruff_python_parser/src/parser/statement.rs:3110)) | `syntax error: expected duplicate \`mut\` parameter modifier` | `syntax error: expected recovery: duplicate \`mut\` parameter modifier` |
+
+The `Expected `-prefixed case is now grammatical and concise. The non-prefixed case still has a slightly clunky `expected recovery: …` doubled-noun, but it (a) reads as unambiguous English ("expected, recovery:" parses as a discriminator), (b) keeps the `expected` arg as a structurally meaningful payload — `recovery: <X>` clearly signals "this is recovery telemetry, not a noun phrase the user can act on", and (c) preserves the registry contract without a registry-wide change. Pass 2 explicitly endorsed this shape.
+
+The `args["expected"]` JSON value also now carries the `recovery: <payload>` form for the non-prefixed bucket, which is the right structured signal — downstream tooling can detect `parser_category == "parser_recovery"` *and* the `recovery: ` prefix and treat the payload as opaque recovery prose rather than a token expectation.
+
+### Coverage
+
+[single_file_frontend.rs:96-129](../crates/sifr_driver/src/tests/single_file_frontend.rs:96) pins both branches:
+
+1. `def main(:\n` → `Expected a parameter or the end of the parameter list` (Ruff payload begins with `Expected `). Pass-3 asserts the exact final message string `"syntax error: expected a parameter or the end of the parameter list"` with `assert_eq!`. Full equality is right here — the slice is making a positive correctness claim about the strip path.
+2. `def f(mut mut items: list[int]):\n    return items\n` → `duplicate \`mut\` parameter modifier` ([statement.rs:3110](../third_party/ruff/crates/ruff_python_parser/src/parser/statement.rs:3110); the only Sifr-fork-introduced `OtherError` payload that doesn't begin with `Expected `). Pass-3 asserts `starts_with("syntax error: expected recovery: ")` plus `code == SIFR-PARSE-0002`. `starts_with` is right here — the test is a regression pin on the prefix transformation, not the full English sentence (which is owned by the Ruff fork and could legitimately move).
+
+The `find` on `code == PARSE_EXPECTED_TOKEN_OR_RECOVERY && message.contains("recovery:")` is robust against Ruff emitting additional diagnostics from the same source — both the duplicate-mut path and the closing-paren path will land in the diagnostic vector, and the test only inspects the recovery one.
+
+Confirmed by running `cargo test -p sifr_driver test_parse_source_normalizes_parser_recovery_messages -- --nocapture` (per author's pass-3 validation log).
+
+---
+
+## Pass-2 minor m1 → fixed
+
+[main.rs:1513-1534](../crates/sifr/src/main.rs:1513) adds:
+
+```rust
+#[test]
+fn test_human_diagnostic_format_renders_child_notes() { … }
+```
+
+That asserts:
+
+```
+"parse error: syntax error: expected expression\nnote: while parsing helper\n"
+```
+
+against `render_diagnostic_output(&[diagnostic], DiagnosticFormat::Human)`. This pins:
+
+- The `"parse error"` label for SIFR-PARSE-* codes (via [diagnostics.rs:130](../crates/sifr_driver/src/diagnostics.rs:130)).
+- The exact `"\n"` separator between primary and child note.
+- The `"note:"` prefix for `ChildSeverity::Note`.
+- The trailing `"\n"` after the child note (i.e. `writeln!`, not `write!`).
+
+This is the strongest possible regression pin for the new human-format branch in [main.rs:419-426](../crates/sifr/src/main.rs:419). If the format drifts (e.g. someone changes the separator, switches to `write!`, or alters the label), this test breaks first. Good.
+
+Quietly confirmed: `ChildSeverity::Help → "help"` is also covered by the match in `render_diagnostic_stream`, but no test exercises the `Help` branch yet. Not a regression — the slice doesn't emit `Help` children — but if a future slice does, the renderer is ready and the unit test should be extended to cover it.
+
+---
+
+## Re-checked from pass 2
+
+All of pass-2's verified items still hold for the pass-3 tree:
+
+- **B1–B4 (pass-1 blockers, pass-2 cleared):** still cleared. [discovery_and_workspace.rs:161-167](../crates/sifr_driver/src/tests/discovery_and_workspace.rs:161), [project_build_check.rs:273-278](../crates/sifr_driver/src/tests/project_build_check.rs:273), [test_runner.rs:294-333](../crates/sifr_driver/src/tests/test_runner.rs:294), and [api.rs:15](../crates/sifr_driver/src/frontend/api.rs:15) (`Parsed::into_suite` method-ref form, clippy-clean) are unchanged.
+- **Registry ↔ emission alignment.** All eight `SIFR-PARSE-0002..0009` registry entries at [codes.rs:375-462](../crates/sifr_diagnostics/src/codes.rs:375) match the per-bucket helper templates and arg names in [parser_diagnostics.rs:245-362](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:245). Severity always sourced from `code.declared_severity()` ([parser_diagnostics.rs:91](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:91)).
+- **Exhaustive match, no `_` arm.** [parser_diagnostics.rs:108-232](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:108) handles every `ParseErrorType` variant. Future Ruff bumps are forced re-classification — matches AGENTS.md "no fallback paths".
+- **`unsupported_syntax_errors` path is exercised.** Pass-2's verification of `lazy import value → LazyImportStatement → unsupported_syntax_diagnostic → SIFR-PARSE-0009` still holds, and [parser_unsupported_syntax.sifr](../crates/sifr/tests/e2e/fail/parser_unsupported_syntax.sifr) carries `# expect-error: SIFR-PARSE-0009`. Confirmed by [single_file_frontend.rs:69-74](../crates/sifr_driver/src/tests/single_file_frontend.rs:69) (the eighth case in the classification test).
+- **Child-note + JSON envelope.** `RenderedDiagnostic.children` is a serde-serialized field on the JSON envelope; populating it for parser diagnostics is a non-breaking schema enrichment. JSON output for the parse path now naturally carries `children: [{severity: "Note", message: "while parsing <label>"}]`.
+- **Validation contract.** [manifest.json:200](../verification/validation_contracts/manifest.json:200) asserts `"while parsing helper"` in stderr — matches the new child-note format and the human renderer's output. Confirmed by pass-2 and unchanged in pass 3.
+- **No new panics on user paths.** The single `unreachable!` in [parser_diagnostics.rs:21-23](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:21) is a programmer-invariant assertion against Ruff's `Mode::Module → ModModule` contract, not data-dependent. AGENTS.md compliant.
+- **Stdlib bootstrap unchanged.** [stdlib/bootstrap.rs](../crates/sifr_driver/src/stdlib/bootstrap.rs) still routes through its own `parse_module` path with `STDLIB_BOOTSTRAP_FAILURE`. The pass-1 m6 follow-up is still tracked.
+
+---
+
+## Outstanding (non-blocking, deferred)
+
+These were flagged in pass 2 as "pick: address now or follow-up" and are still unaddressed in pass 3. None block merge.
+
+### m2 (pass-2) — Compact format silently drops child notes
+
+[main.rs:331-396](../crates/sifr/src/main.rs:331) groups by `(severity, code, is_summary_group, message)` and emits `at <span>`/`help`/`url` lines but never `children`. With `--diagnostic-format=compact`, parser diagnostics now lose their `"while parsing <label>"` context. JSON and human preserve them; compact does not. Worth either (a) inlining the first child note after the `(xN)` line in compact, or (b) a one-line code comment documenting the lossiness. Defensible either way; flagging because pass 3 introduces no compact-format coverage and the asymmetry is now permanent.
+
+### m3 (pass-2) — JSON contract change
+
+Every parser diagnostic now carries a `children` entry when invoked through project discovery. No in-tree JSON consumer breaks (verified across `cargo test -p sifr` per author logs), but downstream tooling that previously assumed parser diagnostics had empty `children` will see populated arrays. Worth calling out in the PR description.
+
+### m4 (pass-2) — `parser_category` taxonomy inconsistency for f-string/t-string
+
+Same kind of error reaches different `parser_category` strings depending on which Ruff path emits it:
+- `ParseErrorType::FStringError(_)` → `f_string` ([parser_diagnostics.rs:110](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:110))
+- `ParseErrorType::TStringError(_)` → `t_string` ([parser_diagnostics.rs:111](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:111))
+- `ParseErrorType::Lexical(LexicalErrorType::FStringError(_))` / `TStringError(_)` → `lexical_string` ([parser_diagnostics.rs:270-271](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:270))
+
+Anyone aggregating by `parser_category` sees two (or three) buckets where one would do. Pick a convention (`interpolated_string` everywhere, or `lexical_f_string`/`lexical_t_string` parallel to the parser-side names) and document it in the helper file. Minor.
+
+### m5 (pass-1 m3 / m6 / m9) — still deferred by design
+
+Per pass 2:
+- m3 (one child note per parser error per module): N copies of `"while parsing <label>"` for an N-error file. Acceptable; renderer-side dedup is a separate concern.
+- m6 (stdlib bootstrap): [stdlib/bootstrap.rs:30-52](../crates/sifr_driver/src/stdlib/bootstrap.rs:30) still funnels stdlib parse failures into `STDLIB_BOOTSTRAP_FAILURE`. `parse_module_with_diagnostics` is now reusable if the bootstrap-failure facade is ever retired.
+- m9 (`latest_ty()` rationale): the comment at [parser_diagnostics.rs:17-19](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:17) still doesn't explain *why `latest_ty()` over `latest()`*. Five-word fix; not blocking.
+
+Recommend filing one issue covering all three.
+
+### m7 (new in pass 3) — `ChildSeverity::Help` rendering branch is dead in tests
+
+[main.rs:421-424](../crates/sifr/src/main.rs:421):
+
+```rust
+let child_label = match child.severity {
+    ChildSeverity::Note => "note",
+    ChildSeverity::Help => "help",
+};
+```
+
+The new `test_human_diagnostic_format_renders_child_notes` covers `ChildSeverity::Note` only. The `Help` arm has zero in-crate coverage — no current emission site uses it. Not a regression (the slice doesn't emit `Help`), but the same one-line trick that pinned the `Note` format would pin `Help` too. Add a sibling test or an additional case if and when a slice introduces `Help` children. Non-blocking.
+
+---
+
+## Things checked and OK in pass 3
+
+- **`recovery_expected` callsite invariant.** Only one caller — [parser_diagnostics.rs:230-231](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:230) (`OtherError` arm). The function is private to the module. Adding/removing prefixes there is contained.
+- **`recovery_expected` empty-string behavior.** Pathologically, `recovery_expected("")` yields `"recovery: "`, which renders as `"syntax error: expected recovery: "`. Ruff doesn't emit empty `OtherError` payloads in the audited surface, so this is theoretical. Not worth guarding; flagging only because it's the one input that produces a trailing-space message.
+- **`assert_eq!` on the `Expected `-prefixed full message.** Brittle to a Ruff-fork rename of the upstream English sentence, but that's the right kind of brittleness — it forces a deliberate update, not a silent regression. The non-prefixed case wisely uses `starts_with` instead.
+- **`test_parse_source_normalizes_parser_recovery_messages` source for the recovery branch.** `def f(mut mut items: list[int])` traces to [statement.rs:3097-3115](../third_party/ruff/crates/ruff_python_parser/src/parser/statement.rs:3097) — the second `mut` token sees `convention.is_mutable() == true` and emits the `OtherError("duplicate \`mut\` parameter modifier")` we expect. The `find` predicate filters to the recovery diagnostic, so additional emitted errors (e.g., subsequent name-as-parameter resolution) don't perturb the test.
+- **Test_runner determinism.** [test_runner.rs:294-333](../crates/sifr_driver/src/tests/test_runner.rs:294) destructures `(message, children)` and asserts full equality across two `run_tests` invocations. Children-aware. Pass-2 invariant preserved.
+- **Validation contract still consistent with renderer.** `"while parsing helper"` exactly matches the format in [parser_diagnostics.rs:84-85](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:84) (`format!("while parsing {label}")`). No drift.
+- **No new clippy violations.** `cargo fmt --check` passed per author's pass-3 log; pass-2's clippy-clean state is preserved (pass 3 only adds tests + a one-line `format!` in `recovery_expected`).
+- **Untracked working-tree noise.** `package-lock.json` and `package.json` are present in `git status` and unrelated to this slice (probably tooling artifacts from another task). They should not land in this slice's PR — confirm exclusion when staging.
+
+---
+
+## Suggested follow-up issues (non-blocking)
+
+1. **Compact-format children rendering** (pass-2 m2). One-line code comment or first-child-inline emission.
+2. **Parser_category taxonomy harmonization** (pass-2 m4). Pick `interpolated_string` everywhere or `lexical_f_string`/`lexical_t_string`; document.
+3. **Stdlib bootstrap parser routing** (pass-1 m6). Either retire the `STDLIB_BOOTSTRAP_FAILURE` facade and route through `parse_module_with_diagnostics`, or annotate why bootstrap intentionally collapses to a single bootstrap-failure code.
+4. **`latest_ty` vs `latest` rationale** (pass-1 m9). One-comment fix at [parser_diagnostics.rs:17-19](../crates/sifr_driver/src/frontend/parser_diagnostics.rs:17).
+5. **`ChildSeverity::Help` test coverage** (pass-3 m7). Add when the first `Help` emission lands.
+
+---
+
+## Summary
+
+Satisfied. M1' is closed grammatically *and* preserves the registry contract; m1 is closed by a tight regression pin on the human renderer; the rest of the slice is unchanged from pass 2's verified-OK state. Validation gate (`scripts/run_all_tests.sh --profile quick`, signature `e1bf653aaa770517`) passes with only advisory wall-time/skew flags. Recommend merge, with the five follow-ups above filed against a tracking issue and linked from the slice PR description.

--- a/verification/validation_contracts/manifest.json
+++ b/verification/validation_contracts/manifest.json
@@ -197,7 +197,7 @@
               "kind": "contains",
               "command_id": "closure_neg_check",
               "stream": "stderr",
-              "text": "[helper] failed to parse"
+              "text": "while parsing helper"
             },
             {
               "kind": "contains",


### PR DESCRIPTION
## Summary

- Add structured parser diagnostic classification for Ruff parser and unsupported-syntax categories, emitting active `SIFR-PARSE-0002..0009` codes with registry-aligned message templates, declared args, and `parser_category` JSON context.
- Route single-file parsing and project import-closure parsing through the shared parser diagnostic helper while preserving latest Sifr syntax support via Ruff's latest target version.
- Preserve reachable-module/file context as diagnostic child notes and render those notes in human CLI output.
- Add representative e2e fail fixtures for every active parser code plus focused driver/CLI tests for classification, recovery-message normalization, deterministic project parse context, and child-note rendering.

## Review

Claude review loop completed and reviewer is satisfied:

- `reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-1.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-2.md`
- `reviews/semantic-diagnostic-code-taxonomy-diag-7-parser-classification-review-pass-3.md`

## Validation

- `cargo fmt --check`
- `cargo test -p sifr_driver parse_source -- --nocapture`
- `cargo test -p sifr_driver test_project_and_test_discovery_parity_reports_reachable_parse_errors -- --nocapture`
- `cargo test -p sifr_driver test_check_project_reports_reachable_parse_errors_in_import_closure -- --nocapture`
- `cargo test -p sifr_driver test_run_tests_reports_deterministic_parse_error_order -- --nocapture`
- `cargo clippy -p sifr_driver --no-deps -- -D warnings`
- `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture`
- `bash scripts/run_validation_contract_matrix.sh`
- `cargo test -p sifr diagnostic_format -- --nocapture`
- `cargo test -p sifr_driver test_parse_source_normalizes_parser_recovery_messages -- --nocapture`
- `cargo test -p sifr test_human_diagnostic_format_renders_child_notes -- --nocapture`
- `scripts/run_all_tests.sh --profile quick` passed with `report_signature=e1bf653aaa770517`; advisory only: warm wall-time budget exceeded and group skew high.

## Follow-ups

Non-blocking items from the satisfied review pass:

- Decide whether compact diagnostics should render child notes or explicitly document compact lossiness.
- Harmonize `parser_category` naming for f-string/t-string lexical paths.
- Clarify stdlib bootstrap parser routing: keep bootstrap-failure facade intentionally or route through the shared helper.
- Add a short rationale for `PythonVersion::latest_ty()` over `latest()` if we want the distinction documented.
- Add `ChildSeverity::Help` human-rendering coverage when the first help child emission lands.