### PR TITLE
Capture large integer literals in HIR

### DIFF
--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -443,6 +443,7 @@ fn collect_expr_error_refs(
             }
         }
         HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
         | HirExpr::FloatLiteral(_)
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)

--- a/crates/sifr_codegen/src/hir_analysis/traversal.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal.rs
@@ -279,6 +279,7 @@ where
         }
         HirExpr::Name { .. }
         | HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
         | HirExpr::FloatLiteral(_)
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -93,8 +93,8 @@ fn discover_sifr_runtime_path() -> Option<PathBuf> {
     env::var_os("SIFR_RUNTIME_PATH")
         .map(PathBuf::from)
         .filter(|path| path.join("Cargo.toml").is_file())
-        .or_else(|| discover_sifr_runtime_path_from_current_dir())
-        .or_else(|| discover_sifr_runtime_path_from_current_exe())
+        .or_else(discover_sifr_runtime_path_from_current_dir)
+        .or_else(discover_sifr_runtime_path_from_current_exe)
 }
 
 fn discover_sifr_runtime_path_from_current_dir() -> Option<PathBuf> {

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -568,6 +568,7 @@ fn validate_expr_lowering_shape(expr: &HirExpr) -> Result<(), CodegenError> {
             Ok(())
         }
         HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
         | HirExpr::FloatLiteral(_)
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)
@@ -1498,6 +1499,7 @@ fn expr_has_result_flow(expr: &HirExpr) -> bool {
         }
         HirExpr::Name { .. }
         | HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
         | HirExpr::FloatLiteral(_)
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)

--- a/crates/sifr_hir/Cargo.toml
+++ b/crates/sifr_hir/Cargo.toml
@@ -14,6 +14,7 @@ sifr_type_system = { workspace = true }
 ruff_text_size = { workspace = true }
 rust_decimal = "1.41.0"
 bigdecimal = "0.4.10"
+num-bigint = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -344,6 +344,9 @@ pub enum HirIteratorOp {
 pub enum HirExpr {
     /// Integer literal
     IntLiteral(i64),
+    /// Canonical decimal integer literal that does not fit in the historical small-literal `i64`
+    /// slot.
+    LargeIntLiteral(String),
     /// Float literal
     FloatLiteral(f64),
     /// String literal
@@ -547,7 +550,7 @@ impl HirExpr {
     /// Get the type of this expression.
     pub fn ty(&self) -> &Type {
         match self {
-            Self::IntLiteral(_) => &Type::Int,
+            Self::IntLiteral(_) | Self::LargeIntLiteral(_) => &Type::Int,
             Self::FloatLiteral(_) => &Type::Float,
             Self::StringLiteral(_) => &Type::Str,
             Self::BoolLiteral(_) => &Type::Bool,

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -32,6 +32,7 @@ use super::expression_sum_sorted::{lower_sorted_call, lower_sum_call};
 use super::fstring_support::lower_fstring_expr;
 use super::generic_constructor_specialization::refine_constructor_return_type_from_args;
 use super::generic_receiver_specialization::refine_generic_class_binding_expr;
+use super::integer_literals::canonical_large_int_literal_text;
 use super::method_call_args::{
     lower_function_call_args, lower_method_call_args, lower_signature_call_args,
     resolved_method_arg_ranges, validate_dict_update_arg, validate_list_extend_arg,
@@ -115,8 +116,13 @@ pub(super) fn lower_expr(expr: &Expr, ctx: &mut LowerCtx) -> Option<HirExpr> {
 pub(super) fn lower_number_literal(num: &ExprNumberLiteral) -> Option<HirExpr> {
     match &num.value {
         Number::Int(i) => {
-            let val = i.as_i64()?;
-            Some(HirExpr::IntLiteral(val))
+            if let Some(val) = i.as_i64() {
+                Some(HirExpr::IntLiteral(val))
+            } else {
+                Some(HirExpr::LargeIntLiteral(canonical_large_int_literal_text(
+                    i,
+                )))
+            }
         }
         Number::Float(f) => Some(HirExpr::FloatLiteral(*f)),
         Number::Complex { .. } => None, // Not supported.

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -46,12 +46,62 @@ fn range_for_after_anchor(source: &str, after: &str, needle: &str) -> TextRange 
     )
 }
 
+fn function_let_value<'a>(module: &'a HirModule, name: &str) -> &'a HirExpr {
+    module
+        .functions
+        .iter()
+        .flat_map(|function| &function.body)
+        .find_map(|stmt| match stmt {
+            HirStmt::Let {
+                name: local_name,
+                value,
+                ..
+            } if local_name == name => Some(value),
+            _ => None,
+        })
+        .expect("expected local binding")
+}
+
 #[test]
 fn test_simple_function() {
     let module = lower_source("def add(a: int, b: int) -> int:\n    return a + b\n").unwrap();
     assert_eq!(module.functions.len(), 1);
     assert_eq!(module.functions[0].name, "add");
     assert_eq!(module.functions[0].return_type, Type::Int);
+}
+
+#[test]
+fn test_large_integer_literals_lower_losslessly_from_source() {
+    let source = "\
+def main():
+    decimal = 9223372036854775808
+    decimal_big = 184467440737095516160
+    decimal_underscored = 1_000_000_000_000_000_000_000
+    hex_mid = 0xffffffffffffffff
+    hexed = 0x10000000000000000
+    hexed_underscored = 0xFFFF_FFFF_FFFF_FFFF_FFFF
+    octaled = 0o2000000000000000000000
+    binaried = 0b10000000000000000000000000000000000000000000000000000000000000000
+";
+    let module = lower_source(source).expect("large integer literals should lower");
+
+    let expected = [
+        ("decimal", "9223372036854775808"),
+        ("decimal_big", "184467440737095516160"),
+        ("decimal_underscored", "1000000000000000000000"),
+        ("hex_mid", "18446744073709551615"),
+        ("hexed", "18446744073709551616"),
+        ("hexed_underscored", "1208925819614629174706175"),
+        ("octaled", "18446744073709551616"),
+        ("binaried", "18446744073709551616"),
+    ];
+
+    for (name, literal_text) in expected {
+        match function_let_value(&module, name) {
+            HirExpr::LargeIntLiteral(actual) => assert_eq!(actual, literal_text),
+            other => panic!("expected large integer literal for {name}, got {other:?}"),
+        }
+    }
 }
 
 #[test]
@@ -2001,6 +2051,7 @@ fn test_iterator_builtins_lower_to_canonical_iterator_call_nodes() {
             HirExpr::EnumVariant { .. }
             | HirExpr::Name { .. }
             | HirExpr::IntLiteral(_)
+            | HirExpr::LargeIntLiteral(_)
             | HirExpr::FloatLiteral(_)
             | HirExpr::StringLiteral(_)
             | HirExpr::BoolLiteral(_)

--- a/crates/sifr_hir/src/lower/integer_literals.rs
+++ b/crates/sifr_hir/src/lower/integer_literals.rs
@@ -1,0 +1,22 @@
+use num_bigint::BigUint;
+use sifr_python_ast::Int;
+
+pub(super) fn canonical_large_int_literal_text(value: &Int) -> String {
+    let text = value.to_string();
+    parse_unsigned_integer_literal_text(&text).map_or(text, |integer| integer.to_str_radix(10))
+}
+
+fn parse_unsigned_integer_literal_text(text: &str) -> Option<BigUint> {
+    let (radix, digits) =
+        if let Some(hex) = text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
+            (16, hex)
+        } else if let Some(octal) = text.strip_prefix("0o").or_else(|| text.strip_prefix("0O")) {
+            (8, octal)
+        } else if let Some(binary) = text.strip_prefix("0b").or_else(|| text.strip_prefix("0B")) {
+            (2, binary)
+        } else {
+            (10, text)
+        };
+    let compact_digits: String = digits.chars().filter(|&ch| ch != '_').collect();
+    BigUint::parse_bytes(compact_digits.as_bytes(), radix)
+}

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -47,6 +47,7 @@ mod if_expression;
 mod import_diagnostics;
 mod imported_defaults;
 mod imports;
+mod integer_literals;
 mod len_aliases;
 mod match_diagnostics;
 mod match_lowering;

--- a/crates/sifr_hir/src/lower/nonlocal_support.rs
+++ b/crates/sifr_hir/src/lower/nonlocal_support.rs
@@ -347,6 +347,7 @@ fn hir_expr_calls_function(expr: &HirExpr, func_name: &str) -> bool {
         HirExpr::EnumVariant { .. }
         | HirExpr::Name { .. }
         | HirExpr::IntLiteral(_)
+        | HirExpr::LargeIntLiteral(_)
         | HirExpr::FloatLiteral(_)
         | HirExpr::StringLiteral(_)
         | HirExpr::BoolLiteral(_)

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -395,6 +395,8 @@ Validation:
 - [x] INT-1 fixed-width conversion substrate wave review satisfied: `reviews/integer-model-int-1-runtime-fixed-width-conversions-review-pass-1b.md`.
 - [x] INT-2A reserved-width diagnostic review pass 1 completed with doc-code normalization blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-1.md`.
 - [x] INT-2A reserved-width diagnostic review pass 2 satisfied after addressing blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-2b.md`.
+- [x] INT-2A large integer literal HIR review pass 1 completed with canonical-representation blocker: `reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md`.
+- [x] INT-2A large integer literal HIR review pass 2 approved after canonical decimal normalization: `reviews/integer-model-int-2a-large-literal-hir-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -404,7 +406,8 @@ Validation:
   - [x] Wave 1B typed fixed-width conversion substrate reviewed and quick-validated: PR #1790.
 - [ ] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.
-  - [ ] Carry INT-2A parser literal lexeme capture, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice.
+  - [x] Parsed integer literals beyond the historical `i64` slot lower to canonical decimal `LargeIntLiteral` HIR across decimal, hex, octal, and binary spellings, with review satisfied and quick validation passing.
+  - [ ] Carry INT-2A default-argument large-literal parity, negative-large-literal unary coverage, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice.
 - [ ] INT-2B HIR, type system, and const fitting
   - [ ] Carry follow-ups from INT-2A reserved-width review: broaden annotation-position tests, align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, and decide reserved-name shadowing policy during `bigint` cleanup.
 - [ ] INT-3 scalar arithmetic and numeric mixing

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -406,7 +406,7 @@ Validation:
   - [x] Wave 1B typed fixed-width conversion substrate reviewed and quick-validated: PR #1790.
 - [ ] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.
-  - [x] Parsed integer literals beyond the historical `i64` slot lower to canonical decimal `LargeIntLiteral` HIR across decimal, hex, octal, and binary spellings, with review satisfied and quick validation passing.
+  - [x] Parsed integer literals beyond the historical `i64` slot lower to canonical decimal `LargeIntLiteral` HIR across decimal, hex, octal, and binary spellings, with review satisfied and quick validation passing: PR #1792.
   - [ ] Carry INT-2A default-argument large-literal parity, negative-large-literal unary coverage, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice.
 - [ ] INT-2B HIR, type system, and const fitting
   - [ ] Carry follow-ups from INT-2A reserved-width review: broaden annotation-position tests, align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, and decide reserved-name shadowing policy during `bigint` cleanup.

--- a/reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md
+++ b/reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md
@@ -1,0 +1,189 @@
+# INT-2A — Large Integer Literal HIR Capture — Review Pass 1b
+
+Reviewer: Claude (Opus 4.7), 2026-05-06.
+
+## Scope under review
+
+Diff against `main` on branch `int-2a-lossless-large-int-literals`. Eight files touched, ~61 LOC:
+
+- `crates/sifr_hir/src/hir_nodes.rs` — adds `HirExpr::LargeIntLiteral(String)` and includes it in `HirExpr::ty()`.
+- `crates/sifr_hir/src/lower/expressions.rs` — `lower_number_literal` now falls back to `HirExpr::LargeIntLiteral(i.to_string())` when `Int::as_i64()` returns `None`.
+- `crates/sifr_hir/src/lower/expressions_tests.rs` — adds `function_let_value` helper, a new positive test `test_large_integer_literals_lower_losslessly_from_source`, and adds the new variant to the leaf-arm of `test_iterator_builtins_lower_to_canonical_iterator_call_nodes`.
+- `crates/sifr_hir/src/lower/nonlocal_support.rs` — adds the new variant to the leaf arm of `hir_expr_calls_function`.
+- `crates/sifr_codegen/src/error_refs.rs`, `hir_analysis/traversal.rs`, `lower_stmt.rs` (`validate_expr_lowering_shape`, `expr_has_result_flow`) — add the new variant to existing leaf-no-recurse / leaf-no-result-flow arms.
+- `crates/sifr_codegen/src/lib.rs` — unrelated clippy-style refactor (`.or_else(|| f())` → `.or_else(f)`).
+
+Phase context:
+- Issue: `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md` (slice = "Carry INT-2A parser literal lexeme capture, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice").
+- Design: `internal_docs/integer_model.md`.
+- Stated slice intent (from the review request): only parser-side lexeme capture for literals that exceed the historical `i64` slot. Fixed-width const fitting and SifrInt arithmetic codegen are explicitly out of scope (INT-2B/INT-3).
+
+## Validation reproduced from the request
+
+The user reports that the following passed before this review:
+`cargo fmt --check`, `git diff --check`,
+`cargo test -p sifr_hir test_large_integer_literals_lower_losslessly_from_source`,
+`cargo test -p sifr_hir`,
+`cargo check -p sifr_codegen -p sifr_driver`,
+`cargo clippy -p sifr_hir -p sifr_codegen -p sifr_driver -- -D warnings`,
+`cargo run -q -p sifr -- check` on a temp file with oversized decimal and hex literals,
+`scripts/run_all_tests.sh --profile quick` (report_signature=`e1bf653aaa770517`).
+
+I did not re-run these. I read the affected source paths plus the relevant Ruff lexer (`third_party/ruff/crates/ruff_python_parser/src/lexer.rs`) and `Int` type (`third_party/ruff/crates/ruff_python_ast/src/int.rs`) to characterize what `i.to_string()` actually emits per radix.
+
+---
+
+## Blocking findings
+
+### B1. The "lossless integer-literal representation" is not consistent across radix and magnitude
+
+The new representation is `LargeIntLiteral(String)` populated by `i.to_string()` where `i: ruff_python_ast::Int`. Tracing through the Ruff lexer and `Int`:
+
+- `lex_decimal_number` strips underscores in `radix_run`, then calls `Int::from_str(s)`. `Int::from_str` parses as `u64`; on overflow it stores `Int::big(s)` where `s` is the **underscore-stripped digit string**.
+- `lex_number_radix` for hex/oct/bin builds an underscore-stripped digit-only `number` AND captures the raw `token = &source[token_range]` (which still contains the `0x`/`0o`/`0b` prefix and any underscores). It calls `Int::from_str_radix(number, radix, token)`. On overflow it stores `Int::big(token)` — the **full original lexeme, prefix and underscores included**.
+- `Int(Number::Small(u64))` displays as decimal (`write!("{value}")`), so any literal that fits in `u64` round-trips through `to_string()` as decimal digits regardless of source radix.
+
+The combined effect of these branches is that `LargeIntLiteral` ends up with *three different* string formats depending on radix and magnitude:
+
+| source                                          | numeric value             | stored string                                  |
+| ----------------------------------------------- | ------------------------- | ---------------------------------------------- |
+| decimal in `[2^63, 2^64-1]`                     | fits `u64`                | underscore-free decimal digits                 |
+| decimal `> 2^64-1`                              | exceeds `u64`             | underscore-free decimal digits (Big path)      |
+| hex/oct/bin in `[2^63, 2^64-1]`                 | fits `u64`                | **decimal digits** (radix prefix dropped)      |
+| hex/oct/bin `> 2^64-1`                          | exceeds `u64`             | **original lexeme** with `0x`/`0o`/`0b` prefix and any underscores preserved |
+
+The phase scope says "Normalize decimal, hex, octal, and binary literals into a *lossless* integer-literal representation for HIR" and the acceptance criterion says "The constructed-AST path and parsed-source path produce equivalent HIR literal representations." This branch-dependent format violates both intents:
+
+1. The representation is not self-describing. A consumer holding `"18446744073709551615"` cannot tell whether the user wrote `0xffff_ffff_ffff_ffff` or `18446744073709551615`. Once INT-2B starts parsing these strings (e.g., into `num_bigint::BigInt`), it will need to autodetect the radix from the prefix — which is fine for the `> 2^64-1` hex/oct/bin band but fails for the `[2^63, 2^64-1]` band where the prefix has already been lost.
+2. Any programmatically-constructed `HirExpr::LargeIntLiteral` (for example the constructed-AST or compile-time-eval path) will need to know which of the three formats to mirror. Today it must pick decimal, but the parsed-source path is inconsistent with that choice in the > `2^64-1` hex/oct/bin band.
+3. The current test (`test_large_integer_literals_lower_losslessly_from_source`) only covers values at exactly `2^64`, which happens to land in the "Big" branch for hex/oct/bin (preserving the prefix) and is `< 2^64` for decimal (preserving decimal digits). The test passes, but it does not exercise the discontinuity.
+
+Recommended fix (pick one before INT-2B starts consuming this node):
+
+- (preferred) Always normalize at lowering time. Either parse the lexeme into a canonical decimal digit string (via `num_bigint::BigInt::from_str_radix` or equivalent in `sifr_runtime`), or shadow Ruff's `Int` by digit-radix-walking the token text. Yes, this adds a parse step, but it makes the HIR shape unambiguous and matches the "lossless" / "equivalent representation" wording in the issue.
+- OR, store a structured node: `LargeIntLiteral { lexeme: String, radix: u8 }`. Consumers parse using `radix`. Avoids decimal conversion at lowering time but needs every consumer to plumb the radix through.
+
+Either choice is fine; the existing one-arg `LargeIntLiteral(String)` is the bug. Locking the wrong shape now is a visible footgun for INT-2B since the type/const-fitting code will be the first real consumer.
+
+(Sub-case worth keeping in mind once you fix this: in the current code, decimal literals that contained underscores have those underscores lossily stripped at lex time — they are gone from `Int::big(s)` even before `lower_number_literal` runs. Hex/oct/bin > `2^64-1` keeps them. Whichever direction you go, decide on a single underscore policy and document it.)
+
+---
+
+## Non-blocking findings
+
+### N1. Test coverage gaps (closely related to B1)
+
+The new test exercises exactly four points, all at `2^64` for the radix bases and `2^63` for decimal. Worth adding:
+
+- Hex/oct/bin literal in the `[i64::MAX + 1, u64::MAX]` band, e.g. `0xFFFF_FFFF_FFFF_FFFF`. This is the band that loses its radix prefix today and would catch the B1 regression after a fix.
+- Decimal literal `> 2^64`, e.g. `184467440737095516160`. The current test happens to skip this; without it, the Number::Big decimal display path is uncovered.
+- Underscored literals in both decimal (`1_000_000_000_000_000_000_000`) and hex (`0xFFFF_FFFF_FFFF_FFFF_FFFF`). The asymmetry in underscore preservation is real today — explicitly pin one behavior.
+- A negative literal beyond `i64::MIN`, e.g. `-9_223_372_036_854_775_809`, asserting the result is `UnaryOp("-", LargeIntLiteral(...))`. This protects the unary-wrapping invariant since `LargeIntLiteral` carries no sign.
+
+### N2. `lower_expr_simple` parity gap (`crates/sifr_hir/src/lower/classes.rs:1249`)
+
+`lower_expr_simple` is used to lower default parameter values during the first pass:
+
+```rust
+Number::Int(i) => Some(HirExpr::IntLiteral(i.as_i64()?)),
+```
+
+For `def foo(x: int = 9_223_372_036_854_775_808): ...`, the `?` returns `None`, the entire `lower_expr_simple` returns `None`, and the default is silently dropped (or the surrounding code rejects the parameter — depends on the caller). That's the same kind of i64-only assumption this PR is otherwise fixing. The acceptance criterion "The constructed-AST path and parsed-source path produce equivalent HIR literal representations" is partly about this kind of internal lowering helper.
+
+The user's framing ("INT-2A parsed-source large integer literal HIR capture") suggests this gap is intentionally deferred to a sibling slice — fine, but it should be tracked explicitly. The phase issue's outstanding bullet "Carry INT-2A parser literal lexeme capture, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice" implicitly covers this; consider linking the file:line so the next slice doesn't miss it.
+
+(One related cousin to mention in the same TODO: `crates/sifr_hir/src/lower/classes.rs:1272` and other places that rebuild a negated literal via `HirExpr::IntLiteral(-v)` only operate on the small path.)
+
+### N3. Codegen path for `LargeIntLiteral` produces `compile_error!` Rust output
+
+This is consistent with the slice intent ("does not implement … full codegen … for INT-2A") but worth flagging because it is silently inherited via fall-through:
+
+- `lower_expr.rs::is_leaf_expr_candidate` and `lower_expr.rs::try_lower_leaf_expr` are not updated, so `try_lower_leaf_or_name_expr(LargeIntLiteral)` returns `None`.
+- `try_lower_simple_let_value` therefore returns `None`, the structured `Let` path at `lib.rs:1444` calls `lower_rendered_expr_for_ir` and `lower_stmt_expr_for_ir` (both return `Ok(None)`), falls to `Ok(false)`, and `emit_stmt` produces
+
+  ```rust
+  compile_error!("structured statement emission missing for production path: ...")
+  ```
+
+A user running `sifr run` or `sifr build` against `x = 9_223_372_036_854_775_808` will hit this — they will see a rustc `compile_error!` macro fire, not a Sifr-side diagnostic. The validation log only mentions `sifr -- check` which never reaches codegen, so this is genuinely untested in the listed gates.
+
+The plumbing is *safe* (no panic, no `unwrap`/`expect` on the new variant on any path I traced — see "Codegen exhaustive-match plumbing safety" below). But the user-visible failure is poor. Two reasonable options:
+
+1. Emit a typed `CodegenError` with a specific code (e.g., a placeholder under `SIFR-INT-0004`/`-0005`/etc., or a generic "large integer literal codegen pending INT-2B/INT-3") at the boundary in codegen, so the message is Sifr-flavored and can be recognized in fail fixtures.
+2. Add a fail-fixture-style test exercising `sifr build` against a large literal and asserting the failure mode, even if the assertion is just "rustc failed with compile_error containing X". That at least pins the current behavior so INT-2B notices when it changes.
+
+### N4. Loss of compile-time tuple index/slice diagnostics for large literals
+
+Two places in `crates/sifr_hir/src/lower/expressions.rs` and `crates/sifr_hir/src/lower/subscript_type.rs:49` match `HirExpr::IntLiteral` to give compile-time tuple-index / tuple-slice diagnostics:
+
+- `subscript_type.rs:49`: tuple indexing with an `IntLiteral` that's out of range fires `tuple index out of range`.
+- `expressions.rs:1852`/`1915`/`1922`: tuple slicing requires `IntLiteral` start/stop, otherwise emits `tuple slicing requires compile-time constant indices`.
+
+After this PR, `t[9_223_372_036_854_775_808]` and `t[: 9_223_372_036_854_775_808]` lower successfully (good), but the compile-time diagnostic that would catch the obvious out-of-range now fires the more generic "compile-time constant indices" path or doesn't fire at all (the `LargeIntLiteral` branch is missing). This is behavioral degradation, not a correctness break — the cases involve impossibly large indices for any real tuple — so non-blocking, but worth noting in the same INT-2B follow-up that touches integer-literal const eval.
+
+### N5. Inline doc comment on `LargeIntLiteral(String)` is too thin
+
+Right now:
+
+```rust
+/// Integer literal that does not fit in the historical small-literal `i64` slot.
+LargeIntLiteral(String),
+```
+
+The string format is the load-bearing detail of this node and (per B1) is currently radix- and magnitude-dependent. At minimum the doc should say something like "format is implementation-defined and may include `0x`/`0o`/`0b` prefixes; consumers should defer parsing until INT-2B introduces the canonical const-fitting path." Better: document the canonical format the moment B1 is fixed.
+
+### N6. Unrelated clippy-style change in `crates/sifr_codegen/src/lib.rs`
+
+```diff
+-        .or_else(|| discover_sifr_runtime_path_from_current_dir())
+-        .or_else(|| discover_sifr_runtime_path_from_current_exe())
++        .or_else(discover_sifr_runtime_path_from_current_dir)
++        .or_else(discover_sifr_runtime_path_from_current_exe)
+```
+
+Looks like a `clippy::redundant_closure` cleanup. Functionally equivalent, but unrelated to the INT-2A scope and adds noise to the review. Consider splitting into its own commit with a cleanup-style title so reviewers can see the integer-model diff without distraction. Non-blocking.
+
+---
+
+## Codegen exhaustive-match plumbing safety
+
+Asked specifically about. I traced every place the diff added `LargeIntLiteral(_)` and every place it did *not* but matches `IntLiteral`. None of the unhandled paths panic on the new variant; they all either return `None`/`false` (skipping an optimization) or fall through a `_ => ...` arm.
+
+| Path | Patched? | Behavior on `LargeIntLiteral` | Verdict |
+| --- | --- | --- | --- |
+| `error_refs.rs::collect_expr_error_refs` | yes (leaf no-error-refs arm) | no error refs to collect | safe |
+| `hir_analysis/traversal.rs` | yes (leaf no-recurse arm) | no children to walk | safe |
+| `lower_stmt.rs::validate_expr_lowering_shape` | yes (leaf "Ok(())" arm) | shape valid | safe |
+| `lower_stmt.rs::expr_has_result_flow` | yes (leaf "false" arm) | no Result flow | safe |
+| `nonlocal_support.rs::hir_expr_calls_function` | yes (leaf "false" arm) | does not call any function | safe |
+| `lower_expr.rs::is_leaf_expr_candidate` | no (wildcard `_ => false`) | not a leaf candidate; structured path taken | safe but unoptimized |
+| `lower_expr.rs::try_lower_leaf_expr` | no (returns `None` by fallthrough) | structured path taken | safe but unoptimized |
+| `lower_stmt.rs::try_lower_match_literal_pattern` | no (returns `None`) | falls to non-literal pattern path | safe |
+| `stmt_support_emitter.rs::negative_range_step_magnitude` | no | range step optimization skipped | safe |
+| `stmt_support_emitter.rs::lower_stmt_expr_for_ir` (and its internal registry helpers) | no | returns `Ok(None)` | safe but reaches `compile_error!` fallback (see N3) |
+| `intrinsic_method_emitters.rs::try_eval_const_int_expr` | no | returns `None` (no const fold) | safe |
+| `helpers.rs::is_reusable_place_expr` (subscript index) | no | treats large-literal-as-index as not reusable | safe |
+| `lower/subscript_type.rs::49` (tuple index const eval) | no | skips compile-time index check (see N4) | safe but degraded |
+| `lower/expressions.rs::1852`/`1915`/`1922` (tuple slice const eval) | no | skips compile-time slice check (see N4) | safe but degraded |
+| `lower/decimal_methods.rs::48`/`50` | no | small-int decimal path returns `None` | safe |
+| `lower/arithmetic_warnings.rs` | no | const-shift / pow warnings skipped | safe |
+| `lower/expression_iter_builtins.rs::109,114` (range zero-start fast path) | no | optimization skipped | safe |
+| `lower/nonempty_method_narrowing.rs::87` (`pop(0)` matcher) | no | narrowing skipped | safe |
+| `lower/method_call_args.rs::466` | no | constructs `IntLiteral(0)` only — unaffected | safe |
+| `lower/numeric_sentinels.rs::116,350` | no | constructs sentinel `IntLiteral` only — unaffected | safe |
+
+Summary: every place that needed to be updated to keep exhaustive matches compiling was updated (otherwise `cargo check` / clippy would have failed, which they did not). Every place that was *not* updated has wildcard-like fallback that returns `None`/`false`/`Ok(None)`. Net effect is "treat `LargeIntLiteral` as opaque and unsupported" — that aligns with the slice's stated scope. The only user-visible degradation is N3 (compile_error! on codegen) and N4 (tuple compile-time index/slice diagnostics).
+
+---
+
+## Recommendation
+
+Hold for B1 before merging, *or* merge as-is provided the response to B1 lands as the very next slice (before INT-2B starts parsing `LargeIntLiteral` strings). The acceptance criterion that names "lossless representation" + "constructed-AST and parsed-source produce equivalent HIR" is the hard constraint here; if you want to keep it, B1 must be fixed before any consumer interprets the string.
+
+Non-blocking items N1–N6 should be tracked in the existing INT-2A follow-up bullet ("Carry INT-2A parser literal lexeme capture, malformed/over-budget literal diagnostics, and parsed/constructed HIR parity in the next INT-2A slice") rather than this PR.
+
+## Additional verifications I'd run before claiming the slice closed
+
+- `cargo run -q -p sifr -- build` against a `.sifr` file containing a large decimal literal AND a large hex literal (>`2^64`) AND a large hex literal in `[2^63, 2^64-1]`. Verify the failure mode (today: `compile_error!`; after a future codegen slice: a Sifr-side diagnostic).
+- Add the four new `lower_source` test cases enumerated in N1 to lock the radix/underscore behavior.
+- A constructed-AST round-trip test that builds `HirExpr::LargeIntLiteral("18446744073709551616")` directly (no parser) and asserts it survives codegen consistently with the parsed-source case — that's the parity acceptance criterion in test form.

--- a/reviews/integer-model-int-2a-large-literal-hir-review-pass-2.md
+++ b/reviews/integer-model-int-2a-large-literal-hir-review-pass-2.md
@@ -1,0 +1,130 @@
+# INT-2A — Large Integer Literal HIR Capture — Review Pass 2
+
+Reviewer: Claude (Opus 4.7), 2026-05-06.
+Branch: `int-2a-lossless-large-int-literals`.
+Prior review: [reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md](reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md).
+
+## Scope under review
+
+Same diff as pass 1b plus the B1 fix. Ten files touched:
+
+- `crates/sifr_hir/Cargo.toml` — adds `num-bigint = { workspace = true }` (workspace pins `0.4.6` in the root `Cargo.toml:55`).
+- `crates/sifr_hir/src/lower/integer_literals.rs` (new) — the canonical-decimal normalizer (`canonical_large_int_literal_text`) and a private `parse_unsigned_integer_literal_text` helper that strips a `0x`/`0o`/`0b` prefix (case-insensitive), removes underscores, and parses via `BigUint::parse_bytes`.
+- `crates/sifr_hir/src/lower/mod.rs` — registers the new module.
+- `crates/sifr_hir/src/lower/expressions.rs` — `lower_number_literal` now branches `i.as_i64()` → `IntLiteral` else `LargeIntLiteral(canonical_large_int_literal_text(i))`. The helper call replaces the previous unguarded `i.to_string()`.
+- `crates/sifr_hir/src/hir_nodes.rs` — `HirExpr::LargeIntLiteral(String)` doc updated to "Canonical decimal integer literal that does not fit in the historical small-literal `i64` slot." `HirExpr::ty()` returns `&Type::Int` for this variant.
+- `crates/sifr_hir/src/lower/expressions_tests.rs` — `function_let_value` helper plus an expanded `test_large_integer_literals_lower_losslessly_from_source` covering eight values across radix × magnitude (see "B1 verification" below). The leaf arm of `test_iterator_builtins_lower_to_canonical_iterator_call_nodes` includes the new variant.
+- `crates/sifr_hir/src/lower/nonlocal_support.rs`, `crates/sifr_codegen/src/error_refs.rs`, `crates/sifr_codegen/src/hir_analysis/traversal.rs`, `crates/sifr_codegen/src/lower_stmt.rs` — leaf-no-recurse / leaf-no-error-refs / leaf-no-result-flow arms updated to include `LargeIntLiteral(_)`. Same shape as pass 1b.
+- `crates/sifr_codegen/src/lib.rs` — unchanged from pass 1b (`.or_else(|| f())` → `.or_else(f)` clippy cleanup).
+
+Validation reported by the user (not re-run by me): `cargo fmt`, `python3 scripts/check_hir_maintainability_guardrails.py` (I re-ran this — `PASS`), targeted unit test, `cargo clippy -p sifr_hir -p sifr_codegen -p sifr_driver -- -D warnings`, `cargo test -p sifr_hir`, and `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`).
+
+---
+
+## B1 verification — RESOLVED
+
+Pass 1b's blocking finding was that `LargeIntLiteral(String)` carried three different formats depending on which Ruff lex branch produced the `Int` (decimal digits when stored in `Number::Small(u64)`, decimal digits when `Number::Big` came from the decimal lexer, and a prefixed-and-underscore-bearing lexeme when `Number::Big` came from the radix lexer).
+
+The fix is a single-pass normalizer at HIR lowering time:
+
+```rust
+pub(super) fn canonical_large_int_literal_text(value: &Int) -> String {
+    let text = value.to_string();
+    parse_unsigned_integer_literal_text(&text).map_or(text, |integer| integer.to_str_radix(10))
+}
+```
+
+I traced every cell of the radix × magnitude matrix that produces a `LargeIntLiteral`:
+
+| source                                | Ruff `Int` storage              | `to_string()` output                  | Helper output (canonical decimal) |
+| ------------------------------------- | ------------------------------- | ------------------------------------- | --------------------------------- |
+| decimal in `[2^63, 2^64-1]`           | `Number::Small(u64)`            | underscore-free decimal digits        | same digits, re-emitted via `BigUint::to_str_radix(10)` |
+| decimal `> 2^64-1`                    | `Number::Big("…")` (no prefix)  | underscore-stripped decimal digits    | re-parses radix-10, re-emits decimal |
+| hex/oct/bin in `[2^63, 2^64-1]`       | `Number::Small(u64)`            | decimal digits (prefix dropped)       | re-parses radix-10, re-emits decimal |
+| hex/oct/bin `> 2^64-1`                | `Number::Big("0x…"/"0o…"/"0b…")` (prefix and underscores intact) | original lexeme | strips prefix, strips `_`, parses `BigUint` at radix 16/8/2, re-emits decimal |
+
+The helper's case-insensitive prefix matching (`0x`/`0X`/`0o`/`0O`/`0b`/`0B`) covers every radix prefix Ruff's lexer accepts. After this pass, the format of `LargeIntLiteral(String)` is unambiguous, self-describing, and consistent across all source spellings — exactly what the issue's "lossless representation" / "constructed-AST and parsed-source produce equivalent HIR" wording requires.
+
+The new test `test_large_integer_literals_lower_losslessly_from_source` exercises eight points, including:
+
+- decimal `[2^63, 2^64-1]` (`9223372036854775808`)
+- decimal `> 2^64-1` (`184467440737095516160`)
+- underscored decimal (`1_000_000_000_000_000_000_000`)
+- hex in `[2^63, 2^64-1]` (`0xffffffffffffffff` — the cell that previously dropped its prefix)
+- hex `> 2^64-1` (`0x10000000000000000`)
+- underscored hex `> 2^64-1` (`0xFFFF_FFFF_FFFF_FFFF_FFFF`)
+- oct `> 2^64-1` (`0o2000000000000000000000`)
+- bin `> 2^64-1` (`0b1` followed by sixty-four zeros)
+
+I sanity-checked each expected canonical decimal in the test against the source value:
+
+- `0xffffffffffffffff` = `18446744073709551615` ✓
+- `0x10000000000000000` = `0xFFFF_FFFF_FFFF_FFFF_FFFF`'s neighbor `0x10000000000000000` = `18446744073709551616` ✓
+- `0xFFFF_FFFF_FFFF_FFFF_FFFF` = `1208925819614629174706175` (= 16^20 − 1) ✓
+- `0o2000000000000000000000` = `2 × 8^21` = `2^64` = `18446744073709551616` ✓
+- `0b1` + 64×`0` = `2^64` = `18446744073709551616` ✓
+- `1_000_000_000_000_000_000_000` underscored → `1000000000000000000000` ✓
+
+The hex `[2^63, 2^64-1]` cell — the one that exposed the discontinuity in pass 1b — now goes through the `Number::Small(u64::MAX)` → decimal-display → re-parse-as-decimal → re-emit-decimal path and correctly produces `"18446744073709551615"`.
+
+**B1 is resolved.**
+
+---
+
+## New blocker check — none introduced
+
+I looked specifically for issues created by the new normalization step or by splitting the helper into its own module:
+
+- **Workspace plumbing**: `num-bigint = { workspace = true }` in `crates/sifr_hir/Cargo.toml` resolves to the existing root pin at `Cargo.toml:55` (`num-bigint = { version = "0.4.6" }`). No new third-party dependency added at the workspace level.
+- **Module wiring**: `crates/sifr_hir/src/lower/mod.rs` registers `mod integer_literals;` in alphabetical position alongside existing siblings; `expressions.rs` imports `super::integer_literals::canonical_large_int_literal_text`. HIR maintainability guardrails pass (re-ran `python3 scripts/check_hir_maintainability_guardrails.py` → `PASS`), so the helper split has not pushed `expressions.rs` over any size threshold and the new file is well under it.
+- **Exhaustive-match plumbing**: identical to pass 1b. The same six leaf arms (`hir_expr_calls_function`, `collect_expr_error_refs`, `process_expr_node` / `validate_expr_lowering_shape` / `expr_has_result_flow`, plus the test's leaf catch-all) include `LargeIntLiteral(_)`. All other consumers fall through wildcards (verified again — see the matrix in pass 1b which is unchanged).
+- **Helper correctness**:
+  - `BigUint::parse_bytes` accepts uppercase + lowercase hex digits, so the helper does not need to lowercase before parsing.
+  - The `.map_or(text, ...)` fallback is defensive; for valid Sifr source it is unreachable because Ruff has already validated digits at lex time. It does not silently corrupt anything — it preserves the Ruff display, which is the same behavior as before the fix on the unreachable branch.
+  - The function is only called when `i.as_i64()` returns `None`, so it is never asked to canonicalize values that already round-trip through `IntLiteral(i64)`.
+  - Empty digits after prefix strip cannot occur (Ruff rejects e.g. `0x` with no digits at lex time).
+  - Negative literals are wrapped in `UnaryOp("-", LargeIntLiteral(...))`; the unsigned-only helper is correct.
+
+No new blockers.
+
+---
+
+## Pass 1b non-blockers — should any be upgraded?
+
+The user explicitly asked whether N2/N3/N4/N6 should now be promoted to blockers. My read on each, after the B1 fix:
+
+- **N2 (`lower_expr_simple` default-arg parity at `crates/sifr_hir/src/lower/classes.rs:1249`)**: still calls `i.as_i64()?`, so a large default is silently dropped from a parameter. This now creates an asymmetry inside the same lowering pass: `def f(x: int = 1 << 100): ...` drops the default, while `x = 1 << 100` lowers cleanly to `LargeIntLiteral`. With the canonical normalizer in hand, plumbing this through is mechanical — `lower_expr_simple` can mirror `lower_number_literal`'s `Some(IntLiteral)` / `Some(LargeIntLiteral(canonical_…))` branch. **My judgment: keep as non-blocker for THIS slice as the user has scoped, but it deserves to be the first item of the next INT-2A slice — the parity criterion is what motivates B1, and N2 is the only remaining direct violation of it inside HIR lowering.** If the next slice does not pick this up, I would upgrade it to a blocker before INT-2A is declared closed.
+- **N3 (`compile_error!` from codegen for `LargeIntLiteral`)**: still applies. Slice scope explicitly excludes large-literal codegen. Stays non-blocking. Flag for INT-2B/INT-3.
+- **N4 (tuple compile-time index/slice diagnostics ignore `LargeIntLiteral`)**: still applies. Behavioral degradation only at indices that cannot be valid for any real tuple; non-blocking. Same INT-2B follow-up.
+- **N6 (clippy cleanup commit shape in `crates/sifr_codegen/src/lib.rs`)**: cosmetic, non-blocking. Note it in the PR description.
+
+None of these should block this slice. N2 is the one that I would most strongly want to see as the very next item.
+
+## Pass 1b N1 (test coverage) — mostly addressed
+
+Pass 1b asked for four extra cases: hex `[i64::MAX+1, u64::MAX]`, decimal `> 2^64`, underscored literals in both decimal and hex, and a negative literal beyond `i64::MIN`. The new test covers the first three with extra octal/binary `> 2^64` cases on top.
+
+The negative-literal beyond `i64::MIN` case (e.g. `-9_223_372_036_854_775_809`) is **not** covered. This is the case that asserts the unary-wrapping invariant `UnaryOp("-", LargeIntLiteral("9223372036854775809"))`. Worth adding in the next slice, but non-blocking — `lower_number_literal` does not see the sign, and the unary wrap is unrelated to B1's normalization.
+
+(Sub-observation: in the existing AST, source `-9_223_372_036_854_775_808` (literal `i64::MIN`) lowers to `UnaryOp("-", LargeIntLiteral("9223372036854775808"))` rather than `IntLiteral(i64::MIN)`, because `9_223_372_036_854_775_808 = 2^63` exceeds `i64::MAX` even though its negation fits `i64::MIN`. This is pre-existing — the new code is not the cause — and it is the kind of edge that an INT-2B const-fitting pass needs to handle. Not a blocker for this slice.)
+
+---
+
+## Helper-specific minor observations (all non-blocking)
+
+These are about `crates/sifr_hir/src/lower/integer_literals.rs` itself:
+
+1. The helper has no direct unit tests of its own; it is exercised through `lower_source`. A small `#[cfg(test)] mod tests { ... }` covering the radix-prefix branches and an underscore-only case would localize regressions if the lexer's display contract ever changes. Non-blocking.
+2. `text` is allocated once via `value.to_string()`; on the success path we discard it and allocate a fresh decimal string from `to_str_radix(10)`. Two allocations per large literal. Acceptable; large literals are rare. Mention only because it is occasionally useful to thread `Cow<'_, str>` through similar helpers.
+3. The `.map_or(text, ...)` fallback trades a panic for a silent passthrough. For an "if Ruff produced this it parses" invariant, an `expect("Ruff lexer produced unparseable integer text")` is also defensible — a programmer-invariant assert is how AGENTS.md describes that case. Either choice is fine; the current one is the safer default.
+4. `LargeIntLiteral(String)`'s doc could spell out "no underscores, no sign, no radix prefix; sign is wrapped in `UnaryOp`" — this is how the canonical format is actually shaped today, and naming it forecloses divergence from a future constructed-AST helper. Non-blocking.
+
+None of these change the verdict.
+
+---
+
+## Final verdict
+
+**Approve.** B1 from pass 1b is fully addressed by the canonical-decimal normalizer; no new blockers were introduced by either the BigUint parse step or the helper-module split; exhaustive-match plumbing remains safe; HIR maintainability guardrails still pass.
+
+The slice can merge as-is. Carry the existing pass 1b non-blockers (N1 negative-case test, N2 default-arg parity, N3 codegen diagnostic, N4 tuple-index diagnostics, N5/N6 doc and commit-shape polish) into the next INT-2A slice. Of those, N2 is the most important — it is the last remaining case where the `i64`-only assumption can silently drop a value at HIR lowering time, and the canonical normalizer in this slice has already done the hard part of the fix.


### PR DESCRIPTION
## Summary
- add canonical decimal `LargeIntLiteral` HIR for parsed integer literals beyond the historical `i64` slot
- normalize decimal, hex, octal, and binary parser output with focused HIR coverage for radix and underscore cases
- wire the new HIR leaf through codegen traversal/error-ref/result-flow plumbing while leaving full exact-int codegen to later INT-2B/INT-3 slices
- include a small clippy cleanup needed by downstream clippy checks

## Reviews
- `reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md` requested canonical literal representation
- `reviews/integer-model-int-2a-large-literal-hir-review-pass-2.md` approved after the canonical-decimal fix

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr_hir test_large_integer_literals_lower_losslessly_from_source`
- `cargo test -p sifr_hir`
- `cargo check -p sifr_codegen -p sifr_driver`
- `cargo clippy -p sifr_hir -p sifr_codegen -p sifr_driver -- -D warnings`
- `cargo run -q -p sifr -- check` on a temp file with oversized decimal and hex literals
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`)

Note: `cargo test -p sifr_codegen` was also tried during exploration and still has unrelated pre-existing failures; the repository quick lane and focused downstream compile/clippy checks pass.