### PR TITLE
INT-1 wave 1: add SifrInt runtime substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/sifr_diagnostics",
+    "crates/sifr_runtime",
     "crates/sifr_type_system",
     "crates/sifr_hir",
     "crates/sifr_codegen",
@@ -34,6 +35,7 @@ sifr_python_parser = { package = "ruff_python_parser", path = "third_party/ruff/
 
 # Sifr-specific crates
 sifr_diagnostics = { path = "crates/sifr_diagnostics" }
+sifr_runtime = { path = "crates/sifr_runtime" }
 sifr_type_system = { path = "crates/sifr_type_system" }
 sifr_hir = { path = "crates/sifr_hir" }
 sifr_codegen = { path = "crates/sifr_codegen" }
@@ -50,6 +52,8 @@ is-macro = { version = "0.3.7" }
 itertools = { version = "0.14.0" }
 memchr = { version = "2.8.0" }
 once_cell = { version = "1.21.4" }
+num-bigint = { version = "0.4.6" }
+num-traits = { version = "0.2.19" }
 rustc-hash = { version = "2.1.2" }
 schemars = { version = "1.2.1" }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -487,6 +487,9 @@ fn infer_dependencies(
     if rust_source.contains("num_bigint::BigInt") || rust_source.contains("use num_bigint") {
         modules.insert("_bigint".to_string());
     }
+    if rust_source.contains("sifr_runtime::") || rust_source.contains("use sifr_runtime") {
+        crates.insert("sifr_runtime".to_string());
+    }
     if rust_source.contains("regex::") {
         crates.insert("regex".to_string());
     }
@@ -1221,6 +1224,9 @@ fn generate_cargo_toml(
                     "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
                 );
             }
+            "sifr_runtime" | "sifr-runtime" => {
+                deps.insert(sifr_runtime_dependency_spec());
+            }
             _ => {}
         }
     }
@@ -1238,6 +1244,49 @@ fn generate_cargo_toml(
     contents.push_str("\n[workspace]\n");
 
     contents
+}
+
+fn sifr_runtime_dependency_spec() -> String {
+    let runtime_path = discover_sifr_runtime_path().unwrap_or_else(compile_time_sifr_runtime_path);
+    let escaped_path = runtime_path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("sifr_runtime = {{ path = \"{escaped_path}\" }}")
+}
+
+fn discover_sifr_runtime_path() -> Option<PathBuf> {
+    env::var_os("SIFR_RUNTIME_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.join("Cargo.toml").is_file())
+        .or_else(|| discover_sifr_runtime_path_from_current_dir())
+        .or_else(|| discover_sifr_runtime_path_from_current_exe())
+}
+
+fn discover_sifr_runtime_path_from_current_dir() -> Option<PathBuf> {
+    env::current_dir()
+        .ok()
+        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
+}
+
+fn discover_sifr_runtime_path_from_current_exe() -> Option<PathBuf> {
+    env::current_exe()
+        .ok()
+        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
+}
+
+fn discover_sifr_runtime_path_from_ancestors(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|ancestor| {
+        let candidate = ancestor.join("crates").join("sifr_runtime");
+        candidate.join("Cargo.toml").is_file().then_some(candidate)
+    })
+}
+
+fn compile_time_sifr_runtime_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")))
+        .join("sifr_runtime")
 }
 
 fn make_entry_function_public(source: &str, entry_fn: &str) -> String {
@@ -3602,6 +3651,15 @@ fn test_generate_cargo_toml_required_toml_uses_preserve_order_feature() {
 
     let cargo_toml = generate_cargo_toml(&stdlib_modules, &required_crates, "sifr_output");
     assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
+}
+
+#[test]
+fn test_generate_cargo_toml_required_sifr_runtime_uses_path_dependency() {
+    let stdlib_modules = BTreeSet::new();
+    let required_crates = normalize_dependency_set(vec!["sifr_runtime".to_string()]);
+
+    let cargo_toml = generate_cargo_toml(&stdlib_modules, &required_crates, "sifr_output");
+    assert!(cargo_toml.contains("sifr_runtime = { path = "));
 }
 
 fn sample_cache_entry(

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -98,6 +98,12 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
             "BigDecimal".to_string(),
         ]));
     }
+    if import_needs.runtime.needs_sifr_int {
+        import_items.push(RustItem::Use(vec![
+            "sifr_runtime".to_string(),
+            "SifrInt".to_string(),
+        ]));
+    }
 
     let mut file_items: Vec<RustItem> = Vec::new();
     file_items.extend(import_items);
@@ -131,6 +137,9 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
             }
             if import_needs.runtime.numeric.needs_bigdecimal {
                 crates.insert("bigdecimal".to_string());
+            }
+            if import_needs.runtime.needs_sifr_int {
+                crates.insert("sifr_runtime".to_string());
             }
             crates
         },

--- a/crates/sifr_codegen/src/ir_imports.rs
+++ b/crates/sifr_codegen/src/ir_imports.rs
@@ -17,6 +17,7 @@ pub(crate) struct IrCollectionImportNeeds {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct IrRuntimeImportNeeds {
     pub(crate) needs_mutex: bool,
+    pub(crate) needs_sifr_int: bool,
     pub(crate) numeric: IrNumericImportNeeds,
 }
 
@@ -432,6 +433,8 @@ fn mark_symbol(symbol: &str, needs: &mut IrImportNeeds) {
         "HashSet" => needs.collections.needs_hashset = true,
         "VecDeque" => needs.collections.needs_vecdeque = true,
         "Mutex" => needs.runtime.needs_mutex = true,
+        "SifrInt" => needs.runtime.needs_sifr_int = true,
+        "sifr_runtime" => needs.runtime.needs_sifr_int = true,
         "BigInt" => needs.runtime.numeric.needs_bigint = true,
         "Decimal" => needs.runtime.numeric.needs_decimal = true,
         "BigDecimal" => needs.runtime.numeric.needs_bigdecimal = true,
@@ -522,5 +525,32 @@ mod tests {
         assert!(!needs.runtime.numeric.needs_bigint);
         assert!(!needs.runtime.numeric.needs_decimal);
         assert!(!needs.runtime.numeric.needs_bigdecimal);
+    }
+
+    #[test]
+    fn collects_sifr_runtime_integer_symbols() {
+        let items = vec![RustItem::Fn {
+            name: "demo".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![RustParam::Named {
+                name: "value".to_string(),
+                ty: RustType::Named("SifrInt".to_string()),
+            }],
+            ret: Some(RustType::Named("SifrInt".to_string())),
+            body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    "sifr_runtime".to_string(),
+                    "SifrInt".to_string(),
+                    "from_i64".to_string(),
+                ])),
+                args: vec![RustExpr::Literal(RustLiteral::Int(1))],
+            }))],
+            is_async: false,
+        }];
+
+        let needs = collect_import_needs_from_items(&items);
+
+        assert!(needs.runtime.needs_sifr_int);
     }
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -64,7 +64,9 @@ pub(crate) use lib_support::{
 use sifr_hir::{HirExpr, HirFunction, HirModule, HirStmt};
 use sifr_type_system::{ParamConvention, Type};
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use stdlib_filter::{
     collect_and_strip_shared_prelude, dedup_rust_items, filter_stdlib_ir_to_needed,
 };
@@ -77,6 +79,49 @@ type IsinstanceUnionMatch = (String, String, String, UnionVariantTypes);
 type IsNoneUnionMatch = (String, String, UnionVariantTypes);
 
 pub use entrypoints::{generate_rust, generate_rust_test, generate_rust_with_metadata};
+
+pub fn sifr_runtime_dependency_spec() -> String {
+    let runtime_path = discover_sifr_runtime_path().unwrap_or_else(compile_time_sifr_runtime_path);
+    let escaped_path = runtime_path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("sifr_runtime = {{ path = \"{escaped_path}\" }}")
+}
+
+fn discover_sifr_runtime_path() -> Option<PathBuf> {
+    env::var_os("SIFR_RUNTIME_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.join("Cargo.toml").is_file())
+        .or_else(|| discover_sifr_runtime_path_from_current_dir())
+        .or_else(|| discover_sifr_runtime_path_from_current_exe())
+}
+
+fn discover_sifr_runtime_path_from_current_dir() -> Option<PathBuf> {
+    env::current_dir()
+        .ok()
+        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
+}
+
+fn discover_sifr_runtime_path_from_current_exe() -> Option<PathBuf> {
+    env::current_exe()
+        .ok()
+        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
+}
+
+fn discover_sifr_runtime_path_from_ancestors(start: &Path) -> Option<PathBuf> {
+    start.ancestors().find_map(|ancestor| {
+        let candidate = ancestor.join("crates").join("sifr_runtime");
+        candidate.join("Cargo.toml").is_file().then_some(candidate)
+    })
+}
+
+fn compile_time_sifr_runtime_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")))
+        .join("sifr_runtime")
+}
 
 #[derive(Clone)]
 struct NestedFnCapture {
@@ -523,6 +568,8 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
         || stdlib_import_needs.runtime.numeric.needs_decimal;
     let needs_bigdecimal = body_import_needs.runtime.numeric.needs_bigdecimal
         || stdlib_import_needs.runtime.numeric.needs_bigdecimal;
+    let needs_sifr_int =
+        body_import_needs.runtime.needs_sifr_int || stdlib_import_needs.runtime.needs_sifr_int;
     let needs_mutex = needs_file_handles
         || needs_logging
         || needs_random_module_state
@@ -567,6 +614,12 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
         import_items.push(RustItem::Use(vec![
             "bigdecimal".to_string(),
             "BigDecimal".to_string(),
+        ]));
+    }
+    if needs_sifr_int {
+        import_items.push(RustItem::Use(vec![
+            "sifr_runtime".to_string(),
+            "SifrInt".to_string(),
         ]));
     }
     if needs_mutex {
@@ -644,6 +697,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             }
             if needs_bigdecimal {
                 crates.insert("bigdecimal".to_string());
+            }
+            if needs_sifr_int {
+                crates.insert("sifr_runtime".to_string());
             }
             crates
         },
@@ -1038,6 +1094,12 @@ edition = "2021"
                     deps.push(
                         "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
                     );
+                }
+            }
+            "sifr_runtime" | "sifr-runtime" => {
+                let dep = sifr_runtime_dependency_spec();
+                if !deps.contains(&dep) {
+                    deps.push(dep);
                 }
             }
             _ => {}

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    generate_rust, generate_rust_multi, generate_rust_multi_with_metadata, generate_rust_test,
-    generate_rust_with_metadata, RustEmitter, RustExpr, RustStmt, RustType, StdlibCode,
+    generate_project_with_deps_and_crates, generate_rust, generate_rust_multi,
+    generate_rust_multi_with_metadata, generate_rust_test, generate_rust_with_metadata,
+    RustEmitter, RustExpr, RustStmt, RustType, StdlibCode,
 };
 use sifr_hir::{
     lower_module, HirClass, HirClassKind, HirExceptHandler, HirExpr, HirFStringPart, HirFunction,
@@ -14,6 +15,17 @@ fn generate_rust_from_source(source: &str) -> String {
     let parsed = parse_module(source).expect("parse failed");
     let lowering = lower_module(parsed.suite()).expect("lowering failed");
     generate_rust(&lowering.module)
+}
+
+fn empty_module() -> HirModule {
+    HirModule {
+        functions: vec![],
+        classes: vec![],
+        imports: vec![],
+        constants: vec![],
+        generic_functions: std::collections::HashMap::new(),
+        type_param_bounds: std::collections::HashMap::new(),
+    }
 }
 
 #[test]
@@ -3484,6 +3496,20 @@ fn test_generate_rust_multi_assembles_single_rust_file() {
     assert!(!generate_block.contains("assert_output_drained("));
     assert!(!generate_block.contains("emitter.output"));
     assert!(!generate_block.contains("module_import_prelude"));
+}
+
+#[test]
+fn test_generate_project_emits_sifr_runtime_path_dependency_when_required() {
+    let module = empty_module();
+    let required_crates = HashSet::from(["sifr_runtime".to_string()]);
+    let (cargo_toml, _main_rs) = generate_project_with_deps_and_crates(
+        &module,
+        "sifr_output",
+        &HashSet::new(),
+        &required_crates,
+    );
+
+    assert!(cargo_toml.contains("sifr_runtime = { path = "));
 }
 
 #[test]

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -403,6 +403,7 @@ fn test_generate_test_runner_cargo_toml_includes_required_crates() {
         "regex".to_string(),
         "rand".to_string(),
         "rand_distr".to_string(),
+        "sifr_runtime".to_string(),
     ]);
 
     let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
@@ -410,6 +411,7 @@ fn test_generate_test_runner_cargo_toml_includes_required_crates() {
     assert!(cargo_toml.contains("regex = \"1.12.3\""));
     assert!(cargo_toml.contains("rand = \"0.10.1\""));
     assert!(cargo_toml.contains("rand_distr = \"0.6.0\""));
+    assert!(cargo_toml.contains("sifr_runtime = { path = "));
 }
 
 #[test]

--- a/crates/sifr_runtime/Cargo.toml
+++ b/crates/sifr_runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sifr_runtime"
+version = "0.0.0"
+publish = false
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sifr_runtime/src/int.rs
+++ b/crates/sifr_runtime/src/int.rs
@@ -1,0 +1,511 @@
+use num_bigint::BigInt;
+use num_bigint::Sign;
+use num_traits::{Signed, ToPrimitive};
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Add, Mul, Neg, Sub};
+use std::str::FromStr;
+
+pub const DEFAULT_MAX_INTEGER_DIGITS: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntegerParseError {
+    Empty,
+    InvalidDigit,
+    DigitLimitExceeded { limit: usize, actual: usize },
+}
+
+impl fmt::Display for IntegerParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("integer text is empty"),
+            Self::InvalidDigit => f.write_str("integer text contains an invalid digit"),
+            Self::DigitLimitExceeded { limit, actual } => {
+                write!(
+                    f,
+                    "integer text has {actual} digits, exceeding the configured limit of {limit}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for IntegerParseError {}
+
+#[derive(Clone, Debug, Eq)]
+pub enum SifrInt {
+    Small(i64),
+    Big(Box<BigInt>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NormalizedIntegerHash {
+    negative: bool,
+    magnitude_be: Vec<u8>,
+}
+
+impl NormalizedIntegerHash {
+    #[must_use]
+    pub fn from_signed(value: i128) -> Self {
+        Self {
+            negative: value.is_negative(),
+            magnitude_be: normalized_magnitude_bytes(&value.unsigned_abs().to_be_bytes()),
+        }
+    }
+
+    #[must_use]
+    pub fn from_unsigned(value: u128) -> Self {
+        Self {
+            negative: false,
+            magnitude_be: normalized_magnitude_bytes(&value.to_be_bytes()),
+        }
+    }
+}
+
+impl SifrInt {
+    #[must_use]
+    pub const fn from_i64(value: i64) -> Self {
+        Self::Small(value)
+    }
+
+    #[must_use]
+    pub fn from_i128(value: i128) -> Self {
+        i64::try_from(value).map_or_else(|_| Self::Big(Box::new(BigInt::from(value))), Self::Small)
+    }
+
+    #[must_use]
+    pub fn from_u128(value: u128) -> Self {
+        i64::try_from(value).map_or_else(|_| Self::Big(Box::new(BigInt::from(value))), Self::Small)
+    }
+
+    #[must_use]
+    pub fn from_bigint(value: BigInt) -> Self {
+        match value.to_i64() {
+            Some(small) => Self::Small(small),
+            None => Self::Big(Box::new(value)),
+        }
+    }
+
+    pub fn parse_decimal(text: &str, max_digits: usize) -> Result<Self, IntegerParseError> {
+        let digit_count = count_decimal_digits(text)?;
+        if digit_count > max_digits {
+            return Err(IntegerParseError::DigitLimitExceeded {
+                limit: max_digits,
+                actual: digit_count,
+            });
+        }
+        let parsed = BigInt::from_str(text).map_err(|_| IntegerParseError::InvalidDigit)?;
+        Ok(Self::from_bigint(parsed))
+    }
+
+    #[must_use]
+    pub fn normalized_hash_key(&self) -> NormalizedIntegerHash {
+        match self {
+            Self::Small(value) => NormalizedIntegerHash::from_signed(i128::from(*value)),
+            Self::Big(value) => {
+                let (sign, magnitude_be) = value.to_bytes_be();
+                NormalizedIntegerHash {
+                    negative: sign == Sign::Minus,
+                    magnitude_be: normalized_magnitude_bytes(&magnitude_be),
+                }
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn as_bigint(&self) -> BigInt {
+        match self {
+            Self::Small(value) => BigInt::from(*value),
+            Self::Big(value) => value.as_ref().clone(),
+        }
+    }
+
+    #[must_use]
+    pub const fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Small(value) => Some(*value),
+            Self::Big(_) => None,
+        }
+    }
+}
+
+impl From<i64> for SifrInt {
+    fn from(value: i64) -> Self {
+        Self::from_i64(value)
+    }
+}
+
+impl From<i128> for SifrInt {
+    fn from(value: i128) -> Self {
+        Self::from_i128(value)
+    }
+}
+
+impl From<u128> for SifrInt {
+    fn from(value: u128) -> Self {
+        Self::from_u128(value)
+    }
+}
+
+impl From<BigInt> for SifrInt {
+    fn from(value: BigInt) -> Self {
+        Self::from_bigint(value)
+    }
+}
+
+impl Add for SifrInt {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Small(left), Self::Small(right)) => left.checked_add(right).map_or_else(
+                || Self::from_i128(i128::from(left) + i128::from(right)),
+                Self::Small,
+            ),
+            (left, right) => Self::from_bigint(left.as_bigint() + right.as_bigint()),
+        }
+    }
+}
+
+impl Add<&SifrInt> for SifrInt {
+    type Output = Self;
+
+    fn add(self, rhs: &SifrInt) -> Self::Output {
+        self + rhs.clone()
+    }
+}
+
+impl Add<SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn add(self, rhs: SifrInt) -> Self::Output {
+        self.clone() + rhs
+    }
+}
+
+impl Add<&SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn add(self, rhs: &SifrInt) -> Self::Output {
+        self.clone() + rhs.clone()
+    }
+}
+
+impl Sub for SifrInt {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Small(left), Self::Small(right)) => left.checked_sub(right).map_or_else(
+                || Self::from_i128(i128::from(left) - i128::from(right)),
+                Self::Small,
+            ),
+            (left, right) => Self::from_bigint(left.as_bigint() - right.as_bigint()),
+        }
+    }
+}
+
+impl Sub<&SifrInt> for SifrInt {
+    type Output = Self;
+
+    fn sub(self, rhs: &SifrInt) -> Self::Output {
+        self - rhs.clone()
+    }
+}
+
+impl Sub<SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn sub(self, rhs: SifrInt) -> Self::Output {
+        self.clone() - rhs
+    }
+}
+
+impl Sub<&SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn sub(self, rhs: &SifrInt) -> Self::Output {
+        self.clone() - rhs.clone()
+    }
+}
+
+impl Mul for SifrInt {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::Small(left), Self::Small(right)) => left.checked_mul(right).map_or_else(
+                || Self::from_i128(i128::from(left) * i128::from(right)),
+                Self::Small,
+            ),
+            (left, right) => Self::from_bigint(left.as_bigint() * right.as_bigint()),
+        }
+    }
+}
+
+impl Mul<&SifrInt> for SifrInt {
+    type Output = Self;
+
+    fn mul(self, rhs: &SifrInt) -> Self::Output {
+        self * rhs.clone()
+    }
+}
+
+impl Mul<SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn mul(self, rhs: SifrInt) -> Self::Output {
+        self.clone() * rhs
+    }
+}
+
+impl Mul<&SifrInt> for &SifrInt {
+    type Output = SifrInt;
+
+    fn mul(self, rhs: &SifrInt) -> Self::Output {
+        self.clone() * rhs.clone()
+    }
+}
+
+impl Neg for SifrInt {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            Self::Small(value) => value
+                .checked_neg()
+                .map_or_else(|| Self::from_i128(-i128::from(value)), Self::Small),
+            Self::Big(value) => Self::from_bigint(-*value),
+        }
+    }
+}
+
+impl Neg for &SifrInt {
+    type Output = SifrInt;
+
+    fn neg(self) -> Self::Output {
+        -self.clone()
+    }
+}
+
+impl FromStr for SifrInt {
+    type Err = IntegerParseError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        Self::parse_decimal(text, DEFAULT_MAX_INTEGER_DIGITS)
+    }
+}
+
+impl PartialEq for SifrInt {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Small(left), Self::Small(right)) => left == right,
+            (Self::Big(left), Self::Big(right)) => left == right,
+            (Self::Small(left), Self::Big(right)) | (Self::Big(right), Self::Small(left)) => {
+                right.to_i64() == Some(*left)
+            }
+        }
+    }
+}
+
+impl PartialOrd for SifrInt {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SifrInt {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Small(left), Self::Small(right)) => left.cmp(right),
+            (Self::Big(left), Self::Big(right)) => left.cmp(right),
+            (Self::Small(left), Self::Big(right)) => match right.to_i64() {
+                Some(right) => left.cmp(&right),
+                None if right.is_negative() => Ordering::Greater,
+                None => Ordering::Less,
+            },
+            (Self::Big(left), Self::Small(right)) => match left.to_i64() {
+                Some(left) => left.cmp(right),
+                None if left.is_negative() => Ordering::Less,
+                None => Ordering::Greater,
+            },
+        }
+    }
+}
+
+impl Hash for SifrInt {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Small(value) => {
+                hash_normalized_integer_parts(
+                    value.is_negative(),
+                    &value.unsigned_abs().to_be_bytes(),
+                    state,
+                );
+            }
+            Self::Big(value) => {
+                let (sign, magnitude_be) = value.to_bytes_be();
+                hash_normalized_integer_parts(sign == Sign::Minus, &magnitude_be, state);
+            }
+        }
+    }
+}
+
+impl fmt::Display for SifrInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Small(value) => fmt::Display::fmt(value, f),
+            Self::Big(value) => fmt::Display::fmt(value, f),
+        }
+    }
+}
+
+fn count_decimal_digits(text: &str) -> Result<usize, IntegerParseError> {
+    let unsigned = text
+        .strip_prefix('-')
+        .or_else(|| text.strip_prefix('+'))
+        .unwrap_or(text);
+    if unsigned.is_empty() {
+        return Err(IntegerParseError::Empty);
+    }
+    if !unsigned.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(IntegerParseError::InvalidDigit);
+    }
+    Ok(unsigned.len())
+}
+
+fn normalized_magnitude_bytes(bytes: &[u8]) -> Vec<u8> {
+    let normalized = strip_leading_zero_bytes(bytes);
+    if normalized.is_empty() {
+        Vec::new()
+    } else {
+        normalized.to_vec()
+    }
+}
+
+fn hash_normalized_integer_parts<H: Hasher>(negative: bool, magnitude_be: &[u8], state: &mut H) {
+    let magnitude = strip_leading_zero_bytes(magnitude_be);
+    let normalized_negative = negative && !magnitude.is_empty();
+    normalized_negative.hash(state);
+    magnitude.len().hash(state);
+    state.write(magnitude);
+}
+
+fn strip_leading_zero_bytes(bytes: &[u8]) -> &[u8] {
+    let first_non_zero = bytes
+        .iter()
+        .position(|byte| *byte != 0)
+        .unwrap_or(bytes.len());
+    &bytes[first_non_zero..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn hash(value: &SifrInt) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn fitting_values_stay_small() {
+        let value = SifrInt::from_i64(42);
+        assert!(matches!(value, SifrInt::Small(42)));
+        assert_eq!(value.to_string(), "42");
+    }
+
+    #[test]
+    fn large_decimal_text_spills_to_big() {
+        let value = SifrInt::parse_decimal("9223372036854775808", DEFAULT_MAX_INTEGER_DIGITS)
+            .unwrap_or_else(|err| panic!("{err}"));
+        assert!(matches!(value, SifrInt::Big(_)));
+        assert_eq!(value.to_string(), "9223372036854775808");
+    }
+
+    #[test]
+    fn parse_enforces_digit_limit_without_panicking() {
+        let err = SifrInt::parse_decimal("12345", 4)
+            .expect_err("digit limit should reject oversized integer text");
+        assert_eq!(
+            err,
+            IntegerParseError::DigitLimitExceeded {
+                limit: 4,
+                actual: 5
+            }
+        );
+    }
+
+    #[test]
+    fn equality_ordering_and_hashing_are_normalized() {
+        let small = SifrInt::Small(1);
+        let big = SifrInt::Big(Box::new(BigInt::from(1_i64)));
+
+        assert_eq!(small, big);
+        assert_eq!(small.cmp(&big), Ordering::Equal);
+        assert_eq!(hash(&small), hash(&big));
+    }
+
+    #[test]
+    fn arithmetic_keeps_small_results_inline() {
+        let result = SifrInt::from_i64(7) + SifrInt::from_i64(5);
+        assert!(matches!(result, SifrInt::Small(12)));
+
+        let product = &SifrInt::from_i64(6) * &SifrInt::from_i64(7);
+        assert!(matches!(product, SifrInt::Small(42)));
+    }
+
+    #[test]
+    fn arithmetic_spills_on_i64_overflow() {
+        let result = SifrInt::from_i64(i64::MAX) + SifrInt::from_i64(1);
+        assert!(matches!(result, SifrInt::Big(_)));
+        assert_eq!(result.to_string(), "9223372036854775808");
+    }
+
+    #[test]
+    fn subtraction_multiplication_and_negation_spill_on_i64_overflow() {
+        let underflow = SifrInt::from_i64(i64::MIN) - SifrInt::from_i64(1);
+        assert!(matches!(underflow, SifrInt::Big(_)));
+        assert_eq!(underflow.to_string(), "-9223372036854775809");
+
+        let product = SifrInt::from_i64(i64::MAX) * SifrInt::from_i64(2);
+        assert!(matches!(product, SifrInt::Big(_)));
+        assert_eq!(product.to_string(), "18446744073709551614");
+
+        let negated = -SifrInt::from_i64(i64::MIN);
+        assert!(matches!(negated, SifrInt::Big(_)));
+        assert_eq!(negated.to_string(), "9223372036854775808");
+    }
+
+    #[test]
+    fn overflow_then_cancel_can_return_to_small() {
+        let result =
+            (SifrInt::from_i64(i64::MAX) + SifrInt::from_i64(1)) - SifrInt::from_i64(i64::MAX);
+
+        assert!(matches!(result, SifrInt::Small(1)));
+    }
+
+    #[test]
+    fn fixed_width_hash_helpers_normalize_signed_and_unsigned_values() {
+        assert_eq!(
+            NormalizedIntegerHash::from_signed(255),
+            NormalizedIntegerHash::from_unsigned(255)
+        );
+        assert_ne!(
+            NormalizedIntegerHash::from_signed(-1),
+            NormalizedIntegerHash::from_unsigned(255)
+        );
+    }
+
+    #[test]
+    fn signed_big_values_order_correctly() {
+        let negative = SifrInt::parse_decimal("-9223372036854775809", DEFAULT_MAX_INTEGER_DIGITS)
+            .unwrap_or_else(|err| panic!("{err}"));
+        let small = SifrInt::from_i64(-10);
+
+        assert!(negative < small);
+    }
+}

--- a/crates/sifr_runtime/src/lib.rs
+++ b/crates/sifr_runtime/src/lib.rs
@@ -1,0 +1,6 @@
+//! Runtime support shared by generated Sifr projects.
+#![cfg_attr(test, allow(clippy::expect_used))]
+
+mod int;
+
+pub use int::{IntegerParseError, NormalizedIntegerHash, SifrInt, DEFAULT_MAX_INTEGER_DIGITS};

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -390,11 +390,14 @@ Validation:
 - [x] Principal-engineer broader-surface review pass 5 completed after pass 4 polish: `reviews/integer-model-fixed-width-contract-review-pass-5-broader-surfaces-final.md`.
 - [x] Phase-plan review pass 1 completed after splitting design and milestones: `reviews/integer-model-phase-plan-review-pass-1.md`.
 - [x] Phase-plan review pass 2 completed after addressing pass 1 blockers: `reviews/integer-model-phase-plan-review-pass-2.md`.
+- [x] INT-1 runtime substrate wave 1 review pass 1 completed with blockers: `reviews/integer-model-int-1-runtime-wave-1-review-pass-1.md`.
+- [x] INT-1 runtime substrate wave 1 review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-1-runtime-wave-1-review-pass-2.md`.
 
 ## Implementation Checklist
 
 - [x] INT-0 contract lock and legacy audit
 - [ ] INT-1 runtime `SifrInt` and ownership semantics
+  - [x] Wave 1 runtime substrate and generated Cargo dependency plumbing reviewed and quick-validated.
 - [ ] INT-2A parser boundary and literal capture
 - [ ] INT-2B HIR, type system, and const fitting
 - [ ] INT-3 scalar arithmetic and numeric mixing

--- a/reviews/integer-model-int-1-runtime-wave-1-review-pass-1.md
+++ b/reviews/integer-model-int-1-runtime-wave-1-review-pass-1.md
@@ -1,0 +1,342 @@
+# Review: INT-1 Runtime Wave 1 — `sifr_runtime` substrate and codegen plumbing (Pass 1)
+
+Reviewer: Claude Opus 4.7
+Date: 2026-05-05
+Phase: `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md`, milestone INT-1
+Design source of truth: `internal_docs/integer_model.md`
+
+## Verdict: NEEDS-CHANGES (one structural blocker, one performance blocker, several quality follow-ups)
+
+The diff lands the right substrate for INT-1 wave 1 — workspace-member crate, exact-`SifrInt` enum with normalized comparison/ordering/hashing, `parse_decimal` with a digit-limit guard, and `sifr_runtime` plumbing into the generated-project Cargo manifest path. The shape is correct and the diff is appropriately scoped to "substrate, not lowering."
+
+But two findings block lock as wave 1:
+
+- **B1.** The `sifr_runtime` Cargo dependency is emitted as an absolute filesystem `path = "..."` baked in at codegen build time via `env!("CARGO_MANIFEST_DIR")`. This works for in-workspace tests but is non-portable for any installed/distributed `sifr` binary. Wave 1 ships the only mechanism that wave 2+ generated user code will rely on, so this needs an answer (or an explicit deferral plan with a tracked follow-up) before lowering starts emitting `SifrInt`.
+- **B2.** `SifrInt::hash` allocates two `BigInt`s and a `String` per call for **every** `Small` value, directly contradicting INT-1's "Small integer construction and simple reuse do not allocate on the big-integer path" acceptance criterion. As soon as INT-3/INT-4 land hash/dict/set keys for `int`, this becomes a measurable regression vs. the design's no-allocation contract.
+
+The remaining items are non-blocking but should be addressed before INT-2A starts depending on these surfaces.
+
+---
+
+## Files reviewed
+
+- `Cargo.toml` (workspace member + workspace dependency entry).
+- `crates/sifr_runtime/Cargo.toml`, `crates/sifr_runtime/src/lib.rs`, `crates/sifr_runtime/src/int.rs` (new crate).
+- `crates/sifr_codegen/src/ir_imports.rs` (symbol → import-needs detection).
+- `crates/sifr_codegen/src/lib.rs` (`generate_project_with_deps_and_crates`, `sifr_runtime_dependency_spec`, import emission).
+- `crates/sifr_codegen/src/entrypoints.rs` (`generate_rust_test` mirror of import emission).
+- `crates/sifr_codegen/src/lib_codegen_tests.rs` (`test_generate_project_emits_sifr_runtime_path_dependency_when_required`).
+- `crates/sifr_driver/src/tests/test_runner.rs` (Cargo manifest test — added `sifr_runtime` to required crates).
+- `crates/sifr/tests/e2e.rs` (dependency inference and Cargo emission for the e2e harness).
+
+---
+
+## Scope check against INT-1 wave 1
+
+This wave correctly limits itself to the runtime substrate. Source-level `int` is not yet lowered to `SifrInt`; HIR/type-system are untouched; no e2e fixtures churn. That matches the user-stated framing and the milestone's "introduce the exact integer runtime representation without changing every integer operator at once" goal.
+
+What this wave delivers against INT-1's scope (`issues/...md` lines 96-106):
+
+| Scope item | Delivered |
+| --- | --- |
+| Create `crates/sifr_runtime` workspace crate | Yes |
+| Generated Cargo manifest links the runtime crate | Yes (with caveat B1) |
+| Canonical `SifrInt` with `Small(i64)` / `Big(Box<BigInt>)` | Yes |
+| Construction from primitives + decimal strings with digit limits | Yes |
+| Clone, equality, ordering, hashing, formatting, basic conversions | Yes (with caveat B2 on hashing performance) |
+| Normalized integer hashing helpers for fixed-width keys | Yes |
+| Source-level `int` value-semantic over non-`Copy` runtime | Deferred to wave 2 (HIR/codegen lowering not touched) |
+| Generated-code panic-shape tests for runtime integer paths | Partial (parse_decimal covered; no broader sweep) |
+
+Deferring the lowering and panic-shape sweep to wave 2 is reasonable. Calling out "wave 1 substrate" explicitly in the eventual PR description would help reviewers and the INT-1 closure check.
+
+---
+
+## Blocking findings
+
+### B1. Generated `sifr_runtime` dependency uses a non-portable absolute path
+
+`crates/sifr_codegen/src/lib.rs:82-93`:
+
+```rust
+fn sifr_runtime_dependency_spec() -> String {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir
+        .parent()
+        .map(|parent| parent.join("sifr_runtime"))
+        .unwrap_or_else(|| manifest_dir.join("../sifr_runtime"));
+    let escaped_path = runtime_path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("sifr_runtime = {{ path = \"{escaped_path}\" }}")
+}
+```
+
+`env!("CARGO_MANIFEST_DIR")` evaluates at compile time of `sifr_codegen` to the *developer's* absolute crate-source path. That literal is then baked into the released `sifr` binary and stamped, verbatim, into every generated user Cargo.toml that needs `sifr_runtime`. The same function is duplicated in `crates/sifr/tests/e2e.rs:1249-1260`.
+
+This is fine for in-tree validation because the embedded absolute path *happens* to point to a real `crates/sifr_runtime/` directory on the dev's machine. The four tests already on the green path (`generate_project_emits_sifr_runtime_path_dependency_when_required`, `generate_test_runner_cargo_toml_includes_required_crates`, `generate_cargo_toml_required_sifr_runtime_uses_path_dependency`) only assert the *prefix* `sifr_runtime = { path = ` and never validate that the path is portable, machine-relative, or installable. They will pass everywhere and silently allow the released compiler to ship broken Cargo manifests.
+
+Failure modes:
+
+- A `cargo install --path crates/sifr` build on machine A, copied to machine B, and run as `sifr build foo.sifr` would emit a Cargo.toml with a `path` that does not exist on B.
+- Even on machine A, moving the workspace to a new location after a release build invalidates every produced manifest.
+- The same applies to any tarball/Homebrew/CI distribution. The compiler has no general way to relocate the dependency.
+
+This is not exercised end-to-end today because no codegen path emits the `SifrInt` symbol or `sifr_runtime::` use yet. The detection rule (`mark_symbol("SifrInt"|"sifr_runtime", ...)` in `ir_imports.rs:436-437`) cannot fire on output that was never produced. So the latent bug only becomes user-visible the moment INT-2A or INT-3 starts emitting `SifrInt` paths in generated code.
+
+Recommended directions (any of these resolves it):
+
+1. **Defer the runtime-link mechanism** explicitly. Document in the issue that `sifr_runtime` is not consumed by user-built artifacts in INT-1 wave 1; the absolute-path manifest exists only for in-tree integration tests, and a portable mechanism (registry publish, vendored sources, runtime-relative path discovery via `sifr` binary location) is a tracked INT-1 wave 2 prerequisite for any milestone that actually emits `SifrInt`. Then add a runtime guard so non-test calls error or skip the `path = "..."` emission with a clear "not yet supported" diagnostic.
+2. **Resolve the path at runtime** from the running `sifr` binary's location (e.g., walk upward looking for `crates/sifr_runtime/Cargo.toml`, with a clear failure message if not found). This keeps the dev-shell story working without baking a build-time absolute path.
+3. **Vendor `sifr_runtime` source into each generated project** — strictly worse for codegen size/duplication but it removes the host-dependency. The design doc explicitly favors a shared crate over per-file vendoring, so this is the worst option.
+4. **Publish `sifr_runtime` to crates.io** (or an internal registry) and emit `sifr_runtime = "x.y.z"`. This matches how `num-bigint`, `rust_decimal`, etc. are handled today. Probably the eventual answer, but requires versioning, publishing, and a CI gate.
+
+For wave 1, option 1 (deferral with a runtime guard so the broken path can never escape) is the smallest correct change. The validation tests should then assert the *current* contract — "in-tree only" — rather than just that the string starts with `sifr_runtime = { path = `.
+
+Also worth noting: the dependency-spec function is now duplicated verbatim across `crates/sifr_codegen/src/lib.rs:82-93` and `crates/sifr/tests/e2e.rs:1249-1260`. Two copies, identical logic, two places to drift. The natural home is `sifr_codegen` with a `pub` re-export so `crates/sifr/tests/e2e.rs` shares it; that also gives a single place to apply whichever resolution above gets picked.
+
+### B2. `SifrInt::hash` allocates twice per `Small` hash
+
+`crates/sifr_runtime/src/int.rs:101-108, 318-322`:
+
+```rust
+pub fn normalized_hash_key(&self) -> NormalizedIntegerHash {
+    let value = self.as_bigint();           // BigInt::from(*small) — allocates
+    NormalizedIntegerHash {
+        negative: value.is_negative(),
+        magnitude_decimal: value.abs().to_str_radix(10),  // String — allocates
+    }
+}
+// ...
+impl Hash for SifrInt {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.normalized_hash_key().hash(state);
+    }
+}
+```
+
+For every `SifrInt::Small(_).hash(state)` call this:
+
+1. allocates a fresh `BigInt` (`as_bigint` → `BigInt::from(*value)`),
+2. allocates another `BigInt` (`value.abs()`),
+3. allocates a decimal `String`,
+4. drops all three.
+
+INT-1's acceptance criteria explicitly include: "Small integer construction and simple reuse do not allocate on the big-integer path." Hashing a `Small` is the canonical "simple reuse" — every `dict[int, V]` lookup, every `set[int]` insert, every `int`-keyed cache. Three allocations per hash is not consistent with that contract.
+
+The cross-family agreement (per `internal_docs/integer_model.md:198-203`: `hash(int(1)) == hash(int8(1))` whenever they compare equal) does require a canonical encoding. The current decimal-string normalization satisfies correctness but is unnecessarily expensive — a canonical magnitude byte form does the same work allocation-free for `Small`. Sketch:
+
+```rust
+impl Hash for SifrInt {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Small(v) => {
+                v.is_negative().hash(state);
+                // Normalize: hash big-endian magnitude bytes with leading-zero stripping,
+                // matching the byte form used for Big and for the fixed-width helpers.
+                hash_magnitude_be(state, &v.unsigned_abs().to_be_bytes());
+            }
+            Self::Big(v) => {
+                v.is_negative().hash(state);
+                let (_, mag_be) = v.to_bytes_be();
+                hash_magnitude_be(state, &mag_be);
+            }
+        }
+    }
+}
+```
+
+`NormalizedIntegerHash::from_signed`/`from_unsigned` would adopt the same canonical form so that `int(1)` / `int8(1)` / `uint8(1)` agree without anyone visiting decimal text. This is a refactor in `int.rs` only; nothing else needs to change.
+
+If this work is genuinely INT-8 territory and you want to keep it deferred, then INT-1 should at minimum carry a regression test that documents the current allocation count (e.g., a `#[ignore]`'d allocator-probe test) so that someone landing INT-3/INT-4 can't merge dict/set integration without explicitly addressing it. Right now there is no signal at all; the design's allocation guarantee is silently violated by a unit-tested-and-passing implementation.
+
+---
+
+## Non-blocking but worth fixing in this wave
+
+### N1. `Big`-vs-`Small` canonicalization is enforced by constructors but not by the public type
+
+All constructors in `int.rs` (`from_i64`, `from_i128`, `from_u128`, `from_bigint`, `parse_decimal`, the arithmetic spill paths) demote to `Small` whenever the value fits in `i64`. So in canonical use, `Big(_)` *only* holds values outside `i64`'s range, and `Small != Big` is therefore decidable in O(1) without reaching for `as_bigint()`.
+
+But the variants are `pub`, so generated/external code can hand-construct `SifrInt::Big(Box::new(BigInt::from(1_i64)))` and break the invariant. The unit test at `int.rs:386-394` does exactly this on purpose to verify cross-form normalization. The design doc anticipated this (`internal_docs/integer_model.md:44-46`):
+
+> If the implementation wants freedom to change the layout later, the variants should be hidden behind constructors and accessors from the first runtime slice.
+
+There are two coherent options:
+
+1. **Document the invariant and lean on it.** Make the variants `pub` (as today), document "constructed `Big(x)` for `x` fitting in i64 is malformed and behavior is unspecified," and replace the cross-form unit test with one that goes through `from_bigint`. Then `PartialEq` and `Hash` can short-circuit `(Small, Big)` to `false` / disjoint hash without an `as_bigint()` allocation.
+2. **Hide the variants.** Make them `pub(crate)` and expose constructors / accessors (`SifrInt::small(i64) -> Self`, `SifrInt::try_as_small(&self) -> Option<i64>`, etc.). This preserves the option to change the layout later (e.g., add `Inline128(i128)` or pack the discriminant) without breaking generated projects that have been built against the old enum.
+
+Either is a net improvement. Today's middle ground (variants public, equality routes everything through `as_bigint()`) costs allocations on every mixed-variant compare for no semantic benefit. Pick a side.
+
+### N2. `PartialEq` and `Ord` allocate unnecessarily on the `Big`/`Big` path
+
+`int.rs:294-316`:
+
+```rust
+impl PartialEq for SifrInt {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Small(left), Self::Small(right)) => left == right,
+            _ => self.as_bigint() == other.as_bigint(),
+        }
+    }
+}
+// Ord identical pattern.
+```
+
+The `_` arm fires for `(Big, Big)`, `(Small, Big)`, and `(Big, Small)`. For `(Big, Big)`, `as_bigint()` clones both inner `BigInt`s for the comparison even though `BigInt` already implements `Eq` / `Ord` directly. Cleaner:
+
+```rust
+match (self, other) {
+    (Self::Small(l), Self::Small(r)) => l == r,
+    (Self::Big(l), Self::Big(r)) => l == r,                    // no clone
+    (Self::Small(_), Self::Big(_)) | (Self::Big(_), Self::Small(_)) => false, // by N1 invariant
+}
+```
+
+If you don't want to commit to N1's invariant, the `(Small, Big)` arm can compare via `BigInt::to_i64()` without allocation. Either way, no clone is needed. Same shape applies to `Ord::cmp`.
+
+### N3. `as_bigint()` clones on `Big` even when borrowing would suffice
+
+`int.rs:110-116`:
+
+```rust
+pub fn as_bigint(&self) -> BigInt {
+    match self {
+        Self::Small(value) => BigInt::from(*value),
+        Self::Big(value) => value.as_ref().clone(),
+    }
+}
+```
+
+Every internal user (`PartialEq`, `Ord`, `Hash`) has to take that owned `BigInt`. A `Cow<'_, BigInt>` accessor would let the `Big` arm hand out a borrow:
+
+```rust
+pub fn as_bigint(&self) -> Cow<'_, BigInt> {
+    match self {
+        Self::Small(v) => Cow::Owned(BigInt::from(*v)),
+        Self::Big(v) => Cow::Borrowed(v),
+    }
+}
+```
+
+Combined with N2, this drops the `Big`/`Big` comparison/hash from "two clones" to "no clones."
+
+### N4. Symbol detection has no unit test
+
+`crates/sifr_codegen/src/ir_imports.rs:436-437` adds two new `mark_symbol` arms (`"SifrInt"` and `"sifr_runtime"` → `needs.runtime.needs_sifr_int = true`), but the existing `tests` module at the bottom of the same file only asserts coverage for `HashMap`, `HashSet`, `VecDeque`, `Mutex`, `BigInt`. The new arms are tested only transitively, through Cargo-toml emission tests that bypass the symbol pipeline entirely (the project test plumbs `"sifr_runtime"` straight into `required_crates`).
+
+A regression where someone renames `SifrInt`, drops one of the two arms, or breaks the syn-path visitor would not fail any test. Add an `ir_imports::tests` case that constructs an item containing `SifrInt` (as `RustExpr::Ident` or `RustType::Named("SifrInt")`) and one that contains `sifr_runtime::SifrInt` (as `RustExpr::Path` or a typed path), and asserts `needs.runtime.needs_sifr_int` is set in both.
+
+### N5. The `generate_rust_test` import path mirrors the main path but is otherwise untested
+
+`crates/sifr_codegen/src/entrypoints.rs:101-106, 141-143` adds the same `needs_sifr_int` → `use sifr_runtime::SifrInt;` + `required_crates` plumbing as `generate_rust_with_stdlib`. There is no unit test that exercises `generate_rust_test`'s SifrInt branch end-to-end. Given that the full project test only exercises `generate_project_with_deps_and_crates`, the test-codegen path is currently uncovered. A small input → output snapshot or assertion in `lib_codegen_tests.rs` for the test-mode path would close the gap.
+
+### N6. `num-bigint` / `num-traits` versions are pinned in three places
+
+The same `num-bigint = "0.4.6"` and `num-traits = "0.2.19"` strings now appear in:
+
+- `crates/sifr_runtime/Cargo.toml:10-11` (the new crate)
+- `crates/sifr_codegen/src/lib.rs:942-944, 1041-1048` (codegen-emitted user manifests)
+- `crates/sifr/tests/e2e.rs:1211-1216` (e2e generator)
+
+Pre-existing duplication (codegen + e2e) is not a wave-1 regression, but the new runtime crate introduces a third site that needs to stay in lock-step. Cargo's resolver will usually paper over a minor mismatch, but if any of these drifts to an incompatible version the generated user crate will see two `num_bigint::BigInt` types and the runtime helpers will silently stop being interchangeable with handwritten BigInt usage.
+
+The natural fix is a single `[workspace.dependencies]` entry for `num-bigint` and `num-traits` in the root `Cargo.toml`, with all three sites referencing it. That's a small refactor and the wave already touches each of those files.
+
+### N7. Arithmetic spill skips the `i128` middle ground
+
+`int.rs:151-238` overflow-fallback paths reach for `BigInt` directly:
+
+```rust
+(Self::Small(left), Self::Small(right)) => left.checked_add(right).map_or_else(
+    || Self::from_bigint(BigInt::from(left) + BigInt::from(right)),
+    Self::Small,
+),
+```
+
+For `i64 + i64` the mathematical result is always representable in `i128`. Routing through `i128` lets the result re-demote to `Small` when subsequent operations bring the magnitude back down, e.g. `i64::MAX + 1 - 1`. Today that sequence permanently allocates a `BigInt`.
+
+Sketch:
+
+```rust
+(Self::Small(l), Self::Small(r)) => left.checked_add(r).map_or_else(
+    || Self::from_i128(i128::from(l) + i128::from(r)),  // demotes when it fits
+    Self::Small,
+),
+```
+
+Same shape for `sub`, `mul`, `neg`. This stays in scope for INT-1 because `from_i128` already exists and demotes correctly. It avoids an allocation on a meaningful chunk of overflow-then-cancel sequences without changing observable semantics.
+
+### N8. Missing runtime tests for spill on `Sub`, `Mul`, and `Neg`
+
+`int.rs` has `arithmetic_spills_on_i64_overflow` for `Add` only. The other three operators have identical `checked_*` → `BigInt` patterns, but no test for `i64::MIN.neg() → Big`, `i64::MIN - 1 → Big`, or `i64::MAX * 2 → Big`. Each of those is a one-line addition and they're cheap insurance against a future refactor of the operator template.
+
+### N9. `IntegerParseError` is debug-quality
+
+`int.rs:11-31`:
+
+```rust
+pub enum IntegerParseError {
+    Empty,
+    InvalidDigit,
+    DigitLimitExceeded { limit: usize, actual: usize },
+}
+```
+
+`InvalidDigit` carries no position or character; `Empty` collapses three different inputs (`""`, `"+"`, `"-"`) into one variant. For wave 1 this is fine — the design's user-facing diagnostics will sit at the parser/HIR boundary, not at this runtime layer. But once `parse_decimal` is called from the JSON / CSV / env / URL boundaries in INT-5, the wrappers will need at least the position of the offending byte to produce useful error messages. Worth a TODO comment so the next milestone doesn't have to retrofit through public API churn.
+
+### N10. `Path` fallback in `sifr_runtime_dependency_spec` is dead code
+
+`crates/sifr_codegen/src/lib.rs:84-87`:
+
+```rust
+let runtime_path = manifest_dir
+    .parent()
+    .map(|parent| parent.join("sifr_runtime"))
+    .unwrap_or_else(|| manifest_dir.join("../sifr_runtime"));
+```
+
+`manifest_dir` is a Cargo crate's source directory; `.parent()` returns `None` only when the path is `/`, which is impossible for a real crate. The fallback is unreachable. It's there to dodge the `expect_used` workspace lint. A clearer pattern is `manifest_dir.parent().unwrap_or(manifest_dir).join("sifr_runtime")` or, if you take B1's option (1) and gate this whole function behind a runtime test-only check, the fallback disappears entirely. Same comment applies to the duplicated copy in `crates/sifr/tests/e2e.rs:1249-1260`.
+
+### N11. `sifr_runtime/Cargo.toml` does not use the workspace dependency aliases
+
+The new manifest declares `num-bigint = "0.4.6"` directly. The rest of the workspace uses `{ workspace = true }` for shared deps. This compounds N6 — moving these to `[workspace.dependencies]` and switching `sifr_runtime/Cargo.toml` to `num-bigint = { workspace = true }` resolves both issues at once.
+
+### N12. `sifr_runtime` lacks a `description`
+
+Minor: `crates/sifr_runtime/Cargo.toml` has no `description` field. None of the other internal `crates/sifr_*/Cargo.toml`s do either, so this matches house style. Mention only because some future packaging step (e.g., publishing to crates.io to address B1's option 4) will need it.
+
+### N13. `parse_decimal` walks the input twice
+
+`count_decimal_digits` validates and counts, then `BigInt::from_str` re-parses. For a 4096-digit string this is two full passes. A combined loop that validates, counts, and parses in a single pass (or relies on `BigInt::from_str` to do the parsing while a precheck only looks at the byte length pre-stripping) would be cheaper. Not load-bearing for wave 1, but the parse path will be on the hot path for JSON ingestion in INT-5.
+
+---
+
+## Verification of provided commands
+
+The user-listed validations all map to surfaces that exist in this diff:
+
+- `cargo test -p sifr_runtime` — runs all 8 tests in `int.rs::tests` (positive: small stay, big spill, hash normalization, ordering, helper construction, arithmetic spill on add). Coverage gaps called out in N8.
+- `cargo clippy -p sifr_runtime -- -D warnings` — the `#![cfg_attr(test, allow(clippy::expect_used))]` correctly silences `expect_err` use inside the test module under workspace `expect_used = "warn"`.
+- `cargo test -p sifr_codegen test_generate_project_emits_sifr_runtime_path_dependency_when_required` — asserts only the `sifr_runtime = { path = ` prefix; does not validate path portability (B1) or the symbol-detection path (N4).
+- `cargo test -p sifr_driver test_generate_test_runner_cargo_toml_includes_required_crates` — same prefix-only assertion.
+- `cargo test -p sifr test_generate_cargo_toml_required_sifr_runtime_uses_path_dependency` — same prefix-only assertion.
+- `cargo check -p sifr_codegen -p sifr --tests` — confirms the type-shape integrates cleanly.
+
+I confirm none of these green commands would catch B1, B2, N4, or N5. They demonstrate "the wiring is in place" but not "the wiring produces correct, portable, performant output." That gap is normal for substrate-only waves; the recommendations above raise it from "implicit" to "tracked."
+
+---
+
+## Recommended path forward
+
+1. Pick a resolution for **B1** — preferably explicit deferral with a runtime guard so the broken-on-distribution Cargo.toml can never escape the dev shell. Reflect the chosen approach in the INT-1 implementation checklist so wave 2 cannot start emitting `SifrInt` until the link mechanism is portable.
+2. Fix **B2** by switching `Hash`/`NormalizedIntegerHash` to a magnitude-byte canonical form, with a regression test that hashing a `Small` does not allocate (allocator probe or counting allocator behind `cfg(test)`). If genuinely deferring to INT-8, add a `#[ignore]`'d regression test now so the deferral is materialized in the test suite, not in commit messages.
+3. Tighten the public API per **N1** — pick "documented invariant" or "hidden variants" and follow through in `PartialEq` / `Ord` / `Hash`.
+4. Close test gaps **N4**, **N5**, **N8**.
+5. Resolve dependency-version duplication **N6** + **N11** by moving `num-bigint`/`num-traits` to `[workspace.dependencies]` and consuming via `{ workspace = true }`.
+6. Apply optimization **N7** (i128 middle-ground), refactor cleanups **N2/N3/N10**, and queue **N9/N13** for the appropriate later milestone.
+
+After these are addressed, this lands as a clean wave 1: the substrate, the dependency plumbing, and a defensible "no observable user behavior change yet, all the contracts the design promises are testable" story for wave 2 to build on.

--- a/reviews/integer-model-int-1-runtime-wave-1-review-pass-2.md
+++ b/reviews/integer-model-int-1-runtime-wave-1-review-pass-2.md
@@ -1,0 +1,100 @@
+# Review: INT-1 Runtime Wave 1 — `sifr_runtime` substrate and codegen plumbing (Pass 2)
+
+Reviewer: Claude Opus 4.7
+Date: 2026-05-05
+Phase: `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md`, milestone INT-1
+Pass-1 artifact: `reviews/integer-model-int-1-runtime-wave-1-review-pass-1.md`
+Design source of truth: `internal_docs/integer_model.md`
+
+## Verdict: SATISFIED
+
+Both pass-1 blockers are resolved within the wave-1 substrate scope, and every follow-up the user enumerated is in place. No remaining correctness blockers for this wave.
+
+---
+
+## B1 — `sifr_runtime` Cargo dependency path resolution
+
+Resolved in [crates/sifr_codegen/src/lib.rs:83-124](crates/sifr_codegen/src/lib.rs:83) and mirrored in [crates/sifr/tests/e2e.rs:1249-1290](crates/sifr/tests/e2e.rs:1249).
+
+`sifr_runtime_dependency_spec()` now defers to `discover_sifr_runtime_path()`, which tries in order:
+
+1. `SIFR_RUNTIME_PATH` env var, gated on `<path>/Cargo.toml` actually being a file ([lib.rs:92-98](crates/sifr_codegen/src/lib.rs:92)).
+2. Walk up from `env::current_dir()` looking for `<ancestor>/crates/sifr_runtime/Cargo.toml` ([lib.rs:100-104](crates/sifr_codegen/src/lib.rs:100), [lib.rs:112-117](crates/sifr_codegen/src/lib.rs:112)).
+3. Walk up from `env::current_exe()` with the same predicate ([lib.rs:106-110](crates/sifr_codegen/src/lib.rs:106)).
+4. Compile-time in-tree fallback joining `CARGO_MANIFEST_DIR`'s parent with `sifr_runtime` ([lib.rs:119-124](crates/sifr_codegen/src/lib.rs:119)).
+
+Each candidate is filtered against an actual `Cargo.toml` predicate before being accepted, so the absolute-path emission can no longer silently bake a broken pointer when SIFR_RUNTIME_PATH is set incorrectly. The compile-time fallback is explicitly scoped as the in-tree last resort, which is consistent with the user's framing of this resolution and acceptable for a substrate-only wave that does not yet emit `SifrInt` from any lowering path.
+
+The same chain is mirrored verbatim in `crates/sifr/tests/e2e.rs` so the in-tree e2e harness picks up `SIFR_RUNTIME_PATH` and ancestor discovery without the codegen crate. Pass-1's note about logical duplication between the two copies still stands as a non-blocking maintenance concern (any later switch — e.g., to a published runtime crate — needs both edited together), but it is out of scope for this verification pass and was not on the user's follow-up list.
+
+## B2 — `SifrInt::hash` no longer allocates for `Small`
+
+Resolved in [crates/sifr_runtime/src/int.rs:337-353](crates/sifr_runtime/src/int.rs:337). The `Hash` impl now branches on the variant directly and feeds bytes into a shared `hash_normalized_integer_parts` helper ([int.rs:387-393](crates/sifr_runtime/src/int.rs:387)):
+
+- `Small(v)` → `v.is_negative()` plus `v.unsigned_abs().to_be_bytes()` (stack 8-byte array, no `BigInt`, no `String`), then leading-zero-stripped + length-prefixed write.
+- `Big(v)` → `BigInt::to_bytes_be()` (the unavoidable magnitude allocation that exists for any byte-form encoding of a `Big`), then the same canonical write.
+
+Cross-form consistency holds: tracing `SifrInt::Small(1).hash(state)` and `NormalizedIntegerHash::from_signed(1).hash(state)` both reduce to `false.hash + write_usize(1) + state.write(&[1])` (the derived `Hash` on `NormalizedIntegerHash` ultimately calls `<[u8]>::hash` which is `write_length_prefix(len)` + `state.write(slice)`, identical to the explicit shape). The `equality_ordering_and_hashing_are_normalized` test at [int.rs:443-450](crates/sifr_runtime/src/int.rs:443) continues to lock the `Small`/`Big` agreement, and the `from_signed`/`from_unsigned` byte form at [int.rs:48-64](crates/sifr_runtime/src/int.rs:48) matches what `Hash for SifrInt` writes — so the `hash(int(1)) == hash(int8(1))` design contract from `internal_docs/integer_model.md:198-203` is preserved while the per-`Small` allocations are gone.
+
+Nice-to-have detail in the helper: `normalized_negative = negative && !magnitude.is_empty()` ([int.rs:388-389](crates/sifr_runtime/src/int.rs:388)) collapses signed/unsigned zero to the same hash, which is correct and was not strictly required.
+
+---
+
+## Follow-up verifications
+
+### PartialEq/Ord avoid BigInt clones where possible
+
+[int.rs:300-310](crates/sifr_runtime/src/int.rs:300) and [int.rs:318-335](crates/sifr_runtime/src/int.rs:318):
+
+- `(Big, Big)` compares the inner `Box<BigInt>` directly with no clone.
+- `(Small, Big)` / `(Big, Small)` for `PartialEq` uses `right.to_i64() == Some(*left)` — no clone, no allocation.
+- `Ord` for `(Small, Big)` / `(Big, Small)` uses `to_i64()` first and only falls back to a sign check (`right.is_negative()` / `left.is_negative()`) when the `Big` is genuinely outside i64 range. Still no clone.
+
+This is the shape recommended in pass-1's N2/N3 (with the sign check substituting for the canonical-invariant short-circuit, which is fine because it gives the same answer without leaning on the public-variant invariant). The `as_bigint()` accessor is still owned-`BigInt`, but the previously-allocating callers no longer use it on the hot paths.
+
+### `Small` overflow uses `i128` middle-ground
+
+`Add`/`Sub`/`Mul`/`Neg` on `(Small, Small)` route through `checked_*` and only on overflow promote to `Self::from_i128(i128::from(l) ⊕ i128::from(r))` ([int.rs:160-168](crates/sifr_runtime/src/int.rs:160), [int.rs:198-206](crates/sifr_runtime/src/int.rs:198), [int.rs:236-244](crates/sifr_runtime/src/int.rs:236), [int.rs:274-282](crates/sifr_runtime/src/int.rs:274)). `from_i128` demotes back to `Small` when the result re-fits, so `i64::MAX + 1 - 1` no longer permanently allocates.
+
+### Spill and overflow-then-cancel test coverage
+
+[int.rs:469-489](crates/sifr_runtime/src/int.rs:469):
+
+- `subtraction_multiplication_and_negation_spill_on_i64_overflow` exercises `i64::MIN - 1`, `i64::MAX * 2`, and `-i64::MIN` and asserts each produces a `Big` with the right textual value.
+- `overflow_then_cancel_can_return_to_small` builds `(i64::MAX + 1) - i64::MAX` and asserts it demotes back to `Small(1)` — directly locking the `i128` middle-ground behavior in.
+
+### `ir_imports` direct symbol coverage
+
+[crates/sifr_codegen/src/ir_imports.rs:530-555](crates/sifr_codegen/src/ir_imports.rs:530) adds `collects_sifr_runtime_integer_symbols`, which builds a `RustItem::Fn` containing both `RustType::Named("SifrInt")` and a `RustExpr::Path(["sifr_runtime", "SifrInt", "from_i64"])` and asserts `needs.runtime.needs_sifr_int`. That covers both `mark_symbol` arms at [ir_imports.rs:436-437](crates/sifr_codegen/src/ir_imports.rs:436) directly, closing pass-1's N4.
+
+### `num-bigint` / `num-traits` workspace dependencies
+
+[Cargo.toml:55-56](Cargo.toml:55) declares both crates under `[workspace.dependencies]`, and [crates/sifr_runtime/Cargo.toml:9-11](crates/sifr_runtime/Cargo.toml:9) consumes them via `{ workspace = true }`. The user-emitted Cargo manifest sites in `sifr_codegen` and `sifr/tests/e2e.rs` still hard-code the version strings (those go into generated user projects, which can't reference our `[workspace.dependencies]`), but that is the intended split — the runtime crate itself is now in lock-step with the workspace.
+
+---
+
+## Observations (not blockers, not on the requested list)
+
+- The duplicated `sifr_runtime_dependency_spec` / `discover_sifr_runtime_path*` block lives both in `crates/sifr_codegen/src/lib.rs:83-124` and `crates/sifr/tests/e2e.rs:1249-1290`. Any future change to the resolution chain has to be applied in both. Re-exporting the codegen helper would remove that drift surface.
+- The cargo-toml-emission tests still assert only the `sifr_runtime = { path = ` prefix; they don't lock the resolved path's well-formedness. That is fine for substrate-only validation, but worth tightening once a real runtime-link mechanism (registry crate, vendored copy, or relocation logic) replaces the in-tree fallback.
+- The `equality_ordering_and_hashing_are_normalized` test still hand-constructs `Big(Box::new(BigInt::from(1_i64)))`, exercising the cross-form invariant. Pass-1's N1 (canonicalization invariant) is unchanged. The `PartialEq`/`Ord` arms now handle this case allocation-free regardless of which side of N1 is eventually picked.
+
+None of the above are blockers for this wave.
+
+---
+
+## Validation matched against the user's listed gates
+
+The validations listed by the user (`cargo fmt`, `cargo test -p sifr_runtime`, `cargo clippy -p sifr_runtime -- -D warnings`, `cargo test -p sifr_codegen collects_sifr_runtime_integer_symbols`, `cargo test -p sifr_codegen test_generate_project_emits_sifr_runtime_path_dependency_when_required`, `cargo test -p sifr_driver test_generate_test_runner_cargo_toml_includes_required_crates`, `cargo test -p sifr test_generate_cargo_toml_required_sifr_runtime_uses_path_dependency`) all map to surfaces present in this diff:
+
+- The new `sifr_runtime` tests at [int.rs:403-510](crates/sifr_runtime/src/int.rs:403) cover the ten unit cases — the original eight plus the two added for sub/mul/neg spills and overflow-then-cancel.
+- The new `ir_imports` test at [ir_imports.rs:530-555](crates/sifr_codegen/src/ir_imports.rs:530) covers the symbol-detection arms.
+- The three Cargo-emission tests cover the `sifr_runtime = { path = ` shape (prefix only — see Observation 2).
+
+`scripts/run_all_tests.sh --profile quick` is the right authoritative gate; the user reports it running after these fixes.
+
+---
+
+## Recommended next step
+
+Land the wave. Track the deferred items (path-resolution test tightening, codegen/e2e dedup, N1 invariant choice, optional `as_bigint()` → `Cow<'_, BigInt>`, and the parser/error-message cleanup from pass-1 N9/N13) under INT-1 wave 2 or the appropriate later milestone — none of them block lock as wave 1.


### PR DESCRIPTION
## Summary

- Add `crates/sifr_runtime` with canonical `SifrInt` (`Small(i64)` / `Big(Box<BigInt>)`) substrate, decimal parsing with digit limits, normalized comparison/ordering/hash behavior, formatting, primitive conversions, and basic exact integer arithmetic helpers.
- Add generated Cargo dependency plumbing for `sifr_runtime`, including runtime path discovery via `SIFR_RUNTIME_PATH`, current-dir/current-exe ancestor lookup, and in-tree fallback.
- Add focused codegen/e2e/test-runner coverage for runtime dependency emission and SifrInt import-need detection.
- Record INT-1 wave 1 review artifacts and tracker status.

## Validation

- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sifr_runtime`
- `cargo clippy -p sifr_runtime -- -D warnings`
- `cargo test -p sifr_codegen collects_sifr_runtime_integer_symbols`
- `cargo test -p sifr_codegen test_generate_project_emits_sifr_runtime_path_dependency_when_required`
- `cargo test -p sifr_driver test_generate_test_runner_cargo_toml_includes_required_crates`
- `cargo test -p sifr test_generate_cargo_toml_required_sifr_runtime_uses_path_dependency`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=55.06s`; group-skew advisory emitted)

## Review

- Pass 1: `reviews/integer-model-int-1-runtime-wave-1-review-pass-1.md` found B1/B2 blockers.
- Pass 2: `reviews/integer-model-int-1-runtime-wave-1-review-pass-2.md` is SATISFIED after fixes.

## Scope

This is an INT-1 substrate wave. It intentionally does not switch source-level `int` lowering to `SifrInt`; that remains for the next INT-1 wave.
