### PR TITLE
Expand bigint transition warning coverage

### DIFF
--- a/crates/sifr_driver/src/tests/single_file_frontend.rs
+++ b/crates/sifr_driver/src/tests/single_file_frontend.rs
@@ -281,6 +281,103 @@ fn test_type_check_source_surfaces_bigint_transition_warning() {
     assert!(primary_span.byte_end > primary_span.byte_start);
 }
 
+fn assert_single_bigint_transition_warning(source: &str, line: u32, context: &str) {
+    let diagnostics = type_check_source(source);
+
+    assert_eq!(diagnostics.len(), 1, "{context}");
+    let diagnostic = &diagnostics[0];
+    assert_eq!(
+        diagnostic.code,
+        DiagnosticCode::INT_BIGINT_TRANSITION_ALIAS.code(),
+        "{context}"
+    );
+    assert_eq!(
+        diagnostic.severity,
+        sifr_diagnostics::Severity::Warning,
+        "{context}"
+    );
+    let primary_span = diagnostic
+        .spans
+        .iter()
+        .find(|span| span.is_primary)
+        .unwrap_or_else(|| panic!("{context} should carry a primary span"));
+    assert_eq!(primary_span.file.as_deref(), Some("main"), "{context}");
+    assert_eq!(primary_span.line, Some(line), "{context}");
+    assert!(primary_span.byte_end > primary_span.byte_start, "{context}");
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_typevar_constraint() {
+    assert_single_bigint_transition_warning(
+        "from typing import TypeVar\n\nT = TypeVar(\"T\", bigint)\n",
+        3,
+        "positional TypeVar constraint",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_typevar_bound_keyword() {
+    assert_single_bigint_transition_warning(
+        "from typing import TypeVar\n\nT = TypeVar(\"T\", bound=bigint)\n",
+        3,
+        "TypeVar bound keyword",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_typevar_constraints_tuple_keyword() {
+    assert_single_bigint_transition_warning(
+        "from typing import TypeVar\n\nT = TypeVar(\"T\", constraints=(bigint, str))\n",
+        3,
+        "TypeVar constraints tuple keyword",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_typevar_constraints_name_keyword() {
+    assert_single_bigint_transition_warning(
+        "from typing import TypeVar\n\nT = TypeVar(\"T\", constraints=bigint)\n",
+        3,
+        "TypeVar constraints name keyword",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_pep695_bound() {
+    assert_single_bigint_transition_warning(
+        "def identity[T: bigint](value: T) -> T:\n    return value\n",
+        1,
+        "PEP 695 bound",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_pep695_tuple_constraint() {
+    assert_single_bigint_transition_warning(
+        "def identity[T: (bigint, str)](value: T) -> T:\n    return value\n",
+        1,
+        "PEP 695 tuple constraint",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_once_for_bigint_class_pep695_bound() {
+    assert_single_bigint_transition_warning(
+        "class Box[T: bigint]:\n    value: T\n",
+        1,
+        "class PEP 695 bound",
+    );
+}
+
+#[test]
+fn test_type_check_source_warns_for_bigint_isinstance_target() {
+    assert_single_bigint_transition_warning(
+        "def main():\n    value: int = 1\n    if isinstance(value, bigint):\n        print(\"legacy\")\n",
+        3,
+        "isinstance target",
+    );
+}
+
 #[test]
 fn test_compile_hello_world() {
     let source = r#"

--- a/crates/sifr_hir/src/lower/builtin_calls.rs
+++ b/crates/sifr_hir/src/lower/builtin_calls.rs
@@ -926,7 +926,12 @@ pub(super) fn lower_isinstance_call(call: &ExprCall, ctx: &mut LowerCtx) -> Opti
     }
     let arg = lower_expr(&call.arguments.args[0], ctx)?;
     let type_name = match &call.arguments.args[1] {
-        Expr::Name(n) => n.id.to_string(),
+        Expr::Name(n) => {
+            if n.id.as_str() == "bigint" {
+                ctx.warn_bigint_transition_alias(n.range());
+            }
+            n.id.to_string()
+        }
         _ => "unknown".to_string(),
     };
     Some(HirExpr::Call {

--- a/crates/sifr_hir/src/lower/classes.rs
+++ b/crates/sifr_hir/src/lower/classes.rs
@@ -255,30 +255,34 @@ pub(super) fn collect_class_type(
     let is_protocol = is_protocol_class(class_def);
     let newtype_inner = get_newtype_inner(class_def);
 
-    // PEP 695: register inline type params (class C[T]) as type variables
-    if let Some(ref type_params) = class_def.type_params {
-        let mut declared_params = Vec::new();
-        for tp in type_params.iter() {
-            if let sifr_python_ast::TypeParam::TypeVar(tv) = tp {
-                let tp_name = tv.name.to_string();
-                ctx.type_vars.insert(tp_name.clone());
-                declared_params.push(tp_name.clone());
-                if let Some(ref bound) = tv.bound {
-                    let specs = parse_typevar_bound_expr(bound, ctx);
-                    if !specs.is_empty() {
-                        ctx.type_param_bounds
-                            .entry(class_name.clone())
-                            .or_default()
-                            .entry(tp_name)
-                            .or_default()
-                            .extend(specs);
+    // PEP 695: register inline type params (class C[T]) as type variables.
+    // Class collection runs twice; bounds are source-shape declarations and should only emit
+    // diagnostics/register specs once.
+    if !validate_iteration_protocols {
+        if let Some(ref type_params) = class_def.type_params {
+            let mut declared_params = Vec::new();
+            for tp in type_params.iter() {
+                if let sifr_python_ast::TypeParam::TypeVar(tv) = tp {
+                    let tp_name = tv.name.to_string();
+                    ctx.type_vars.insert(tp_name.clone());
+                    declared_params.push(tp_name.clone());
+                    if let Some(ref bound) = tv.bound {
+                        let specs = parse_typevar_bound_expr(bound, ctx);
+                        if !specs.is_empty() {
+                            ctx.type_param_bounds
+                                .entry(class_name.clone())
+                                .or_default()
+                                .entry(tp_name)
+                                .or_default()
+                                .extend(specs);
+                        }
                     }
                 }
             }
-        }
-        if !declared_params.is_empty() {
-            ctx.class_declared_type_params
-                .insert(class_name.clone(), declared_params);
+            if !declared_params.is_empty() {
+                ctx.class_declared_type_params
+                    .insert(class_name.clone(), declared_params);
+            }
         }
     }
 

--- a/crates/sifr_hir/src/lower/typevar_annotations.rs
+++ b/crates/sifr_hir/src/lower/typevar_annotations.rs
@@ -22,15 +22,25 @@ fn invalid_typevar_shape(ctx: &mut LowerCtx, message: impl Into<String>, range: 
     );
 }
 
+fn warn_bigint_transition_name(ctx: &mut LowerCtx, name: &str, range: TextRange) {
+    if name == "bigint" {
+        ctx.warn_bigint_transition_alias(range);
+    }
+}
+
 /// Parse a `TypeVar` bound/constraint expression from PEP 695 syntax.
 /// `T: Bound` is treated as a hard bound; `T: (A, B)` is treated as constraints.
 pub(crate) fn parse_typevar_bound_expr(expr: &Expr, ctx: &mut LowerCtx) -> Vec<String> {
     match expr {
-        Expr::Name(name) => vec![name.id.to_string()],
+        Expr::Name(name) => {
+            warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
+            vec![name.id.to_string()]
+        }
         Expr::Tuple(tuple) => {
             let mut specs = Vec::new();
             for elt in &tuple.elts {
                 if let Expr::Name(name) = elt {
+                    warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
                     specs.push(encode_typevar_constraint(&name.id));
                 } else {
                     invalid_typevar_shape(
@@ -68,7 +78,10 @@ pub(crate) fn parse_typevar_declaration_specs(call: &ExprCall, ctx: &mut LowerCt
     for arg in call.arguments.args.iter().skip(1) {
         saw_constraints = true;
         match arg {
-            Expr::Name(name) => specs.push(encode_typevar_constraint(&name.id)),
+            Expr::Name(name) => {
+                warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
+                specs.push(encode_typevar_constraint(&name.id));
+            }
             _ => invalid_typevar_shape(
                 ctx,
                 "TypeVar positional constraints must be simple type names",
@@ -93,7 +106,10 @@ pub(crate) fn parse_typevar_declaration_specs(call: &ExprCall, ctx: &mut LowerCt
                 }
                 saw_bound = true;
                 match &kw.value {
-                    Expr::Name(name) => specs.push(name.id.to_string()),
+                    Expr::Name(name) => {
+                        warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
+                        specs.push(name.id.to_string());
+                    }
                     _ => invalid_typevar_shape(
                         ctx,
                         "TypeVar bound must be a simple type name",
@@ -115,6 +131,7 @@ pub(crate) fn parse_typevar_declaration_specs(call: &ExprCall, ctx: &mut LowerCt
                     Expr::Tuple(tuple) => {
                         for elt in &tuple.elts {
                             if let Expr::Name(name) = elt {
+                                warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
                                 specs.push(encode_typevar_constraint(&name.id));
                             } else {
                                 invalid_typevar_shape(
@@ -126,6 +143,7 @@ pub(crate) fn parse_typevar_declaration_specs(call: &ExprCall, ctx: &mut LowerCt
                         }
                     }
                     Expr::Name(name) => {
+                        warn_bigint_transition_name(ctx, name.id.as_str(), name.range());
                         specs.push(encode_typevar_constraint(&name.id));
                     }
                     _ => invalid_typevar_shape(

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -405,6 +405,8 @@ Validation:
 - [x] INT-2B fixed-width const expression fitting review pass 1c completed with shadowing/diagnostic/test blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-1c.md`.
 - [x] INT-2B fixed-width const expression fitting review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-2b-const-expression-fitting-review-pass-2.md`.
 - [x] INT-2B cross-module const fitting review satisfied: `reviews/integer-model-int-2b-cross-module-const-fitting-review-pass-1b.md`.
+- [x] INT-2B `bigint` warning coverage review pass 1 completed with duplicate-warning/test-coverage blockers: `reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md`.
+- [x] INT-2B `bigint` warning coverage review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -423,7 +425,8 @@ Validation:
   - [x] `bigint` annotations emit warning-only `SIFR-INT-0011` transition diagnostics while preserving the temporary `Type::BigInt` path, review is satisfied, and quick validation is passing: PR #1797.
   - [x] Same-module fixed-width const expression fitting covers integer arithmetic, shifts, non-negative exponentiation, parentheses, immutable module constants, shadowing-safe name lookup, over-budget diagnostics, and no implicit narrowing outside assignment/module-constant surfaces; review is satisfied and quick validation is passing: PR #1798.
   - [x] Imported immutable module constants carry const-evaluable integer values through the project frontend/export API, including alias-aware fitting and shadowing-safe rejection; review is satisfied and quick validation is passing: PR #1799.
-  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, decide whether stdlib bootstrap exports should populate `constant_integer_values`, and document or implement transitive re-export semantics for imported constants.
+  - [x] `SIFR-INT-0011` transition warning coverage includes `isinstance(..., bigint)`, TypeVar bounds/constraints, PEP 695 function/class bounds, and class-bound single-emission behavior; review is satisfied and quick validation is passing: PR #1800.
+  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, decide whether `bigint(...)` constructor calls should warn before public `bigint` removal, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, decide whether stdlib bootstrap exports should populate `constant_integer_values`, and document or implement transitive re-export semantics for imported constants.
 - [ ] INT-3 scalar arithmetic and numeric mixing
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries

--- a/reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md
+++ b/reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md
@@ -1,0 +1,115 @@
+# INT-2B Bigint Warning Coverage — Review Pass 1
+
+Branch: `int-2b-bigint-warning-coverage`
+Scope reviewed: uncommitted working-tree changes that extend `SIFR-INT-0011` (the `bigint` transition-alias warning, severity `Warning`) from annotation resolution alone to two additional source positions explicitly called out as gaps by the prior slice's review:
+
+1. `isinstance(_, bigint)` second argument.
+2. `TypeVar` bounds and constraints — both PEP 695 inline syntax (`def f[T: bigint]`, `class C[T: bigint]`) and the legacy declaration form (`T = TypeVar("T", bigint)`, `bound=`, `constraints=`).
+
+The follow-up note that scopes this slice lives at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426): *"add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal"*. The earlier review that called these out is [reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md:30-37](reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md:30) ("Concern 1: Coverage is annotation-only; two other source positions silently bypass the warning").
+
+## Files reviewed
+
+- `crates/sifr_hir/src/lower/builtin_calls.rs` — emits the warning when `isinstance(_, bigint)` is lowered.
+- `crates/sifr_hir/src/lower/typevar_annotations.rs` — emits the warning from every TypeVar bound/constraint parse path.
+- `crates/sifr_driver/src/tests/single_file_frontend.rs` — three new driver-level tests covering one entry path each.
+
+No diagnostics-registry, generated-docs, or phase-tracker files are touched (and none need to be — the existing `SIFR-INT-0011` registration already covers the new emit sites).
+
+## Local validation observed during review
+
+Run from the working tree:
+
+- `cargo test -p sifr_driver -- bigint` → 4 passed (`test_type_check_source_surfaces_bigint_transition_warning` plus the three new tests).
+- `cargo clippy -p sifr_hir -p sifr_driver` → clean.
+- `cargo fmt --check` → clean.
+- `python3 scripts/check_hir_maintainability_guardrails.py` → PASS.
+- Hand-crafted CLI probe `class C[T: bigint]:` via `cargo run -q -p sifr -- --diagnostic-format=json check` → 1 warning at the bound span (CLI-level dedupe applies; see Concern 1).
+
+`scripts/run_all_tests.sh --profile quick` was not run during this review — should be run before opening the PR per [AGENTS.md](AGENTS.md).
+
+## What is correct
+
+1. **Single helper for the typevar-annotation emit sites.** [typevar_annotations.rs:25-29](crates/sifr_hir/src/lower/typevar_annotations.rs:25) introduces `warn_bigint_transition_name` and threads it through every `Expr::Name` arm in both `parse_typevar_bound_expr` and `parse_typevar_declaration_specs`. The helper is a 4-line, pure name-equality + `ctx.warn_bigint_transition_alias(range)` call — no allocation, no formatting. This is the right granularity: emission lives next to the AST shape recognition, not duplicated at every call site.
+2. **All seven AST shapes that resolve the literal name `bigint` to a TypeVar bound/constraint are wired.** Specifically, in `parse_typevar_bound_expr`: PEP 695 simple name ([line 36](crates/sifr_hir/src/lower/typevar_annotations.rs:36)) and PEP 695 tuple constraint ([line 43](crates/sifr_hir/src/lower/typevar_annotations.rs:43)). In `parse_typevar_declaration_specs`: positional constraint ([line 82](crates/sifr_hir/src/lower/typevar_annotations.rs:82)), `bound=` keyword ([line 110](crates/sifr_hir/src/lower/typevar_annotations.rs:110)), `constraints=` tuple ([line 134](crates/sifr_hir/src/lower/typevar_annotations.rs:134)), and `constraints=` single name ([line 146](crates/sifr_hir/src/lower/typevar_annotations.rs:146)). I cross-checked each branch — every `Expr::Name` arm that ultimately pushes a `bigint`-derived spec also runs the helper.
+3. **`isinstance` emit site is at the right layer.** [builtin_calls.rs:929-934](crates/sifr_hir/src/lower/builtin_calls.rs:929) fires inside `lower_isinstance_call` against `call.arguments.args[1]`, exactly where the literal name is read for the lowered call. The warning fires once per `isinstance(_, bigint)` expression.
+4. **No false positives.** The branch-bodies of the helper are guarded by `name == "bigint"`. For non-`bigint` bounds/constraints the new code is a no-op and the existing logic is untouched. None of `int`, `float`, `Comparable`, `Addable`, `Hashable`, user `class`, or user-defined type aliases trip the warning.
+5. **Lookup ordering preserves the prior shadowing semantics.** None of the new emit sites consult the scope/alias tables before the name check, but that is consistent with how the previously-shipped annotation emit at [typing_and_functions.rs:439](crates/sifr_hir/src/lower/typing_and_functions.rs:439) treats `bigint`: the warning has always been a string-literal diagnostic gated only on the source spelling, intentionally not on type-resolution outcomes. Users who shadow `bigint` (`type bigint = int`) hit the alias path inside `resolve_annotation_expr` *before* reaching the `bigint`-string check — but for TypeVar bounds and `isinstance` the design treats the literal token as the trigger because the lowering path needs the literal string spec for downstream bound/constraint encoding. The new behavior is consistent with the prior slice's design choice; just note that, unlike `resolve_annotation_expr`, the new emit sites cannot be silenced by a user-defined `bigint` alias. That is acceptable because constraint/bound parsing operates on the literal name shape.
+6. **No new lints, no new warnings, no new format diffs, no panic risks.** Each new line is straight diagnostic plumbing.
+7. **Tests assert the right invariants for the three covered paths.** Each new test asserts `diagnostics.len() == 1`, the `INT_BIGINT_TRANSITION_ALIAS` code, severity `Warning`, primary span presence, span file, span line, and `byte_end > byte_start` (matches the existing parent-commit test's structure at [single_file_frontend.rs:255-282](crates/sifr_driver/src/tests/single_file_frontend.rs:255)). The asserted line numbers (`Some(3)` for the `TypeVar` and `isinstance` cases, `Some(1)` for the PEP 695 case) point at the line containing the `bigint` token, not at the surrounding statement, which is the user-helpful span.
+8. **Existing tests remain green.** The parent-commit test `test_type_check_source_surfaces_bigint_transition_warning` (annotation `value: bigint = bigint(1)`) still asserts exactly one warning. The constructor call `bigint(1)` continues to be silent (consistent with the slice's stated scope, which lists only `isinstance` and TypeVar bounds).
+
+## Concerns and gaps
+
+### 1. `class C[T: bigint]` double-emits at the HIR warnings vector (CLI dedup hides it)
+
+`collect_class_type` is invoked twice from [mod.rs:587, 597](crates/sifr_hir/src/lower/mod.rs:587) — once before alias resolution and once after — and both invocations call `parse_typevar_bound_expr(bound, ctx)` for class type parameters at [classes.rs:267](crates/sifr_hir/src/lower/classes.rs:267). With this slice's change, that means every `class C[T: bigint]:` pushes **two** `LoweringWarningDiagnostic::BigIntTransitionAlias` entries onto `ctx.warnings` with identical `(code, message_template, primary_span)` keys.
+
+This is masked at the CLI by [diagnostics.rs:69 `deduplicate_recovery_diagnostics`](crates/sifr_driver/src/diagnostics.rs:69) (called from `apply_diagnostic_recovery_limits`), which collapses identical `(code, message_template, dedupe_args, primary_span)` pairs. I confirmed empirically: a `--diagnostic-format=json check` of `class C[T: bigint]:` returns one warning. But:
+
+- `crates/sifr_driver/src/frontend/api.rs::type_check_source` does **not** dedup. Anything that consumes `LoweringResult.warnings` directly (e.g. future HIR-level unit tests, snapshot harnesses, alternate frontends) sees a duplicate. A test like `assert_eq!(type_check_source("class C[T: bigint]:\n    pass\n").len(), 1)` would fail today.
+- The prior slice's `invalid_typevar_shape` errors in `parse_typevar_bound_expr` already had this property (so this is an inherited architectural shape, not a new bug introduced by this slice). It just becomes visible here because this is the first time a *warning* is emitted from that double-call site.
+- The duplicate is a function of where the helper is invoked, not of the helper itself; gating in `collect_class_type` (e.g. only run `parse_typevar_bound_expr` when `validate_iteration_protocols == false`, since the bound shape doesn't change between passes) would fix it for every diagnostic flowing through that function, not only `SIFR-INT-0011`.
+
+Given the parent-commit test depends on `type_check_source.len() == 1` semantics, I think this slice should not ship a code path where that invariant *would* be violated for one of its supported shapes. **Recommendation**: either add a single-pass guard inside `collect_class_type` so the bound parse runs once, or add an explicit `assert_eq!(...len(), 1)` test for `class C[T: bigint]:` that goes through `type_check_source` and force-fixes the issue. A test alone (without the guard) would fail today and is the cleanest way to surface this.
+
+### 2. Three reachable emit sites have no test coverage
+
+The slice's intent is "add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds." Test coverage of the new emit sites:
+
+| Emit site | File:line | Test |
+| --- | --- | --- |
+| PEP 695 simple-name bound | typevar_annotations.rs:36 | `test_type_check_source_warns_for_bigint_pep695_bound` ✓ |
+| PEP 695 tuple constraint  | typevar_annotations.rs:43 | — |
+| `TypeVar("T", bigint)` positional | typevar_annotations.rs:82 | `test_type_check_source_warns_for_bigint_typevar_constraint` ✓ |
+| `TypeVar("T", bound=bigint)` keyword | typevar_annotations.rs:110 | — |
+| `TypeVar("T", constraints=(bigint, ...))` tuple | typevar_annotations.rs:134 | — |
+| `TypeVar("T", constraints=bigint)` single name | typevar_annotations.rs:146 | — |
+| `lower_isinstance_call` | builtin_calls.rs:931 | `test_type_check_source_warns_for_bigint_isinstance_target` ✓ |
+
+Four of seven branches are unexercised. They are structurally distinct AST arms (each has its own `match` arm + its own `warn_bigint_transition_name` call), and a regression in any one would be silent until the eventual `bigint` removal slice fails to delete a path. Each test would be ~10 lines copied from the existing template.
+
+**Recommendation**: add at least one regression test per untested branch. Concretely:
+
+- `def f[T: (bigint, str)](value: T) -> T: ...` (PEP 695 tuple constraint).
+- `T = TypeVar("T", bound=bigint)` (keyword bound).
+- `T = TypeVar("T", constraints=(bigint, str))` (keyword constraints tuple).
+- `T = TypeVar("T", constraints=bigint)` (keyword constraints single name) — note this asserts that the `Expr::Name` branch at typevar_annotations.rs:146 fires; without it the line would only be exercised by manual probing.
+
+If concern (1) is also resolved, add a class PEP 695 test (`class C[T: bigint]:`) too, asserting `diagnostics.len() == 1` to lock in the single-emission contract.
+
+### 3. `detect_narrowing_condition` for `isinstance(_, bigint)` is silent (but the warning still fires once per source line)
+
+[statements.rs:1832](crates/sifr_hir/src/lower/statements.rs:1832) re-resolves the second arg of an `if isinstance(...)` for narrowing purposes via `resolve_type_annotation`. It does not warn. This is fine for *user-visible* counting (the same source line goes through `lower_isinstance_call` for the expression itself, which now warns once). But it adds a fourth place in the codebase where the literal string `"bigint"` is mapped to `Type::BigInt` without using the centralized resolver — joining [typing_and_functions.rs:439](crates/sifr_hir/src/lower/typing_and_functions.rs:439), [type_bounds.rs:12](crates/sifr_hir/src/lower/type_bounds.rs:12), and [infer.rs:51](crates/sifr_type_system/src/infer.rs:51). The prior review already flagged this duplication ([reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md:39-41](reviews/integer-model-int-2b-bigint-transition-diagnostic-review-pass-1.md:39)). Not new debt from this slice; flagged here only because the slice's existence highlights that the duplication still has not been consolidated and the `bigint` removal slice will need to delete all four sites in lockstep.
+
+### 4. The `bigint(...)` constructor call (`expressions.rs:856`) remains silent
+
+`bigint(1)` produces a `Type::BigInt` value with no warning. The slice's stated scope is `isinstance` + `TypeVar` bounds, so this is intentionally out-of-scope. It is worth recording explicitly in the milestone tracker so that the constructor (and the `from sifr import bigint`-style import alias, if it exists) is not forgotten before `bigint` removal. Currently, `value = bigint(1)` (no annotation) is a fully silent way to introduce a `Type::BigInt` value into the program, which arguably is the strongest "silent bigint mention" remaining in the language. Not blocking this slice; flag the gap.
+
+### 5. Phase tracker not updated
+
+The slice closes part of the bundled follow-up bullet at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426). The bullet groups several items (`SIFR-INT-0003` registry placement, e2e fail fixture, reserved-name shadowing, `SIFR-INT-0011` `isinstance`/TypeVar coverage, fixed-width formatting, stdlib bootstrap exports, transitive re-exports), so it's defensibly left ticked off only when the whole bundle closes. But the prior slice's review is referenced in a per-slice line ([line 423](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:423)) — this slice should add an analogous line referencing this review's outcome and the eventual PR. Currently there is no acknowledgement of the slice in the tracker. Not a code blocker; a documentation/hygiene gap.
+
+### 6. Diagnostic registry's representative-fixture pointer is not refreshed
+
+[codes.rs:786](crates/sifr_diagnostics/src/codes.rs:786) and [internal_docs/diagnostic_codes.md:95](internal_docs/diagnostic_codes.md:95) still point only at `test_type_check_source_surfaces_bigint_transition_warning`. The field is "representative", so a single canonical pointer is acceptable per the registry contract. Not a blocker. If the team wants the registry to reflect the broadest fixture, the `isinstance` test is arguably more broadly representative; either way, no action required for this slice.
+
+### 7. No `.sifr` demo or e2e fixture
+
+This is a diagnostics-only slice; the existing unit tests are sufficient. No `verification/` or `demos/` change is warranted.
+
+## Verdict-blocking summary
+
+- **Concern 1** (class PEP 695 double-emit at the lowering layer) is a real defect that ships hidden by CLI dedup. Without a guard or a test covering it, the next consumer of `LoweringResult.warnings` (or the next class-aware test) will trip on it. The fix is a one-line gate inside `collect_class_type`, and the test is a copy of the PEP 695 function test with `class C[T: bigint]: pass`.
+- **Concern 2** (four untested emit sites) is the slice's own definition of "coverage" being only partly delivered. Each missing branch is structurally distinct and trivially testable.
+
+Concerns 3–7 are non-blocking observations.
+
+## Requested changes
+
+1. Add a regression test (and, if needed, a single-pass guard in `collect_class_type`) so that `class C[T: bigint]:` produces exactly one `SIFR-INT-0011` warning at the lowering layer (`type_check_source` consumer view), not just at the CLI.
+2. Add tests for the four currently-untested emit branches (PEP 695 tuple constraint, `bound=` keyword, `constraints=` tuple, `constraints=` single name). Each is a ~10-line copy of the existing template.
+3. Add a per-slice line under the INT-2B section of [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md) noting this review and the eventual PR, consistent with [line 423](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:423).
+4. Run and report `scripts/run_all_tests.sh --profile quick` before the PR.
+
+VERDICT: CHANGES REQUESTED

--- a/reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-2.md
+++ b/reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-2.md
@@ -1,0 +1,107 @@
+# INT-2B Bigint Warning Coverage — Review Pass 2
+
+Branch: `int-2b-bigint-warning-coverage`
+Scope reviewed: incremental changes since pass 1, in response to the requested changes in [reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md](reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md).
+
+Files in delta:
+
+- `crates/sifr_hir/src/lower/classes.rs` — class type-param block now gated by `if !validate_iteration_protocols`.
+- `crates/sifr_hir/src/lower/typevar_annotations.rs` — unchanged from pass 1 (helper + 6 emit sites already in place).
+- `crates/sifr_hir/src/lower/builtin_calls.rs` — unchanged from pass 1 (`isinstance` emit site already in place).
+- `crates/sifr_driver/src/tests/single_file_frontend.rs` — five new tests covering the four previously untested TypeVar branches plus the class PEP 695 single-emission contract.
+
+## Verification of pass-1 requested changes
+
+### Requested change 1 — `class C[T: bigint]` single-emission contract
+
+**Status: Resolved.**
+
+[classes.rs:258-287](crates/sifr_hir/src/lower/classes.rs:258) now wraps the entire PEP 695 class type-param block (type-var registration, bound parsing, `class_declared_type_params` insertion) in `if !validate_iteration_protocols { … }`. Because `collect_class_type` is invoked from [mod.rs:587](crates/sifr_hir/src/lower/mod.rs:587) with `false` and from [mod.rs:597](crates/sifr_hir/src/lower/mod.rs:597) with `true`, the bound is now parsed exactly once per class definition.
+
+I traced the dependent state to confirm the gating is safe across passes:
+
+- `ctx.type_vars` is a `HashSet` populated only by inserts; the first-pass insert is observable in pass 2 even though pass 2 no longer re-inserts. Annotations like `value: T` inside the class body still resolve correctly in pass 2.
+- `ctx.class_declared_type_params` is read at [classes.rs:727](crates/sifr_hir/src/lower/classes.rs:727) (after the class-body loop) in *both* passes; the first-pass entry persists to the second pass.
+- `ctx.type_param_bounds` is the storage for parsed bound specs and is also populated only in pass 1 now. Bounds resolve from the literal AST shape (`Expr::Name`, `Expr::Tuple` of names) and do not depend on alias resolution that occurs between the two passes — so first-pass-only parsing is semantically equivalent to the previous double-parse.
+
+The accompanying test [single_file_frontend.rs:363-370](crates/sifr_driver/src/tests/single_file_frontend.rs:363) (`test_type_check_source_warns_once_for_bigint_class_pep695_bound`) routes `class Box[T: bigint]:\n    value: T\n` through `type_check_source` and asserts `diagnostics.len() == 1`, locking in the single-emission invariant at the HIR layer (i.e., before CLI dedup). This is exactly the missing test pass 1 called out, and it will fail without the guard.
+
+### Requested change 2 — Test the four untested emit branches
+
+**Status: Resolved.**
+
+| Emit site | File:line | Test |
+| --- | --- | --- |
+| PEP 695 simple-name bound | typevar_annotations.rs:36 | `test_type_check_source_warns_for_bigint_pep695_bound` ✓ (unchanged) |
+| PEP 695 tuple constraint | typevar_annotations.rs:43 | `test_type_check_source_warns_for_bigint_pep695_tuple_constraint` ✓ (new) |
+| `TypeVar("T", bigint)` positional | typevar_annotations.rs:82 | `test_type_check_source_warns_for_bigint_typevar_constraint` ✓ (unchanged) |
+| `TypeVar("T", bound=bigint)` keyword | typevar_annotations.rs:110 | `test_type_check_source_warns_for_bigint_typevar_bound_keyword` ✓ (new) |
+| `TypeVar("T", constraints=(bigint, …))` tuple | typevar_annotations.rs:134 | `test_type_check_source_warns_for_bigint_typevar_constraints_tuple_keyword` ✓ (new) |
+| `TypeVar("T", constraints=bigint)` single name | typevar_annotations.rs:146 | `test_type_check_source_warns_for_bigint_typevar_constraints_name_keyword` ✓ (new) |
+| `lower_isinstance_call` second arg | builtin_calls.rs:931 | `test_type_check_source_warns_for_bigint_isinstance_target` ✓ (unchanged) |
+| Class PEP 695 simple-name bound | typevar_annotations.rs:36 (via classes.rs:270) | `test_type_check_source_warns_once_for_bigint_class_pep695_bound` ✓ (new) |
+
+All seven structurally-distinct emit sites that touch a literal `bigint` token are now exercised, plus the class PEP 695 single-emission contract.
+
+To avoid duplication of the assertion boilerplate, the tests share a helper `assert_single_bigint_transition_warning` at [single_file_frontend.rs:284-307](crates/sifr_driver/src/tests/single_file_frontend.rs:284) that asserts:
+
+- exactly one diagnostic,
+- code `INT_BIGINT_TRANSITION_ALIAS`,
+- severity `Warning`,
+- a primary span on file `main`, the expected line, and `byte_end > byte_start`,
+- a context string for failure attribution.
+
+Each new test is a one-line call into the helper. The asserted line numbers (`Some(1)` for inline PEP 695 syntax, `Some(3)` for the legacy declaration form) point at the line containing the `bigint` token, which is the user-helpful span. The shared helper does not duplicate the more rigorous assertions in `test_type_check_source_surfaces_bigint_transition_warning` (message-template equality, `args.is_empty()`), but those invariants are implicitly covered by the parent-commit test, so the slim helper is acceptable for the new branches.
+
+### Requested change 3 — Phase tracker per-slice line
+
+**Status: Not addressed.** [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:420-426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:420) still does not have a per-slice bullet for this slice analogous to [line 423](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:423) (which references the prior `bigint`-annotation slice's review and PR). The bundled follow-up at [line 426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426) still lists "add `SIFR-INT-0011` coverage for silent `bigint` mentions in `isinstance` and TypeVar bounds if they remain before removal" without any acknowledgement that this slice closes that bullet.
+
+Pass 1 explicitly classified this as "Not a code blocker; a documentation/hygiene gap." I retain that classification — the PR-opening step is the natural place to add the per-slice line and the eventual PR number, and gating the verdict on it would block on a paperwork item that the slice author can resolve without further code review. **Non-blocking, but please add the line before opening the PR.**
+
+### Requested change 4 — Run `scripts/run_all_tests.sh --profile quick`
+
+**Status: Resolved.** Reported by the user in this review's invocation: `report_signature=e1bf653aaa770517 wall_time=67.26s`. Plus the targeted runs (`cargo fmt`/`check`, `cargo test -p sifr_driver bigint`, `cargo test -p sifr_hir typevar`, `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings`) all clean per the same report.
+
+## Recheck of pass-1 non-blocking concerns
+
+- **Concern 3** (`detect_narrowing_condition` re-resolves the literal `bigint` silently at [statements.rs:1832](crates/sifr_hir/src/lower/statements.rs:1832)): unchanged, still non-blocking. The user-visible span is already counted by the `lower_isinstance_call` emit, so the narrowing path is silent only at the *type-resolution* layer, not at the user-visible diagnostic count. Carries forward to the eventual centralized-resolver consolidation.
+- **Concern 4** (`bigint(1)` constructor at [expressions.rs:856](crates/sifr_hir/src/lower/expressions.rs:856) remains silent): out of scope for this slice by design.
+- **Concern 5** (phase tracker hygiene): see Requested change 3 above.
+- **Concern 6** (registry's representative-fixture pointer at [codes.rs:786](crates/sifr_diagnostics/src/codes.rs:786) and [internal_docs/diagnostic_codes.md:95](internal_docs/diagnostic_codes.md:95)): no action required by the registry contract.
+- **Concern 7** (no `.sifr` demo / e2e fixture): not warranted for a diagnostics-only slice.
+
+## What is correct in the new delta
+
+1. **Single-pass guard is at the right granularity.** Wrapping the entire type-params block (not just the bound-parse helper call) means `class_declared_type_params` is also inserted only once. Inserting twice was already idempotent (`HashMap::insert` overwrites with the same value), so this is a cleanup rather than a fix — but it is correct.
+2. **The guard predicate is the right condition.** `validate_iteration_protocols` is `false` exactly on the first call site and `true` exactly on the second; so `if !validate_iteration_protocols` reads as "only run during pass 1," which matches the comment at [classes.rs:259-260](crates/sifr_hir/src/lower/classes.rs:259) and the actual scheduler at [mod.rs:585-599](crates/sifr_hir/src/lower/mod.rs:585).
+3. **Test helper trades verbosity for failure attribution.** The `context` argument threaded into every `assert_eq!` makes a failing test's output identify the specific TypeVar branch, not just the line number of the assertion. This is a small but real maintainability win.
+4. **No new lints, no new warnings, no new format diffs, no panic risks.** The delta is entirely diagnostic plumbing and test code.
+5. **The parent-commit test (`test_type_check_source_surfaces_bigint_transition_warning`) still asserts `diagnostics.len() == 1`** for the annotation path, so its stronger message-template/args assertions still anchor the canonical fixture. The new helper-driven tests intentionally are not the canonical fixture.
+6. **No regressions to non-`bigint` paths.** All new emit sites are guarded by `name == "bigint"`. `int`, `float`, user classes, and user-defined type aliases all bypass the helper.
+
+## Concerns and gaps
+
+None blocking. The two pass-1 verdict-blocking concerns (class double-emit; four untested branches) are fully resolved, and every reachable emit site that maps a literal `bigint` token to a TypeVar bound/constraint or `isinstance` target now has at least one regression test. The class single-emission contract is enforced at the HIR layer, not just at CLI dedup.
+
+The remaining pass-1 items are non-blocking and either tracked elsewhere (concerns 3, 4, 6, 7) or outside the code-review surface (concern 5 / requested change 3, the phase-tracker line).
+
+## Verdict-blocking summary
+
+- Concern 1 from pass 1 (class PEP 695 double-emit): **Resolved** via the single-pass guard at [classes.rs:261](crates/sifr_hir/src/lower/classes.rs:261), with an explicit `diagnostics.len() == 1` test at [single_file_frontend.rs:363](crates/sifr_driver/src/tests/single_file_frontend.rs:363).
+- Concern 2 from pass 1 (four untested emit branches): **Resolved** via four new tests at [single_file_frontend.rs:318-343](crates/sifr_driver/src/tests/single_file_frontend.rs:318) and [single_file_frontend.rs:354-361](crates/sifr_driver/src/tests/single_file_frontend.rs:354).
+
+Validation reported in the invocation:
+
+- `cargo fmt`/`cargo check` clean.
+- `cargo test -p sifr_driver bigint` passing.
+- `cargo test -p sifr_hir typevar` passing.
+- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings` clean.
+- `scripts/run_all_tests.sh --profile quick` passing (`report_signature=e1bf653aaa770517`, `wall_time=67.26s`).
+
+## Follow-ups (non-blocking, for the PR-opening step)
+
+1. Add a per-slice bullet under [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:420](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:420) referencing this review and the eventual PR number, consistent with [line 423](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:423). The bundled follow-up at [line 426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426) can then drop the `isinstance`/TypeVar-bound clause (or leave it scoped to the eventual `bigint` removal).
+2. The `bigint(...)` constructor at [expressions.rs:856](crates/sifr_hir/src/lower/expressions.rs:856) remains the strongest "silent bigint mention" in the language. If the milestone tracker doesn't already enumerate it as a pre-removal cleanup target, it's worth a single-line entry so it isn't forgotten.
+
+VERDICT: SATISFIED


### PR DESCRIPTION
## Summary
- Emit `SIFR-INT-0011` for `bigint` mentions in TypeVar bounds/constraints and `isinstance(..., bigint)` targets.
- Avoid duplicate class PEP 695 bigint warnings by parsing class type parameter bounds only during the first class collection pass.
- Add single-warning driver tests across positional TypeVar constraints, `bound=`, `constraints=`, PEP 695 function/class bounds, tuple constraints, and `isinstance`.

## Validation
- `cargo fmt && cargo fmt --check`
- `cargo test -p sifr_driver bigint -- --nocapture` (9 passed)
- `cargo test -p sifr_hir typevar -- --nocapture` (14 passed)
- `cargo clippy -p sifr_hir -p sifr_driver -- -D warnings`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=67.26s`)

## Review
- `reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-1.md`: CHANGES REQUESTED
- `reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-2.md`: SATISFIED

## Follow-ups Tracked
- `bigint(...)` constructor calls remain intentionally out of this slice and should be handled in the eventual public bigint removal/cleanup slice.
