### PR TITLE
Clean up module const integer fallback paths

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -2,6 +2,9 @@
 
 PI: float = 3.14159
 MAX_RETRIES: int = 3
+BASE_LIMIT: int = 250
+LIMIT: int = BASE_LIMIT + 4
+NEGATIVE_LIMIT: int = -(MAX_RETRIES + 10)
 
 def circle_area(r: float) -> float:
     return PI * r * r
@@ -9,3 +12,5 @@ def circle_area(r: float) -> float:
 def main():
     assert str(circle_area(5.0)) == '78.53975'
     assert str(MAX_RETRIES) == '3'
+    assert str(LIMIT) == '254'
+    assert str(NEGATIVE_LIMIT) == '-13'

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -396,6 +396,115 @@ fn test_fixed_width_const_expression_budget_has_int_code() {
 }
 
 #[test]
+fn test_module_constant_export_uses_prior_const_name() {
+    let module = lower_source(
+        "BASE: int = 250\nLIMIT: int = BASE + 4\n\ndef main() -> uint8:\n    value: uint8 = LIMIT + 1\n    return value\n",
+    )
+    .expect("module constants should reuse earlier const-evaluable names");
+
+    let main_fn = &module.functions[0];
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[0] else {
+        panic!("expected uint8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::U8));
+    assert!(matches!(value, HirExpr::IntLiteral(255)));
+}
+
+#[test]
+fn test_module_constant_export_uses_unary_prior_const_name() {
+    let module = lower_source(
+        "BASE: int = 10\nNEGATIVE: int = -(BASE + 3)\n\ndef main() -> int8:\n    value: int8 = NEGATIVE\n    return value\n",
+    )
+    .expect("module constants should reuse earlier const-evaluable names through unary expressions");
+
+    let main_fn = &module.functions[0];
+    let HirStmt::Let { ty, value, .. } = &main_fn.body[0] else {
+        panic!("expected int8 let");
+    };
+    assert_eq!(ty, &Type::FixedInt(FixedIntType::I8));
+    assert!(matches!(value, HirExpr::IntLiteral(-13)));
+}
+
+#[test]
+fn test_module_constant_export_does_not_retype_fixed_width_name_as_int() {
+    let module = lower_source(
+        "BASE: uint8 = 250\nLIMIT: int = BASE + 4\n\ndef main():\n    print(\"ok\")\n",
+    )
+    .expect("mixed fixed-width to int module const reuse should stay out of export lowering");
+
+    assert!(
+        module
+            .constants
+            .iter()
+            .any(|(name, ty, value)| name == "BASE"
+                && ty == &Type::FixedInt(FixedIntType::U8)
+                && matches!(value, HirExpr::IntLiteral(250))),
+        "source fixed-width module constant should still be collected"
+    );
+    assert!(
+        module.constants.iter().all(|(name, _, _)| name != "LIMIT"),
+        "module lowering should not synthesize an int-typed name for a fixed-width constant"
+    );
+}
+
+#[test]
+fn test_module_fixed_width_const_expression_budget_has_int_code_once() {
+    let source = "LIMIT: uint8 = 10 ** 5000\n\ndef main():\n    print(\"ok\")\n";
+    let errors = lower_source(source)
+        .expect_err("module fixed-width over-budget const expression should fail");
+
+    let budget_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| error.code == Some(DiagnosticCode::INT_EVAL_BUDGET_EXCEEDED))
+        .collect();
+    assert_eq!(
+        budget_errors.len(),
+        1,
+        "module fixed-width over-budget const expressions should emit one budget diagnostic: {errors:?}"
+    );
+    assert_eq!(
+        budget_errors[0].message,
+        "integer literal exceeds compile-time evaluation budget: 5001 decimal digits (max 4096)"
+    );
+    assert_eq!(
+        budget_errors[0].primary_range,
+        Some(range_for(source, "10 ** 5000"))
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code != Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)),
+        "over-budget module const expressions should not also emit range diagnostics: {errors:?}"
+    );
+}
+
+#[test]
+fn test_module_int_over_budget_const_expr_stays_hir_diagnostic() {
+    let source = "LIMIT: int = 10 ** 5000\n\ndef main():\n    print(\"ok\")\n";
+    let errors = lower_source(source)
+        .expect_err("module int over-budget const expression should fail in HIR");
+
+    let budget_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| error.code == Some(DiagnosticCode::INT_EVAL_BUDGET_EXCEEDED))
+        .collect();
+    assert_eq!(
+        budget_errors.len(),
+        1,
+        "module int over-budget const expressions should not reach codegen: {errors:?}"
+    );
+    assert_eq!(
+        errors.len(),
+        1,
+        "module int over-budget const expressions should not emit follow-on diagnostics: {errors:?}"
+    );
+    assert_eq!(
+        budget_errors[0].primary_range,
+        Some(range_for(source, "10 ** 5000"))
+    );
+}
+
+#[test]
 fn test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated() {
     let literal = "1".repeat(4097);
     let source = format!("def main():\n    too_large: uint8 = {literal}\n");

--- a/crates/sifr_hir/src/lower/module_constants_lowering.rs
+++ b/crates/sifr_hir/src/lower/module_constants_lowering.rs
@@ -1,9 +1,11 @@
 use crate::HirExpr;
 use ruff_text_size::Ranged;
-use sifr_python_ast::{Expr, Stmt};
+use sifr_python_ast::{Expr, Stmt, UnaryOp};
 use sifr_type_system::Type;
 
-use super::simple_expr::lower_integer_const_expr_simple;
+use super::simple_expr::{
+    integer_binop_source, lower_integer_const_expr_simple, negate_simple_expr,
+};
 use super::typing_and_functions::resolve_annotation_expr;
 use super::{fixed_width_fitting, LowerCtx};
 
@@ -33,7 +35,7 @@ fn collect_annotated_constant(
     let Some(ref value_expr) = ann.value else {
         return;
     };
-    let Some(mut hir_value) = lower_integer_const_expr_simple(value_expr) else {
+    let Some(mut hir_value) = lower_module_integer_const_expr(value_expr, ctx) else {
         return;
     };
 
@@ -78,7 +80,7 @@ fn collect_bare_constant(
     if ctx.type_vars.contains(&var_name) {
         return;
     }
-    let Some(hir_value) = lower_integer_const_expr_simple(&assign.value) else {
+    let Some(hir_value) = lower_module_integer_const_expr(&assign.value, ctx) else {
         return;
     };
 
@@ -91,4 +93,50 @@ fn collect_bare_constant(
     );
     ctx.scope.define(var_name.clone(), ty.clone());
     constants.push((var_name, ty, hir_value));
+}
+
+fn lower_module_integer_const_expr(expr: &Expr, ctx: &LowerCtx) -> Option<HirExpr> {
+    match expr {
+        Expr::Name(name) if ctx.const_integer_values.contains_key(name.id.as_str()) => {
+            let scope_ty = &ctx.scope.lookup(name.id.as_str())?.ty;
+            if !matches!(scope_ty, Type::Int) {
+                return None;
+            }
+            Some(HirExpr::Name {
+                name: name.id.to_string(),
+                ty: Type::Int,
+            })
+        }
+        Expr::UnaryOp(unary) if matches!(unary.op, UnaryOp::UAdd) => {
+            lower_module_integer_const_expr(&unary.operand, ctx)
+        }
+        Expr::UnaryOp(unary) if matches!(unary.op, UnaryOp::USub) => {
+            let operand = lower_module_integer_const_expr(&unary.operand, ctx)?;
+            negate_module_integer_const_expr(operand)
+        }
+        Expr::BinOp(binop) => {
+            let left = lower_module_integer_const_expr(&binop.left, ctx)?;
+            let right = lower_module_integer_const_expr(&binop.right, ctx)?;
+            if !matches!(left.ty(), Type::Int) || !matches!(right.ty(), Type::Int) {
+                return None;
+            }
+            Some(HirExpr::BinOp {
+                left: Box::new(left),
+                op: integer_binop_source(binop.op)?.to_string(),
+                right: Box::new(right),
+                ty: Type::Int,
+            })
+        }
+        _ => lower_integer_const_expr_simple(expr),
+    }
+}
+
+fn negate_module_integer_const_expr(expr: HirExpr) -> Option<HirExpr> {
+    negate_simple_expr(expr.clone()).or_else(|| {
+        matches!(expr.ty(), Type::Int).then(|| HirExpr::UnaryOp {
+            op: "-".to_string(),
+            operand: Box::new(expr),
+            ty: Type::Int,
+        })
+    })
 }

--- a/crates/sifr_hir/src/lower/simple_expr.rs
+++ b/crates/sifr_hir/src/lower/simple_expr.rs
@@ -166,7 +166,7 @@ fn lower_expr_simple_inner(expr: &Expr, allow_integer_binop: bool) -> Option<Hir
     }
 }
 
-fn negate_simple_expr(expr: HirExpr) -> Option<HirExpr> {
+pub(super) fn negate_simple_expr(expr: HirExpr) -> Option<HirExpr> {
     match expr {
         HirExpr::IntLiteral(value) => Some(HirExpr::IntLiteral(-value)),
         HirExpr::LargeIntLiteral(value) => Some(HirExpr::UnaryOp {
@@ -179,7 +179,7 @@ fn negate_simple_expr(expr: HirExpr) -> Option<HirExpr> {
     }
 }
 
-fn integer_binop_source(op: Operator) -> Option<&'static str> {
+pub(super) fn integer_binop_source(op: Operator) -> Option<&'static str> {
     match op {
         Operator::Add => Some("+"),
         Operator::Sub => Some("-"),

--- a/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md
+++ b/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md
@@ -1,0 +1,166 @@
+# INT-2B Module Const / Fixed-Width Fallback Cleanup — Review Pass 2
+
+**Verdict:** Blockers found.
+
+## Scope reviewed
+
+Working-tree diff against `2b5bd78e` on `int-2b-module-const-fallback-cleanup`:
+
+- [crates/sifr_hir/src/lower/fixed_width_fitting.rs](crates/sifr_hir/src/lower/fixed_width_fitting.rs)
+- [crates/sifr_hir/src/lower/module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs)
+- [crates/sifr_hir/src/lower/simple_expr.rs](crates/sifr_hir/src/lower/simple_expr.rs)
+- [crates/sifr_hir/src/lower/expressions_tests.rs](crates/sifr_hir/src/lower/expressions_tests.rs)
+
+Reference docs:
+- [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md) (slice item: "Carry remaining follow-ups from INT-2A/INT-2B reviews: clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable.")
+- [internal_docs/integer_model.md](internal_docs/integer_model.md)
+
+## Summary of intended changes
+
+1. **Split const evaluation paths.** [fixed_width_fitting.rs:78-105](crates/sifr_hir/src/lower/fixed_width_fitting.rs:78) introduces `const_integer_value_for_export` (with `emit_budget_diagnostics: false`) and re-routes `remember_module_const_integer` through it, threading the flag down through `evaluate_left_shift`, `evaluate_pow`, and `reject_if_over_budget`. The validation entry point `const_integer_value` continues to emit budget diagnostics.
+2. **Module-aware lowering.** [module_constants_lowering.rs:98-143](crates/sifr_hir/src/lower/module_constants_lowering.rs:98) replaces the `lower_integer_const_expr_simple` call sites with a new `lower_module_integer_const_expr` that resolves prior module-cached `Name`s, plus unary `+`/`-` and binops over them. `simple_expr.rs` exposes `negate_simple_expr` and `integer_binop_source` as `pub(super)` for reuse.
+3. **Tests.** Three new HIR-level tests in [expressions_tests.rs:399-442](crates/sifr_hir/src/lower/expressions_tests.rs:399) cover (a) `LIMIT: int = 10 ** 5000` not erroring on the export path, (b) `LIMIT: int = BASE + 4` folding through to a `uint8` initializer, and (c) `NEGATIVE: int = -(BASE + 3)` folding through to an `int8` initializer.
+
+## Blocker — internal compiler panic for over-budget `int` module constants
+
+The `_for_export` flag muting suppresses `SIFR-INT-0004` for module-level `int` constants whose const evaluation exceeds the 4096-decimal-digit compile-time budget. With the prior code, the `remember_module_const_integer` call would re-evaluate and fail validation (because `validate_annotated_constant_initializer` returns `NotConst` for non-fixed-width `Type::Int`, leaving the budget guard in `remember_module_const_integer` as the only emitter). After the change, no diagnostic is emitted and lowering succeeds — but the resulting HIR shape is not codegen-safe.
+
+Reproduction:
+
+```sifr
+# /tmp/limit_pow.sifr
+LIMIT: int = 10 ** 5000
+
+def main():
+    print("ok")
+```
+
+- Before this branch: `cargo run -q -p sifr -- check /tmp/limit_pow.sifr` ⇒ `type error: integer literal exceeds compile-time evaluation budget: 5001 decimal digits (max 4096)`. Clean `SIFR-INT-0004`.
+- After this branch: `cargo run -q -p sifr -- check /tmp/limit_pow.sifr` ⇒ `no errors found`, then `cargo run -q -p sifr -- emit /tmp/limit_pow.sifr` panics:
+  ```
+  thread 'main' panicked at crates/sifr_codegen/src/module_constants.rs:12:17:
+  structured module constant emission missing for production path (LIMIT):
+  unsupported module constant lowering shape: name=LIMIT, ty=Int,
+  value=BinOp { left: IntLiteral(10), op: "**", right: IntLiteral(5000), ty: Int }
+  internal compiler error: internal compiler panic during single-file code generation: ...
+  ```
+
+Variants that reproduce the same regression on this branch (all panic at codegen):
+
+- `LIMIT = 10 ** 5000` (bare assignment, no annotation).
+- `LIMIT: int = -(10 ** 5000)` (unary-negated over-budget).
+- `LIMIT: int = 999999999999999999999999999999999999` (large literal exceeding `i64`, no `**` involved — unrelated to this PR but reachable from any over-budget module int annotation).
+
+The `**` regression is the worst one because [fixed_width_fitting.rs:280-294](crates/sifr_hir/src/lower/fixed_width_fitting.rs:280) ran a *budget* gate that now no longer trips on the export path, while [crates/sifr_codegen/src/lower_expr.rs:1503-1519](crates/sifr_codegen/src/lower_expr.rs:1503) does not list `**` as a "safe simple binop". So `try_lower_simple_module_constant_item_result_impl` returns `Ok(None)` for primitive `Type::Int` with a `**` BinOp, and [crates/sifr_codegen/src/module_constants.rs:8-15](crates/sifr_codegen/src/module_constants.rs:8) escalates that to a panic.
+
+A second variant doesn't panic but emits unsound Rust:
+
+```sifr
+LIMIT: int = 1 << 99999
+```
+
+emits `const LIMIT: i64 = (1 as i64) << (99999 as i64);`, which `rustc` rejects:
+```
+error[E0080]: attempt to shift left by `99999_i64`, which would overflow
+```
+Previously this case also raised the clean `SIFR-INT-0004` at HIR. After this branch the diagnostic is silently moved to a downstream `rustc` error.
+
+### Why this matters for the slice
+
+The slice's stated remit is "clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable." Replacing a clean `SIFR-INT-0004` diagnostic with an internal-compiler panic on a non-fixed-width construct is the opposite of cleanup — it's a UX regression that contradicts the AGENTS.md commitment that "if it compiles, it works" and that there are no user-triggerable runtime panics. (The panic here is at compile time, not runtime, but it is still a `panic!` reached from valid-looking user input.)
+
+The PR description correctly identifies that "const export-cache remembering for module-level int constants must not emit fixed-width budget diagnostics just because a module int constant is over budget." That intent is right *if* downstream codegen can represent the construct. Today it can't:
+- `Type::Int` is still emitted as `i64` in module constant codegen ([crates/sifr_codegen/src/lower_item.rs:88-105](crates/sifr_codegen/src/lower_item.rs:88)) — the SifrInt-backed `int` from INT-1 is not yet wired into module-level constant lowering. INT-3/INT-1 wave 2 work is what unlocks this.
+- `try_lower_leaf_or_name_expr_result` ([crates/sifr_codegen/src/lower_item.rs:71-79](crates/sifr_codegen/src/lower_item.rs:71)) doesn't accept `LargeIntLiteral` either.
+
+Until that lands, suppressing the budget gate creates an unreachable-by-design path that explodes at codegen.
+
+### Suggested resolutions (any one fixes the blocker)
+
+- **Preferred**: keep `remember_module_const_integer` calling the diagnostic-emitting path (i.e., revert the `_for_export` split), at least until codegen learns to emit over-budget `int` module constants. The previous duplicate-diagnostic risk cited as the motivation for this split is already prevented by the `error_count_before_initializer` guard in [module_constants_lowering.rs:44-60](crates/sifr_hir/src/lower/module_constants_lowering.rs:44): `remember_module_const_integer` only runs when validation didn't error, so the only way it can re-emit is when validation didn't gate (i.e., when the target was non-fixed-width and we genuinely *do* want to error). Concretely, for `LIMIT: int = 10 ** 5000` the legacy single-emission of `SIFR-INT-0004` is the right behavior right now.
+- **Alternative**: keep the export-path mute *only* when the const RHS is already representable by codegen (for example, leaf or simple-binop over leaves where the `**` operator is rejected at lowering, mirroring `is_safe_simple_binop`). This is more invasive and duplicates codegen invariants in HIR.
+- **Alternative**: extend codegen to emit over-budget `int` module constants via the SifrInt runtime's big-integer constructor. That's a real INT-1/INT-3 surface and is out of scope for a "cleanup" slice.
+
+Either way, the test `test_module_int_over_budget_const_expr_is_not_export_cache_diagnostic` ([expressions_tests.rs:398-412](crates/sifr_hir/src/lower/expressions_tests.rs:398)) needs to be reframed: it currently asserts the regression as if it were the desired behavior, but it only exercises HIR (`lower_source`) and so misses the downstream panic.
+
+## Non-blocking findings
+
+### N1 — Dead branch in `negate_module_integer_const_expr`
+
+[module_constants_lowering.rs:130-143](crates/sifr_hir/src/lower/module_constants_lowering.rs:130):
+
+```rust
+fn negate_module_integer_const_expr(expr: HirExpr) -> Option<HirExpr> {
+    if let Some(negated) = negate_simple_expr(expr.clone()) {
+        return Some(negated);
+    }
+    if matches!(expr.ty(), Type::Int) {
+        Some(HirExpr::UnaryOp { op: "-".to_string(), operand: Box::new(expr), ty: Type::Int })
+    } else {
+        negate_simple_expr(expr)
+    }
+}
+```
+
+The final `else` arm calls `negate_simple_expr` on an expression that already produced `None` from `negate_simple_expr` two lines up — `negate_simple_expr` only depends on the variant, not on context, so it returns `None` again. The arm is unreachable in practice and reads like a stray copy/paste. Either drop the branch:
+
+```rust
+fn negate_module_integer_const_expr(expr: HirExpr) -> Option<HirExpr> {
+    negate_simple_expr(expr.clone()).or_else(|| {
+        matches!(expr.ty(), Type::Int).then(|| HirExpr::UnaryOp {
+            op: "-".to_string(),
+            operand: Box::new(expr),
+            ty: Type::Int,
+        })
+    })
+}
+```
+
+…or, if the intent is "wrap in UnaryOp only when the operand is `int`", say so directly without the dead arm.
+
+### N2 — Missing module-level fixed-width budget regression test
+
+The PR adds [test_module_int_over_budget_const_expr_is_not_export_cache_diagnostic](crates/sifr_hir/src/lower/expressions_tests.rs:398) but doesn't add a positive `SIFR-INT-0004` assertion at module scope. The existing [test_fixed_width_const_expression_budget_has_int_code](crates/sifr_hir/src/lower/expressions_tests.rs:378) only covers function-body assignments. Given that the fix in this slice deliberately changes the budget-emission behavior at module scope, a pinning test like
+
+```rust
+let source = "LIMIT: uint8 = 10 ** 5000\n\ndef main():\n    print(\"ok\")\n";
+```
+
+asserting the diagnostic is emitted exactly once and points at `10 ** 5000` would prevent silent regressions on the still-load-bearing fixed-width path. (I confirmed manually via `sifr check` that the diagnostic still fires today.)
+
+### N3 — Tests do not cover the codegen surface for the new module-constant shape
+
+[test_module_constant_export_uses_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:414) and [test_module_constant_export_uses_unary_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:429) verify HIR, but the new constant exports `BASE: int = 250` followed by `LIMIT: int = BASE + 4` only become genuinely useful when codegen renders the BinOp HIR through the safe-simple-binop path. I sanity-checked end-to-end with `sifr emit` (`const BASE: i64 = 250 as i64;` / `const LIMIT: i64 = BASE + (4 as i64);`), so the happy path works today — but a focused codegen snapshot test (or e2e fixture in `verification/`) would prevent later codegen restrictions from silently breaking the slice's externally-visible promise.
+
+### N4 — Naming nit
+
+`lower_module_integer_const_expr` and `negate_module_integer_const_expr` borrow `LowerCtx` only for the `const_integer_values` map. Passing `&LowerCtx` (already done) is fine, but the function reads as if it should grow to manage scope. Worth adding a one-line doc comment that the only piece of `ctx` it reads is the const-integer cache and that the caller is responsible for budget validation. (Optional — the call sites in `collect_annotated_constant` / `collect_bare_constant` are short enough that this is not load-bearing.)
+
+## Determinism / duplication check
+
+I traced the flow for both the fix-target and the existing fixed-width path:
+
+- `LIMIT: uint8 = 10 ** 5000`: `validate_fixed_width_initializer` runs `const_integer_value` (emit=true) → `evaluate_pow` → `reject_if_over_budget` emits `SIFR-INT-0004` once and returns `Rejected`. `validate_annotated_constant_initializer` returns `None`. The `error_count_before_initializer` guard in `collect_annotated_constant` skips `remember_module_const_integer`, so no second emission. ✓ One diagnostic, deterministic. Manual `sifr check` confirms.
+- `LIMIT: int = 250 + 4`: validation early-returns `NotConst`; `remember_module_const_integer` evaluates and caches `254`. ✓
+- `LIMIT: int = BASE + 4` (with prior `BASE: int = 250`): identical to above, with `BASE` resolved through `const_integer_values`. ✓
+- `BASE: int = 254` shadowed by inner-scope `BASE: int = 100` then `value: uint8 = BASE + 1`: `is_shadowed_by_inner_scope` short-circuits to `Unsupported`, validate produces a `TYPE_MISMATCH`. Existing test [test_fixed_width_const_expression_does_not_fold_shadowed_module_constant](crates/sifr_hir/src/lower/expressions_tests.rs:328) still passes. ✓
+
+No diagnostic-duplication concerns introduced by the split.
+
+## Scope drift
+
+- `simple_expr.rs` exposes two helpers as `pub(super)` (`negate_simple_expr`, `integer_binop_source`). Tightly scoped reuse, no drift.
+- The `lower_module_integer_const_expr` recursion is a small, contained replacement of the prior call. It does not pull in general expression lowering; it only adds the Name/UnaryOp/BinOp cases needed for module-level cross-const folding. No drift.
+- No unrelated test deletions or renames.
+
+## Validation reproduced
+
+- `cargo fmt` — clean.
+- `cargo test -p sifr_hir fixed_width -- --nocapture` — 13/13 passing locally.
+- `cargo test -p sifr_hir module_ -- --nocapture` — 8/8 passing locally.
+
+These do not exercise codegen, which is where the blocker lands.
+
+## Verdict
+
+**Blockers found.** The `_for_export` muting of `SIFR-INT-0004` turns previously-clean compile errors into either an internal compiler panic (`**` over budget, `LargeIntLiteral` over `i64`) or a `rustc` error (`<<` past `i64`) for module-level `int` constants. The slice's intent is sound but cannot land safely until codegen can emit over-budget `int` module constants, or until the export path stops accepting expressions that codegen will reject. Pick one of the suggested resolutions before merging, and add the missing module-level fixed-width budget test and a codegen smoke check to keep this from re-regressing.

--- a/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-3.md
+++ b/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-3.md
@@ -1,0 +1,141 @@
+# INT-2B Module Const / Fixed-Width Fallback Cleanup — Review Pass 3
+
+**Verdict:** Blockers found.
+
+## Scope reviewed
+
+Working-tree diff against `2b5bd78e` on `int-2b-module-const-fallback-cleanup`:
+
+- [crates/sifr_hir/src/lower/module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs)
+- [crates/sifr_hir/src/lower/simple_expr.rs](crates/sifr_hir/src/lower/simple_expr.rs)
+- [crates/sifr_hir/src/lower/expressions_tests.rs](crates/sifr_hir/src/lower/expressions_tests.rs)
+- [crates/sifr/tests/e2e/pass/module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr)
+
+Reference docs:
+- [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md) (slice item: "Carry remaining follow-ups from INT-2A/INT-2B reviews: clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable.")
+- [reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md)
+
+## Pass-2 blocker resolution
+
+The pass-2 blocker — `_for_export` muting of `SIFR-INT-0004` letting over-budget `int` module constants escape HIR and either panic codegen (`**`) or produce `rustc` errors (`<<`) — is closed. The revised diff drops the export-cache split entirely. `fixed_width_fitting.rs` is unchanged from the parent commit, and [module_constants_lowering.rs:54-59](crates/sifr_hir/src/lower/module_constants_lowering.rs:54) routes `remember_module_const_integer` through the original diagnostic-emitting `const_integer_value`. I re-traced the four pass-2 reproducers:
+
+- `LIMIT: int = 10 ** 5000` ⇒ `evaluate_pow` → `reject_if_over_budget` emits one `SIFR-INT-0004`. `lower_module_with_externals` returns `Err`, so codegen never runs. Confirmed by `sifr check` and by [test_module_int_over_budget_const_expr_stays_hir_diagnostic](crates/sifr_hir/src/lower/expressions_tests.rs:466).
+- `LIMIT = 10 ** 5000` (bare) ⇒ same path through `collect_bare_constant`/`remember_module_const_integer`, one `SIFR-INT-0004`.
+- `LIMIT: int = -(10 ** 5000)` ⇒ `negate_module_integer_const_expr` wraps in `UnaryOp("-", BinOp, Int)`; const_integer_value's `"-"` arm propagates `Rejected` from the inner BinOp evaluation. One `SIFR-INT-0004`.
+- `LIMIT: int = 1 << 99999` ⇒ `evaluate_left_shift` short-circuits via `MAX_EXACT_SHIFT_OR_EXPONENT`, emits one `SIFR-INT-0004`.
+
+The pass-2 N1 (dead `negate_simple_expr` else arm), N2 (missing module-level fixed-width budget regression test), and N3 (codegen smoke for the new shape) are also addressed: [negate_module_integer_const_expr](crates/sifr_hir/src/lower/module_constants_lowering.rs:130) now uses `or_else`+`then`, [test_module_fixed_width_const_expression_budget_has_int_code_once](crates/sifr_hir/src/lower/expressions_tests.rs:435) pins the `uint8 = 10 ** 5000` single-emission, and [module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr:5) covers `BASE_LIMIT + 4` and `-(MAX_RETRIES + 10)` end-to-end.
+
+## Criteria from the pass-3 brief
+
+1. Module-level `int` over-budget const expressions should remain clean HIR diagnostics and not reach codegen — **met** (above).
+2. Module-level fixed-width over-budget const expressions should emit exactly one budget diagnostic and no range/type follow-on — **met**: validate path emits `SIFR-INT-0004` and returns `Rejected`; the [error_count_before_initializer](crates/sifr_hir/src/lower/module_constants_lowering.rs:53) guard then skips `remember_module_const_integer`. Pinned by [test_module_fixed_width_const_expression_budget_has_int_code_once](crates/sifr_hir/src/lower/expressions_tests.rs:435).
+3. Module constants may reuse prior const-evaluable names through unary/binop expressions without general expression lowering — **met functionally for `int` reuse**; see new blocker below for the `int`/fixed-width crossover variant.
+4. The e2e module constants fixture should provide sufficient codegen smoke for the new name/binop/unary module const shapes — **met**: `BASE_LIMIT: int = 250` / `LIMIT: int = BASE_LIMIT + 4` exercises the BinOp+Name codegen path; `NEGATIVE_LIMIT: int = -(MAX_RETRIES + 10)` exercises the UnaryOp+BinOp+Name path; both have value assertions in `main`.
+
+## New blocker — mixed `int` ⇄ fixed-width module constant references emit broken Rust
+
+[lower_module_integer_const_expr](crates/sifr_hir/src/lower/module_constants_lowering.rs:98) accepts any prior name that lives in `ctx.const_integer_values` and synthesizes `HirExpr::Name { ty: Type::Int }` regardless of the source constant's actual scope type. Because `remember_module_const_integer` happily caches BigInt values for *fixed-width* module constants too (see the existing passing test [test_fixed_width_const_expression_uses_module_integer_constants](crates/sifr_hir/src/lower/expressions_tests.rs:313), which depends on that cache populating from `BASE: int = 250 + 4`), this new path will now resolve `Name`s for fixed-width-typed constants while reporting `Type::Int` to downstream codegen.
+
+The result is that codegen renders Rust expressions that reference a fixed-width (`u8`/`i32`/...) const inside an `i64`-context expression, which `rustc` rejects.
+
+Reproductions on the working tree (`sifr check` reports "no errors found"):
+
+```sifr
+BASE: uint8 = 250
+ALIAS: int = BASE
+def main():
+    print(str(ALIAS))
+```
+`sifr emit` ⇒ `const BASE: u8 = 250u8;` / `const ALIAS: i64 = BASE;`
+`sifr run` ⇒ `error[E0308]: mismatched types ... expected 'i64', found 'u8'`
+
+```sifr
+BASE: uint8 = 250
+LIMIT: int = BASE + 4
+def main():
+    print(str(LIMIT))
+```
+`sifr emit` ⇒ `const BASE: u8 = 250u8;` / `const LIMIT: i64 = BASE + (4 as i64);`
+`sifr run` ⇒ `error[E0277]: cannot add 'i64' to 'u8'` (also `E0308` x2).
+
+```sifr
+BASE: uint8 = 250
+NEG: int = -BASE
+def main():
+    print(str(NEG))
+```
+`sifr emit` ⇒ `const BASE: u8 = 250u8;` / `const NEG: i64 = -BASE;`
+`sifr run` ⇒ `error[E0308]: ... expected 'i64', found 'u8'` (and `E0600` since `-` is not defined on `u8`).
+
+For comparison, on the parent commit `2b5bd78e` the alias case fails with `type error: undefined variable: 'ALIAS'` because the prior `lower_integer_const_expr_simple` did not handle `Name`s, so `ALIAS` was not collected as a module constant. The function-body equivalent (`def main(): value: int = BASE + 1`) still fails cleanly today with `unsupported operand type(s) for +: 'uint8' and 'int'` because regular expression lowering uses scope-resolved types — only this new module-level path bypasses that resolution.
+
+### Why this matters for the slice
+
+The slice's stated remit is "clean up fixed-width diagnostic formatting/fallback paths as those code paths become reachable." The pass-2 blocker called out a different reachable path that produced rustc errors / panics; pass 3 closes that one but introduces a new reachable path (mixed-type module const reuse) that produces rustc errors from valid-looking Sifr source. This contradicts AGENTS.md's "if it compiles, it works" commitment for the front-end gate (`sifr check` returns "no errors") and is exactly the class of issue the slice is meant to prevent.
+
+The new pass-3 tests don't catch this because [test_module_constant_export_uses_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:399) and [test_module_constant_export_uses_unary_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:414) only assert on the *folded* `IntLiteral` produced by fixed-width fitting in a function body — they never look at the unfolded HIR shape that codegen sees for the mixed module-level case. The e2e fixture is all `int`-typed.
+
+### Suggested resolution
+
+Restrict the `Name` arm in `lower_module_integer_const_expr` to constants whose scope-resolved type is `Type::Int`. The scope is already populated by the time later constants are collected (each iteration calls `ctx.scope.define(var_name, ty)`), and `is_shadowed_by_inner_scope` already shows the lookup pattern. A minimal change:
+
+```rust
+Expr::Name(name) if ctx.const_integer_values.contains_key(name.id.as_str()) => {
+    let scope_ty = ctx.scope.lookup(name.id.as_str()).cloned()?;
+    if !matches!(scope_ty, Type::Int) {
+        return None;
+    }
+    Some(HirExpr::Name { name: name.id.to_string(), ty: Type::Int })
+}
+```
+
+Falling back to `None` here will leave the constant un-collected (today's behavior on `2b5bd78e`), so a downstream "undefined variable" / "unsupported operand" diagnostic surfaces instead of a generated Rust type mismatch. Add a regression test (HIR-level: assert lowering succeeds on a clean `BASE: int = 250\nLIMIT: int = BASE + 4` *and* that lowering of `BASE: uint8 = 250\nLIMIT: int = BASE + 4` does not produce a `LIMIT` entry in `module.constants` — or alternatively reports a clean diagnostic).
+
+A more complete alternative would be to also store the source type alongside the BigInt in `const_integer_values` and propagate it into the synthesized `Name`'s `ty`, but that is more invasive and isn't required for this slice; the simple "only reuse when source is `Type::Int`" cut is sufficient.
+
+## Non-blocking findings
+
+### N1 — Module int over-budget test does not pin total error count
+
+[test_module_int_over_budget_const_expr_stays_hir_diagnostic](crates/sifr_hir/src/lower/expressions_tests.rs:466) asserts there is exactly one `INT_EVAL_BUDGET_EXCEEDED` but does not also assert that no other diagnostic is emitted. Trace shows none today (validate is a no-op for `Type::Int` annotations and `value_ty == declared_type`), but adding either an `errors.len() == 1` check or a "no `TYPE_MISMATCH` follow-on" assertion (parallel to [test_module_fixed_width_const_expression_budget_has_int_code_once:455](crates/sifr_hir/src/lower/expressions_tests.rs:455)) would be a cheap pinning win.
+
+### N2 — Pre-existing `LargeIntLiteral` codegen panic is still reachable from this PR's surface
+
+Untouched by this slice, but worth re-flagging: a literal that fits within the 4096-decimal-digit budget but exceeds `i64` (e.g. `LIMIT: int = 999999999999999999999999999999999999`) survives `lower_module_integer_const_expr` → `lower_integer_const_expr_simple` → `LargeIntLiteral`, then `try_lower_simple_module_constant_item_result_impl` returns `Ok(None)` (since `try_lower_leaf_expr` does not handle `LargeIntLiteral`), which `emit_module_constants` escalates to a `panic!` at [module_constants.rs:12](crates/sifr_codegen/src/module_constants.rs:12). Pass 2 noted this as out of scope for the cleanup slice and tied it to the SifrInt wiring under INT-1/INT-3. Worth tracking explicitly so it doesn't get lost.
+
+### N3 — Naming/doc nit (optional)
+
+`lower_module_integer_const_expr` and `negate_module_integer_const_expr` borrow `LowerCtx` only for `const_integer_values`. The pass-2 N4 suggestion to add a one-line note that they read only the const-integer cache and that callers handle budget validation still applies. Small, can be skipped.
+
+## Determinism / duplication check
+
+I traced the diagnostic emission count for the relevant module-scope cases:
+
+- `LIMIT: uint8 = 10 ** 5000` (over-budget fixed-width): validate path emits one `SIFR-INT-0004`, `error_count_before_initializer` guard skips `remember_module_const_integer`. ✓ One emission.
+- `LIMIT: int = 10 ** 5000` (over-budget int): validate is a no-op (NotConst), `remember_module_const_integer` emits one `SIFR-INT-0004`. ✓ One emission.
+- `LIMIT: int = -(10 ** 5000)`: same path; `Rejected` propagates through the `"-"` arm of `const_integer_value`, single emission. ✓
+- `LIMIT: int = BASE + 4` with prior `BASE: int = 250`: validate is a no-op, `remember_module_const_integer` evaluates to `254`, no diagnostic. ✓
+- Shadowed module constant via inner-scope rebind ([test_fixed_width_const_expression_does_not_fold_shadowed_module_constant](crates/sifr_hir/src/lower/expressions_tests.rs:329)): `is_shadowed_by_inner_scope` short-circuits to `Unsupported`, validate produces a single `TYPE_MISMATCH`, no range diagnostic. ✓
+
+No duplicate-emission concerns introduced. The duplicate-emission risk that originally motivated the (pass-2) `_for_export` split was, as pass 2 already noted, already prevented by the `error_count_before_initializer` guard, so reverting the split was safe.
+
+## Scope drift
+
+- `simple_expr.rs` exposes `negate_simple_expr` and `integer_binop_source` as `pub(super)`. Tightly scoped reuse, no drift.
+- `lower_module_integer_const_expr` is a contained replacement of the prior `lower_integer_const_expr_simple` call site for module constants. It only adds `Name`/`UnaryOp`/`BinOp` cases needed for module-level cross-const folding and falls through to `lower_integer_const_expr_simple` for the pre-existing leaf shapes. No drift.
+- E2E fixture additions are localized to the existing `module_constants.sifr` and assert structurally; no unrelated test deletions or renames.
+
+## Validation reproduced
+
+- `cargo fmt` — clean.
+- `cargo test -p sifr_hir fixed_width -- --nocapture` — passing locally.
+- `cargo test -p sifr_hir module_ -- --nocapture` — passing locally.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr` — passing.
+- `cargo run -q -p sifr -- check /tmp/limit_pow.sifr` (with `LIMIT: int = 10 ** 5000`) ⇒ clean `SIFR-INT-0004`, codegen not invoked.
+
+The new blocker was reproduced via the three mixed-type cases above; none of these are exercised by the in-tree test suite.
+
+## Verdict
+
+**Blockers found.** Pass 2's blocker is closed and the four explicit pass-3 criteria are met for the all-`int` shapes the brief calls out. However, the same `lower_module_integer_const_expr` `Name` arm that enables `int` reuse silently re-routes mixed-type module constants (e.g. `int = uint8_const`, `int = uint8_const + N`, `int = -uint8_const`) into codegen with a synthesized `Type::Int` Name, producing rustc errors from valid-looking Sifr source on the front-end gate. Constrain the `Name` arm to scope-`Type::Int` constants (or otherwise refuse to fold across types) and add a HIR-level regression test before merging. Once that lands, the slice is otherwise in good shape.

--- a/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md
+++ b/reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md
@@ -1,0 +1,115 @@
+# INT-2B Module Const / Fixed-Width Fallback Cleanup — Review Pass 4
+
+**Verdict:** Satisfied with non-blocking suggestions.
+
+## Scope reviewed
+
+Working-tree diff against `2b5bd78e` on `int-2b-module-const-fallback-cleanup`:
+
+- [crates/sifr_hir/src/lower/module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs)
+- [crates/sifr_hir/src/lower/simple_expr.rs](crates/sifr_hir/src/lower/simple_expr.rs)
+- [crates/sifr_hir/src/lower/expressions_tests.rs](crates/sifr_hir/src/lower/expressions_tests.rs)
+- [crates/sifr/tests/e2e/pass/module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr)
+
+Reference docs:
+- [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)
+- [reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md)
+- [reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-3.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-3.md)
+
+## Pass-3 blocker resolution — closed
+
+The pass-3 blocker was that [lower_module_integer_const_expr](crates/sifr_hir/src/lower/module_constants_lowering.rs:98)'s `Name` arm accepted any prior name living in `ctx.const_integer_values` and synthesized `HirExpr::Name { ty: Type::Int }` regardless of the source constant's actual scope type. Mixed-type module constants such as
+
+```sifr
+BASE: uint8 = 250
+ALIAS: int = BASE
+```
+
+passed `sifr check` and then failed at `rustc` with `E0308`/`E0277`/`E0600`.
+
+The revised diff guards the `Name` arm with a scope-type check:
+
+```rust
+Expr::Name(name) if ctx.const_integer_values.contains_key(name.id.as_str()) => {
+    let scope_ty = &ctx.scope.lookup(name.id.as_str())?.ty;
+    if !matches!(scope_ty, Type::Int) {
+        return None;
+    }
+    Some(HirExpr::Name { name: name.id.to_string(), ty: Type::Int })
+}
+```
+
+Trace for the three pass-3 reproducers:
+
+- `BASE: uint8 = 250\nALIAS: int = BASE` ⇒ `BASE` is cached in `const_integer_values` after `collect_annotated_constant` runs `remember_module_const_integer`, but `ctx.scope.define("BASE", Type::FixedInt(U8))` records the fixed-width type. When `ALIAS` is lowered, the `Name` arm's `matches!(scope_ty, Type::Int)` guard fires and returns `None`. `collect_annotated_constant` early-returns at the `let-else`, so `ALIAS` is never collected and never appears in `ctx.scope`. `main`'s use of `ALIAS` then surfaces as an undefined-variable diagnostic at the regular HIR resolution pass instead of a synthesized `Type::Int` Name reaching codegen. Confirmed by the user's manual `sifr check` reproduction and pinned at HIR by [test_module_constant_export_does_not_retype_fixed_width_name_as_int](crates/sifr_hir/src/lower/expressions_tests.rs:430).
+- `BASE: uint8 = 250\nLIMIT: int = BASE + 4` ⇒ The `BinOp` arm recurses: left = `lower_module_integer_const_expr(BASE)` returns `None` (same scope-type guard). The `?` shortcircuits and the BinOp returns `None`. `LIMIT` is not collected. Same outcome as above.
+- `BASE: uint8 = 250\nNEG: int = -BASE` ⇒ The `USub` arm calls `lower_module_integer_const_expr(BASE)` which returns `None` and propagates through `?` before ever reaching `negate_module_integer_const_expr`. `NEG` is not collected.
+
+I also verified the symmetric all-`int` case still works:
+
+- `BASE: int = 250\nLIMIT: int = BASE + 4` ⇒ `BASE` is cached at 250, `ctx.scope.define("BASE", Type::Int)`. `LIMIT`'s BinOp arm: left → `Some(Name{name:"BASE", ty:Int})`, right → `IntLiteral(4)`, both `Type::Int`, returns `Some(BinOp{...})`. `remember_module_const_integer` evaluates to 254. Pinned at HIR by [test_module_constant_export_uses_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:399) and end-to-end by the e2e fixture.
+- `BASE: int = 10\nNEGATIVE: int = -(BASE + 3)` ⇒ inner BinOp lowers to `BinOp{Name(BASE,Int), "+", IntLiteral(3), Int}`; `negate_simple_expr(BinOp)` returns `None`; the `or_else` arm matches `Type::Int` and wraps in `UnaryOp{-, BinOp, Int}`; `const_integer_value` evaluates the `"-"` arm → -13. Pinned by [test_module_constant_export_uses_unary_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:413).
+
+The scope-type guard correctly leverages the fact that `collect_annotated_constant`/`collect_bare_constant` define the declared type *after* `remember_module_const_integer` but before the next iteration's lowering call, so the cache and scope type are consistent. `ctx.scope.lookup(...).ty` (the declared type, not `effective_type`) is the right field — narrowing is not applied at module scope during initial collection.
+
+## Criteria from the pass-4 brief
+
+1. **Module const name reuse should work for prior `int` constants through unary/binop forms** — **met**. The all-`int` paths are exercised by the two new HIR tests and by the e2e fixture (`BASE_LIMIT: int = 250` / `LIMIT: int = BASE_LIMIT + 4` / `NEGATIVE_LIMIT: int = -(MAX_RETRIES + 10)`).
+2. **Module const name reuse should not retype fixed-width constants as int** — **met**. The scope-type guard (`matches!(scope_ty, Type::Int)`) refuses to synthesize an `int`-typed `Name` for a fixed-width source. Pinned by [test_module_constant_export_does_not_retype_fixed_width_name_as_int](crates/sifr_hir/src/lower/expressions_tests.rs:430), which asserts both that the source `BASE: uint8 = 250` is preserved and that `LIMIT` is *not* collected.
+3. **Module-level fixed-width and `int` over-budget expressions should emit clean HIR diagnostics and not duplicate diagnostics** — **met**. For the `uint8 = 10 ** 5000` path, `validate_fixed_width_initializer` evaluates and emits exactly one `SIFR-INT-0004`, then the `error_count_before_initializer` guard at [module_constants_lowering.rs:53](crates/sifr_hir/src/lower/module_constants_lowering.rs:53) skips `remember_module_const_integer`. For the `int = 10 ** 5000` path, validation is `NotConst` (no follow-on `TYPE_MISMATCH`) and `remember_module_const_integer` emits exactly one `SIFR-INT-0004`. Pinned by [test_module_fixed_width_const_expression_budget_has_int_code_once](crates/sifr_hir/src/lower/expressions_tests.rs:435) and [test_module_int_over_budget_const_expr_stays_hir_diagnostic](crates/sifr_hir/src/lower/expressions_tests.rs:466) — the latter now also pins `errors.len() == 1`, addressing pass-3 N1.
+4. **The e2e module constants fixture should still smoke-test codegen for the all-`int` name/binop/unary shapes** — **met**. `BASE_LIMIT + 4` exercises BinOp + Name; `-(MAX_RETRIES + 10)` exercises UnaryOp + BinOp + Name. The `assert str(LIMIT) == '254'` and `assert str(NEGATIVE_LIMIT) == '-13'` checks tie the runtime values down.
+
+## Determinism / duplication check
+
+I retraced diagnostic emission counts for the relevant module-scope cases under the new code:
+
+- `LIMIT: uint8 = 10 ** 5000`: `validate_fixed_width_initializer` → `evaluate_pow` → `reject_if_over_budget` emits one `SIFR-INT-0004` and returns `Rejected`. The `error_count_before_initializer` guard skips `remember_module_const_integer`. ✓ One emission.
+- `LIMIT: int = 10 ** 5000`: `validate_annotated_constant_initializer` is a no-op (`NotConst`, types match); `remember_module_const_integer` evaluates and emits one `SIFR-INT-0004`. ✓ One emission, total `errors.len() == 1` pinned.
+- `LIMIT: int = -(10 ** 5000)`: `negate_module_integer_const_expr` wraps the inner BinOp in `UnaryOp("-", BinOp, Int)`; `const_integer_value`'s `"-"` arm propagates `Rejected` from the inner pow evaluation, so the budget diagnostic still emits once.
+- `LIMIT: int = 1 << 99999`: `evaluate_left_shift` short-circuits via `MAX_EXACT_SHIFT_OR_EXPONENT` and emits one `SIFR-INT-0004`.
+- `BASE: uint8 = 250\nLIMIT: int = BASE + 4`: scope-type guard returns `None` from the `Name` arm; `collect_annotated_constant` early-returns at the `let-else`. `LIMIT` is not collected and not `define`d in scope. No new diagnostic at this site; `main`'s use of `LIMIT` surfaces a clean undefined-variable error at the regular pass.
+- `BASE: int = 254` shadowed by an inner-scope `BASE: int = 100` then `value: uint8 = BASE + 1`: pre-existing path; `is_shadowed_by_inner_scope` short-circuits to `Unsupported`, single `TYPE_MISMATCH`, no range diagnostic. ✓
+
+No duplicate-emission concerns introduced.
+
+## Scope drift
+
+- `simple_expr.rs` exposes `negate_simple_expr` and `integer_binop_source` as `pub(super)`. Tightly scoped reuse, no drift.
+- `lower_module_integer_const_expr` only adds the `Name`/`UnaryOp`/`BinOp` cases needed for module-level cross-const folding and falls through to `lower_integer_const_expr_simple` for leaf shapes. No drift into general expression lowering.
+- E2E fixture additions are localized and assert structurally; no unrelated test deletions or renames.
+- The pass-3 fix is a single inserted scope-type check and an early `?` on `ctx.scope.lookup(...)`. Minimal surface change.
+
+## Non-blocking findings
+
+### N1 — `test_module_constant_export_does_not_retype_fixed_width_name_as_int` does not assert the user-visible diagnostic
+
+[test_module_constant_export_does_not_retype_fixed_width_name_as_int](crates/sifr_hir/src/lower/expressions_tests.rs:430) verifies that `LIMIT` is absent from `module.constants`, but the `def main(): print("ok")` body does not reference `LIMIT`, so it doesn't pin the *user-visible* outcome (undefined-variable diagnostic at the call site). The brief calls this out in the validation note, but it's only manually verified. A second test asserting that `BASE: uint8 = 250\nLIMIT: int = BASE + 4\n\ndef main():\n    print(str(LIMIT))\n` returns `Err` with an undefined-variable diagnostic on `LIMIT` would harden against future drift in the regular-pass resolution path interacting with this slice.
+
+This is a hardening nit, not a blocker — the structural assertion already pins the load-bearing invariant (no synthesized `Type::Int` Name for a fixed-width source).
+
+### N2 — Bare unary on a name (`-BASE`) has no focused test
+
+The new tests cover `LIMIT: int = BASE + 4` (BinOp + Name) and `NEGATIVE: int = -(BASE + 3)` (USub + BinOp + Name), but the simpler bare-unary case (`-BASE` with no inner BinOp) isn't exercised on its own. Tracing it: `lower_module_integer_const_expr(USub(Name))` recurses to `Name(BASE, Int)`, then `negate_module_integer_const_expr` falls through `negate_simple_expr` (which only matches literal variants) into the `or_else` arm and wraps in `UnaryOp("-", Name, Int)`. `const_integer_value`'s `"-"` arm evaluates correctly. Functionally fine, just not directly pinned. A one-line addition like `BASE: int = 5\nNEG: int = -BASE` in the e2e fixture (or a third HIR test) would close the gap.
+
+### N3 — Pass-3 N3 (doc comment) still applies
+
+`lower_module_integer_const_expr` and `negate_module_integer_const_expr` borrow `&LowerCtx` only for `const_integer_values` and (now) `scope`. A one-line note that they read only those fields and that callers are responsible for budget validation would help future readers — same suggestion as pass-2 N4 and pass-3 N3. Optional.
+
+### N4 — Pre-existing `LargeIntLiteral` codegen panic still reachable
+
+Untouched by this slice and also flagged in pass-3 N2: a literal in budget but exceeding `i64` (e.g., `LIMIT: int = 999999999999999999999999999999999999`) survives `lower_module_integer_const_expr` → `lower_integer_const_expr_simple` → `LargeIntLiteral`, then `try_lower_simple_module_constant_item_result_impl` returns `Ok(None)`, and `emit_module_constants` panics at [crates/sifr_codegen/src/module_constants.rs:12](crates/sifr_codegen/src/module_constants.rs:12). Out of scope for this slice (tied to SifrInt wiring under INT-1/INT-3 wave 2), but worth tracking explicitly so it doesn't get lost behind the pass-3 fix.
+
+## Validation reproduced
+
+I re-traced rather than re-ran the user's listed validations. The cited results are consistent with the code:
+
+- `cargo fmt` — code is fmt-clean.
+- `cargo test -p sifr_hir fixed_width -- --nocapture` — the `fixed_width` test names cover the budget/range/folding paths the diff touches.
+- `cargo test -p sifr_hir module_ -- --nocapture` — the four new `test_module_*` tests pin all four pass-4 criteria.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr` — the new fixture asserts `LIMIT == 254` and `NEGATIVE_LIMIT == -13`, which match the BigInt evaluation traced above.
+- `sifr check` on the three pass-3 mixed-type repros — the scope-type guard makes those `LIMIT`/`ALIAS`/`NEG` constants un-collected, so `main`'s reference resolves to an undefined-variable diagnostic at the regular pass.
+- `sifr check` on `LIMIT: int = 10 ** 5000` — `remember_module_const_integer`'s budget gate still fires once.
+
+## Verdict
+
+**Satisfied with non-blocking suggestions.** The pass-3 blocker is closed — `lower_module_integer_const_expr` now requires the scope-resolved type of a reused module-const name to be `Type::Int` before synthesizing `HirExpr::Name { ty: Type::Int }`, so mixed-type reuse falls back to today's "undefined variable" surface at the regular pass instead of producing rustc errors from valid-looking Sifr source. All four explicit pass-4 criteria are met, the new HIR tests pin both the positive `int`-reuse paths and the negative mixed-type guard, and the e2e fixture covers codegen for the new shapes. The non-blocking suggestions (broader regression test for the user-visible diagnostic on mixed-type reuse, optional bare-unary coverage, doc comment, and the pre-existing in-budget `LargeIntLiteral` codegen panic) can land separately or stay as follow-ups; none of them gates merge.


### PR DESCRIPTION
## Summary
- allow module constants to reuse prior const-evaluable `int` constants through name, unary, and integer-binop forms
- keep fixed-width module constants from being retyped as `int` during module-constant export lowering
- pin module-scope fixed-width and `int` over-budget diagnostics so they stay clean HIR errors and do not reach codegen
- add e2e module-constant coverage for all-`int` name/binop/unary codegen shapes

## Reviews
- `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-2.md`: blockers found; over-budget module `int` constants could reach codegen after muting export-cache diagnostics
- `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-3.md`: blockers found; mixed fixed-width -> `int` module constants could reach rustc errors
- `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md`: satisfied with non-blocking suggestions

## Validation
- `cargo fmt`
- `cargo test -p sifr_hir fixed_width -- --nocapture`
- `cargo test -p sifr_hir module_ -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- manual `sifr check` repros for over-budget module `int` and mixed fixed-width module const reuse
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=86.64s`)
