### PR TITLE
Add fixed-width const expression fitting

### DIFF
--- a/crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr
+++ b/crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr
@@ -1,0 +1,3 @@
+def main():
+    too_wide: uint8 = 2 ** 8  # expect-error: SIFR-INT-0001 col=23
+    too_large: uint8 = 10 ** 5000  # expect-error: SIFR-INT-0004 col=23

--- a/crates/sifr/tests/e2e/pass/fixed_width_const_expression_assignment.sifr
+++ b/crates/sifr/tests/e2e/pass/fixed_width_const_expression_assignment.sifr
@@ -1,0 +1,15 @@
+BASE: int = 250 + 4
+
+def main() -> None:
+    value: uint8 = BASE + 1
+    mixed: uint8 = (1 + 2) * 40 + (20 >> 1)
+    powered: uint16 = 2 ** 12
+    shifted: uint8 = (1 << 6) + (9 // 2) + (9 % 2)
+    signed: int8 = -10 * 5
+    negated: int16 = -(100 + 27)
+    print(value)
+    print(mixed)
+    print(powered)
+    print(shifted)
+    print(signed)
+    print(negated)

--- a/crates/sifr_hir/src/lower/class_field_inference.rs
+++ b/crates/sifr_hir/src/lower/class_field_inference.rs
@@ -2,7 +2,7 @@ use sifr_python_ast::{Expr, Operator, Stmt, UnaryOp};
 use sifr_type_system::Type;
 use std::collections::HashMap;
 
-use super::{classes::lower_expr_simple, LowerCtx};
+use super::{simple_expr::lower_expr_simple, LowerCtx};
 
 fn merge_inferred_types(existing: Type, inferred: Type) -> Type {
     if matches!(existing.resolve_alias(), Type::Any | Type::Unknown)

--- a/crates/sifr_hir/src/lower/classes.rs
+++ b/crates/sifr_hir/src/lower/classes.rs
@@ -4,7 +4,7 @@ use crate::hir_nodes::{
 };
 use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
-use sifr_python_ast::{Expr, Number, Stmt, StmtClassDef, UnaryOp};
+use sifr_python_ast::{Expr, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 use std::collections::HashMap;
 
@@ -13,8 +13,8 @@ use super::diagnostics::{
     collect_enum_variants, get_newtype_inner, get_parent_class, has_decorator, is_enum_class,
     is_error_class, is_operator_dunder, is_protocol_class,
 };
-use super::integer_literals::canonical_large_int_literal_text;
 use super::protocol_diagnostics;
+use super::simple_expr::lower_expr_simple;
 use super::statements::lower_stmts;
 use super::typing_and_functions::resolve_annotation_expr;
 use super::{parse_typevar_bound_expr, LowerCtx};
@@ -1239,153 +1239,5 @@ pub(super) fn collect_literal_coverage(
             }
             _ => {}
         }
-    }
-}
-
-/// Lower a simple expression (literal values only) without requiring a full `LowerCtx`.
-/// Used for collecting default parameter values in the first pass.
-pub(super) fn lower_expr_simple(expr: &Expr) -> Option<HirExpr> {
-    match expr {
-        Expr::NumberLiteral(num) => match &num.value {
-            Number::Int(i) => {
-                if let Some(value) = i.as_i64() {
-                    Some(HirExpr::IntLiteral(value))
-                } else {
-                    Some(HirExpr::LargeIntLiteral(canonical_large_int_literal_text(
-                        i,
-                    )))
-                }
-            }
-            Number::Float(f) => Some(HirExpr::FloatLiteral(*f)),
-            Number::Complex { .. } => None,
-        },
-        Expr::StringLiteral(s) => Some(HirExpr::StringLiteral(s.value.to_str().to_string())),
-        Expr::BytesLiteral(bytes) => {
-            let mut elements = Vec::new();
-            for part in &bytes.value {
-                for value in part.as_slice() {
-                    elements.push(HirExpr::IntLiteral(i64::from(*value)));
-                }
-            }
-            Some(HirExpr::ListLiteral {
-                elements,
-                ty: Type::Bytes,
-            })
-        }
-        Expr::BooleanLiteral(b) => Some(HirExpr::BoolLiteral(b.value)),
-        Expr::NoneLiteral(_) => Some(HirExpr::NoneLiteral),
-        Expr::UnaryOp(unary) if matches!(unary.op, UnaryOp::USub) => {
-            // Handle negative literals like -1
-            if let Some(inner) = lower_expr_simple(&unary.operand) {
-                match inner {
-                    HirExpr::IntLiteral(v) => Some(HirExpr::IntLiteral(-v)),
-                    HirExpr::LargeIntLiteral(value) => Some(HirExpr::UnaryOp {
-                        op: "-".to_string(),
-                        operand: Box::new(HirExpr::LargeIntLiteral(value)),
-                        ty: Type::Int,
-                    }),
-                    HirExpr::FloatLiteral(v) => Some(HirExpr::FloatLiteral(-v)),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        }
-        Expr::List(list) => {
-            let mut elements = Vec::new();
-            let mut elem_ty: Option<Type> = None;
-            for elt in &list.elts {
-                let lowered = lower_expr_simple(elt)?;
-                let lowered_ty = lowered.ty().clone();
-                if let Some(ref expected) = elem_ty {
-                    if !lowered_ty.is_assignable_to(expected) {
-                        return None;
-                    }
-                } else {
-                    elem_ty = Some(lowered_ty);
-                }
-                elements.push(lowered);
-            }
-            Some(HirExpr::ListLiteral {
-                elements,
-                ty: Type::List(Box::new(elem_ty.unwrap_or(Type::Any))),
-            })
-        }
-        Expr::Set(set) => {
-            let mut elements = Vec::new();
-            let mut elem_ty: Option<Type> = None;
-            for elt in &set.elts {
-                let lowered = lower_expr_simple(elt)?;
-                let lowered_ty = lowered.ty().clone();
-                if let Some(ref expected) = elem_ty {
-                    if !lowered_ty.is_assignable_to(expected) {
-                        return None;
-                    }
-                } else {
-                    elem_ty = Some(lowered_ty);
-                }
-                elements.push(lowered);
-            }
-            Some(HirExpr::SetLiteral {
-                elements,
-                ty: Type::Set(Box::new(elem_ty.unwrap_or(Type::Any))),
-            })
-        }
-        Expr::Dict(dict) => {
-            let mut keys = Vec::new();
-            let mut values = Vec::new();
-            let mut key_ty: Option<Type> = None;
-            let mut val_ty: Option<Type> = None;
-
-            for item in &dict.items {
-                let key_expr = item.key.as_ref()?;
-                let lowered_key = lower_expr_simple(key_expr)?;
-                let lowered_val = lower_expr_simple(&item.value)?;
-                let lowered_key_ty = lowered_key.ty().clone();
-                let lowered_val_ty = lowered_val.ty().clone();
-
-                if let Some(ref expected) = key_ty {
-                    if !lowered_key_ty.is_assignable_to(expected) {
-                        return None;
-                    }
-                } else {
-                    key_ty = Some(lowered_key_ty);
-                }
-
-                if let Some(ref expected) = val_ty {
-                    if !lowered_val_ty.is_assignable_to(expected) {
-                        return None;
-                    }
-                } else {
-                    val_ty = Some(lowered_val_ty);
-                }
-
-                keys.push(lowered_key);
-                values.push(lowered_val);
-            }
-
-            Some(HirExpr::DictLiteral {
-                keys,
-                values,
-                ty: Type::Dict(
-                    Box::new(key_ty.unwrap_or(Type::Any)),
-                    Box::new(val_ty.unwrap_or(Type::Any)),
-                ),
-            })
-        }
-        Expr::Tuple(tuple) => {
-            let mut elements = Vec::new();
-            let mut element_types = Vec::new();
-            for elt in &tuple.elts {
-                let lowered = lower_expr_simple(elt)?;
-                element_types.push(lowered.ty().clone());
-                elements.push(lowered);
-            }
-            Some(HirExpr::TupleLiteral {
-                elements,
-                ty: Type::Tuple(element_types),
-            })
-        }
-        _ => None,
     }
 }

--- a/crates/sifr_hir/src/lower/default_args.rs
+++ b/crates/sifr_hir/src/lower/default_args.rs
@@ -1,4 +1,4 @@
-use super::{classes::lower_expr_simple, LowerCtx};
+use super::{simple_expr::lower_expr_simple, LowerCtx};
 use crate::hir_nodes::HirExpr;
 use ruff_text_size::Ranged;
 use sifr_diagnostics::DiagnosticCode;

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    classes::lower_expr_simple,
     expressions::{lower_named_expr, resolve_method_type},
+    simple_expr::lower_expr_simple,
     LowerCtx,
 };
 use crate::{lower_module, HirDiagnostic, HirExpr, HirModule, HirStmt};
@@ -226,9 +226,7 @@ fn test_fixed_width_literal_assignment_fits() {
         panic!("expected second statement to be int8 let");
     };
     assert_eq!(ty, &Type::FixedInt(FixedIntType::I8));
-    assert!(
-        matches!(value, HirExpr::UnaryOp { op, operand, .. } if op == "-" && matches!(operand.as_ref(), HirExpr::IntLiteral(128)))
-    );
+    assert!(matches!(value, HirExpr::IntLiteral(-128)));
 
     let HirStmt::Let { ty, value, .. } = &main_fn.body[2] else {
         panic!("expected third statement to be uint64 let");
@@ -280,6 +278,152 @@ fn test_fixed_width_module_constant_out_of_range_has_int_code() {
 }
 
 #[test]
+fn test_fixed_width_const_expression_assignment_fits_and_folds() {
+    let module = lower_source(
+        "def main() -> uint8:\n    value: uint8 = (1 + 2) * 40 + (20 >> 1)\n    shifted: uint8 = (1 << 6) + (9 // 2) + (9 % 2)\n    signed: int8 = -10 * 5\n    negated: int16 = -(100 + 27)\n    return value\n",
+    )
+    .expect("fitting fixed-width const expression assignment should lower");
+
+    let main_fn = &module.functions[0];
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[0] else {
+        panic!("expected uint8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::U8));
+    assert!(matches!(value, HirExpr::IntLiteral(130)));
+
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[1] else {
+        panic!("expected shifted uint8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::U8));
+    assert!(matches!(value, HirExpr::IntLiteral(69)));
+
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[2] else {
+        panic!("expected signed int8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::I8));
+    assert!(matches!(value, HirExpr::IntLiteral(-50)));
+
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[3] else {
+        panic!("expected negated int16 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::I16));
+    assert!(matches!(value, HirExpr::IntLiteral(-127)));
+}
+
+#[test]
+fn test_fixed_width_const_expression_uses_module_integer_constants() {
+    let module = lower_source(
+        "BASE: int = 250 + 4\n\ndef main() -> uint8:\n    value: uint8 = BASE + 1\n    return value\n",
+    )
+    .expect("module integer constants should participate in const fitting");
+
+    let main_fn = &module.functions[0];
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[0] else {
+        panic!("expected uint8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::U8));
+    assert!(matches!(value, HirExpr::IntLiteral(255)));
+}
+
+#[test]
+fn test_fixed_width_const_expression_does_not_fold_shadowed_module_constant() {
+    let source = "\
+BASE: int = 254
+
+def main():
+    BASE: int = 100
+    value: uint8 = BASE + 1
+";
+    let errors = lower_source(source)
+        .expect_err("shadowed module constant should not participate in const fitting");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.message == "type mismatch: expected 'uint8', got 'int'"
+            && error.primary_range
+                == Some(range_for_after_anchor(
+                    source,
+                    "value: uint8 = ",
+                    "BASE + 1",
+                ))
+    }));
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)),
+        "shadowed module constants should not be folded into range diagnostics: {errors:?}"
+    );
+}
+
+#[test]
+fn test_fixed_width_const_expression_out_of_range_has_int_code() {
+    let source = "def main():\n    too_wide: uint8 = 2 ** 8\n";
+    let errors =
+        lower_source(source).expect_err("out-of-range fixed-width const expression should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)
+            && error.message
+                == "integer value 256 does not fit target type uint8; valid range is 0..=255"
+            && error.primary_range == Some(range_for(source, "2 ** 8"))
+    }));
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::TYPE_MISMATCH)),
+        "range diagnostics should not be followed by generic type mismatches: {errors:?}"
+    );
+}
+
+#[test]
+fn test_fixed_width_const_expression_budget_has_int_code() {
+    let source = "def main():\n    too_large: uint8 = 10 ** 5000\n";
+    let errors =
+        lower_source(source).expect_err("over-budget fixed-width const expression should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_EVAL_BUDGET_EXCEEDED)
+            && error.message
+                == "integer literal exceeds compile-time evaluation budget: 5001 decimal digits (max 4096)"
+            && error.primary_range == Some(range_for(source, "10 ** 5000"))
+    }));
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)),
+        "over-budget const expressions should not also emit range diagnostics: {errors:?}"
+    );
+}
+
+#[test]
+fn test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated() {
+    let literal = "1".repeat(4097);
+    let source = format!("def main():\n    too_large: uint8 = {literal}\n");
+    let errors =
+        lower_source(&source).expect_err("over-budget fixed-width literal should fail once");
+
+    let budget_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| error.code == Some(DiagnosticCode::INT_EVAL_BUDGET_EXCEEDED))
+        .collect();
+    assert_eq!(
+        budget_errors.len(),
+        1,
+        "over-budget literal should not duplicate diagnostics: {errors:?}"
+    );
+    assert_eq!(
+        budget_errors[0].primary_range,
+        Some(range_for(&source, &literal))
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::TYPE_MISMATCH)),
+        "already-diagnosed over-budget literals should not emit generic mismatches: {errors:?}"
+    );
+}
+
+#[test]
 fn test_fixed_width_assignment_from_non_const_int_is_still_mismatch() {
     let source = "def main():\n    source: int = 1\n    target: uint8 = source\n";
     let errors = lower_source(source).expect_err("non-const int narrowing should fail");
@@ -289,6 +433,23 @@ fn test_fixed_width_assignment_from_non_const_int_is_still_mismatch() {
             && error.message == "type mismatch: expected 'uint8', got 'int'"
             && error.primary_range
                 == Some(range_for_after_anchor(source, "target: uint8 = ", "source"))
+    }));
+}
+
+#[test]
+fn test_fixed_width_assignment_from_non_const_binop_is_still_mismatch() {
+    let source = "def main():\n    source: int = 1\n    target: uint8 = source + 1\n";
+    let errors = lower_source(source).expect_err("non-const int binop narrowing should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.message == "type mismatch: expected 'uint8', got 'int'"
+            && error.primary_range
+                == Some(range_for_after_anchor(
+                    source,
+                    "target: uint8 = ",
+                    "source + 1",
+                ))
     }));
 }
 

--- a/crates/sifr_hir/src/lower/fixed_width_fitting.rs
+++ b/crates/sifr_hir/src/lower/fixed_width_fitting.rs
@@ -5,19 +5,31 @@ use ruff_text_size::TextRange;
 use sifr_diagnostics::DiagnosticCode;
 use sifr_type_system::{FixedIntType, Type};
 
+const MAX_EXACT_SHIFT_OR_EXPONENT: u32 = 13_610;
+
+pub(super) enum FixedWidthInitializerFit {
+    NotConst,
+    Fits(HirExpr),
+    Rejected,
+}
+
 pub(super) fn validate_fixed_width_initializer(
     ctx: &mut LowerCtx,
     target: &Type,
     value: &HirExpr,
     range: TextRange,
-) -> Option<bool> {
+) -> FixedWidthInitializerFit {
     let Type::FixedInt(fixed) = target.resolve_alias() else {
-        return None;
+        return FixedWidthInitializerFit::NotConst;
     };
-    let value = const_integer_value(value)?;
+    let value = match const_integer_value(ctx, value, range) {
+        ConstIntegerValue::Value(value) => value,
+        ConstIntegerValue::Unsupported => return FixedWidthInitializerFit::NotConst,
+        ConstIntegerValue::Rejected => return FixedWidthInitializerFit::Rejected,
+    };
     let (min, max) = fixed_range(*fixed);
     if value >= min && value <= max {
-        return Some(true);
+        return FixedWidthInitializerFit::Fits(bigint_to_hir_integer_literal(&value));
     }
 
     ctx.error_with_code_at(
@@ -31,7 +43,7 @@ pub(super) fn validate_fixed_width_initializer(
         ),
         range,
     );
-    Some(false)
+    FixedWidthInitializerFit::Rejected
 }
 
 pub(super) fn validate_annotated_constant_initializer(
@@ -39,10 +51,12 @@ pub(super) fn validate_annotated_constant_initializer(
     declared_type: &Type,
     value: &HirExpr,
     range: TextRange,
-) {
+) -> Option<HirExpr> {
     let fixed_width_fit = validate_fixed_width_initializer(ctx, declared_type, value, range);
-    if fixed_width_fit.is_some() {
-        return;
+    match fixed_width_fit {
+        FixedWidthInitializerFit::Fits(value) => return Some(value),
+        FixedWidthInitializerFit::Rejected => return None,
+        FixedWidthInitializerFit::NotConst => {}
     }
 
     let value_ty = value.ty();
@@ -58,17 +72,225 @@ pub(super) fn validate_annotated_constant_initializer(
             range,
         );
     }
+    None
 }
 
-fn const_integer_value(value: &HirExpr) -> Option<BigInt> {
-    match value {
-        HirExpr::IntLiteral(value) => Some(BigInt::from(*value)),
-        HirExpr::LargeIntLiteral(value) => value.parse().ok(),
-        HirExpr::UnaryOp { op, operand, .. } if op == "+" => const_integer_value(operand),
-        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
-            const_integer_value(operand).map(|value| -value)
+pub(super) fn remember_module_const_integer(
+    ctx: &mut LowerCtx,
+    name: &str,
+    value: &HirExpr,
+    range: TextRange,
+) {
+    if let ConstIntegerValue::Value(value) = const_integer_value(ctx, value, range) {
+        ctx.const_integer_values.insert(name.to_string(), value);
+    }
+}
+
+enum ConstIntegerValue {
+    Value(BigInt),
+    Unsupported,
+    Rejected,
+}
+
+fn const_integer_value(ctx: &mut LowerCtx, value: &HirExpr, range: TextRange) -> ConstIntegerValue {
+    let evaluated = match value {
+        HirExpr::IntLiteral(value) => BigInt::from(*value),
+        HirExpr::LargeIntLiteral(value) => {
+            if value.trim_start_matches('-').len()
+                > super::integer_literal_diagnostics::INTEGER_EVAL_DECIMAL_DIGIT_BUDGET
+            {
+                return ConstIntegerValue::Rejected;
+            }
+            match value.parse() {
+                Ok(value) => value,
+                Err(_) => return ConstIntegerValue::Unsupported,
+            }
         }
-        _ => None,
+        HirExpr::Name { name, .. } => {
+            if is_shadowed_by_inner_scope(ctx, name) {
+                return ConstIntegerValue::Unsupported;
+            }
+            return ctx
+                .const_integer_values
+                .get(name)
+                .cloned()
+                .map_or(ConstIntegerValue::Unsupported, ConstIntegerValue::Value);
+        }
+        HirExpr::UnaryOp { op, operand, .. } if op == "+" => {
+            return const_integer_value(ctx, operand, range);
+        }
+        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
+            match const_integer_value(ctx, operand, range) {
+                ConstIntegerValue::Value(value) => -value,
+                other => return other,
+            }
+        }
+        HirExpr::BinOp {
+            left, op, right, ..
+        } => {
+            let left = match const_integer_value(ctx, left, range) {
+                ConstIntegerValue::Value(value) => value,
+                other => return other,
+            };
+            let right = match const_integer_value(ctx, right, range) {
+                ConstIntegerValue::Value(value) => value,
+                other => return other,
+            };
+            match evaluate_integer_binop(ctx, &left, op, &right, range) {
+                ConstIntegerValue::Value(value) => value,
+                other => return other,
+            }
+        }
+        _ => return ConstIntegerValue::Unsupported,
+    };
+    reject_if_over_budget(ctx, evaluated, range)
+}
+
+fn evaluate_integer_binop(
+    ctx: &mut LowerCtx,
+    left: &BigInt,
+    op: &str,
+    right: &BigInt,
+    range: TextRange,
+) -> ConstIntegerValue {
+    let zero = BigInt::from(0);
+    match op {
+        "+" => ConstIntegerValue::Value(left + right),
+        "-" => ConstIntegerValue::Value(left - right),
+        "*" => ConstIntegerValue::Value(left * right),
+        "//" => {
+            if right == &zero {
+                return ConstIntegerValue::Unsupported;
+            }
+            ConstIntegerValue::Value(python_floor_div(left, right))
+        }
+        "%" => {
+            if right == &zero {
+                return ConstIntegerValue::Unsupported;
+            }
+            ConstIntegerValue::Value(python_mod(left, right))
+        }
+        "<<" => evaluate_left_shift(ctx, left, right, range),
+        ">>" => evaluate_right_shift(left, right),
+        "**" => evaluate_pow(ctx, left, right, range),
+        _ => ConstIntegerValue::Unsupported,
+    }
+}
+
+fn python_floor_div(left: &BigInt, right: &BigInt) -> BigInt {
+    let zero = BigInt::from(0);
+    let quotient = left / right;
+    let remainder = left % right;
+    if remainder != zero && ((left < &zero) != (right < &zero)) {
+        quotient - 1
+    } else {
+        quotient
+    }
+}
+
+fn python_mod(left: &BigInt, right: &BigInt) -> BigInt {
+    left - (python_floor_div(left, right) * right)
+}
+
+fn evaluate_left_shift(
+    ctx: &mut LowerCtx,
+    left: &BigInt,
+    right: &BigInt,
+    range: TextRange,
+) -> ConstIntegerValue {
+    let Some(shift) = non_negative_u32(right) else {
+        return ConstIntegerValue::Unsupported;
+    };
+    if shift > MAX_EXACT_SHIFT_OR_EXPONENT && left != &BigInt::from(0) {
+        emit_budget_exceeded(ctx, approximate_left_shift_digits(left, shift), range);
+        return ConstIntegerValue::Rejected;
+    }
+    ConstIntegerValue::Value(left << shift as usize)
+}
+
+fn evaluate_right_shift(left: &BigInt, right: &BigInt) -> ConstIntegerValue {
+    let Some(shift) = non_negative_u32(right) else {
+        return ConstIntegerValue::Unsupported;
+    };
+    ConstIntegerValue::Value(left >> shift as usize)
+}
+
+fn evaluate_pow(
+    ctx: &mut LowerCtx,
+    left: &BigInt,
+    right: &BigInt,
+    range: TextRange,
+) -> ConstIntegerValue {
+    let Some(exponent) = non_negative_u32(right) else {
+        return ConstIntegerValue::Unsupported;
+    };
+    let abs_left = if left < &BigInt::from(0) {
+        -left
+    } else {
+        left.clone()
+    };
+    if exponent > MAX_EXACT_SHIFT_OR_EXPONENT && abs_left > BigInt::from(1) {
+        emit_budget_exceeded(ctx, approximate_pow_digits(&abs_left, exponent), range);
+        return ConstIntegerValue::Rejected;
+    }
+    ConstIntegerValue::Value(left.pow(exponent))
+}
+
+fn is_shadowed_by_inner_scope(ctx: &LowerCtx, name: &str) -> bool {
+    let frame_count = ctx.scope.frame_count();
+    frame_count > 1
+        && ctx
+            .scope
+            .lookup_in_frame_range(name, 1, frame_count - 1)
+            .is_some()
+}
+
+fn non_negative_u32(value: &BigInt) -> Option<u32> {
+    if value < &BigInt::from(0) {
+        return None;
+    }
+    u32::try_from(value.clone()).ok()
+}
+
+fn reject_if_over_budget(ctx: &mut LowerCtx, value: BigInt, range: TextRange) -> ConstIntegerValue {
+    let digits = decimal_digit_count(&value);
+    if digits > super::integer_literal_diagnostics::INTEGER_EVAL_DECIMAL_DIGIT_BUDGET {
+        emit_budget_exceeded(ctx, digits, range);
+        return ConstIntegerValue::Rejected;
+    }
+    ConstIntegerValue::Value(value)
+}
+
+fn emit_budget_exceeded(ctx: &mut LowerCtx, digits: usize, range: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::INT_EVAL_BUDGET_EXCEEDED,
+        format!(
+            "integer literal exceeds compile-time evaluation budget: {digits} decimal digits (max {})",
+            super::integer_literal_diagnostics::INTEGER_EVAL_DECIMAL_DIGIT_BUDGET
+        ),
+        range,
+    );
+}
+
+fn decimal_digit_count(value: &BigInt) -> usize {
+    value.to_str_radix(10).trim_start_matches('-').len()
+}
+
+fn approximate_left_shift_digits(left: &BigInt, shift: u32) -> usize {
+    let bit_digits = u64::from(shift).saturating_mul(30_103) / 100_000 + 1;
+    let bit_digits = usize::try_from(bit_digits).unwrap_or(usize::MAX);
+    decimal_digit_count(left).saturating_add(bit_digits)
+}
+
+fn approximate_pow_digits(abs_left: &BigInt, exponent: u32) -> usize {
+    decimal_digit_count(abs_left).saturating_mul(usize::try_from(exponent).unwrap_or(usize::MAX))
+}
+
+fn bigint_to_hir_integer_literal(value: &BigInt) -> HirExpr {
+    if let Ok(value) = i64::try_from(value.clone()) {
+        HirExpr::IntLiteral(value)
+    } else {
+        HirExpr::LargeIntLiteral(value.to_str_radix(10))
     }
 }
 

--- a/crates/sifr_hir/src/lower/integer_literal_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/integer_literal_diagnostics.rs
@@ -6,7 +6,7 @@ use sifr_python_ast::{Expr, Number, Stmt};
 use super::integer_literals::canonical_large_int_literal_text;
 use super::LowerCtx;
 
-const INTEGER_EVAL_DECIMAL_DIGIT_BUDGET: usize = 4096;
+pub(super) const INTEGER_EVAL_DECIMAL_DIGIT_BUDGET: usize = 4096;
 
 pub(super) fn validate_module_integer_literals(stmts: &[Stmt], ctx: &mut LowerCtx) {
     let mut visitor = IntegerLiteralBudgetVisitor { ctx };

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -55,6 +55,7 @@ mod match_diagnostics;
 mod match_lowering;
 mod method_call_args;
 mod min_max_validation;
+mod module_constants_lowering;
 mod module_function_registry;
 mod mutating_methods;
 mod name_diagnostics;
@@ -81,6 +82,7 @@ mod sequence_guard_updates;
 mod sequence_guards;
 mod sequence_pointers;
 mod sequence_shapes;
+mod simple_expr;
 mod statement_diagnostics;
 #[cfg(test)]
 mod statement_diagnostics_tests;
@@ -94,7 +96,7 @@ mod type_bounds;
 mod type_var_collection;
 mod typevar_annotations;
 mod typing_and_functions;
-use classes::{collect_class_type, lower_class, lower_expr_simple};
+use classes::{collect_class_type, lower_class};
 use default_args::collect_function_defaults;
 use generic_inference::infer_type_var_bindings;
 use imports::resolve_imports_early;
@@ -109,9 +111,7 @@ pub(super) use typevar_annotations::{
     decode_typevar_constraint, encode_typevar_constraint, parse_typevar_bound_expr,
     parse_typevar_declaration_specs,
 };
-use typing_and_functions::{
-    extract_function_type, lower_function, register_builtins, resolve_annotation_expr,
-};
+use typing_and_functions::{extract_function_type, lower_function, register_builtins};
 /// Structured diagnostics produced during HIR lowering.
 #[derive(Debug, Clone)]
 pub struct HirDiagnostic {
@@ -198,6 +198,7 @@ pub(super) struct LowerCtx {
     inferred_binding_hints: Vec<HashMap<String, Type>>,
     empty_collection_hint_adoption: Vec<bool>,
     empty_dict_specializations: HashMap<String, Type>,
+    const_integer_values: HashMap<String, num_bigint::BigInt>,
 }
 impl LowerCtx {
     fn new() -> Self {
@@ -240,6 +241,7 @@ impl LowerCtx {
             inferred_binding_hints: Vec::new(),
             empty_collection_hint_adoption: Vec::new(),
             empty_dict_specializations: HashMap::new(),
+            const_integer_values: HashMap::new(),
         }
     }
     fn warn_arithmetic_overflow_risk(&mut self, operation: &'static str, range: TextRange) {
@@ -1104,45 +1106,7 @@ fn lower_module_impl(
         }
     }
 
-    // Collect module-level constants (annotated assignments at top level)
-    let mut constants = Vec::new();
-    for stmt in stmts {
-        if let Stmt::AnnAssign(ann) = stmt {
-            if let Expr::Name(name) = ann.target.as_ref() {
-                let var_name = name.id.to_string();
-                let ty = resolve_annotation_expr(&ann.annotation, &mut ctx);
-                if let Some(ref value_expr) = ann.value {
-                    if let Some(hir_value) = lower_expr_simple(value_expr) {
-                        fixed_width_fitting::validate_annotated_constant_initializer(
-                            &mut ctx,
-                            &ty,
-                            &hir_value,
-                            value_expr.range(),
-                        );
-                        ctx.scope.define(var_name.clone(), ty.clone());
-                        constants.push((var_name, ty, hir_value));
-                    }
-                }
-            }
-        }
-        // Also handle bare assignments: PI = 3.14 (without annotation)
-        if let Stmt::Assign(assign) = stmt {
-            if assign.targets.len() == 1 {
-                if let Expr::Name(name) = &assign.targets[0] {
-                    let var_name = name.id.to_string();
-                    // Skip TypeVar declarations (already handled)
-                    if ctx.type_vars.contains(&var_name) {
-                        continue;
-                    }
-                    if let Some(hir_value) = lower_expr_simple(&assign.value) {
-                        let ty = hir_value.ty().clone();
-                        ctx.scope.define(var_name.clone(), ty.clone());
-                        constants.push((var_name, ty, hir_value));
-                    }
-                }
-            }
-        }
-    }
+    let constants = module_constants_lowering::collect_module_constants(stmts, &mut ctx);
 
     // Second pass: lower function bodies and class method bodies
     let mut functions = Vec::new();

--- a/crates/sifr_hir/src/lower/module_constants_lowering.rs
+++ b/crates/sifr_hir/src/lower/module_constants_lowering.rs
@@ -1,0 +1,94 @@
+use crate::HirExpr;
+use ruff_text_size::Ranged;
+use sifr_python_ast::{Expr, Stmt};
+use sifr_type_system::Type;
+
+use super::simple_expr::lower_integer_const_expr_simple;
+use super::typing_and_functions::resolve_annotation_expr;
+use super::{fixed_width_fitting, LowerCtx};
+
+pub(super) fn collect_module_constants(
+    stmts: &[Stmt],
+    ctx: &mut LowerCtx,
+) -> Vec<(String, Type, HirExpr)> {
+    let mut constants = Vec::new();
+    for stmt in stmts {
+        collect_annotated_constant(stmt, ctx, &mut constants);
+        collect_bare_constant(stmt, ctx, &mut constants);
+    }
+    constants
+}
+
+fn collect_annotated_constant(
+    stmt: &Stmt,
+    ctx: &mut LowerCtx,
+    constants: &mut Vec<(String, Type, HirExpr)>,
+) {
+    let Stmt::AnnAssign(ann) = stmt else {
+        return;
+    };
+    let Expr::Name(name) = ann.target.as_ref() else {
+        return;
+    };
+    let Some(ref value_expr) = ann.value else {
+        return;
+    };
+    let Some(mut hir_value) = lower_integer_const_expr_simple(value_expr) else {
+        return;
+    };
+
+    let var_name = name.id.to_string();
+    let ty = resolve_annotation_expr(&ann.annotation, ctx);
+    let error_count_before_initializer = ctx.error_count();
+    if let Some(folded_value) = fixed_width_fitting::validate_annotated_constant_initializer(
+        ctx,
+        &ty,
+        &hir_value,
+        value_expr.range(),
+    ) {
+        hir_value = folded_value;
+    }
+    if ctx.error_count() == error_count_before_initializer {
+        fixed_width_fitting::remember_module_const_integer(
+            ctx,
+            &var_name,
+            &hir_value,
+            value_expr.range(),
+        );
+    }
+    ctx.scope.define(var_name.clone(), ty.clone());
+    constants.push((var_name, ty, hir_value));
+}
+
+fn collect_bare_constant(
+    stmt: &Stmt,
+    ctx: &mut LowerCtx,
+    constants: &mut Vec<(String, Type, HirExpr)>,
+) {
+    let Stmt::Assign(assign) = stmt else {
+        return;
+    };
+    if assign.targets.len() != 1 {
+        return;
+    }
+    let Expr::Name(name) = &assign.targets[0] else {
+        return;
+    };
+    let var_name = name.id.to_string();
+    if ctx.type_vars.contains(&var_name) {
+        return;
+    }
+    let Some(hir_value) = lower_integer_const_expr_simple(&assign.value) else {
+        return;
+    };
+
+    let ty = hir_value.ty().clone();
+    fixed_width_fitting::remember_module_const_integer(
+        ctx,
+        &var_name,
+        &hir_value,
+        assign.value.range(),
+    );
+    ctx.scope.define(var_name.clone(), ty.clone());
+    constants.push((var_name, ty, hir_value));
+}

--- a/crates/sifr_hir/src/lower/simple_expr.rs
+++ b/crates/sifr_hir/src/lower/simple_expr.rs
@@ -1,0 +1,194 @@
+use crate::hir_nodes::HirExpr;
+use sifr_python_ast::{Expr, Number, Operator, UnaryOp};
+use sifr_type_system::Type;
+
+use super::integer_literals::canonical_large_int_literal_text;
+
+/// Lower a simple expression without requiring a full `LowerCtx`.
+/// Used for collecting default parameter values in the first pass.
+pub(super) fn lower_expr_simple(expr: &Expr) -> Option<HirExpr> {
+    lower_expr_simple_inner(expr, false)
+}
+
+pub(super) fn lower_integer_const_expr_simple(expr: &Expr) -> Option<HirExpr> {
+    lower_expr_simple_inner(expr, true)
+}
+
+fn lower_expr_simple_inner(expr: &Expr, allow_integer_binop: bool) -> Option<HirExpr> {
+    match expr {
+        Expr::NumberLiteral(num) => match &num.value {
+            Number::Int(i) => {
+                if let Some(value) = i.as_i64() {
+                    Some(HirExpr::IntLiteral(value))
+                } else {
+                    Some(HirExpr::LargeIntLiteral(canonical_large_int_literal_text(
+                        i,
+                    )))
+                }
+            }
+            Number::Float(f) => Some(HirExpr::FloatLiteral(*f)),
+            Number::Complex { .. } => None,
+        },
+        Expr::StringLiteral(s) => Some(HirExpr::StringLiteral(s.value.to_str().to_string())),
+        Expr::BytesLiteral(bytes) => {
+            let mut elements = Vec::new();
+            for part in &bytes.value {
+                for value in part.as_slice() {
+                    elements.push(HirExpr::IntLiteral(i64::from(*value)));
+                }
+            }
+            Some(HirExpr::ListLiteral {
+                elements,
+                ty: Type::Bytes,
+            })
+        }
+        Expr::BooleanLiteral(b) => Some(HirExpr::BoolLiteral(b.value)),
+        Expr::NoneLiteral(_) => Some(HirExpr::NoneLiteral),
+        Expr::UnaryOp(unary) if matches!(unary.op, UnaryOp::UAdd) => {
+            lower_expr_simple_inner(&unary.operand, allow_integer_binop)
+        }
+        Expr::UnaryOp(unary) if matches!(unary.op, UnaryOp::USub) => {
+            lower_expr_simple_inner(&unary.operand, allow_integer_binop)
+                .and_then(negate_simple_expr)
+        }
+        Expr::BinOp(binop) => {
+            if !allow_integer_binop {
+                return None;
+            }
+            let left = lower_expr_simple_inner(&binop.left, true)?;
+            let right = lower_expr_simple_inner(&binop.right, true)?;
+            if !matches!(left.ty(), Type::Int) || !matches!(right.ty(), Type::Int) {
+                return None;
+            }
+            Some(HirExpr::BinOp {
+                left: Box::new(left),
+                op: integer_binop_source(binop.op)?.to_string(),
+                right: Box::new(right),
+                ty: Type::Int,
+            })
+        }
+        Expr::List(list) => {
+            let mut elements = Vec::new();
+            let mut elem_ty: Option<Type> = None;
+            for elt in &list.elts {
+                let lowered = lower_expr_simple_inner(elt, allow_integer_binop)?;
+                let lowered_ty = lowered.ty().clone();
+                if let Some(ref expected) = elem_ty {
+                    if !lowered_ty.is_assignable_to(expected) {
+                        return None;
+                    }
+                } else {
+                    elem_ty = Some(lowered_ty);
+                }
+                elements.push(lowered);
+            }
+            Some(HirExpr::ListLiteral {
+                elements,
+                ty: Type::List(Box::new(elem_ty.unwrap_or(Type::Any))),
+            })
+        }
+        Expr::Set(set) => {
+            let mut elements = Vec::new();
+            let mut elem_ty: Option<Type> = None;
+            for elt in &set.elts {
+                let lowered = lower_expr_simple_inner(elt, allow_integer_binop)?;
+                let lowered_ty = lowered.ty().clone();
+                if let Some(ref expected) = elem_ty {
+                    if !lowered_ty.is_assignable_to(expected) {
+                        return None;
+                    }
+                } else {
+                    elem_ty = Some(lowered_ty);
+                }
+                elements.push(lowered);
+            }
+            Some(HirExpr::SetLiteral {
+                elements,
+                ty: Type::Set(Box::new(elem_ty.unwrap_or(Type::Any))),
+            })
+        }
+        Expr::Dict(dict) => {
+            let mut keys = Vec::new();
+            let mut values = Vec::new();
+            let mut key_ty: Option<Type> = None;
+            let mut val_ty: Option<Type> = None;
+
+            for item in &dict.items {
+                let key_expr = item.key.as_ref()?;
+                let lowered_key = lower_expr_simple_inner(key_expr, allow_integer_binop)?;
+                let lowered_val = lower_expr_simple_inner(&item.value, allow_integer_binop)?;
+                let lowered_key_ty = lowered_key.ty().clone();
+                let lowered_val_ty = lowered_val.ty().clone();
+
+                if let Some(ref expected) = key_ty {
+                    if !lowered_key_ty.is_assignable_to(expected) {
+                        return None;
+                    }
+                } else {
+                    key_ty = Some(lowered_key_ty);
+                }
+
+                if let Some(ref expected) = val_ty {
+                    if !lowered_val_ty.is_assignable_to(expected) {
+                        return None;
+                    }
+                } else {
+                    val_ty = Some(lowered_val_ty);
+                }
+
+                keys.push(lowered_key);
+                values.push(lowered_val);
+            }
+
+            Some(HirExpr::DictLiteral {
+                keys,
+                values,
+                ty: Type::Dict(
+                    Box::new(key_ty.unwrap_or(Type::Any)),
+                    Box::new(val_ty.unwrap_or(Type::Any)),
+                ),
+            })
+        }
+        Expr::Tuple(tuple) => {
+            let mut elements = Vec::new();
+            let mut element_types = Vec::new();
+            for elt in &tuple.elts {
+                let lowered = lower_expr_simple_inner(elt, allow_integer_binop)?;
+                element_types.push(lowered.ty().clone());
+                elements.push(lowered);
+            }
+            Some(HirExpr::TupleLiteral {
+                elements,
+                ty: Type::Tuple(element_types),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn negate_simple_expr(expr: HirExpr) -> Option<HirExpr> {
+    match expr {
+        HirExpr::IntLiteral(value) => Some(HirExpr::IntLiteral(-value)),
+        HirExpr::LargeIntLiteral(value) => Some(HirExpr::UnaryOp {
+            op: "-".to_string(),
+            operand: Box::new(HirExpr::LargeIntLiteral(value)),
+            ty: Type::Int,
+        }),
+        HirExpr::FloatLiteral(value) => Some(HirExpr::FloatLiteral(-value)),
+        _ => None,
+    }
+}
+
+fn integer_binop_source(op: Operator) -> Option<&'static str> {
+    match op {
+        Operator::Add => Some("+"),
+        Operator::Sub => Some("-"),
+        Operator::Mult => Some("*"),
+        Operator::FloorDiv => Some("//"),
+        Operator::Mod => Some("%"),
+        Operator::Pow => Some("**"),
+        Operator::LShift => Some("<<"),
+        Operator::RShift => Some(">>"),
+        _ => None,
+    }
+}

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -9,7 +9,7 @@ use super::container_literal_specialization::{
 use super::control_flow_conditions::validate_control_flow_condition;
 use super::diagnostics::{collect_raise_error_types, format_type_name, is_valid_error_type};
 use super::expressions::{lower_expr, lower_star_unpack_assign, lower_tuple_unpack_assign};
-use super::fixed_width_fitting::validate_fixed_width_initializer;
+use super::fixed_width_fitting::{validate_fixed_width_initializer, FixedWidthInitializerFit};
 use super::flow_helpers::{expr_to_literal_value, then_body_always_exits};
 use super::for_loop_safety::{is_collection_backed_iter_source, loop_body_mutates_iter_source};
 use super::function_flow::infer_function_return_type;
@@ -1056,9 +1056,11 @@ pub(super) fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Optio
         let is_int_to_bigint = final_ty == Type::Int && declared_type == Type::BigInt;
         let fixed_width_fit =
             validate_fixed_width_initializer(ctx, &declared_type, &expr, initializer_range);
-        if !is_int_to_bigint
-            && fixed_width_fit.is_none()
-            && !final_ty.is_assignable_to(&declared_type)
+        let fixed_width_not_const = matches!(fixed_width_fit, FixedWidthInitializerFit::NotConst);
+        if let FixedWidthInitializerFit::Fits(folded_expr) = fixed_width_fit {
+            expr = folded_expr;
+        }
+        if !is_int_to_bigint && fixed_width_not_const && !final_ty.is_assignable_to(&declared_type)
         {
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -11,11 +11,11 @@ use sifr_type_system::{
 };
 use std::collections::HashMap;
 
-use super::classes::lower_expr_simple;
 use super::diagnostics::{format_type_name, is_valid_error_type};
 use super::expressions::lower_expr;
 use super::function_flow::{collect_yield_types, infer_function_return_type};
 use super::nonlocal_support::collect_declared_nonlocals;
+use super::simple_expr::lower_expr_simple;
 use super::statements::lower_stmts;
 use super::{substitute_type_vars, LowerCtx};
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -402,6 +402,8 @@ Validation:
 - [x] INT-2B fixed-width type variants and annotation resolution review satisfied: `reviews/integer-model-int-2b-fixed-width-type-variants-review-pass-1.md`.
 - [x] INT-2B fixed-width const literal fitting review satisfied after retry: `reviews/integer-model-int-2b-fixed-width-const-fitting-review-pass-1b.md`.
 - [x] INT-2B `bigint` transition annotation diagnostic review satisfied: `reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md`.
+- [x] INT-2B fixed-width const expression fitting review pass 1c completed with shadowing/diagnostic/test blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md`.
+- [x] INT-2B fixed-width const expression fitting review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -418,7 +420,8 @@ Validation:
   - [x] Fixed-width signed, unsigned, and pointer-sized integer annotations resolve in compiler-owned type layers, nested reserved-width annotation coverage was broadened, review is satisfied, and quick validation is passing: PR #1795.
   - [x] Direct fixed-width const literal fitting accepts fitting annotated assignments/module constants, rejects out-of-range initializers with `SIFR-INT-0001`, preserves non-const/call narrowing rejections, emits suffixed Rust literals, review is satisfied, and quick validation is passing: PR #1796.
   - [x] `bigint` annotations emit warning-only `SIFR-INT-0011` transition diagnostics while preserving the temporary `Type::BigInt` path, review is satisfied, and quick validation is passing: PR #1797.
-  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal, and clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable.
+  - [x] Same-module fixed-width const expression fitting covers integer arithmetic, shifts, non-negative exponentiation, parentheses, immutable module constants, shadowing-safe name lookup, over-budget diagnostics, and no implicit narrowing outside assignment/module-constant surfaces; review is satisfied and quick validation is passing: PR #1798.
+  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, convert inline fixed-width const-expression e2e fail comments to canonical leading `expect-error` annotations if those codes need e2e enforcement, and revisit module-level `int` over-budget remember-path behavior during cross-module const propagation.
 - [ ] INT-3 scalar arithmetic and numeric mixing
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries

--- a/reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md
+++ b/reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md
@@ -1,0 +1,183 @@
+# INT-2B const expression fitting — review pass 1c
+
+Branch: `int-2b-const-expression-fitting`
+Local validation reported by author: `scripts/run_all_tests.sh --profile quick` `report_signature=e1bf653aaa770517` (70.12s).
+
+## Scope fit
+
+In scope and implemented:
+- New const-eval evaluator [`fixed_width_fitting.rs:95`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:95) covers integer/large integer literals, unary `+`/`-`, binary `+`/`-`/`*`/`//`/`%`/`<<`/`>>`/non-negative `**`, parentheses (transparently via the regular HIR shape), and same-module immutable integer constants.
+- `validate_fixed_width_initializer` now returns `FixedWidthInitializerFit` (NotConst / Fits(HirExpr) / Rejected) so the caller can both suppress duplicate `TYPE_MISMATCH` and replace the HIR value with a folded literal ([`fixed_width_fitting.rs:10`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:10), [`statements.rs:1057`](crates/sifr_hir/src/lower/statements.rs:1057)).
+- Folded value is `IntLiteral(i64)` when fitting, `LargeIntLiteral(decimal)` otherwise, so the existing codegen suffix path (`fixed_width_literal_expr_for_target`) round-trips into `255u8`, `-128i8`, `18446744073709551615u64` style emission.
+- New `LowerCtx.const_integer_values: HashMap<String, BigInt>` stores evaluated module constants for later fitting ([`mod.rs:201`](crates/sifr_hir/src/lower/mod.rs:201)). Population happens in [`module_constants_lowering.rs`](crates/sifr_hir/src/lower/module_constants_lowering.rs), guarded by `error_count_before_initializer == error_count()` so rejected/erroring constants are never remembered.
+- Module-constant collection refactored out of `lower_module_impl` into `module_constants_lowering::collect_module_constants`, plus `lower_expr_simple` was relocated from `classes.rs` into a new `simple_expr.rs` (alongside a binop-aware variant `lower_integer_const_expr_simple`). Pure rearrangement with one functional extension (binops in const-context only).
+- Two-tier budget enforcement: an early `MAX_EXACT_SHIFT_OR_EXPONENT = 13_610` short-circuit for `<<` / `**` to avoid pathological allocation, plus a final `reject_if_over_budget` against `INTEGER_EVAL_DECIMAL_DIGIT_BUDGET = 4096` on every evaluated result. `INT_EVAL_BUDGET_EXCEEDED` constant promoted to `pub(super)` for sharing with the parser visitor.
+- Tests: four new HIR unit tests covering positive fold, module-const reference, out-of-range (`SIFR-INT-0001`), and over-budget (`SIFR-INT-0004`); two e2e fixtures (`fixed_width_const_expression_assignment.sifr`, `fixed_width_const_expression_out_of_range.sifr`).
+
+Out of scope and **correctly** untouched:
+- Function call arguments, returns, list/dict elements, generic specialization continue to use plain `is_assignable_to` — no fitting attempted there. The previous `test_fixed_width_call_argument_literal_is_not_implicitly_narrowed` guard is still in place.
+- No cross-module const propagation; imported names never enter `const_integer_values`.
+
+## Correctness review
+
+**Statement-level branching is sound.** `lower_ann_assign` ([`statements.rs:1057-1074`](crates/sifr_hir/src/lower/statements.rs:1057)) now derives `fixed_width_not_const = matches!(_, NotConst)`, replaces `expr` only on `Fits(_)`, and continues to suppress the legacy `TYPE_MISMATCH` whenever fitting fired (whether Fits or Rejected). Behavior parity with the prior `Option<bool>` shape is preserved, with the bonus that `Fits(folded)` actually substitutes the HIR.
+
+**Python-correct `//` and `%`.** `python_floor_div` and `python_mod` ([`fixed_width_fitting.rs:170-183`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:170)) handle the negative-remainder case correctly (matches CPython semantics). Zero-divisor short-circuits to `Unsupported` instead of dividing — no panic.
+
+**Budget two-tier check.** `evaluate_left_shift` / `evaluate_pow` short-circuit on `shift > 13_610` / `exponent > 13_610` and `abs_left > 1`, then the result is digit-counted and rejected if > 4096. Threshold is calibrated to base 2 (`log10(2) * 13_610 ≈ 4096`), so `2 ** 13_610` (≈ 4096 digits) lands at the budget boundary and `2 ** 13_611` early-rejects without computing. For larger bases the conservatism is preserved by the post-evaluation digit check.
+
+**No panics on user-triggered paths.** `BigInt::pow(u32)`, `<<` / `>>` with bounded shifts, parsing via `value.parse()`, and `i64::try_from(BigInt)` all return without panicking. `decimal_digit_count` handles 0 and negatives correctly. No `unwrap` / `expect` / `assert!` in the new evaluator.
+
+**Folded HIR/codegen consistency.** `bigint_to_hir_integer_literal` produces `IntLiteral(i64)` when the value fits and `LargeIntLiteral(decimal)` otherwise. Negative values past `i64::MIN` are unreachable through fitting (no fixed-width target permits them), so `LargeIntLiteral` strings emitted by the fitter remain unsigned-canonical. `fixed_width_literal_expr_for_target` walks `IntLiteral` / `LargeIntLiteral` / unary `+`/`-` and suffixes correctly; the `-128i8` corner case still works.
+
+**Same-module constant remember/use ordering.** `collect_module_constants` runs before function-body lowering, so `BASE: int = 250 + 4` is in `const_integer_values` by the time `value: uint8 = BASE + 1` evaluates. The error_count guard correctly prevents storing a value when `validate_annotated_constant_initializer` produced any diagnostic — out-of-range and over-budget module constants are not remembered.
+
+## Findings
+
+### F1 — Module-constant lookup is scope-blind (correctness, edge case)
+
+[`fixed_width_fitting.rs:102-108`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:102):
+
+```rust
+HirExpr::Name { name, .. } => {
+    return ctx
+        .const_integer_values
+        .get(name)
+        .cloned()
+        .map_or(ConstIntegerValue::Unsupported, ConstIntegerValue::Value);
+}
+```
+
+`HirExpr::Name` carries only a `String`, and the lookup is keyed purely on that string. If a function-body local, parameter, comprehension binding, or `for` loop variable shadows a same-named module constant, the fitter folds the source-level reference using the *module* value rather than the bound value. The local frame in `ctx.scope.frames` correctly resolves the Name to the local at the regular-lowerer stage, but the const-eval pass ignores that and substitutes the stale module value.
+
+Concrete reproducer (not currently in the test suite):
+
+```python
+BASE: int = 254
+
+def main() -> uint8:
+    BASE: int = 100        # shadow
+    return BASE + 1        # in a uint8-annotated let, this would silently fold to 255
+```
+
+`value: uint8 = BASE + 1` here would emit `IntLiteral(255)` instead of either rejecting (no const ref to module BASE) or honoring the local 100. This is a silent wrong-answer if the user shadows. Same hazard for parameters (`def main(BASE: int) -> uint8: value: uint8 = BASE + 1`) and `for BASE in [...]`.
+
+The minimal, mechanical fix uses the existing scope API ([`scope.rs:131,237`](crates/sifr_hir/src/scope.rs:131)): in the `Name` arm, before consulting `const_integer_values`, check whether `ctx.scope.lookup_in_frame_range(name, 1, ctx.scope.frame_count() - 1)` returns `Some(_)`; if so, the name is shadowed by an inner frame and the const value must not be folded. Two lines, no new infrastructure.
+
+Severity: real correctness bug, low frequency in practice, no test coverage today. Worth either fixing inline or pinning the current behavior in a test (so the team knows what was decided) before landing.
+
+### F2 — Duplicate `SIFR-INT-0004` for over-budget literal tokens
+
+`integer_literal_diagnostics::validate_module_integer_literals` runs first ([`mod.rs:526`](crates/sifr_hir/src/lower/mod.rs:526)) and emits `SIFR-INT-0004` for any literal token whose canonical decimal length exceeds `INTEGER_EVAL_DECIMAL_DIGIT_BUDGET`. The new `const_integer_value` for `LargeIntLiteral` ([`fixed_width_fitting.rs:98`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:98)) then parses the same string, falls through to `reject_if_over_budget`, and emits a *second* `SIFR-INT-0004` with the same code/message/range. Triggers for any annotated-fixed-width or remember-path module literal where the bare literal already exceeds budget, e.g.:
+
+```python
+LIMIT: uint8 = 100000…(5000-digit literal)…000   # parser-level emits, then fitter re-emits
+LIMIT = 100000…(5000-digit literal)…000          # same on the bare path via remember_module_const_integer
+```
+
+Existing tests don't catch the duplicate (they all use `errors.iter().any(...)`).
+
+Cheap fix: in the `LargeIntLiteral` arm, short-circuit when `value.trim_start_matches('-').len() > INTEGER_EVAL_DECIMAL_DIGIT_BUDGET` and return `Unsupported`. The parser-level diagnostic remains the canonical signal and the fitter doesn't compound it.
+
+Severity: quality, not functional — the user still gets the right error. Worth fixing for noise reduction.
+
+### F3 — Misleading "1 decimal digits" for early shift/pow rejection
+
+[`fixed_width_fitting.rs:194-198, 222-226`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:194):
+
+```rust
+if shift > MAX_EXACT_SHIFT_OR_EXPONENT && left != &BigInt::from(0) {
+    emit_budget_exceeded(ctx, decimal_digit_count(left), range);
+    return ConstIntegerValue::Rejected;
+}
+…
+emit_budget_exceeded(ctx, decimal_digit_count(left), range);
+```
+
+The early-rejection path passes `decimal_digit_count(left)` (the *base*'s digit count, e.g., `1` for `2`, `2` for `16`). For `2 ** 100_000` the user sees:
+
+```
+integer literal exceeds compile-time evaluation budget: 1 decimal digits (max 4096)
+```
+
+…which is misleading — the offending magnitude is the result, not the base. An approximation `((digits(left) as u64) * (exponent as u64)).min(usize::MAX) as usize` (or `((exponent as f64) * (left.bits() as f64) * 0.301).ceil()` for bases > 1) would already be more honest. Alternatively, plumb a separate "would-exceed-budget" diagnostic that doesn't claim a specific digit count.
+
+Existing tests pass because `10 ** 5000` falls through the early threshold (`5000 < 13_610`) and the *result* is digit-counted by `reject_if_over_budget` — that path already reports the correct `5001 decimal digits`.
+
+Severity: message-quality polish.
+
+### F4 — Module-level `int` annotations can newly trigger `SIFR-INT-0004` from the remember path
+
+`remember_module_const_integer` is called for every annotated/bare module integer assignment that survives validation ([`module_constants_lowering.rs:52,86`](crates/sifr_hir/src/lower/module_constants_lowering.rs:52)). For a non-fitting target (`int`) where the initializer evaluates to > 4096 digits, the inner `reject_if_over_budget` still emits `SIFR-INT-0004`, even though the user didn't ask for fitting:
+
+```python
+LIMIT: int = 10 ** 5000   # at module scope, now errors with SIFR-INT-0004
+COUNT       = 10 ** 5000  # same on the bare path
+```
+
+The same expression *inside a function body* with the same `int` annotation does not error today, because `validate_fixed_width_initializer` returns `NotConst` early before evaluating, and there's no remember step. This produces an inconsistent compile contract depending on declaration scope.
+
+Defensible per the design ("any evaluated integer result" — `internal_docs/integer_model.md:101`), but the inconsistency is worth noting in the PR description, and arguably the remember path should silently fail (returning `Unsupported`) rather than emitting from a "we tried to be helpful" code path.
+
+Severity: behavioral surprise, defensible by spec. Worth a note.
+
+### F5 — Module-level Name references and unary-on-non-literal don't lower
+
+[`simple_expr.rs`](crates/sifr_hir/src/lower/simple_expr.rs) has no `Expr::Name` arm, and `negate_simple_expr` only flips `IntLiteral` / `LargeIntLiteral` / `FloatLiteral` (not `BinOp` / `Name`). So the following module-level forms silently fail to lower as constants and are dropped from the module entirely (no `ctx.scope.define`, no `constants.push`):
+
+```python
+LIMIT: int    = 100
+DERIVED: int  = LIMIT + 1     # dropped — Name unsupported in lower_integer_const_expr_simple
+NEGATED: int  = -(2 + 3)      # dropped — negate_simple_expr can't wrap a BinOp
+```
+
+The legacy `lower_expr_simple` had the same gap, so this is a *limitation*, not a regression. The function-body path goes through the regular HIR lowerer, which produces `HirExpr::Name` and `HirExpr::UnaryOp { op: "-", operand: <any>, … }`, both of which `const_integer_value` handles. So `z: uint8 = LIMIT` *inside* `def main()` still folds.
+
+If the team wants module-level chaining (and the design doc's `LIMIT: int = 200; z: uint8 = LIMIT` example does suggest it), `lower_integer_const_expr_simple` would need a `Name` arm that consults `ctx.const_integer_values` (or the prior collected constants), and `negate_simple_expr` would need to wrap arbitrary lowered HIR with `UnaryOp { op: "-", operand, ty: Int }` when the inner expression has type `Int`.
+
+Severity: limitation, no regression, but a discoverability paper-cut (silent drop is worse than a diagnostic). Worth a follow-up note in the INT-2B follow-ups bullet.
+
+### F6 — Test coverage gaps for documented features
+
+The unit and e2e tests exercise `+`, `-`, `*`, `>>`, and `**`. Not exercised by any added test:
+
+- `<<` (left shift) — coded path, no fixture.
+- `//` and `%` — coded paths, no fixture (and `// 0` / `% 0` short-circuit to `Unsupported`, falling through to `TYPE_MISMATCH`, which is worth pinning so a future change to that arm doesn't silently regress).
+- Negative const expressions, e.g., `value: int8 = -10 * 5` (= -50) and `value: int16 = -(100 + 27)`.
+- Non-const-operand binop falling through to `TYPE_MISMATCH`, e.g., `value: uint8 = some_func() + 1` (currently relies on the existing `test_fixed_width_assignment_from_non_const_int_is_still_mismatch` for the bare `Name` case but not for binops with one non-const operand).
+- Module-constant shadowing (see F1).
+- A module-level fitting fixture, e.g., `LIMIT: uint8 = 250 + 4` consumed in `main()`, to round-trip the `lower_item.rs` codegen path through e2e.
+
+The current e2e pass fixture exercises `BASE + 1`, `(1 + 2) * 40 + (20 >> 1)`, and `2 ** 12`; the e2e fail fixture exercises `2 ** 8` and `10 ** 5000`. Coverage is reasonable for the headline acceptance criteria but understates what's actually wired up.
+
+Severity: gaps, not regressions. Each is a one-line fixture or one assertion.
+
+### F7 — Folding bypasses Name-shape ownership tracking
+
+After folding, [`statements.rs:1083-1101`](crates/sifr_hir/src/lower/statements.rs:1083) checks `if let HirExpr::Name { name, ty } = value { … mark_moved … }`. When the source was `value: uint8 = SOME_NAME` and `SOME_NAME` was a `Move`-ownership binding, the fold replaces the `Name` with an `IntLiteral` and the move-tracking branch never runs.
+
+For `Type::Int` specifically, this is currently benign because exact `int` is value-semantic and source-level use shouldn't move the binding (per `internal_docs/integer_model.md` Compiler Architecture Impact §9). But the implication of folding before the move check is worth documenting; if INT-3 changes ownership semantics for any integer-typed binding, this elision could quietly change observable behavior.
+
+Severity: latent, depends on future ownership policy. Note for the follow-ups bullet.
+
+## Tests reviewed
+
+- `test_fixed_width_const_expression_assignment_fits_and_folds` — covers `(1 + 2) * 40 + (20 >> 1) = 130` for uint8 and asserts `IntLiteral(130)` fold.
+- `test_fixed_width_const_expression_uses_module_integer_constants` — `BASE: int = 250 + 4` then `BASE + 1` for uint8, asserts `IntLiteral(255)` fold; pins same-module const propagation in the no-shadowing case.
+- `test_fixed_width_const_expression_out_of_range_has_int_code` — `2 ** 8` against uint8, pins SIFR-INT-0001 message and range, and asserts no shadow `TYPE_MISMATCH`.
+- `test_fixed_width_const_expression_budget_has_int_code` — `10 ** 5000` against uint8, pins SIFR-INT-0004 message (`5001 decimal digits`) and asserts no shadow SIFR-INT-0001.
+- `test_fixed_width_literal_assignment_fits` — updated to assert `IntLiteral(-128)` instead of `UnaryOp("-", IntLiteral(128))` after the fold, locking in the i8-MIN normalization.
+- e2e `fixed_width_const_expression_assignment.sifr` (round-trips the module-const path + binop + pow through the compiler).
+- e2e `fixed_width_const_expression_out_of_range.sifr` (col-pinned SIFR-INT-0001 and SIFR-INT-0004).
+
+Coverage matches headline acceptance criteria from `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md` lines 162-167 modulo the gaps listed in F6.
+
+## Verdict
+
+The implementation is well-structured: the evaluator is small, the budget enforcement is layered correctly, the FixedWidthInitializerFit refactor is clean, and the codegen suffix path is reused without churn. Core acceptance criteria (`x: uint8 = 100 + 27` ok, `x: uint8 = 256` rejects with SIFR-INT-0001, `10 ** 5000` rejects with SIFR-INT-0004, no implicit narrowing in calls/returns/lists) are met for the same-module case.
+
+The most material issue is F1 (scope-blind Name lookup): a real silent-wrong-answer bug under module-constant shadowing, mitigated only by the rarity of that pattern in practice. The fix is two lines using the existing scope frame API. F2 (duplicate diagnostic) and F3 (misleading early-reject digit count) are quality issues; F4 is a defensible behavioral note; F5 is a pre-existing limitation; F6 is a test-coverage gap; F7 is latent.
+
+Recommendation: address F1 (or, at minimum, add a regression test that pins the current scope-blind behavior so the team has explicitly chosen it), tighten the duplicate emission in F2, and add the `<<`/`//`/`%`/negative-const test cases from F6. None of the other findings are blocking.
+
+VERDICT: CHANGES REQUESTED

--- a/reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md
+++ b/reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md
@@ -1,0 +1,183 @@
+# INT-2B const expression fitting — review pass 2
+
+Branch: `int-2b-const-expression-fitting`
+Local validation reported by author: `scripts/run_all_tests.sh --profile quick` `report_signature=e1bf653aaa770517` (102.26s).
+
+## Summary
+
+The four pass-1c findings flagged for action (F1, F2, F3, and the F6 coverage gaps) are addressed correctly. The fixes are minimal, reuse existing infrastructure, and are pinned by new unit tests. F4 (module-level remember-path SIFR-INT-0004 from `int` annotations), F5 (module-level Name/unary-on-non-literal not lowered by `lower_integer_const_expr_simple`), and F7 (folding bypasses Name-shape ownership tracking) are unchanged and remain documented as non-blocking by pass 1c.
+
+## Pass-1c follow-up verification
+
+### F1 — Scope-blind module-constant lookup → fixed
+
+[`fixed_width_fitting.rs:109-118`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:109) now guards the `Name` arm with `is_shadowed_by_inner_scope`:
+
+```rust
+HirExpr::Name { name, .. } => {
+    if is_shadowed_by_inner_scope(ctx, name) {
+        return ConstIntegerValue::Unsupported;
+    }
+    return ctx.const_integer_values.get(name).cloned()
+        .map_or(ConstIntegerValue::Unsupported, ConstIntegerValue::Value);
+}
+```
+
+[`fixed_width_fitting.rs:239-246`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:239) implements the helper exactly as suggested:
+
+```rust
+fn is_shadowed_by_inner_scope(ctx: &LowerCtx, name: &str) -> bool {
+    let frame_count = ctx.scope.frame_count();
+    frame_count > 1
+        && ctx.scope.lookup_in_frame_range(name, 1, frame_count - 1).is_some()
+}
+```
+
+Verified against the scope model:
+- `frames[0]` is the module scope, populated by `module_constants_lowering::collect_*` via `ctx.scope.define`. Skipping frame 0 means a same-named module constant does not register as a shadow of itself.
+- Function bodies push frame 1 via `ctx.enter_function_scope` ([`function_scopes.rs:11-17`](crates/sifr_hir/src/lower/function_scopes.rs:11)), and parameters land there via `define_parameter`. So a parameter named `BASE` is detected.
+- `if`/`else`/`while`/`for`/comprehension bodies all push their own frames ([`statements.rs:1700,1741,1770,1988,2005,2109,2178`](crates/sifr_hir/src/lower/statements.rs:1700)), so for-loop targets and nested-block locals are also covered.
+- `lookup_in_frame_range(_, 1, 0)` returns `None` (start > end), so the `frame_count > 1` short-circuit isn't strictly necessary for safety but keeps the call shape obvious.
+
+The fold-vs-mismatch ordering is correct in the test scenario:
+- `BASE: int = 100` inside `main()` is processed via `lower_ann_assign`, which lowers the value (no fold), then `scope.define_explicit_local("BASE", Int)` — frame[1] now contains BASE.
+- The next statement `value: uint8 = BASE + 1` lowers `BASE` as `HirExpr::Name { name: "BASE", ty: Int }`. `validate_fixed_width_initializer` calls `const_integer_value`, which sees the frame[1] BASE, returns `Unsupported`, and the binop falls through to `NotConst`. The TYPE_MISMATCH emission covers the whole `BASE + 1` range, which is exactly what the test asserts.
+
+`test_fixed_width_const_expression_does_not_fold_shadowed_module_constant` ([`expressions_tests.rs:328-356`](crates/sifr_hir/src/lower/expressions_tests.rs:328)) pins this with the reproducer from the pass-1c finding and additionally asserts that `INT_FIXED_WIDTH_OUT_OF_RANGE` is *not* emitted (which would have been the silent-wrong-answer signature: stale module BASE=254 would have folded to 255, fitting uint8 cleanly).
+
+The fix is conservative: any locally-bound `BASE` (even a mutable one) blocks the fold. That's the right call — only the regular HIR pipeline knows whether the local is itself a constant, and the fitter shouldn't try to second-guess that.
+
+### F2 — Duplicate `SIFR-INT-0004` for over-budget LargeIntLiteral → fixed
+
+[`fixed_width_fitting.rs:98-108`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:98) now short-circuits before parsing:
+
+```rust
+HirExpr::LargeIntLiteral(value) => {
+    if value.trim_start_matches('-').len()
+        > super::integer_literal_diagnostics::INTEGER_EVAL_DECIMAL_DIGIT_BUDGET
+    {
+        return ConstIntegerValue::Rejected;
+    }
+    match value.parse() { ... }
+}
+```
+
+Returning `Rejected` rather than `Unsupported` is the right choice here:
+- `validate_fixed_width_initializer` propagates `Rejected → FixedWidthInitializerFit::Rejected`, which suppresses the legacy `TYPE_MISMATCH` in [`statements.rs:1057-1074`](crates/sifr_hir/src/lower/statements.rs:1057).
+- The parser-level `validate_module_integer_literals` already emitted SIFR-INT-0004 (the AST visitor walks function bodies via `walk_stmt → visit_body`, so function-body literals are covered too). No second SIFR-INT-0004 is emitted.
+- If the arm returned `Unsupported`, the user would see SIFR-INT-0004 *plus* TYPE_MISMATCH, which is louder than the original duplicate.
+
+The remember-path is consistent: `remember_module_const_integer` only inserts on `ConstIntegerValue::Value`, so an over-budget literal isn't memoized but also doesn't re-emit.
+
+`test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated` ([`expressions_tests.rs:399-424`](crates/sifr_hir/src/lower/expressions_tests.rs:399)) asserts exactly one SIFR-INT-0004 (filter + `assert_eq!(len, 1)`) and no TYPE_MISMATCH for a 4097-digit literal in a uint8-annotated assignment. Direct pin.
+
+### F3 — Misleading "1 decimal digits" in early shift/pow rejection → improved
+
+[`fixed_width_fitting.rs:279-287`](crates/sifr_hir/src/lower/fixed_width_fitting.rs:279) introduces conservative estimators:
+
+```rust
+fn approximate_left_shift_digits(left: &BigInt, shift: u32) -> usize {
+    let bit_digits = u64::from(shift).saturating_mul(30_103) / 100_000 + 1;
+    let bit_digits = usize::try_from(bit_digits).unwrap_or(usize::MAX);
+    decimal_digit_count(left).saturating_add(bit_digits)
+}
+
+fn approximate_pow_digits(abs_left: &BigInt, exponent: u32) -> usize {
+    decimal_digit_count(abs_left).saturating_mul(usize::try_from(exponent).unwrap_or(usize::MAX))
+}
+```
+
+Spot-checks on the message values:
+- `1 << 100_000` → `1 + 30_103 = 30_104` (vs. the pre-fix `1`).
+- `2 ** 100_000` → `1 * 100_000 = 100_000` (actual ≈ 30_103). Conservative overestimate by ~3×.
+- `9 ** 13_611` (just past the early threshold) → `1 * 13_611 = 13_611` (vs. actual ≈ 12_989). Slight overestimate, but >>4096 so the user reads "way over budget" loud and clear.
+
+These are saturating to avoid overflow on very large `u32` operands, with `unwrap_or(usize::MAX)` guarding the cast for 32-bit hosts. No panic surface. The estimates are intentionally upper-bounds (so the user never sees a digit count that *understates* the magnitude). Net: the message is now informative instead of misleading.
+
+The post-evaluation digit count in `reject_if_over_budget` is unchanged and continues to report the exact result digit count (`5001 decimal digits` for `10 ** 5000`, asserted by `test_fixed_width_const_expression_budget_has_int_code`).
+
+### F6 — Test coverage gaps → addressed (mostly)
+
+New coverage relative to pass 1c:
+
+| Operator / case | Test |
+|---|---|
+| `<<`, `//`, `%` | `test_fixed_width_const_expression_assignment_fits_and_folds` ([`expressions_tests.rs:281-311`](crates/sifr_hir/src/lower/expressions_tests.rs:281)) — `(1 << 6) + (9 // 2) + (9 % 2)` folds to `IntLiteral(69)` |
+| Negative const expressions | Same test — `-10 * 5 → IntLiteral(-50)`, `-(100 + 27) → IntLiteral(-127)` |
+| Module-constant shadowing | `test_fixed_width_const_expression_does_not_fold_shadowed_module_constant` |
+| Non-const operand in binop fallback | `test_fixed_width_assignment_from_non_const_binop_is_still_mismatch` ([`expressions_tests.rs:439-454`](crates/sifr_hir/src/lower/expressions_tests.rs:439)) |
+| Duplicate over-budget literal | `test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated` |
+| E2E roundtrip of new operators | [`fixed_width_const_expression_assignment.sifr`](crates/sifr/tests/e2e/pass/fixed_width_const_expression_assignment.sifr) — `(1 << 6) + (9 // 2) + (9 % 2)`, `-10 * 5`, `-(100 + 27)` |
+
+Two minor coverage residuals worth noting (neither is a blocker):
+
+1. **No test pins zero-divisor short-circuit.** `// 0` and `% 0` in a fixed-width const expression return `Unsupported` from `evaluate_integer_binop` and fall through to `TYPE_MISMATCH` (since result type is Int and target is fixed-width). A test like `value: uint8 = 5 // 0` would assert TYPE_MISMATCH (not a runtime divide-by-zero diagnostic). Without it, a future change to that arm could silently regress to "fold to 0 via panic" or similar.
+2. **No module-level fitting fixture.** The pass test exercises module→function const propagation, but `LIMIT: uint8 = 250 + 4` consumed only at module scope (e.g., feeding a class default through `lower_item.rs`) is not present in any e2e fixture. The existing unit test `test_fixed_width_module_constant_out_of_range_has_int_code` covers the rejection path, but the success path through `lower_item.rs:88` is unverified end-to-end. Consider adding when an INT-2C-or-later milestone exercises module-scope fixed-width state.
+
+### F4 / F5 / F7 — unchanged (per pass 1c, non-blocking)
+
+- **F4** (module-level `LIMIT: int = 10 ** 5000` emits SIFR-INT-0004 from the `remember_module_const_integer` path, while the same expression inside a function body with `int` annotation does not): still present. The author's response did not address this and pass 1c flagged it as defensible by spec — worth a note in the PR description.
+- **F5** (module-level `Name`/unary-on-non-literal silently dropped by `lower_integer_const_expr_simple`): still present. `simple_expr.rs` has no `Expr::Name` arm and `negate_simple_expr` only flips literal numerics. Not a regression.
+- **F7** (folded `value: uint8 = SOME_NAME` short-circuits the `HirExpr::Name` move-tracking branch in [`statements.rs:1084-1101`](crates/sifr_hir/src/lower/statements.rs:1084)): unchanged. Benign for `Type::Int` per the integer model doc; document as a follow-up if INT-3 changes integer ownership semantics.
+
+## New observations
+
+### N1 — E2E fail fixture inline annotations are decorative, not enforced
+
+[`crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr`](crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr) uses inline trailing-comment annotations:
+
+```python
+def main():
+    too_wide: uint8 = 2 ** 8  # expect-error: SIFR-INT-0001 col=23
+    too_large: uint8 = 10 ** 5000  # expect-error: SIFR-INT-0004 col=23
+```
+
+`parse_expect_error_line` ([`crates/sifr/tests/e2e.rs:614`](crates/sifr/tests/e2e.rs:614)) calls `line.strip_prefix("# expect-error:")`, which only matches when the comment is at the *start* of the line. The canonical form is illustrated by [`annotated_variable_requires_initializer.sifr:1`](crates/sifr/tests/e2e/fail/annotated_variable_requires_initializer.sifr:1):
+
+```python
+# expect-error[col=5]: SIFR-NAME-0006
+```
+
+The current fixture's annotations are therefore not parsed — `expected` is empty for this fixture, so `test_e2e_fail` only asserts that compilation fails (any diagnostic counts). The codes (SIFR-INT-0001, SIFR-INT-0004) are *not* enforced by the e2e harness. The unit tests `test_fixed_width_const_expression_out_of_range_has_int_code` and `test_fixed_width_const_expression_budget_has_int_code` do assert codes/messages/ranges, so coverage exists in spirit.
+
+Also note: the column claims in the inline annotations don't match. Line 2 has the literal at column 23 (correct), but line 3's literal `10 ** 5000` starts at column 24 (after `too_large: uint8 = `), not 23. Since neither column is enforced, the discrepancy is invisible today.
+
+Recommendation: convert the inline annotations to canonical `# expect-error[col=N]: SIFR-INT-NNNN` lines preceding each test line, or remove them so the file doesn't suggest enforcement that isn't happening. Severity: documentation/polish, not functional.
+
+### N2 — F3 estimator is correct under saturating arithmetic; covered
+
+The new estimator helpers use `u64::saturating_mul(30_103)` and `usize::saturating_mul`, so even pathological `u32::MAX` exponents won't overflow and won't panic. `usize::try_from(u32).unwrap_or(usize::MAX)` is fine on 64-bit hosts and saturates cleanly on 32-bit. No new panic surface. Confirmed by inspection.
+
+## Panics / no-user-path violations
+
+None. Spot-checked all new code:
+- `fixed_width_fitting.rs:99` — `value.trim_start_matches('-').len()` is total.
+- `fixed_width_fitting.rs:201,212,224` — `non_negative_u32` returns `None` for negative or oversize, no panic.
+- `fixed_width_fitting.rs:280-281` — `saturating_mul`, `unwrap_or` fallback.
+- `fixed_width_fitting.rs:286` — `saturating_mul`, `unwrap_or` fallback.
+- `fixed_width_fitting.rs:290` — `i64::try_from(BigInt)` fallback to `LargeIntLiteral`.
+- No new `assert!`/`unwrap`/`expect` on user-triggerable paths.
+
+## Validation independent of author report
+
+I did not re-run the suites; the author reports `cargo fmt --check`, targeted `cargo test -p sifr_hir fixed_width`, `cargo clippy -p sifr_hir -p sifr_codegen -- -D warnings`, the e2e fail suite, the e2e pass fixture (`run`-mode, output `255 / 130 / 4096 / 69 / -50 / -127`), the HIR maintainability guardrails, and `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, 102.26s). The signature is unchanged from pass 1c, suggesting these changes are localized and don't regress the broader suite.
+
+The pass-fixture output values match by-hand evaluation:
+- `BASE + 1 = 254 + 1 = 255` ✓
+- `(1 + 2) * 40 + (20 >> 1) = 120 + 10 = 130` ✓
+- `2 ** 12 = 4096` ✓
+- `(1 << 6) + (9 // 2) + (9 % 2) = 64 + 4 + 1 = 69` ✓
+- `-10 * 5 = -50` ✓
+- `-(100 + 27) = -127` ✓
+
+## Verdict
+
+All pass-1c blockers are resolved with minimal, well-scoped changes. The F1 fix uses the existing scope frame API and is correctly conservative; F2 silently drops the duplicate without weakening the existing TYPE_MISMATCH suppression; F3 swaps the misleading base-digit count for a saturating, conservative result-digit estimate; F6 closes the headline test gaps for `<<`, `//`, `%`, negative const expressions, shadowing, non-const binop fallback, and duplicate over-budget literals.
+
+Two non-blocking polish items in this pass:
+- N1: convert the inline e2e fail annotations to the canonical leading-line form, or drop them — they currently don't enforce the codes/columns they appear to.
+- F4 (carryover from pass 1c): briefly note in the PR description the module-level `int` annotation behavior so reviewers know the inconsistency is intentional and bounded to that scope.
+
+Neither is required to land this slice. The implementation is ready for PR.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary
- Adds same-module fixed-width const-expression fitting for integer literals, unary signs, arithmetic, shifts, non-negative exponentiation, parentheses, and immutable module constants.
- Folds fitting fixed-width const expressions to integer literal HIR so existing codegen emits fixed-width suffixed Rust literals.
- Emits `SIFR-INT-0001` for evaluated out-of-range values and `SIFR-INT-0004` for evaluated over-budget values.
- Refactors simple expression and module-constant lowering into focused modules to stay within HIR guardrails.

## Review
- `reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md`: changes requested.
- `reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md`: satisfied.

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_hir fixed_width -- --nocapture`
- `cargo clippy -p sifr_hir -p sifr_codegen -- -D warnings`
- `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/fixed_width_const_expression_assignment.sifr`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile quick` passed: `report_signature=e1bf653aaa770517`, `wall_time=102.26s`

Known warning noise from existing fixtures includes `SIFR-INT-0011` bigint transition warnings.

## Notes
- Cross-module const propagation/import fitting remains out of scope for this PR.
- Module-level `int` constants with over-budget remembered expressions may emit `SIFR-INT-0004`; this follows the current evaluated-result budget contract and is intentionally left for follow-up if the policy changes.