### PR TITLE
Propagate imported integer const values

### DIFF
--- a/crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr
+++ b/crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr
@@ -1,3 +1,5 @@
 def main():
-    too_wide: uint8 = 2 ** 8  # expect-error: SIFR-INT-0001 col=23
-    too_large: uint8 = 10 ** 5000  # expect-error: SIFR-INT-0004 col=23
+    # expect-error[col=23]: SIFR-INT-0001
+    too_wide: uint8 = 2 ** 8
+    # expect-error[col=24]: SIFR-INT-0004
+    too_large: uint8 = 10 ** 5000

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -282,6 +282,7 @@ impl RootedEntrypointPlan {
             module: main_module,
             function_defaults: std::collections::HashMap::new(),
             function_varargs: std::collections::HashMap::new(),
+            constant_integer_values: std::collections::HashMap::new(),
             reveal_types: main_diag.reveal_types,
             warnings: main_diag.warnings,
         };

--- a/crates/sifr_driver/src/project/exports.rs
+++ b/crates/sifr_driver/src/project/exports.rs
@@ -13,6 +13,7 @@ pub(crate) fn collect_module_exports(
     let mut class_exports = HashMap::new();
     let mut class_type_param_exports = HashMap::new();
     let mut const_exports = HashMap::new();
+    let mut const_integer_value_exports = HashMap::new();
     let mut default_exports = HashMap::new();
     let mut vararg_exports = HashMap::new();
 
@@ -92,6 +93,9 @@ pub(crate) fn collect_module_exports(
     for (name, ty, _) in &module.constants {
         if !name.starts_with('_') {
             const_exports.insert(name.clone(), ty.clone());
+            if let Some(value) = lowering_result.constant_integer_values.get(name) {
+                const_integer_value_exports.insert(name.clone(), value.clone());
+            }
         }
     }
 
@@ -119,4 +123,9 @@ pub(crate) fn collect_module_exports(
     external_defs
         .constants
         .insert(module_name.to_string(), const_exports);
+    if !const_integer_value_exports.is_empty() {
+        external_defs
+            .constant_integer_values
+            .insert(module_name.to_string(), const_integer_value_exports);
+    }
 }

--- a/crates/sifr_driver/src/project/frontend.rs
+++ b/crates/sifr_driver/src/project/frontend.rs
@@ -42,6 +42,7 @@ pub(crate) fn compile_frontend_modules(
             module,
             function_defaults,
             function_varargs,
+            constant_integer_values,
             reveal_types,
             warnings,
         } = result;
@@ -49,6 +50,7 @@ pub(crate) fn compile_frontend_modules(
             module: module.clone(),
             function_defaults,
             function_varargs,
+            constant_integer_values,
             reveal_types: reveal_types.clone(),
             warnings: warnings.clone(),
         };
@@ -91,6 +93,7 @@ pub(crate) fn compile_single_frontend_module_with_source(
         module,
         function_defaults,
         function_varargs,
+        constant_integer_values,
         reveal_types,
         warnings,
     } = result;
@@ -98,6 +101,7 @@ pub(crate) fn compile_single_frontend_module_with_source(
         module: module.clone(),
         function_defaults,
         function_varargs,
+        constant_integer_values,
         reveal_types: reveal_types.clone(),
         warnings: warnings.clone(),
     };
@@ -168,6 +172,7 @@ pub(crate) fn collect_project_hir_source_modules(
             module,
             function_defaults,
             function_varargs,
+            constant_integer_values,
             reveal_types,
             warnings,
         } = result;
@@ -175,6 +180,7 @@ pub(crate) fn collect_project_hir_source_modules(
             module: module.clone(),
             function_defaults,
             function_varargs,
+            constant_integer_values,
             reveal_types: reveal_types.clone(),
             warnings: warnings.clone(),
         };

--- a/crates/sifr_driver/src/tests/project_graph.rs
+++ b/crates/sifr_driver/src/tests/project_graph.rs
@@ -4,6 +4,7 @@ use crate::{
     compile_stdlib, compute_module_compile_order, FrontendDiagnosticStyle,
 };
 use sifr_diagnostics::DiagnosticCode;
+use sifr_hir::{HirExpr, HirStmt};
 use sifr_type_system::Type;
 use std::collections::HashMap;
 
@@ -584,4 +585,94 @@ ANSWER: int = 42
         .get("constants_mod")
         .expect("constants module exports should exist");
     assert_eq!(constants.get("ANSWER"), Some(&Type::Int));
+    let constant_values = result
+        .external_defs
+        .constant_integer_values
+        .get("constants_mod")
+        .expect("integer constant values should be exported");
+    assert_eq!(
+        constant_values
+            .get("ANSWER")
+            .map(std::string::ToString::to_string),
+        Some("42".to_string())
+    );
+}
+
+#[test]
+fn test_project_lowering_fits_imported_integer_constants() {
+    let mut parsed_modules = HashMap::new();
+    parsed_modules.insert(
+        "main".to_string(),
+        parse_suite(
+            r#"
+from constants_mod import BASE as LIMIT
+
+def main() -> uint8:
+    value: uint8 = LIMIT + 1
+    return value
+"#,
+        ),
+    );
+    parsed_modules.insert(
+        "constants_mod".to_string(),
+        parse_suite(
+            r#"
+BASE: int = 250 + 4
+"#,
+        ),
+    );
+
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let result = collect_project_hir_modules(&parsed_modules, stdlib_defs)
+        .expect("project lowering should fit imported integer constants");
+    let main_module = result
+        .hir_modules
+        .get("main")
+        .expect("main module should lower");
+    let main_fn = main_module
+        .functions
+        .iter()
+        .find(|function| function.name == "main")
+        .expect("main function should lower");
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[0] else {
+        panic!("expected first statement to be fitted let");
+    };
+    assert_eq!(ty.display_name(), "uint8");
+    assert!(matches!(value, HirExpr::IntLiteral(255)));
+}
+
+#[test]
+fn test_project_lowering_does_not_fold_shadowed_imported_integer_constant() {
+    let mut parsed_modules = HashMap::new();
+    parsed_modules.insert(
+        "main".to_string(),
+        parse_suite(
+            r#"
+from constants_mod import BASE
+
+def main():
+    BASE: int = 100
+    value: uint8 = BASE + 1
+"#,
+        ),
+    );
+    parsed_modules.insert(
+        "constants_mod".to_string(),
+        parse_suite(
+            r#"
+BASE: int = 254
+"#,
+        ),
+    );
+
+    let stdlib_defs = compile_stdlib().expect("stdlib should compile").defs;
+    let Err(errors) = collect_project_hir_modules(&parsed_modules, stdlib_defs) else {
+        panic!("shadowed imported integer constant should not fit");
+    };
+    assert!(errors.iter().any(|error| {
+        error.code == DiagnosticCode::TYPE_MISMATCH.code()
+            && error
+                .message
+                .contains("[main] type mismatch: expected 'uint8', got 'int'")
+    }));
 }

--- a/crates/sifr_hir/src/lower/compat_imports.rs
+++ b/crates/sifr_hir/src/lower/compat_imports.rs
@@ -158,6 +158,14 @@ pub(super) fn ensure_synthetic_stdlib_import(
         if let Some(module_consts) = externals.constants.get(module_name) {
             if let Some(const_ty) = module_consts.get(member_name) {
                 ctx.scope.define(alias.clone(), const_ty.clone());
+                if let Some(value) = externals
+                    .constant_integer_values
+                    .get(module_name)
+                    .and_then(|module_values| module_values.get(member_name))
+                {
+                    ctx.const_integer_values
+                        .insert(alias.clone(), value.clone());
+                }
                 found = true;
             }
         }

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -105,7 +105,14 @@ pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ct
                 for name in &names {
                     let local = local_name_for(name);
                     if let Some(const_ty) = module_consts.get(name) {
-                        ctx.scope.define(local, const_ty.clone());
+                        ctx.scope.define(local.clone(), const_ty.clone());
+                        if let Some(value) = externals
+                            .constant_integer_values
+                            .get(&module_key)
+                            .and_then(|module_values| module_values.get(name))
+                        {
+                            ctx.const_integer_values.insert(local, value.clone());
+                        }
                     }
                 }
             }

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -452,6 +452,7 @@ pub struct LoweringResult {
     pub module: HirModule,
     pub function_defaults: std::collections::HashMap<String, Vec<(usize, HirExpr)>>,
     pub function_varargs: std::collections::HashMap<String, usize>,
+    pub constant_integer_values: std::collections::HashMap<String, num_bigint::BigInt>,
     /// `reveal_type()` diagnostics (informational, printed to stderr)
     pub reveal_types: Vec<RevealTypeDiagnostic>,
     /// Compiler warnings (non-fatal diagnostics)
@@ -470,6 +471,9 @@ pub struct ExternalDefs {
         std::collections::HashMap<String, std::collections::HashMap<String, Vec<String>>>,
     /// Map of `module_name` -> (`constant_name` -> Type)
     pub constants: std::collections::HashMap<String, std::collections::HashMap<String, Type>>,
+    /// Map of `module_name` -> (`constant_name` -> compile-time integer value)
+    pub constant_integer_values:
+        std::collections::HashMap<String, std::collections::HashMap<String, num_bigint::BigInt>>,
     /// Set of class names that are error types (class Foo(Error)) across all modules
     pub error_types: std::collections::HashSet<String>,
     /// Map of `module_name` -> (`owner_name` -> (`type_var_name` -> bounds))
@@ -927,7 +931,14 @@ fn lower_module_impl(
                             if let Some(module_consts) = externals.constants.get(&stdlib_module_key)
                             {
                                 if let Some(const_ty) = module_consts.get(name) {
-                                    ctx.scope.define(local, const_ty.clone());
+                                    ctx.scope.define(local.clone(), const_ty.clone());
+                                    if let Some(value) = externals
+                                        .constant_integer_values
+                                        .get(&stdlib_module_key)
+                                        .and_then(|module_values| module_values.get(name))
+                                    {
+                                        ctx.const_integer_values.insert(local, value.clone());
+                                    }
                                     found = true;
                                 }
                             }
@@ -1074,6 +1085,14 @@ fn lower_module_impl(
                     if let Some(module_consts) = externals.constants.get(&module_name) {
                         if let Some(const_ty) = module_consts.get(name) {
                             ctx.scope.define(local.clone(), const_ty.clone());
+                            if let Some(value) = externals
+                                .constant_integer_values
+                                .get(&module_name)
+                                .and_then(|module_values| module_values.get(name))
+                            {
+                                ctx.const_integer_values
+                                    .insert(local.clone(), value.clone());
+                            }
                             found = true;
                         }
                     }
@@ -1144,6 +1163,7 @@ fn lower_module_impl(
             },
             function_defaults: ctx.function_defaults.clone(),
             function_varargs: ctx.vararg_functions.clone(),
+            constant_integer_values: ctx.const_integer_values.clone(),
             reveal_types: ctx.reveal_types,
             warnings: ctx.warnings,
         })

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -404,6 +404,7 @@ Validation:
 - [x] INT-2B `bigint` transition annotation diagnostic review satisfied: `reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md`.
 - [x] INT-2B fixed-width const expression fitting review pass 1c completed with shadowing/diagnostic/test blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md`.
 - [x] INT-2B fixed-width const expression fitting review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md`.
+- [x] INT-2B cross-module const fitting review satisfied: `reviews/integer-model-int-2b-cross-module-const-fitting-review-pass-1b.md`.
 
 ## Implementation Checklist
 
@@ -421,7 +422,8 @@ Validation:
   - [x] Direct fixed-width const literal fitting accepts fitting annotated assignments/module constants, rejects out-of-range initializers with `SIFR-INT-0001`, preserves non-const/call narrowing rejections, emits suffixed Rust literals, review is satisfied, and quick validation is passing: PR #1796.
   - [x] `bigint` annotations emit warning-only `SIFR-INT-0011` transition diagnostics while preserving the temporary `Type::BigInt` path, review is satisfied, and quick validation is passing: PR #1797.
   - [x] Same-module fixed-width const expression fitting covers integer arithmetic, shifts, non-negative exponentiation, parentheses, immutable module constants, shadowing-safe name lookup, over-budget diagnostics, and no implicit narrowing outside assignment/module-constant surfaces; review is satisfied and quick validation is passing: PR #1798.
-  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, convert inline fixed-width const-expression e2e fail comments to canonical leading `expect-error` annotations if those codes need e2e enforcement, and revisit module-level `int` over-budget remember-path behavior during cross-module const propagation.
+  - [x] Imported immutable module constants carry const-evaluable integer values through the project frontend/export API, including alias-aware fitting and shadowing-safe rejection; review is satisfied and quick validation is passing: PR #1799.
+  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, decide whether stdlib bootstrap exports should populate `constant_integer_values`, and document or implement transitive re-export semantics for imported constants.
 - [ ] INT-3 scalar arithmetic and numeric mixing
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries

--- a/reviews/integer-model-int-2b-cross-module-const-fitting-review-pass-1b.md
+++ b/reviews/integer-model-int-2b-cross-module-const-fitting-review-pass-1b.md
@@ -1,0 +1,81 @@
+# Review — INT-2B Cross-Module Const Fitting (pass 1b)
+
+Branch: `int-2b-cross-module-const-fitting`
+Reference: [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](../issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md), [internal_docs/integer_model.md](../internal_docs/integer_model.md)
+Reviewer scope: correctness, regressions, missing tests, API contract, panic / no-user-path violations, PR readiness.
+
+## Scope verified
+
+The diff threads compile-time `BigInt` values for module-level integer constants through the producer-side export API and the consumer-side import resolution paths, so the existing `validate_fixed_width_initializer` path can fold imported constants:
+
+- HIR-side wiring
+  - [crates/sifr_hir/src/lower/mod.rs:455](../crates/sifr_hir/src/lower/mod.rs:455) — `LoweringResult.constant_integer_values: HashMap<String, BigInt>`.
+  - [crates/sifr_hir/src/lower/mod.rs:475](../crates/sifr_hir/src/lower/mod.rs:475) — `ExternalDefs.constant_integer_values: HashMap<String, HashMap<String, BigInt>>`.
+  - [crates/sifr_hir/src/lower/mod.rs:1166](../crates/sifr_hir/src/lower/mod.rs:1166) — final `LoweringResult` carries `ctx.const_integer_values.clone()`.
+- Import resolution (three sites)
+  - [crates/sifr_hir/src/lower/imports.rs:104](../crates/sifr_hir/src/lower/imports.rs:104) — early `from M import X [as Y]` pass, alias-aware via `local_name_for(name)`.
+  - [crates/sifr_hir/src/lower/mod.rs:929](../crates/sifr_hir/src/lower/mod.rs:929) — stdlib full-import branch.
+  - [crates/sifr_hir/src/lower/mod.rs:1083](../crates/sifr_hir/src/lower/mod.rs:1083) — local-module full-import branch.
+  - [crates/sifr_hir/src/lower/compat_imports.rs:158](../crates/sifr_hir/src/lower/compat_imports.rs:158) — synthetic stdlib alias path used by compatibility shims.
+- Producer-side gating
+  - [crates/sifr_driver/src/project/exports.rs:93](../crates/sifr_driver/src/project/exports.rs:93) iterates `module.constants` (already filtered to non-`_`-prefix and only present when the producer module proved const-evaluability via `module_constants_lowering::collect_annotated_constant`/`collect_bare_constant`), and only writes through to `external_defs.constant_integer_values` when an integer value is present.
+- Plumbing
+  - [crates/sifr_driver/src/project/frontend.rs](../crates/sifr_driver/src/project/frontend.rs) threads the new field through the three destructure/reconstruct sites used by the test, single-file, and source-mode entry points.
+  - [crates/sifr_driver/src/build/entrypoint.rs:285](../crates/sifr_driver/src/build/entrypoint.rs:285) re-emits an empty map for the resynthesized main `LoweringResult`. Codegen does not consume this field (`grep` shows no reads outside `lower/`/`project/`), so this is correct.
+- Tests
+  - [crates/sifr_driver/src/tests/project_graph.rs:588](../crates/sifr_driver/src/tests/project_graph.rs:588) extends the existing local-constants export test to assert `external_defs.constant_integer_values["constants_mod"]["ANSWER"] == 42`.
+  - [crates/sifr_driver/src/tests/project_graph.rs:602](../crates/sifr_driver/src/tests/project_graph.rs:602) `test_project_lowering_fits_imported_integer_constants` proves the fitted let body collapses `LIMIT + 1` to `HirExpr::IntLiteral(255)` under the alias `LIMIT` for `BASE = 250 + 4`.
+  - [crates/sifr_driver/src/tests/project_graph.rs:644](../crates/sifr_driver/src/tests/project_graph.rs:644) `test_project_lowering_does_not_fold_shadowed_imported_integer_constant` asserts that an inner local rebinding `BASE: int = 100` blocks the fold and surfaces `SIFR-TYPE-0002`.
+- E2E fixture conversion
+  - [crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr](../crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr) now uses canonical leading-line `# expect-error[col=N]: SIFR-INT-…` annotations.
+
+## Correctness assessment
+
+### Producer side
+
+- Only public, const-evaluable module constants are exported. `collect_annotated_constant` only adds an entry to `module.constants` when `lower_integer_const_expr_simple` returns `Some` (literal/unary/binop tree over int literals) and the resulting initializer either fits the annotated type or is non-fixed-width [crates/sifr_hir/src/lower/module_constants_lowering.rs:36](../crates/sifr_hir/src/lower/module_constants_lowering.rs:36). `collect_bare_constant` follows the same gate. Because `remember_module_const_integer` runs the same `const_integer_value` evaluator that fitting uses, it only stores values within the 4096-decimal-digit budget — over-budget results never reach `ctx.const_integer_values`, so the export will not propagate something the consumer cannot legally fold either. This satisfies the contract in [internal_docs/integer_model.md:101](../internal_docs/integer_model.md:101).
+- Producer-side ordering inside a module is sound. Imports are processed first (insert imported value), then `collect_module_constants` runs and may overwrite the same name with the local module-level value. So a redeclaration like `from M import BASE` followed by `BASE: int = 100` ends with `ctx.const_integer_values["BASE"] == 100`, which is also what gets exported. `module.constants` is the export key, so a stale import-time value is never re-exported as the local module's constant.
+
+### Consumer side
+
+- Each of the four insertion sites uses the alias-aware local name (`local_name_for(name)` / the `alias` parameter passed to `ensure_synthetic_stdlib_import`). The positive test exercises the alias case (`from constants_mod import BASE as LIMIT` → `value: uint8 = LIMIT + 1` folds to `255`).
+- Lookup uses `externals.constant_integer_values.get(module_key).and_then(|m| m.get(name))`. When the producer is a non-int constant or stdlib module without integer values, the lookup is `None` and nothing changes — the existing scope/type wiring is unaffected.
+- Shadowing safety is delegated to the existing `is_shadowed_by_inner_scope` check in `fixed_width_fitting::const_integer_value` ([crates/sifr_hir/src/lower/fixed_width_fitting.rs:109](../crates/sifr_hir/src/lower/fixed_width_fitting.rs:109)). When fitting `BASE + 1` while the function frame defines a local `BASE`, the lookup returns `Unsupported` and `validate_fixed_width_initializer` falls through to a regular type check, producing `SIFR-TYPE-0002`. The new shadow test confirms this end-to-end through the project lowering pipeline.
+
+### Lifetime / staleness of the global map
+
+`ctx.const_integer_values` is a flat per-module `HashMap`, not a frame-stacked structure. That is acceptable here because the only writers are: (a) import resolution (executed once, per-module) and (b) `remember_module_const_integer`, which runs only at module top level. Function-scope locals never insert into the map; they instead suppress folding via `is_shadowed_by_inner_scope`. So the map cannot accumulate stale per-function state across nested function bodies, and the absence of a "pop on scope exit" is intentional.
+
+### Diagnostic / panic surface
+
+No new `unwrap`/`expect` is added on user-reachable paths. All new lookups use `get(...).and_then(...)`. Cloning a `BigInt` is allocating but infallible. No new monolithic file or HIR guardrail risk — only field additions to existing structs.
+
+### E2E fixture
+
+- `parse_expect_error_line` only matches lines that *start* with `# expect-error:` or `# expect-error[`. The original trailing form (`too_wide: uint8 = 2 ** 8  # expect-error: SIFR-INT-0001 col=23`) was therefore silently ignored by the harness — converting to leading-comment form makes the fixture actually enforce the codes. This is a real (pre-existing) fix.
+- Column counts verified against the source: column 23 is the `2` in `2 ** 8`, column 24 is the `1` in `10 ** 5000`. Both diagnostic codes (`SIFR-INT-0001` for fixed-width out-of-range; `SIFR-INT-0004` for the budget-exceeded `10 ** 5000`) are active in the registry [crates/sifr_diagnostics/src/codes.rs:62](../crates/sifr_diagnostics/src/codes.rs:62), [crates/sifr_diagnostics/src/codes.rs:64](../crates/sifr_diagnostics/src/codes.rs:64).
+
+## Notes / suggested follow-ups (non-blocking)
+
+1. **Stdlib bootstrap does not propagate `constant_integer_values`.** [crates/sifr_driver/src/stdlib/bootstrap.rs](../crates/sifr_driver/src/stdlib/bootstrap.rs) collects exports through a bespoke loop that *does not* call `collect_module_exports`, and it never populates `stdlib_defs.constant_integer_values`. As a result, importing a const-evaluable integer constant from any stdlib module will not fold into a fixed-width target — only user-project modules participate. This is consistent with the slice description ("…through the existing sifr_driver frontend/project API"), but it leaves a real asymmetry: a user module exposing `BASE: int = 254` participates, while the same constant exposed from a stdlib module does not. Worth tracking as a follow-up so stdlib integer constants get the same treatment (or worth an explicit decision that stdlib stays opted-out).
+2. **Shadowing test only covers declare-before-use.** The new shadow test verifies the local rebinding precedes the use site. It does not cover the case where the local rebinding occurs *after* a use of `BASE` in the same function body. Whether Sifr's resolver hoists the local binding (Python-style "function scope name capture") or treats the pre-declaration use as the imported binding is a deeper resolver question and probably out of scope for this slice — but it is a latent edge case that the current test does not pin down.
+3. **Fixture style divergence.** The sibling `fixed_width_literal_out_of_range.sifr` places both `expect-error` annotations at the top of file before the `def main():`. The new fixture uses inline-leading comments adjacent to each erroring line. Both forms are accepted by `parse_expect_error_line` and both are enforced; this is a stylistic note rather than a correctness issue.
+4. **Plumbing duplication.** Three sites in `project/frontend.rs` destructure-then-reconstruct the `LoweringResult` only to clone `module`. The new field threads through cleanly, but a one-line `let lowering_result = result.clone();` would be simpler. Pure style; not in scope.
+5. **Re-export semantics.** The current export rule is "export only constants the producer itself defined." Transitive re-export (e.g., `consumer.sifr` doing `from constants_mod import ANSWER` and then importing into `main`) is not honored — `main` must import `ANSWER` directly from `constants_mod`. That matches `internal_docs/integer_model.md:101` ("Imported immutable module constants may carry const-evaluable status across module boundaries…"), which is silent on transitive re-export. Worth noting for future docs but not a defect.
+
+## Validation review
+
+The reported local validation set covers the relevant surfaces:
+- `cargo test -p sifr_driver project_lowering` exercises the three new project-graph tests.
+- `cargo test -p sifr_hir fixed_width` exercises the fitting evaluator.
+- `cargo test -p sifr --test e2e test_e2e_fail` exercises the converted fixture.
+- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` with workspace pedantic lints.
+- `scripts/run_all_tests.sh --profile quick` (signature `e1bf653aaa770517`, ~73s) provides whole-tree signal.
+
+No additional validation gaps were identified for the slice's stated scope.
+
+## Readiness
+
+The slice is focused, the data flow is sound, the producer-side gating is conservative (tied to `module.constants`, the same set that already passed const-evaluability), the consumer-side preserves shadowing safety via the existing mechanism, and the tests cover both the happy path (with alias) and the negative path (shadow). The e2e fixture conversion is correct and converts a previously-silent annotation form into one the harness actually enforces. The stdlib propagation gap is the only substantive open question and is best handled as a follow-up rather than reopening this slice.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary
- Add `LoweringResult.constant_integer_values` and `ExternalDefs.constant_integer_values` so proven const-evaluable integer values can cross module boundaries.
- Export public module constants only when the producer has a recorded compile-time integer value, and import those values under local aliases for fixed-width const fitting.
- Cover alias fitting and local-shadowing safety in project lowering tests.
- Convert the fixed-width const-expression fail fixture to canonical leading `expect-error` comments so the harness enforces it.

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_driver project_lowering -- --nocapture`
- `cargo test -p sifr_hir fixed_width -- --nocapture`
- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings`
- `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=72.92s`)

## Review
- `reviews/integer-model-int-2b-cross-module-const-fitting-review-pass-1b.md`: SATISFIED

## Follow-ups Tracked
- Stdlib bootstrap does not yet populate `constant_integer_values`, so stdlib integer constants are not part of this cross-module fitting path.
- Transitive re-export of imported constants is not implemented; consumers must import from the defining module for const fitting.
