### PR TITLE
Add fixed-width integer type variants

### DIFF
--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -106,6 +106,7 @@ fn collect_type_error_refs(
             collect_type_error_refs(ret, referenced, builtin_error_classes);
         }
         Type::Int
+        | Type::FixedInt(_)
         | Type::Float
         | Type::Bool
         | Type::Str

--- a/crates/sifr_codegen/src/expr_ref_emitter.rs
+++ b/crates/sifr_codegen/src/expr_ref_emitter.rs
@@ -5,6 +5,7 @@ use sifr_type_system::Type;
 fn uses_debug_display_format(ty: &Type) -> bool {
     match crate::resolve_alias_type_for_plain_call(ty) {
         Type::Int
+        | Type::FixedInt(_)
         | Type::Float
         | Type::Bool
         | Type::Str

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -5,6 +5,7 @@ use sifr_type_system::{FunctionType, ParamConvention, Type};
 fn registry_uses_debug_display_format(ty: &Type) -> bool {
     match crate::resolve_alias_type_for_plain_call(ty) {
         Type::Int
+        | Type::FixedInt(_)
         | Type::Float
         | Type::Bool
         | Type::Str

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -326,6 +326,7 @@ impl RustEmitter {
     fn uses_debug_display_format_for_ir(ty: &Type) -> bool {
         match crate::resolve_alias_type_for_plain_call(ty) {
             Type::Int
+            | Type::FixedInt(_)
             | Type::Float
             | Type::Bool
             | Type::Str

--- a/crates/sifr_hir/src/lower/type_alias_tests.rs
+++ b/crates/sifr_hir/src/lower/type_alias_tests.rs
@@ -2,7 +2,7 @@ use crate::{lower_module, HirDiagnostic, HirModule, HirStmt};
 use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_parser::parse_module;
-use sifr_type_system::Type;
+use sifr_type_system::{FixedIntType, Type};
 
 fn lower_source(source: &str) -> Result<HirModule, Vec<HirDiagnostic>> {
     let parsed = parse_module(source).expect("parse failed");
@@ -132,6 +132,63 @@ fn test_reserved_integer_width_annotations_have_int_code() {
             .all(|error| error.code != Some(DiagnosticCode::NAME_UNKNOWN_TYPE)),
         "reserved width names should not fall through to generic unknown-type diagnostics"
     );
+}
+
+#[test]
+fn test_nested_reserved_integer_width_annotations_have_int_code() {
+    let source = "type BadMap = dict[str, uint128]\n\ndef bad() -> list[int128]:\n    return []\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+
+    assert!(errors.iter().any(|error| {
+        error.message == "reserved integer width name 'uint128' is not supported yet"
+            && error.code == Some(DiagnosticCode::INT_RESERVED_WIDTH_NAME)
+            && error.primary_range == Some(range_for_after(source, "str, ", "uint128"))
+    }));
+    assert!(errors.iter().any(|error| {
+        error.message == "reserved integer width name 'int128' is not supported yet"
+            && error.code == Some(DiagnosticCode::INT_RESERVED_WIDTH_NAME)
+            && error.primary_range == Some(range_for_after(source, "list[", "int128"))
+    }));
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::NAME_UNKNOWN_TYPE)),
+        "nested reserved width names should not fall through to generic unknown-type diagnostics"
+    );
+}
+
+#[test]
+fn test_fixed_width_integer_annotations_resolve_in_hir_signatures() {
+    let result = lower_source(
+        "def widths(a: int8, b: int16, c: int32, d: int64, e: uint8, f: uint16, g: uint32, h: uint64, i: isize, j: usize) -> usize:\n    return j\n",
+    )
+    .expect("fixed-width integer annotations should lower");
+
+    let widths = result
+        .functions
+        .iter()
+        .find(|function| function.name == "widths")
+        .expect("widths function missing");
+
+    let actual: Vec<Type> = widths.params.iter().map(|param| param.ty.clone()).collect();
+    assert_eq!(
+        actual,
+        vec![
+            Type::FixedInt(FixedIntType::I8),
+            Type::FixedInt(FixedIntType::I16),
+            Type::FixedInt(FixedIntType::I32),
+            Type::FixedInt(FixedIntType::I64),
+            Type::FixedInt(FixedIntType::U8),
+            Type::FixedInt(FixedIntType::U16),
+            Type::FixedInt(FixedIntType::U32),
+            Type::FixedInt(FixedIntType::U64),
+            Type::FixedInt(FixedIntType::ISize),
+            Type::FixedInt(FixedIntType::USize),
+        ]
+    );
+    assert_eq!(widths.return_type, Type::FixedInt(FixedIntType::USize));
 }
 
 #[test]

--- a/crates/sifr_type_system/src/infer.rs
+++ b/crates/sifr_type_system/src/infer.rs
@@ -1,6 +1,6 @@
 //! Type inference for Sifr expressions.
 
-use crate::types::Type;
+use crate::types::{FixedIntType, Type};
 
 /// Infer the type of a literal value from its string representation and kind.
 pub fn infer_literal_type(kind: LiteralKind) -> Type {
@@ -27,6 +27,16 @@ pub enum LiteralKind {
 pub fn resolve_type_annotation(name: &str) -> Option<Type> {
     match name {
         "int" => Some(Type::Int),
+        "int8" => Some(Type::FixedInt(FixedIntType::I8)),
+        "int16" => Some(Type::FixedInt(FixedIntType::I16)),
+        "int32" => Some(Type::FixedInt(FixedIntType::I32)),
+        "int64" => Some(Type::FixedInt(FixedIntType::I64)),
+        "uint8" => Some(Type::FixedInt(FixedIntType::U8)),
+        "uint16" => Some(Type::FixedInt(FixedIntType::U16)),
+        "uint32" => Some(Type::FixedInt(FixedIntType::U32)),
+        "uint64" => Some(Type::FixedInt(FixedIntType::U64)),
+        "isize" => Some(Type::FixedInt(FixedIntType::ISize)),
+        "usize" => Some(Type::FixedInt(FixedIntType::USize)),
         "float" => Some(Type::Float),
         "bool" => Some(Type::Bool),
         "str" => Some(Type::Str),
@@ -61,6 +71,46 @@ mod tests {
     #[test]
     fn test_resolve_type_annotations() {
         assert_eq!(resolve_type_annotation("int"), Some(Type::Int));
+        assert_eq!(
+            resolve_type_annotation("int8"),
+            Some(Type::FixedInt(FixedIntType::I8))
+        );
+        assert_eq!(
+            resolve_type_annotation("int16"),
+            Some(Type::FixedInt(FixedIntType::I16))
+        );
+        assert_eq!(
+            resolve_type_annotation("int32"),
+            Some(Type::FixedInt(FixedIntType::I32))
+        );
+        assert_eq!(
+            resolve_type_annotation("int64"),
+            Some(Type::FixedInt(FixedIntType::I64))
+        );
+        assert_eq!(
+            resolve_type_annotation("uint8"),
+            Some(Type::FixedInt(FixedIntType::U8))
+        );
+        assert_eq!(
+            resolve_type_annotation("uint16"),
+            Some(Type::FixedInt(FixedIntType::U16))
+        );
+        assert_eq!(
+            resolve_type_annotation("uint32"),
+            Some(Type::FixedInt(FixedIntType::U32))
+        );
+        assert_eq!(
+            resolve_type_annotation("uint64"),
+            Some(Type::FixedInt(FixedIntType::U64))
+        );
+        assert_eq!(
+            resolve_type_annotation("isize"),
+            Some(Type::FixedInt(FixedIntType::ISize))
+        );
+        assert_eq!(
+            resolve_type_annotation("usize"),
+            Some(Type::FixedInt(FixedIntType::USize))
+        );
         assert_eq!(resolve_type_annotation("float"), Some(Type::Float));
         assert_eq!(resolve_type_annotation("str"), Some(Type::Str));
         assert_eq!(resolve_type_annotation("bytes"), Some(Type::Bytes));

--- a/crates/sifr_type_system/src/lib.rs
+++ b/crates/sifr_type_system/src/lib.rs
@@ -15,8 +15,8 @@ pub use check::{
 };
 pub use infer::infer_literal_type;
 pub use types::{
-    FunctionType, IterationCapability, IterationMetadata, OwnershipKind, ParamConvention,
-    ParamMutability, ParamOwnership, Type,
+    FixedIntType, FunctionType, IterationCapability, IterationMetadata, OwnershipKind,
+    ParamConvention, ParamMutability, ParamOwnership, Type,
 };
 pub mod narrow;
 pub use literal::{widen as widen_literal, LiteralValue};

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -4,8 +4,10 @@ use crate::union::make_union;
 /// Represents a type in the Sifr language.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
-    /// 64-bit integer (`int` in Sifr, `i64` in Rust)
+    /// Exact source-level integer (`int` in Sifr).
     Int,
+    /// Explicit fixed-width integer family for representation-sensitive values.
+    FixedInt(FixedIntType),
     /// 64-bit float (`float` in Sifr, `f64` in Rust)
     Float,
     /// Boolean (`bool`)
@@ -111,6 +113,71 @@ pub enum Type {
     Decimal,
     /// Arbitrary-precision decimal (`bigdecimal` in Sifr, `bigdecimal::BigDecimal` in Rust)
     BigDecimal,
+}
+
+/// Explicit fixed-width integer types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FixedIntType {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    ISize,
+    USize,
+}
+
+impl FixedIntType {
+    #[must_use]
+    pub const fn source_name(self) -> &'static str {
+        match self {
+            Self::I8 => "int8",
+            Self::I16 => "int16",
+            Self::I32 => "int32",
+            Self::I64 => "int64",
+            Self::U8 => "uint8",
+            Self::U16 => "uint16",
+            Self::U32 => "uint32",
+            Self::U64 => "uint64",
+            Self::ISize => "isize",
+            Self::USize => "usize",
+        }
+    }
+
+    #[must_use]
+    pub const fn rust_name(self) -> &'static str {
+        match self {
+            Self::I8 => "i8",
+            Self::I16 => "i16",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::U8 => "u8",
+            Self::U16 => "u16",
+            Self::U32 => "u32",
+            Self::U64 => "u64",
+            Self::ISize => "isize",
+            Self::USize => "usize",
+        }
+    }
+
+    #[must_use]
+    pub const fn variant_prefix(self) -> &'static str {
+        match self {
+            Self::I8 => "Int8",
+            Self::I16 => "Int16",
+            Self::I32 => "Int32",
+            Self::I64 => "Int64",
+            Self::U8 => "Uint8",
+            Self::U16 => "Uint16",
+            Self::U32 => "Uint32",
+            Self::U64 => "Uint64",
+            Self::ISize => "Isize",
+            Self::USize => "Usize",
+        }
+    }
 }
 
 /// Iterator/iterable capabilities carried through typing and lowering.
@@ -446,6 +513,7 @@ impl Type {
     pub fn ownership(&self) -> OwnershipKind {
         match self {
             Self::Int
+            | Self::FixedInt(_)
             | Self::Float
             | Self::Bool
             | Self::None
@@ -500,6 +568,7 @@ impl Type {
     pub fn display_name(&self) -> String {
         match self {
             Self::Int => "int".to_string(),
+            Self::FixedInt(fixed) => fixed.source_name().to_string(),
             Self::Float => "float".to_string(),
             Self::Bool => "bool".to_string(),
             Self::Str => "str".to_string(),
@@ -575,6 +644,7 @@ impl Type {
     pub fn rust_type(&self) -> String {
         match self {
             Self::Int => "i64".to_string(),
+            Self::FixedInt(fixed) => fixed.rust_name().to_string(),
             Self::Float => "f64".to_string(),
             Self::Bool => "bool".to_string(),
             Self::Str => "String".to_string(),
@@ -726,6 +796,7 @@ impl Type {
     fn type_to_enum_variant_prefix(ty: &Type) -> String {
         match ty {
             Type::Int => "Int".to_string(),
+            Type::FixedInt(fixed) => fixed.variant_prefix().to_string(),
             Type::Float => "Float".to_string(),
             Type::Bool => "Bool".to_string(),
             Type::Str => "Str".to_string(),
@@ -1335,6 +1406,10 @@ mod tests {
     #[test]
     fn test_ownership_primitives_are_copy() {
         assert_eq!(Type::Int.ownership(), OwnershipKind::Copy);
+        assert_eq!(
+            Type::FixedInt(FixedIntType::U8).ownership(),
+            OwnershipKind::Copy
+        );
         assert_eq!(Type::Float.ownership(), OwnershipKind::Copy);
         assert_eq!(Type::Bool.ownership(), OwnershipKind::Copy);
         assert_eq!(Type::None.ownership(), OwnershipKind::Copy);
@@ -1348,10 +1423,27 @@ mod tests {
     #[test]
     fn test_rust_type_mapping() {
         assert_eq!(Type::Int.rust_type(), "i64");
+        assert_eq!(Type::FixedInt(FixedIntType::I8).rust_type(), "i8");
+        assert_eq!(Type::FixedInt(FixedIntType::I16).rust_type(), "i16");
+        assert_eq!(Type::FixedInt(FixedIntType::I32).rust_type(), "i32");
+        assert_eq!(Type::FixedInt(FixedIntType::I64).rust_type(), "i64");
+        assert_eq!(Type::FixedInt(FixedIntType::U8).rust_type(), "u8");
+        assert_eq!(Type::FixedInt(FixedIntType::U16).rust_type(), "u16");
+        assert_eq!(Type::FixedInt(FixedIntType::U32).rust_type(), "u32");
+        assert_eq!(Type::FixedInt(FixedIntType::U64).rust_type(), "u64");
+        assert_eq!(Type::FixedInt(FixedIntType::ISize).rust_type(), "isize");
+        assert_eq!(Type::FixedInt(FixedIntType::USize).rust_type(), "usize");
         assert_eq!(Type::Float.rust_type(), "f64");
         assert_eq!(Type::Bool.rust_type(), "bool");
         assert_eq!(Type::Str.rust_type(), "String");
         assert_eq!(Type::None.rust_type(), "()");
+    }
+
+    #[test]
+    fn test_fixed_width_type_names_and_union_variants() {
+        let fixed = Type::FixedInt(FixedIntType::U32);
+        assert_eq!(fixed.display_name(), "uint32");
+        assert_eq!(fixed.union_variant_name(), "Uint32");
     }
 
     #[test]

--- a/crates/sifr_type_system/src/union.rs
+++ b/crates/sifr_type_system/src/union.rs
@@ -171,7 +171,7 @@ fn deduplicate(types: &mut Vec<Type>) {
 }
 
 /// Sort types for consistent ordering.
-/// Order: None, Bool, Int, Float, Str, `LiteralBool`, `LiteralInt`, `LiteralStr`,
+/// Order: None, Bool, Int, fixed-width ints, Float, Str, `LiteralBool`, `LiteralInt`, `LiteralStr`,
 ///        List, Dict, Tuple, Range, Iterable, Iterator, Function, Unknown, Any, Never, Union, Intersection, Alias
 fn sort_members(types: &mut [Type]) {
     types.sort_by_key(type_sort_key);
@@ -182,29 +182,30 @@ fn type_sort_key(ty: &Type) -> (u8, String) {
         Type::None => (0, String::new()),
         Type::Bool => (1, String::new()),
         Type::Int => (2, String::new()),
-        Type::Float => (3, String::new()),
-        Type::Str => (4, String::new()),
-        Type::Bytes => (5, String::new()),
-        Type::LiteralBool(v) => (6, format!("{v}")),
-        Type::LiteralInt(v) => (7, format!("{v}")),
-        Type::LiteralStr(v) => (8, v.clone()),
-        Type::List(_) => (9, String::new()),
-        Type::Dict(_, _) => (10, String::new()),
-        Type::Set(_) => (11, String::new()),
-        Type::Tuple(_) => (12, String::new()),
-        Type::Range => (12, String::new()),
-        Type::Iterable(_) => (13, String::new()),
-        Type::Iterator(_) => (14, String::new()),
-        Type::Function(_) => (15, String::new()),
-        Type::Unknown => (16, String::new()),
-        Type::Any => (17, String::new()),
-        Type::Never => (18, String::new()),
-        Type::Union(_) => (19, String::new()),
-        Type::Intersection(_) => (20, String::new()),
+        Type::FixedInt(fixed) => (3, fixed.source_name().to_string()),
+        Type::Float => (4, String::new()),
+        Type::Str => (5, String::new()),
+        Type::Bytes => (6, String::new()),
+        Type::LiteralBool(v) => (7, format!("{v}")),
+        Type::LiteralInt(v) => (8, format!("{v}")),
+        Type::LiteralStr(v) => (9, v.clone()),
+        Type::List(_) => (10, String::new()),
+        Type::Dict(_, _) => (11, String::new()),
+        Type::Set(_) => (12, String::new()),
+        Type::Tuple(_) => (13, String::new()),
+        Type::Range => (13, String::new()),
+        Type::Iterable(_) => (14, String::new()),
+        Type::Iterator(_) => (15, String::new()),
+        Type::Function(_) => (16, String::new()),
+        Type::Unknown => (17, String::new()),
+        Type::Any => (18, String::new()),
+        Type::Never => (19, String::new()),
+        Type::Union(_) => (20, String::new()),
+        Type::Intersection(_) => (21, String::new()),
         Type::Alias {
             name, type_args, ..
         } => (
-            21,
+            22,
             if type_args.is_empty() {
                 name.clone()
             } else {
@@ -219,16 +220,16 @@ fn type_sort_key(ty: &Type) -> (u8, String) {
                 )
             },
         ),
-        Type::Class { name, .. } => (22, name.clone()),
-        Type::Result(_, _) => (23, String::new()),
-        Type::Protocol { name, .. } => (24, name.clone()),
-        Type::Newtype { name, .. } => (25, name.clone()),
-        Type::TypeVar(name) => (26, name.clone()),
-        Type::Callable(..) => (27, String::new()),
-        Type::Enum { name, .. } => (28, name.clone()),
-        Type::BigInt => (29, String::new()),
-        Type::Decimal => (30, String::new()),
-        Type::BigDecimal => (31, String::new()),
+        Type::Class { name, .. } => (23, name.clone()),
+        Type::Result(_, _) => (24, String::new()),
+        Type::Protocol { name, .. } => (25, name.clone()),
+        Type::Newtype { name, .. } => (26, name.clone()),
+        Type::TypeVar(name) => (27, name.clone()),
+        Type::Callable(..) => (28, String::new()),
+        Type::Enum { name, .. } => (29, name.clone()),
+        Type::BigInt => (30, String::new()),
+        Type::Decimal => (31, String::new()),
+        Type::BigDecimal => (32, String::new()),
     }
 }
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -399,6 +399,7 @@ Validation:
 - [x] INT-2A large integer literal HIR review pass 2 approved after canonical decimal normalization: `reviews/integer-model-int-2a-large-literal-hir-review-pass-2.md`.
 - [x] INT-2A large integer literal default/unary parity review satisfied: `reviews/integer-model-int-2a-large-literal-defaults-parity-review-pass-1b.md`.
 - [x] INT-2A boundary diagnostics and parsed/constructed parity review satisfied: `reviews/integer-model-int-2a-boundary-diagnostics-review-pass-1.md`.
+- [x] INT-2B fixed-width type variants and annotation resolution review satisfied: `reviews/integer-model-int-2b-fixed-width-type-variants-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -412,7 +413,8 @@ Validation:
   - [x] Default-argument large-literal parity and negative-large-literal unary coverage implemented, review satisfied, and quick validation passing: PR #1793.
   - [x] Malformed integer token text has typed parser diagnostic coverage, over-budget integer literals emit `SIFR-INT-0004`, parsed/constructed HIR parity is covered, review is satisfied, and quick validation is passing: PR #1794.
 - [ ] INT-2B HIR, type system, and const fitting
-  - [ ] Carry follow-ups from INT-2A reserved-width review: broaden annotation-position tests, align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, and decide reserved-name shadowing policy during `bigint` cleanup.
+  - [x] Fixed-width signed, unsigned, and pointer-sized integer annotations resolve in compiler-owned type layers, nested reserved-width annotation coverage was broadened, review is satisfied, and quick validation is passing: PR #1795.
+  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, and clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable.
 - [ ] INT-3 scalar arithmetic and numeric mixing
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries

--- a/reviews/integer-model-int-2b-fixed-width-type-variants-review-pass-1.md
+++ b/reviews/integer-model-int-2b-fixed-width-type-variants-review-pass-1.md
@@ -1,0 +1,130 @@
+# INT-2B — Fixed-width Type Variants — Review Pass 1
+
+Reviewer: Claude (Opus 4.7), 2026-05-06.
+Branch: `int-2b-fixed-width-type-variants`.
+Validation: `scripts/run_all_tests.sh --profile quick` passed, `report_signature=e1bf653aaa770517`.
+Working tree: 9 modified files, no new files, no submodule changes, no fixture/snapshot churn.
+
+## Scope under review
+
+This slice introduces the `Type::FixedInt(FixedIntType)` variant and its annotation resolution. The user has explicitly carved the scope:
+
+- In scope: fixed-width type representation (`int8`/`int16`/`int32`/`int64`/`uint8`/`uint16`/`uint32`/`uint64`/`isize`/`usize`) and HIR-level annotation resolution.
+- Out of scope: const fitting (literal-into-fixed-width assignment), range diagnostics, fixed-width arithmetic promotion, bigint public-removal.
+
+I read every diff hunk in full and walked the surrounding match arms in [crates/sifr_type_system/src/types.rs](crates/sifr_type_system/src/types.rs), [crates/sifr_type_system/src/check.rs](crates/sifr_type_system/src/check.rs), [crates/sifr_type_system/src/union.rs](crates/sifr_type_system/src/union.rs), [crates/sifr_codegen/src/preamble.rs](crates/sifr_codegen/src/preamble.rs), [crates/sifr_codegen/src/lower_expr.rs](crates/sifr_codegen/src/lower_expr.rs), [crates/sifr_codegen/src/lower_item.rs](crates/sifr_codegen/src/lower_item.rs), [crates/sifr_codegen/src/expr_ref_emitter.rs](crates/sifr_codegen/src/expr_ref_emitter.rs), [crates/sifr_codegen/src/generic_bounds_helpers.rs](crates/sifr_codegen/src/generic_bounds_helpers.rs), [crates/sifr_hir/src/lower/diagnostics.rs](crates/sifr_hir/src/lower/diagnostics.rs), [crates/sifr_hir/src/lower/typing_and_functions.rs](crates/sifr_hir/src/lower/typing_and_functions.rs), and [crates/sifr_hir/src/hir_nodes.rs](crates/sifr_hir/src/hir_nodes.rs) to look for places that match `Type::Int` exhaustively but silently ignore `Type::FixedInt`.
+
+---
+
+## Correctness analysis
+
+### `Type::FixedInt` variant ([crates/sifr_type_system/src/types.rs:7-10](crates/sifr_type_system/src/types.rs:7))
+
+The new variant carries a `FixedIntType` enum with all 10 widths. `FixedIntType` is `Copy + Eq + Hash`, derives match the rest of the file's primitive-helper enums, and the `source_name` / `rust_name` / `variant_prefix` accessors are exhaustive over the 10 variants. No mismatch between source name (`int8`/`uint8`) and Rust name (`i8`/`u8`).
+
+Spot-checked the three key surfaces that consume `Type::Int`:
+
+- `ownership()` ([types.rs:515](crates/sifr_type_system/src/types.rs:515)) — `FixedInt(_)` joins the primitive Copy bucket. Correct: all 10 widths are `Copy` in Rust.
+- `display_name()` ([types.rs:571](crates/sifr_type_system/src/types.rs:571)) — emits `source_name()`. Correct.
+- `rust_type()` ([types.rs:647](crates/sifr_type_system/src/types.rs:647)) — emits `rust_name()`. Correct.
+- `type_to_enum_variant_prefix()` ([types.rs:799](crates/sifr_type_system/src/types.rs:799)) — emits `variant_prefix()` (PascalCase). The new test `test_fixed_width_type_names_and_union_variants` ([types.rs:1442-1447](crates/sifr_type_system/src/types.rs:1442)) exercises both `display_name` and `union_variant_name` for `FixedInt(U32)`.
+
+### Annotation resolution ([crates/sifr_type_system/src/infer.rs:28-39](crates/sifr_type_system/src/infer.rs:28))
+
+All 10 source names are added to `resolve_type_annotation`. The new unit assertions ([infer.rs:73-112](crates/sifr_type_system/src/infer.rs:73)) cover each name. The reserved-name short-circuit at [crates/sifr_hir/src/lower/typing_and_functions.rs:435](crates/sifr_hir/src/lower/typing_and_functions.rs:435) still fires for `int128`/`uint128` *before* `resolve_type_annotation` is consulted, so those still get `INT_RESERVED_WIDTH_NAME` (verified by both the existing `test_reserved_integer_width_annotations_have_int_code` and the new nested test).
+
+### Union sort key ([crates/sifr_type_system/src/union.rs:182-233](crates/sifr_type_system/src/union.rs:182))
+
+The sort key was renumbered: `Int=2`, `FixedInt(_)=3` (with `source_name()` as secondary), and every subsequent variant shifted by +1 through `BigDecimal=32`. Two observations:
+
+- The pre-existing duplicate primary key for `Tuple` and `Range` (both `(13, "")` after the shift, same shape as `(12, "")` before) is carried forward unchanged. Not a new bug.
+- The lexicographic secondary key on `source_name()` orders `int16 < int32 < int64 < int8 < isize < uint16 < uint32 < uint64 < uint8 < usize` — that is, `int8` sorts after `int64` because `"int16"` < `"int8"` lexicographically. It is deterministic and has no functional impact (no snapshot in the suite enumerates a union of fixed-width ints today), but worth noting if a future slice cares about presentation order.
+
+`make_union` deduplication relies on `PartialEq` on `Type`, which derives correctly through `FixedInt(FixedIntType)` so `int8 | int8` collapses to `int8`. `types_overlap` and `member_contains` ([union.rs:237-263](crates/sifr_type_system/src/union.rs:237)) only special-case literal-vs-base; `FixedInt(I8)` and `Int` are correctly treated as non-overlapping (no auto-promotion in narrowing).
+
+### Codegen helpers ([crates/sifr_codegen](crates/sifr_codegen))
+
+The four `uses_debug_display_format`-style predicates were updated in lock-step:
+
+- [error_refs.rs:108](crates/sifr_codegen/src/error_refs.rs:108) — leaf primitive bucket (no error-class refs to collect).
+- [expr_ref_emitter.rs:7](crates/sifr_codegen/src/expr_ref_emitter.rs:7) — Display (`{}`) bucket, not Debug (`{:?}`).
+- [intrinsic_method_emitters.rs:7](crates/sifr_codegen/src/intrinsic_method_emitters.rs:7) — same.
+- [stmt_support_emitter.rs:328](crates/sifr_codegen/src/stmt_support_emitter.rs:328) — same.
+
+Since `i8`/`i16`/.../`isize`/`usize` all `impl Display`, classifying `FixedInt(_)` with `Int`/`Float` is correct.
+
+`sifr_type_to_rust_type` in [preamble.rs:5](crates/sifr_codegen/src/preamble.rs:5) reaches `FixedInt(_)` through the `_ => RustType::Named(ty.rust_type())` fallback, which yields `RustType::Named("i8")` etc. — handled correctly without an explicit arm.
+
+### HIR test coverage ([crates/sifr_hir/src/lower/type_alias_tests.rs](crates/sifr_hir/src/lower/type_alias_tests.rs))
+
+Two new tests, both well-targeted:
+
+- `test_nested_reserved_integer_width_annotations_have_int_code` ([type_alias_tests.rs:138-158](crates/sifr_hir/src/lower/type_alias_tests.rs:138)) — `dict[str, uint128]` and `list[int128]` both surface `INT_RESERVED_WIDTH_NAME` *and* the test asserts no `NAME_UNKNOWN_TYPE` leak. Closes a real concern about reserved-name detection inside container annotations.
+- `test_fixed_width_integer_annotations_resolve_in_hir_signatures` ([type_alias_tests.rs:161-192](crates/sifr_hir/src/lower/type_alias_tests.rs:161)) — declares a function taking all 10 fixed-width annotations and returning `usize`, then verifies the resolved param/return `Type` values exactly. This is the load-bearing assertion that ties annotation resolution → HIR `FunctionType` correctly.
+
+Validation passing locally without snapshot churn means no existing union ordering or codegen fixture regressed.
+
+---
+
+## Out-of-scope behaviors (intentional, verified)
+
+These are *not* defects — they are consistent with the slice's stated scope, and I confirmed each one fails closed rather than producing wrong code:
+
+- `Type::Int` is *not* assignable to `Type::FixedInt(_)` and vice versa ([types.rs:1238-1244](crates/sifr_type_system/src/types.rs:1238)). `LiteralInt(_) → FixedInt(_)` is also rejected. So `x: int8 = 5` will emit a type error today (no const-fitting). Confirmed by inspecting `is_assignable_to`.
+- `is_numeric()` ([types.rs:836](crates/sifr_type_system/src/types.rs:836)) does not include `FixedInt`. Consequence: `int8 + int8`, unary `-int8`, and `<`/`>` on `FixedInt` all hit `TYPE_UNSUPPORTED_OPERATOR` in [check.rs](crates/sifr_type_system/src/check.rs). That matches the explicit deferral of "fixed-width arithmetic promotion."
+- `is_integral_numeric_type` in [check.rs:21-23](crates/sifr_type_system/src/check.rs:21) is unchanged, so `Decimal × int8` is rejected too. Consistent.
+- `HirExpr::IntLiteral(_).ty()` ([hir_nodes.rs:553](crates/sifr_hir/src/lower/../hir_nodes.rs:553)) still returns `&Type::Int`. Slice does not introduce a `FixedIntLiteral` or fitting; integer literals stay `Int`.
+
+Each of these is the correct closure point for this slice — they cause type errors at the boundary the slice did not extend, not silent miscompilation.
+
+---
+
+## Latent rough edges (not blocking, callouts for the next slice)
+
+The following are paths that the new variant *can* technically reach today but for which the slice did not adjust the existing `Type::Int`-only logic. None is exercised by the slice's tests or by any current demo, but each is a future-slice tax:
+
+1. `format_type_name` in [crates/sifr_hir/src/lower/diagnostics.rs:46-58](crates/sifr_hir/src/lower/diagnostics.rs:46) falls through to `Debug` for `FixedInt`, so a future user-facing diagnostic like `Result[int8, NotAClass]` would render as `"FixedInt(I8) is not a valid error type"` rather than `"int8 is not a valid error type"`. Routing through `Type::display_name()` (or adding a `FixedInt(_)` arm) would fix it. Not exercised today because the slice did not add any code path that drives `format_type_name(&FixedInt(_))`.
+
+2. `option_inner_from_rust_type` in [crates/sifr_codegen/src/expr_ref_emitter.rs:55-73](crates/sifr_codegen/src/expr_ref_emitter.rs:55) only special-cases `i64`/`f64`/`bool`/`String` substrings of `Option<T>`'s rust_type; `Option<i8>` etc. fall to `Some(Type::Unknown)`. The primary path (`option_inner_type` reading the Sifr-side `Type::Union`) catches Sifr-typed Option-of-int8 first, so this fallback only matters for intrinsic-returned options whose Sifr type lost the union shape. Latent at best.
+
+3. `normalize_simple_compare_scalar_type` and `normalize_simple_numeric_scalar_type` ([lower_expr.rs:1676,1687](crates/sifr_codegen/src/lower_expr.rs:1676)) do not classify `FixedInt(_)`. Today this is unreachable because `is_numeric` rejects fixed-width comparisons / arithmetic in the type checker before these helpers get called; if a future slice extends `is_numeric` it should also extend these.
+
+4. `is_simple_module_primitive_const_type` ([lower_item.rs:17-22](crates/sifr_codegen/src/lower_item.rs:17)) excludes `FixedInt`. Module-level `const x: int8 = 5` would not pass type-checking anyway (no const-fit), so this is not yet reachable.
+
+5. `Type::Range` and `Type::Bytes` iteration always yield `Type::Int` ([types.rs:888,893](crates/sifr_type_system/src/types.rs:888)) — out of scope for this slice but a known follow-up if range/bytes become parametrizable.
+
+I did not find any place where the new variant could currently produce wrong code, panic, or bypass a diagnostic; every uncovered match arm is gated upstream by the existing `is_numeric` / `is_assignable_to` discipline, which the slice deliberately did not relax.
+
+---
+
+## Tests / validation
+
+- 11 new `resolve_type_annotation` assertions in [infer.rs](crates/sifr_type_system/src/infer.rs:71-112) — one per width plus the existing `int`.
+- 10 new `rust_type` assertions in [types.rs:1425-1435](crates/sifr_type_system/src/types.rs:1425).
+- New `test_ownership_primitives_are_copy` row for `FixedInt(U8)` ([types.rs:1409-1412](crates/sifr_type_system/src/types.rs:1409)).
+- New `test_fixed_width_type_names_and_union_variants` ([types.rs:1442-1447](crates/sifr_type_system/src/types.rs:1442)).
+- New `test_fixed_width_integer_annotations_resolve_in_hir_signatures` end-to-end through HIR lowering.
+- New nested-container reserved-width test.
+- `report_signature=e1bf653aaa770517` matches a prior INT-2A run, consistent with this slice making no fixture/snapshot/codegen-output changes.
+
+Test surface is appropriate for the scope: representation + annotation resolution. No e2e fixture is needed because no end-user-visible behavior compiles a new program shape — fixed-width values cannot yet be initialized, arithmetic'd, or compared.
+
+---
+
+## Style / scope hygiene
+
+- All four codegen helper edits are pure pass-through additions to existing match alternation lists — no behavior change for non-`FixedInt` types.
+- The union sort renumbering was done atomically (every subsequent key shifted +1); no bucket was left at the old index.
+- Public re-export of `FixedIntType` from [crates/sifr_type_system/src/lib.rs:18](crates/sifr_type_system/src/lib.rs:18) follows the existing alphabetical-ish neighbor (`FunctionType`).
+- No comments were added that explain *what* the obvious code does; the doc comments on the new variant and on `FixedIntType` accessors describe *why* they exist (representation-sensitive values, source vs. Rust naming).
+- No fallback paths or compatibility shims introduced.
+
+Slice fits comfortably under "PR-sized." Diff is +240 / -36 across 9 files.
+
+---
+
+## Verdict rationale
+
+The slice does exactly what it says: introduces `Type::FixedInt(FixedIntType)`, plumbs the four representation methods (ownership, display, rust_type, variant prefix) and the union sort key, wires annotation resolution for the 10 source names, and verifies the wiring with both unit assertions and an HIR-level signature test. Every unchanged surface I checked is gated upstream by `is_numeric` / `is_assignable_to`, which the slice intentionally leaves narrow — so the deferred work (const fitting, arithmetic promotion, range diagnostics) cannot leak through. Latent rough edges 1–5 above are real but each requires *future-scope* code paths to reach, none corrupts behavior today, and noting them is preferable to expanding this slice.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary
- add compiler-owned fixed-width integer type variants for signed, unsigned, and pointer-sized integer annotations
- resolve fixed-width annotation names through type-system/HIR signatures
- keep arithmetic, const fitting, and narrowing out of scope for later INT-2B slices
- record Claude milestone review artifact under reviews/

## Validation
- cargo check -p sifr_type_system -p sifr_hir -p sifr_codegen
- cargo test -p sifr_type_system fixed_width
- cargo test -p sifr_type_system test_resolve_type_annotations
- cargo test -p sifr_type_system test_rust_type_mapping
- cargo test -p sifr_type_system test_ownership_primitives_are_copy
- cargo test -p sifr_hir fixed_width_integer_annotations_resolve
- cargo test -p sifr_hir integer_width_annotations
- python3 scripts/check_hir_maintainability_guardrails.py
- cargo clippy -p sifr_type_system -p sifr_hir -p sifr_codegen -- -D warnings
- scripts/run_all_tests.sh --profile quick (PASS; report_signature=e1bf653aaa770517)

Review: reviews/integer-model-int-2b-fixed-width-type-variants-review-pass-1.md (VERDICT: SATISFIED)