### PR TITLE
Track stdlib folding coverage slice

### DIFF
--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -409,6 +409,7 @@ Validation:
 - [x] INT-2B `bigint` warning coverage review pass 2 satisfied after addressing blockers: `reviews/integer-model-int-2b-bigint-warning-coverage-review-pass-2.md`.
 - [x] INT-2B `bigint(...)` constructor warning review satisfied: `reviews/integer-model-int-2b-bigint-constructor-warning-review-pass-1.md`.
 - [x] INT-2B stdlib constant integer value export review satisfied: `reviews/integer-model-int-2b-stdlib-const-values-review-pass-1.md`.
+- [x] INT-2B stdlib constant folding integration coverage review satisfied: `reviews/integer-model-int-2b-stdlib-folding-coverage-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -430,7 +431,8 @@ Validation:
   - [x] `SIFR-INT-0011` transition warning coverage includes `isinstance(..., bigint)`, TypeVar bounds/constraints, PEP 695 function/class bounds, and class-bound single-emission behavior; review is satisfied and quick validation is passing: PR #1800.
   - [x] `bigint(...)` constructor calls now emit `SIFR-INT-0011` transition warnings, with constructor-only coverage and annotation-only warning coverage preserved; review is satisfied and quick validation is passing: PR #1801.
   - [x] Stdlib bootstrap now exports public recorded `constant_integer_values` for `.sifr` stdlib constants, preserving project-module export parity without adding a direct `num-bigint` dependency to `sifr_driver`; review is satisfied and quick validation is passing: PR #1802.
-  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, add stdlib constant folding integration coverage, and document or implement transitive re-export semantics for imported constants.
+  - [x] Stdlib fixed-width fitting now has integration coverage proving a real `.sifr` stdlib integer constant (`sifr.logging.DEBUG`) folds through import into a `uint8` initializer; review is satisfied and quick validation is passing: PR #1804.
+  - [ ] Carry remaining follow-ups from INT-2A/INT-2B reviews: align `SIFR-INT-0003` registry table placement with future INT entries, add an e2e fail fixture, decide reserved-name shadowing policy during `bigint` cleanup, clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable, and document or implement transitive re-export semantics for imported constants.
 - [ ] INT-3 scalar arithmetic and numeric mixing
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries


### PR DESCRIPTION
## Summary
- Record the satisfied INT-2B stdlib folding coverage review artifact.
- Mark PR #1804 complete in the phase checklist.
- Remove the now-closed stdlib constant folding integration coverage item from the remaining follow-up list.

## Validation
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, wall time 57.76s)
