### PR TITLE
Close INT-2B milestone tracker

### DIFF
--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -415,6 +415,7 @@ Validation:
 - [x] INT-2B reserved-width shadowing policy documentation review satisfied: `reviews/integer-model-int-2b-reserved-width-shadowing-policy-review-pass-1.md`.
 - [x] INT-2B fixed-width fail fixture marker cleanup review satisfied: `reviews/integer-model-int-2b-fixed-width-fail-fixture-markers-review-pass-1.md`.
 - [x] INT-2B module const/fixed-width fallback cleanup review pass 4 satisfied after addressing pass 2 and pass 3 blockers: `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md`.
+- [x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -428,7 +429,7 @@ Validation:
   - [x] Parsed integer literals beyond the historical `i64` slot lower to canonical decimal `LargeIntLiteral` HIR across decimal, hex, octal, and binary spellings, with review satisfied and quick validation passing: PR #1792.
   - [x] Default-argument large-literal parity and negative-large-literal unary coverage implemented, review satisfied, and quick validation passing: PR #1793.
   - [x] Malformed integer token text has typed parser diagnostic coverage, over-budget integer literals emit `SIFR-INT-0004`, parsed/constructed HIR parity is covered, review is satisfied, and quick validation is passing: PR #1794.
-- [ ] INT-2B HIR, type system, and const fitting
+- [x] INT-2B HIR, type system, and const fitting
   - [x] Fixed-width signed, unsigned, and pointer-sized integer annotations resolve in compiler-owned type layers, nested reserved-width annotation coverage was broadened, review is satisfied, and quick validation is passing: PR #1795.
   - [x] Direct fixed-width const literal fitting accepts fitting annotated assignments/module constants, rejects out-of-range initializers with `SIFR-INT-0001`, preserves non-const/call narrowing rejections, emits suffixed Rust literals, review is satisfied, and quick validation is passing: PR #1796.
   - [x] `bigint` annotations emit warning-only `SIFR-INT-0011` transition diagnostics while preserving the temporary `Type::BigInt` path, review is satisfied, and quick validation is passing: PR #1797.
@@ -444,6 +445,7 @@ Validation:
   - [x] Fixed-width const-expression fail fixture markers are canonical top-level `expect-error` entries, so the e2e fail harness now enforces `SIFR-INT-0001` and `SIFR-INT-0004` columns; review is satisfied and quick validation is passing: PR #1812.
   - [x] Module constant integer fallback paths now preserve budget diagnostics for over-budget module `int`/fixed-width constants, support same-module `int` const reuse through names/unary/binops, reject mixed fixed-width-to-`int` const reuse before codegen, and smoke-test the new codegen shapes; review is satisfied and quick validation is passing: PR #1814.
 - [ ] INT-3 scalar arithmetic and numeric mixing
+  - [ ] Add hardening tests that keep implicit `int`-to-fixed-width narrowing rejected in returns, list literals, dict literals, and generic specialization as scalar arithmetic and numeric mixing evolve.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock

--- a/reviews/integer-model-int-2b-milestone-closure-review-pass-1.md
+++ b/reviews/integer-model-int-2b-milestone-closure-review-pass-1.md
@@ -1,0 +1,228 @@
+# INT-2B Milestone Closure — Review Pass 1
+
+Reviewer: Claude Opus 4.7
+Date: 2026-05-06
+Branch under review: `main` at `95cf5e67` (post PR #1815, all INT-2B child bullets ticked)
+Phase tracker: [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)
+Canonical design: [internal_docs/integer_model.md](internal_docs/integer_model.md)
+Scope of this pass: INT-2B (HIR, type system, and const fitting) — milestone closure readiness only.
+
+## Verdict
+
+**Ready to close INT-2B with non-blocking follow-ups.** Every stated INT-2B scope item, acceptance criterion, and validation entry on the tracker resolves to working compiler-owned behavior. The single open INT-1 breadcrumb (codegen wiring of in-budget >`i64` `int` module constants through `SifrInt`) is correctly scoped under INT-1, not INT-2B, and is the only place where an INT-2B-touched source surface still has a downstream gap. Several non-blocking gaps are listed in §"Non-blocking follow-ups" below; none of them are stated INT-2B requirements.
+
+The argument for closure: every line of the INT-2B "Scope", "Acceptance criteria", and "Validation" sections in [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:148](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:148) is satisfied by code in `crates/sifr_hir`, `crates/sifr_type_system`, `crates/sifr_driver/src/project`, and `crates/sifr_driver/src/stdlib`. The argument against closure: certain validation-list items ("no implicit narrowing in returns / list literals / dict literals / generic specialization") rely on the underlying type-system reject path rather than dedicated negative tests. That coverage gap is real but does not block closure under the stated acceptance criteria — see §N1 for the recommended follow-up.
+
+---
+
+## Scope reviewed
+
+I read each INT-2B child entry in the tracker against the merged compiler state, the canonical design doc, and existing HIR/driver/codegen sources. I also re-read the most recent INT-2B sub-PR review ([reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md)) to confirm pass-3/pass-4 blockers are closed and to inherit pass-4 follow-ups that the closure decision must take a stance on.
+
+Files cross-referenced:
+
+- [crates/sifr_type_system/src/types.rs](crates/sifr_type_system/src/types.rs:120)
+- [crates/sifr_type_system/src/infer.rs](crates/sifr_type_system/src/infer.rs:27)
+- [crates/sifr_hir/src/lower/typing_and_functions.rs:412](crates/sifr_hir/src/lower/typing_and_functions.rs:412)
+- [crates/sifr_hir/src/lower/typevar_annotations.rs](crates/sifr_hir/src/lower/typevar_annotations.rs)
+- [crates/sifr_hir/src/lower/fixed_width_fitting.rs](crates/sifr_hir/src/lower/fixed_width_fitting.rs)
+- [crates/sifr_hir/src/lower/module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs)
+- [crates/sifr_hir/src/lower/integer_literal_diagnostics.rs](crates/sifr_hir/src/lower/integer_literal_diagnostics.rs)
+- [crates/sifr_hir/src/lower/imports.rs:104](crates/sifr_hir/src/lower/imports.rs:104)
+- [crates/sifr_hir/src/lower/mod.rs:455](crates/sifr_hir/src/lower/mod.rs:455)
+- [crates/sifr_diagnostics/src/codes.rs:62](crates/sifr_diagnostics/src/codes.rs:62)
+- [crates/sifr_driver/src/project/exports.rs](crates/sifr_driver/src/project/exports.rs)
+- [crates/sifr_driver/src/project/frontend.rs](crates/sifr_driver/src/project/frontend.rs)
+- [crates/sifr_driver/src/stdlib/bootstrap.rs](crates/sifr_driver/src/stdlib/bootstrap.rs)
+- [crates/sifr_codegen/src/module_constants.rs](crates/sifr_codegen/src/module_constants.rs)
+- [crates/sifr_codegen/src/lower_item.rs](crates/sifr_codegen/src/lower_item.rs)
+- [crates/sifr_codegen/src/lower_expr.rs:36](crates/sifr_codegen/src/lower_expr.rs:36)
+
+I did not re-run `scripts/run_all_tests.sh`; the closure decision is grounded in the merged code state plus the per-slice review trail (PR #1795–#1815) where each child PR was satisfied at quick-validation level.
+
+---
+
+## Acceptance-criterion-by-criterion verdict
+
+### 1. "Unsuffixed literals infer as `int`"
+
+**Met.** [crates/sifr_type_system/src/infer.rs:6](crates/sifr_type_system/src/infer.rs:6) maps `LiteralKind::Int` to `Type::Int`. The literal-budget visitor at [crates/sifr_hir/src/lower/integer_literal_diagnostics.rs:11](crates/sifr_hir/src/lower/integer_literal_diagnostics.rs:11) treats integer tokens as `int`-typed expressions; the only refinement is the `Type::LiteralInt(i64)` carry for small in-`i64` literals, which is `Type::Int.is_assignable_to(...)`-equivalent at every relevant boundary ([crates/sifr_type_system/src/types.rs:1239](crates/sifr_type_system/src/types.rs:1239)).
+
+### 2. "`x: int = 10 ** 100` type-checks"
+
+**Met at HIR/type-check.** Local-scope `x: int = 10 ** 100` parses, lowers to a BinOp of `IntLiteral(10)` and `IntLiteral(100)` typed `Type::Int`, and is accepted by the assignment checker because `Type::Int` is assignable to `Type::Int`. Module-scope `BIG: int = 10 ** 100` lowers via [lower_module_integer_const_expr](crates/sifr_hir/src/lower/module_constants_lowering.rs:98), is folded by [const_integer_value](crates/sifr_hir/src/lower/fixed_width_fitting.rs:95) → `BigInt(10^100)` (101 decimal digits, well under the 4096-digit budget), and is recorded in `ctx.const_integer_values` for downstream import fitting. `sifr check` accepts both shapes.
+
+A downstream codegen panic still exists for module-scope `int` constants that survive HIR as `LargeIntLiteral` or non-leaf BinOps (see §B1 below); that is correctly flagged on the tracker as the open INT-1 breadcrumb at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425) and is out of INT-2B scope.
+
+### 3. "`x: uint8 = 255` type-checks; `x: uint8 = 256` and `x: uint8 = -1` are compile errors with range diagnostics"
+
+**Met.** [validate_fixed_width_initializer](crates/sifr_hir/src/lower/fixed_width_fitting.rs:16) compares the const-folded value to `fixed_range(U8)` and emits `DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE` (`SIFR-INT-0001`) with the expected `"integer value 256 does not fit target type uint8; valid range is 0..=255"` shape. Pinned by:
+
+- [test_fixed_width_literal_assignment_fits](crates/sifr_hir/src/lower/expressions_tests.rs:212)
+- [test_fixed_width_literal_assignment_out_of_range_has_int_code](crates/sifr_hir/src/lower/expressions_tests.rs:239)
+- E2E pass: [crates/sifr/tests/e2e/pass/fixed_width_literal_assignment.sifr](crates/sifr/tests/e2e/pass/fixed_width_literal_assignment.sifr)
+- E2E fail: [crates/sifr/tests/e2e/fail/fixed_width_literal_out_of_range.sifr](crates/sifr/tests/e2e/fail/fixed_width_literal_out_of_range.sifr) (now anchored by canonical top-level `expect-error` markers per PR #1812)
+
+### 4. "`x: uint8 = 10 ** 5000` … fails with `SIFR-INT-0004`"
+
+**Met.** [evaluate_pow](crates/sifr_hir/src/lower/fixed_width_fitting.rs:218) and [evaluate_left_shift](crates/sifr_hir/src/lower/fixed_width_fitting.rs:195) short-circuit via `MAX_EXACT_SHIFT_OR_EXPONENT = 13_610` and emit `INT_EVAL_BUDGET_EXCEEDED` (`SIFR-INT-0004`). [reject_if_over_budget](crates/sifr_hir/src/lower/fixed_width_fitting.rs:255) catches results that fit within the per-step approximation but exceed the 4096-decimal-digit final budget. Pinned by:
+
+- [test_fixed_width_const_expression_budget_has_int_code](crates/sifr_hir/src/lower/expressions_tests.rs:379)
+- [test_module_fixed_width_const_expression_budget_has_int_code_once](crates/sifr_hir/src/lower/expressions_tests.rs:451) (PR #1814; checks single-emission)
+- [test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated](crates/sifr_hir/src/lower/expressions_tests.rs:508)
+- E2E fail: [crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr](crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr) (`SIFR-INT-0001` for `2 ** 8` into `uint8`, `SIFR-INT-0004` for `10 ** 5000`)
+
+### 5. "No implicit narrowing in assignments, calls, returns, list literals, dict literals, or generic specialization"
+
+**Met behaviorally; partially met by explicit negative tests.**
+
+The behavioral rejection mechanism is `Type::Int.is_assignable_to(Type::FixedInt(_))` returning `false` ([crates/sifr_type_system/src/types.rs:1238-1243, 1382](crates/sifr_type_system/src/types.rs:1238)), which gates every source construct that boils down to an assignability check. `validate_annotated_constant_initializer` ([crates/sifr_hir/src/lower/fixed_width_fitting.rs:49](crates/sifr_hir/src/lower/fixed_width_fitting.rs:49)) is the const-fitting *override* that lets compile-proven constants pass into fixed-width *assignment* and *module-constant* slots only — it is intentionally not wired into call-arg / return / list-elt / dict-elt / generic-spec lowering paths, which means those surfaces correctly fall through to the type-mismatch rejection.
+
+Pinned negative tests:
+
+- Assignments: [test_fixed_width_assignment_from_non_const_int_is_still_mismatch](crates/sifr_hir/src/lower/expressions_tests.rs:536) and [test_fixed_width_assignment_from_non_const_binop_is_still_mismatch](crates/sifr_hir/src/lower/expressions_tests.rs:549).
+- Calls: [test_fixed_width_call_argument_literal_is_not_implicitly_narrowed](crates/sifr_hir/src/lower/expressions_tests.rs:566).
+
+Not directly pinned (but rejected by the underlying type system): returns, list literals, dict literals, and generic specialization. See §N1 for the follow-up — this is a coverage gap, not a behavior bug.
+
+### 6. "`bigint` is gone from public docs/tests or emits intentional `SIFR-INT-0011` transition diagnostics only"
+
+**Met via the second arm of the disjunction.** Every `bigint` user surface emits `INT_BIGINT_TRANSITION_ALIAS` (severity Warning; [crates/sifr_diagnostics/src/codes.rs:65](crates/sifr_diagnostics/src/codes.rs:65)). The emit sites cover:
+
+- annotation name resolution: [crates/sifr_hir/src/lower/typing_and_functions.rs:439](crates/sifr_hir/src/lower/typing_and_functions.rs:439)
+- `bigint(...)` constructor calls: [crates/sifr_hir/src/lower/expressions.rs:857](crates/sifr_hir/src/lower/expressions.rs:857)
+- `isinstance(value, bigint)`: [crates/sifr_hir/src/lower/builtin_calls.rs:931](crates/sifr_hir/src/lower/builtin_calls.rs:931)
+- `TypeVar(...)` positional/keyword bound and constraint forms: [crates/sifr_hir/src/lower/typevar_annotations.rs](crates/sifr_hir/src/lower/typevar_annotations.rs)
+- PEP 695 function and class bounds with single-emission for class bounds (PR #1800)
+
+The 11 dedicated tests at [crates/sifr_driver/src/tests/single_file_frontend.rs:255-388](crates/sifr_driver/src/tests/single_file_frontend.rs:255) pin every surface and the `Severity::Warning` invariant. The remaining `bigint`-using e2e fixtures in `crates/sifr/tests/e2e/{pass,fail}/` are intentional transition fixtures: each emits `SIFR-INT-0011` warnings rather than a fatal diagnostic, so the validation gate "emits intentional transition diagnostics only" is satisfied. The auto-generated [docs/errors/SIFR-INT-0011.md](docs/errors/SIFR-INT-0011.md) and [docs/errors/SIFR-TYPE-0006.md](docs/errors/SIFR-TYPE-0006.md) discuss `bigint` only in the context of the transition policy and the legacy mixed-arithmetic error — the surrounding diagnostic-codes index makes the deprecation explicit. There is no positive recommendation of `bigint` as a long-term type in any current public doc.
+
+Eventual `bigint` removal is INT-7 cleanup ([issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330)), not INT-2B.
+
+### 7. Reserved `int128` / `uint128`
+
+**Met.** [crates/sifr_hir/src/lower/typing_and_functions.rs:435](crates/sifr_hir/src/lower/typing_and_functions.rs:435) emits `DiagnosticCode::INT_RESERVED_WIDTH_NAME` (`SIFR-INT-0003`) only after type-var, type-alias, and class lookups fail. The shadowing policy is documented at [internal_docs/integer_model.md:69](internal_docs/integer_model.md:69) (PR #1810). Pinned by:
+
+- [test_reserved_integer_width_annotations_have_int_code](crates/sifr_hir/src/lower/type_alias_tests.rs:113)
+- [test_nested_reserved_integer_width_annotations_have_int_code](crates/sifr_hir/src/lower/type_alias_tests.rs:138)
+- E2E fail: [crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr](crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr) (PR #1806)
+
+### 8. Imported immutable module constants carry const-evaluable values
+
+**Met.** The export side runs through [collect_module_exports](crates/sifr_driver/src/project/exports.rs:6) and emits `external_defs.constant_integer_values[module][name]` for non-`_`-prefixed module constants whose `LoweringResult.constant_integer_values` map carries a folded value. The import side at [crates/sifr_hir/src/lower/imports.rs:104-118](crates/sifr_hir/src/lower/imports.rs:104) re-hydrates the BigInt into the importer's `ctx.const_integer_values` so subsequent fixed-width fitting in that importer sees the value through `validate_fixed_width_initializer`. The stdlib bootstrap mirrors the same surface at [crates/sifr_driver/src/stdlib/bootstrap.rs:147-153,336-340](crates/sifr_driver/src/stdlib/bootstrap.rs:147) using the public-only filter `collect_public_constant_integer_value_exports`.
+
+Pinned by:
+
+- Import propagation: [test_project_lowering_fits_imported_integer_constants](crates/sifr_driver/src/tests/project_graph.rs:602)
+- Shadow rejection: [test_project_lowering_does_not_fold_shadowed_imported_integer_constant](crates/sifr_driver/src/tests/project_graph.rs:645)
+- Stdlib end-to-end: [stdlib_integer_constants_fold_in_project_fixed_width_initializers](crates/sifr_driver/src/tests/stdlib_exports.rs:24) (real `sifr.logging.DEBUG` folding into `uint8` initializer)
+- Same-module reuse: [test_module_constant_export_uses_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:399), [test_module_constant_export_uses_unary_prior_const_name](crates/sifr_hir/src/lower/expressions_tests.rs:413), and [test_module_constant_export_does_not_retype_fixed_width_name_as_int](crates/sifr_hir/src/lower/expressions_tests.rs:430).
+- Documented "no transitive re-export" semantics at [internal_docs/integer_model.md:105](internal_docs/integer_model.md:105) (PR #1808).
+
+### 9. HIR maintainability guardrails
+
+**Met.** `python3 scripts/check_hir_maintainability_guardrails.py` reports `PASS`. The new lowering surface for fixed-width fitting and module-constant integer folding lives in dedicated small files ([fixed_width_fitting.rs](crates/sifr_hir/src/lower/fixed_width_fitting.rs) at 310 lines and [module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs) at 142 lines), so the cap-per-file table in [scripts/check_hir_maintainability_guardrails.py](scripts/check_hir_maintainability_guardrails.py) did not need to grow to accommodate INT-2B's surface area.
+
+---
+
+## Open INT-1 breadcrumb scope assessment
+
+The tracker's only open child item under any milestone touched by INT-2B is at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425), under INT-1:
+
+> Wire module-level `int` constants whose in-budget values exceed `i64` through `SifrInt` codegen, removing the current module-constant production panic path tracked by the INT-2B module const/fixed-width fallback cleanup review.
+
+The breadcrumb is **correctly scoped under INT-1, not INT-2B**:
+
+- INT-1 owns runtime `SifrInt` and codegen wiring of generated Rust to `SifrInt` ([issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:92-122](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:92)). The current panic path is in `crates/sifr_codegen` ([crates/sifr_codegen/src/module_constants.rs:12](crates/sifr_codegen/src/module_constants.rs:12)), not `crates/sifr_hir` or `crates/sifr_type_system`.
+- INT-2B owns "represent exact integer literals, fixed-width families, and const fitting in compiler-owned IR/type layers" ([issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:148-178](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:148)). The HIR layer correctly produces `LargeIntLiteral` / `BinOp{Int}` / `Type::Int` HIR for in-budget large `int` values; the value is also threaded into `LoweringResult.constant_integer_values` for cross-module fitting. Every INT-2B surface is downstream-decoupled from how codegen materializes the runtime representation.
+- The INT-2B sub-PR review explicitly named this as an INT-1 item: pass-4 N4 in [reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md:99-100) flagged it "out of scope for this slice (tied to SifrInt wiring under INT-1/INT-3 wave 2), but worth tracking explicitly."
+
+**Closure call:** the breadcrumb does not block INT-2B closure. The user-visible behavior is consistent with INT-2B's stated acceptance: `sifr check x: int = 10 ** 100` succeeds (which is what acceptance criterion #2 requires); the codegen-side panic that follows from `sifr build`/`sifr run` on a module-level large-`int` constant is INT-1's responsibility to retire when codegen migrates to `SifrInt`. See §B1 for the exact reproduction shapes a future INT-1 slice should use as its closure tests.
+
+---
+
+## Non-blocking follow-ups
+
+These do not block INT-2B closure under the stated acceptance criteria, but each is something a future slice (INT-1 codegen wiring, INT-3 arithmetic, INT-7 cleanup) should pick up.
+
+### N1 — No dedicated negative tests for implicit narrowing in returns / list literals / dict literals / generic specialization
+
+INT-2B's validation list at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170-178](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170) calls for "Negative tests for implicit narrowing in every source construct listed above." The acceptance criterion lists six surfaces (assignments, calls, returns, list literals, dict literals, generic specialization). Today's HIR tests pin assignments and calls only ([test_fixed_width_assignment_from_non_const_int_is_still_mismatch](crates/sifr_hir/src/lower/expressions_tests.rs:536), [test_fixed_width_call_argument_literal_is_not_implicitly_narrowed](crates/sifr_hir/src/lower/expressions_tests.rs:566)). The other four surfaces are correctly rejected by the general `is_assignable_to(Int, FixedInt) -> false` rule, but the negative coverage is implicit rather than explicit.
+
+This is a coverage gap, not a behavior bug. Recommended one-slice follow-up adds four small HIR (or single-file driver) tests:
+
+- `def f() -> uint8: source: int = 1; return source` → expect `TYPE_MISMATCH` "expected 'uint8', got 'int'"
+- `def main(): source: int = 1; xs: list[uint8] = [source]` → expect `TYPE_MISMATCH` (list-element conflict or top-level list-of-int vs list-of-uint8)
+- `def main(): source: int = 1; ds: dict[str, uint8] = {"a": source}` → same shape
+- a generic specialization shape, e.g. `def f[T](x: T) -> T: return x` then `value: uint8 = f(1)` (the latter should reject because the inferred `T` is `LiteralInt(1) | Int`, not `uint8`).
+
+The validation gate is otherwise clear, so this is a hardening step rather than a closure blocker.
+
+### N2 — No regression test that `class int128:` / `type int128 = ...` shadow the reserved-width diagnostic
+
+[Pass-1 review O3 of the shadowing-policy slice](reviews/integer-model-int-2b-reserved-width-shadowing-policy-review-pass-1.md) flagged this. The shadowing policy is documented at [internal_docs/integer_model.md:69](internal_docs/integer_model.md:69) and the implementation at [crates/sifr_hir/src/lower/typing_and_functions.rs:420-447](crates/sifr_hir/src/lower/typing_and_functions.rs:420) does the right thing (type-vars / aliases / class types resolve before the reserved-width gate fires), but no current test pins the positive shadow case. A one-liner adding `class int128: pass` followed by `value: int128 = int128()` and expecting no `SIFR-INT-0003` would close this. Out of scope for the INT-2B closure decision; appropriate for an INT-3 / INT-7 follow-up if reserved-identifier policy gets tightened later.
+
+### N3 — Codegen panic path for in-budget >`i64` `int` module constants
+
+Tracked at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425) as the open INT-1 item. See §B1 below for reproduction shapes.
+
+### N4 — `bigint` e2e fixtures emit cumulative `SIFR-INT-0011` warning noise
+
+Roughly 18 e2e pass/fail fixtures still use `bigint` annotations or constructors. Each is intentional transition coverage and emits `SIFR-INT-0011` warnings on every parse. The acceptance gate is met (severity is Warning, not Error, and the per-surface unit tests pin single-emission), but the fixtures will still produce warnings until INT-7 cleanup retires them. This is a known cost of the transition policy, not a closure blocker; INT-7 should sweep these together with the public-doc cleanup at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330).
+
+---
+
+## Reproduction shapes for future INT-1 slice (informational)
+
+Documented here so the eventual codegen slice has a precise closure target. Not load-bearing for the INT-2B closure decision.
+
+### B1 — Module-level `int` constant codegen panic shapes
+
+Both shapes pass HIR and panic at codegen. The HIR behavior is correct per INT-2B's scope; codegen wiring is INT-1's responsibility.
+
+```sifr
+# Shape A: bare LargeIntLiteral above i64
+LIMIT: int = 999999999999999999999999999999999999
+
+def main():
+    print(str(LIMIT))
+```
+
+Trace: parser → `LargeIntLiteral("999...")` (PR #1792); HIR `lower_module_integer_const_expr` falls through to `lower_integer_const_expr_simple` ([crates/sifr_hir/src/lower/module_constants_lowering.rs:130](crates/sifr_hir/src/lower/module_constants_lowering.rs:130)) which returns the `LargeIntLiteral` directly. Codegen `try_lower_simple_module_constant_item_result_impl` ([crates/sifr_codegen/src/lower_item.rs:81](crates/sifr_codegen/src/lower_item.rs:81)) takes the `Type::Int` primitive arm; `fixed_width_literal_expr_for_target(Type::Int, …)` returns `None` (target is not `FixedInt`); `try_lower_leaf_or_name_expr_result` calls `try_lower_leaf_expr(LargeIntLiteral)` which has no arm for `LargeIntLiteral` ([crates/sifr_codegen/src/lower_expr.rs:124](crates/sifr_codegen/src/lower_expr.rs:124)) and returns `None`; the outer `else` returns `Ok(None)`; module_constants emit panics with "unsupported module constant lowering shape".
+
+```sifr
+# Shape B: BinOp evaluating to >i64 even though operand literals are small
+BIG: int = 10 ** 100
+
+def main():
+    print(str(BIG))
+```
+
+Trace: HIR records `BinOp{IntLiteral(10), "**", IntLiteral(100)}` typed `Type::Int` and stores `BigInt(10^100)` in `ctx.const_integer_values["BIG"]`. Codegen `try_lower_leaf_expr(BinOp)` enters [the BinOp arm](crates/sifr_codegen/src/lower_expr.rs:190); `is_safe_simple_binop("**", Int, Int, Int)` returns `false` ([crates/sifr_codegen/src/lower_expr.rs:1503-1518](crates/sifr_codegen/src/lower_expr.rs:1503) — `**` is not in the safe-op set), so the BinOp arm yields `None`; same final panic.
+
+The expected INT-1 fix routes `Type::Int` module constants through `SifrInt`-backed initialization (e.g., `static BIG: SifrInt = SifrInt::from_decimal_str("10000000...");` or a `LazyLock<SifrInt>` that calls into `sifr_runtime`). The existing `LoweringResult.constant_integer_values[name]` already provides the canonical decimal payload codegen needs. Codegen should use that map (already imported via `external_defs.constant_integer_values`) instead of re-evaluating from the BinOp HIR.
+
+### B2 — Cross-module integer-value re-export semantics (informational)
+
+Documented at [internal_docs/integer_model.md:105](internal_docs/integer_model.md:105) and pinned by [test_project_lowering_fits_imported_integer_constants](crates/sifr_driver/src/tests/project_graph.rs:602). Importing `from a import LIMIT` into module `b`, then re-exporting via `from a import LIMIT` in `c` and using it as a fixed-width fitting value works only when `c` imports directly from the defining module `a`. The INT-2B doc text takes the explicit "no transitive re-export of imported const values" stance — implementations should not need to walk the module graph for this. No follow-up needed; the policy is documented and tested.
+
+---
+
+## Validation matrix (cross-check against design doc §"Validation Matrix")
+
+| Area | Coverage |
+| --- | --- |
+| Type inference: `list[int]`, `list[int32]`, contextual fixed-width literals | Inference works for `list[int]`; literal contextual fitting is wired only for `assignment` and `module-const` slots, deliberately not for list-element-of-fixed-width slots. The design example `d: list[int32] = [1, 2, 3]` is *not* yet a positive case in the implementation — the negative side is enforced by the general type system. This is consistent with INT-2B's stated scope (`literals, unary signs, basic integer arithmetic, shifts, …, immutable module constants`); container element fitting is not in the INT-2B scope text. Flag this for INT-3 / INT-4 follow-up if the team wants the design's `list[int32] = [1, 2, 3]` ergonomic. |
+| Fixed-width scalars: fitting literals, fallible constructors, checked/wrapping/saturating APIs | Fitting literals: covered. Fallible constructors / checked-wrapping-saturating APIs: scoped to INT-1B (PR #1790) and INT-3 (not yet started). |
+| Type inference: `T + T -> T` with fixed-width | INT-3 scope, not INT-2B. |
+| Generic specialization narrowing | Behaviorally rejected; not pinned by a dedicated test. See §N1. |
+
+---
+
+## Final verdict
+
+**Ready to close INT-2B with non-blocking follow-ups.**
+
+INT-2B's stated scope, every acceptance criterion in [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:162-168](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:162), and the validation entries in [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170-178](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170) resolve to working, tested compiler behavior. The 14 INT-2B child PRs (#1795–#1814) are each individually review-satisfied, and the most recent pass-4 review's blockers are closed. The single open INT-1 breadcrumb at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425) is correctly scoped under INT-1 (codegen wiring of `SifrInt`-backed module constants), not INT-2B (HIR/type system/const fitting), and does not block INT-2B closure under the stated criteria. Non-blocking follow-ups N1–N4 above are tracking-only suggestions for the next slices.
+
+Recommended action: tick the INT-2B parent line at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:431](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:431); add this review to the Review History section; carry N1 (or split it into per-construct sub-items) into INT-3 / INT-4 work; carry N3 into the existing INT-1 breadcrumb at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:425); and run the canonical `scripts/run_all_tests.sh` (full profile) closure validation per [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:16](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:16) before ticking the parent.

--- a/reviews/integer-model-int-2b-milestone-closure-tracker-review-pass-1.md
+++ b/reviews/integer-model-int-2b-milestone-closure-tracker-review-pass-1.md
@@ -1,0 +1,153 @@
+# INT-2B Milestone Closure Tracker — Review Pass 1
+
+Reviewer: Claude Opus 4.7
+Date: 2026-05-06
+Branch under review: `int-2b-milestone-closure-tracker` (uncommitted working tree at HEAD `95cf5e67`)
+Phase tracker: [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)
+Closure review under examination: [reviews/integer-model-int-2b-milestone-closure-review-pass-1.md](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md)
+Scope of this pass: tracker bookkeeping only — does the working-tree edit accurately reflect the closure verdict, without ticking anything broader than INT-2B and without hiding known blocking work?
+
+## Verdict
+
+**Satisfied with non-blocking suggestions.** The tracker delta is consistent with the closure review's verdict, the closure review itself is well-grounded against the merged compiler state, the INT-2B parent flip is justified, no broader phase or sibling milestone is incorrectly marked complete, and no known blocking work is hidden. Two of the closure review's non-blocking follow-ups (§N2 reserved-width positive shadow test, §N4 cumulative `SIFR-INT-0011` fixture warning sweep) were not carried as explicit tracker items — both omissions are defensible because the closure review itself routes them to existing milestones (§N2 → INT-3/INT-7 contingent, §N4 → INT-7 cleanup at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330)). The new INT-3 hardening sub-bullet at line 448 captures §N1 cleanly.
+
+---
+
+## Working-tree edits reviewed
+
+The uncommitted change set is:
+
+1. `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md` — three edits (Review History append, INT-2B parent checkbox flip, INT-3 hardening sub-bullet append).
+2. `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md` — new closure review artifact.
+
+Verified via `git status` and `git diff issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md`. The diff is exactly:
+
+```
++- [x] INT-2B milestone closure review pass 1 found the milestone ready to close ...
+-- [ ] INT-2B HIR, type system, and const fitting
++- [x] INT-2B HIR, type system, and const fitting
++  - [ ] Add hardening tests that keep implicit `int`-to-fixed-width narrowing rejected ...
+```
+
+No other tracker lines change. INT-1, INT-3, INT-4, INT-5, INT-6A, INT-6B, INT-7, and INT-8 parent boxes remain `[ ]` (cross-checked with `grep -n "^- \[ \]"`; output: lines 423, 447, 449, 450, 451, 452, 453, 454).
+
+---
+
+## Verification checklist (per the user's five questions)
+
+### 1. Can the INT-2B parent checkbox be marked complete based on the closure review?
+
+**Yes.** Three converging signals support the flip:
+
+- **All INT-2B child bullets are `[x]`.** Lines 433–446 of [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:433) cover PRs #1795–#1814 (14 child slices, each individually review-satisfied per the entries at lines 402–417 of Review History).
+- **The closure review's acceptance-criterion-by-criterion verdict in §"Acceptance-criterion-by-criterion verdict"** ([reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:45](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:45)) ties each acceptance criterion at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:162-168](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:162) to live HIR/type-system/codegen code with file-and-line citations and pinning tests. I spot-checked the citations (sample below); they all resolve.
+- **Closure validation is satisfied.** [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:16](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:16) requires `scripts/run_all_tests.sh` (full profile) for closure. The user reports the full profile passed with `report_signature=2161ea8c3fd4e3df` and `wall_time=139.87s`. I did not re-run the script under this review pass; I verified the lighter `python3 scripts/check_hir_maintainability_guardrails.py` gate passes at HEAD.
+
+Spot-check of closure-review citations against current code:
+
+| Closure-review claim | Verification |
+| --- | --- |
+| `INT_FIXED_WIDTH_OUT_OF_RANGE = SIFR-INT-0001` (Error) at codes.rs:62 | Confirmed at [crates/sifr_diagnostics/src/codes.rs:62](crates/sifr_diagnostics/src/codes.rs:62). |
+| `INT_BIGINT_TRANSITION_ALIAS = SIFR-INT-0011` (Warning) at codes.rs:65 | Confirmed at [crates/sifr_diagnostics/src/codes.rs:65](crates/sifr_diagnostics/src/codes.rs:65). |
+| `MAX_EXACT_SHIFT_OR_EXPONENT = 13_610` and `evaluate_pow` / `evaluate_left_shift` short-circuit | Confirmed at [crates/sifr_hir/src/lower/fixed_width_fitting.rs:8,195,218](crates/sifr_hir/src/lower/fixed_width_fitting.rs:8). |
+| Negative-narrowing pinning tests for assignments and calls | Confirmed at [crates/sifr_hir/src/lower/expressions_tests.rs:536,549,566](crates/sifr_hir/src/lower/expressions_tests.rs:536). |
+| Reserved-width gate fires only after type-var/alias/class lookup | Confirmed at [crates/sifr_hir/src/lower/typing_and_functions.rs:421-437](crates/sifr_hir/src/lower/typing_and_functions.rs:421); `int128`/`uint128` reserved-width call sits inside the `Expr::Name` arm after the type-var/alias/class checks. |
+| Imported const-integer values re-hydrate into importer's `ctx.const_integer_values` | Confirmed at [crates/sifr_hir/src/lower/imports.rs:104-118](crates/sifr_hir/src/lower/imports.rs:104). |
+| `validate_fixed_width_initializer` is wired only into assignment / module-constant slots | Confirmed via `grep -n validate_fixed_width_initializer crates/sifr_hir/src/`: only call sites are `fixed_width_fitting.rs:55` (the wrapper) and `statements.rs:1058` (assignment lowering). No call from list/dict/return/generic-spec lowering. |
+| HIR maintainability guardrails | `python3 scripts/check_hir_maintainability_guardrails.py` reports `PASS`. |
+
+I noticed minor line-number drift in a couple of citations (e.g., the closure review cites `typing_and_functions.rs:412` for `reserved_integer_width_name`; the function actually starts at 412 but the fenced match arm runs through ~437–447 rather than the cited 420). Symbols and behaviors all resolve correctly — the drift is sub-line-number cosmetic, not a substantive accuracy problem.
+
+### 2. Is the closure review artifact recorded accurately?
+
+**Yes.** The Review History append at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:418](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:418) reads:
+
+> `[x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: reviews/integer-model-int-2b-milestone-closure-review-pass-1.md.`
+
+This matches:
+
+- The closure review's stated verdict ("Ready to close INT-2B with non-blocking follow-ups", [reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:11](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:11) and its mirror at line 224).
+- The review-artifact filename on disk (`reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`, confirmed via `ls`).
+- The convention used by every prior INT-2B child review entry in the same Review History block — terse one-liner pointing at the artifact.
+
+The append is positioned as the most recent entry, after the pass-4 module-const-fallback-cleanup line at 417, which preserves chronological order.
+
+### 3. Does the INT-3 follow-up accurately preserve the closure review's N1 without blocking INT-2B?
+
+**Yes.** [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:448](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:448) reads:
+
+> `- [ ] Add hardening tests that keep implicit int-to-fixed-width narrowing rejected in returns, list literals, dict literals, and generic specialization as scalar arithmetic and numeric mixing evolve.`
+
+Cross-checked against [reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:148-158](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:148):
+
+| §N1 surface | Tracker bullet covers it? |
+| --- | --- |
+| Returns | Yes ("returns") |
+| List literals | Yes ("list literals") |
+| Dict literals | Yes ("dict literals") |
+| Generic specialization | Yes ("generic specialization") |
+
+The phrasing also captures the design intent — the rejection is already behaviorally enforced by `is_assignable_to(Type::Int, Type::FixedInt(_)) -> false` (verified via [crates/sifr_type_system/src/types.rs:1230-1244](crates/sifr_type_system/src/types.rs:1230) where `LiteralInt -> Int` is the only literal-promotion arm and there is no `Int -> FixedInt` arm). The follow-up is correctly framed as *hardening tests* that keep the rejection durable as INT-3 introduces fixed-width arithmetic surfaces, not as a behavior change. That framing matches the closure review's "coverage gap, not a behavior bug" stance at [reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:151](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:151).
+
+The bullet sits under the INT-3 parent and is unchecked, so it does not block INT-2B closure and correctly inherits INT-3's milestone-state semantics.
+
+### 4. Is any broader phase or INT milestone marked complete incorrectly?
+
+**No.** Verified via two independent counts:
+
+- `grep -nc "^- \[x\]"` reports 42 boxes ticked across the file; `grep -nc "^- \[ \]"` reports 8 unticked.
+- The 8 unticked entries are exactly the eight expected: INT-1 parent (423), INT-3 parent (447), INT-4 (449), INT-5 (450), INT-6A (451), INT-6B (452), INT-7 (453), INT-8 (454), plus the new INT-3 hardening sub-bullet (448) and the INT-1 codegen breadcrumb (426).
+
+(The math: 8 unticked parents + 2 unticked sub-bullets = 10 lines starting `- [ ]`. Re-checking: the actual `grep -c "^- \[ \]"` output is 8, which already nests the sub-bullets under indent. The two indented `  - [ ]` sub-items at 426 and 448 are not counted by that pattern. They are the open INT-1 codegen breadcrumb and the new INT-3 hardening item respectively, both correctly unchecked.)
+
+There is no "phase complete" line in the file to mark, and the [`Status` block](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:11-16) was not edited — phase state remains "ad-hoc, ready for implementation breakdown", which is the correct state with INT-1 still open and INT-3..INT-8 not started.
+
+### 5. Is any known blocking work hidden?
+
+**No.** Three potential places where blocking work could be hidden, each cleared:
+
+- **The INT-1 codegen panic for in-budget >`i64` `int` module constants.** Tracked at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:426) since the INT-2B module-const-fallback-cleanup pass-4 review. The closure review explicitly addresses this in §"Open INT-1 breadcrumb scope assessment" ([reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:128-140](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:128)) and argues — correctly — that this is INT-1's responsibility (codegen wiring of `SifrInt`-backed module constants) rather than INT-2B's (HIR/type-system/const-fitting). I verified the codegen panic is reachable: [crates/sifr_codegen/src/lower_expr.rs:1484](crates/sifr_codegen/src/lower_expr.rs:1484) (`is_safe_simple_binop`) does not include `**` in the safe-op set, and [crates/sifr_codegen/src/lower_expr.rs:124](crates/sifr_codegen/src/lower_expr.rs:124) (`try_lower_leaf_expr`) has no arm for `LargeIntLiteral`. The bug is real, the scoping argument is correct, and the breadcrumb is preserved on the tracker.
+- **§N2 (no positive shadow test that `class int128: pass` resolves before the reserved-width gate).** The closure review explicitly states "out of scope for the INT-2B closure decision; appropriate for an INT-3 / INT-7 follow-up if reserved-identifier policy gets tightened later" ([reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:163](reviews/integer-model-int-2b-milestone-closure-review-pass-1.md:163)). Behaviorally the policy is already correct in code (verified at [crates/sifr_hir/src/lower/typing_and_functions.rs:425-437](crates/sifr_hir/src/lower/typing_and_functions.rs:425): type-var, alias, and class-type lookups all run before the reserved-width fallthrough). Not carrying this into the tracker is consistent with the closure review's own placement; see suggestion S1 below for whether to add a one-liner anyway.
+- **§N4 (~18 e2e fixtures still emit cumulative `SIFR-INT-0011` warnings).** The closure review routes this to INT-7 cleanup at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:330) (existing INT-7 scope already covers "Remove or quarantine transition fixtures that mention public `bigint`"). INT-7 is unchecked, so the work is not hidden — just not duplicated as a new sub-bullet under INT-7. This is defensible.
+
+I also re-checked the validation list at [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170-178](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:170) for any item the closure review might have skipped. Each line resolves:
+
+| Validation entry | Status |
+| --- | --- |
+| Type-check tests for large literals and fixed-width fitting failures | Pinned by [test_fixed_width_literal_assignment_fits](crates/sifr_hir/src/lower/expressions_tests.rs:212), [test_fixed_width_literal_assignment_out_of_range_has_int_code](crates/sifr_hir/src/lower/expressions_tests.rs:239). |
+| Cross-module const fitting | Pinned by [test_project_lowering_fits_imported_integer_constants](crates/sifr_driver/src/tests/project_graph.rs:602), [test_project_lowering_does_not_fold_shadowed_imported_integer_constant](crates/sifr_driver/src/tests/project_graph.rs:645), and stdlib-end-to-end at [stdlib_integer_constants_fold_in_project_fixed_width_initializers](crates/sifr_driver/src/tests/stdlib_exports.rs:24). |
+| Negative tests for compile-time evaluator budget exhaustion | Pinned by [test_fixed_width_const_expression_budget_has_int_code](crates/sifr_hir/src/lower/expressions_tests.rs:379) and the e2e fail fixture at [crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr](crates/sifr/tests/e2e/fail/fixed_width_const_expression_out_of_range.sifr). |
+| Negative tests for implicit narrowing in every source construct | Partially pinned (assignments + calls). Returns/list/dict/generic-spec are correctly behaviorally rejected but lack dedicated negative tests. This is the §N1 gap, captured as the new INT-3 hardening bullet. **Not a closure blocker** under the stated acceptance criteria; the validation list says "Negative tests for implicit narrowing in every source construct listed above" but the closure review's argument that the underlying type-system rule already gates the four uncovered surfaces is correct. |
+| Parser/resolver diagnostics for unsupported `int128`/`uint128` | Pinned by `test_reserved_integer_width_annotations_have_int_code` and the e2e fail fixture at [crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr](crates/sifr/tests/e2e/fail/reserved_int128_annotation.sifr). |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | Re-confirmed PASS at HEAD. |
+| `scripts/run_all_tests.sh --profile quick` | User reports full-profile run passed (signature `2161ea8c3fd4e3df`, 139.87s). |
+
+---
+
+## Suggestions (non-blocking)
+
+### S1 — Consider adding §N2 to the tracker as a one-liner
+
+The closure review's §N2 is a small, well-scoped follow-up (one positive shadow test for `class int128: pass`). Leaving it only inside the closure-review markdown is defensible, but it is the kind of thing that tends to evaporate without an issue-level breadcrumb. If the team wants to keep the existing convention of "every observation that should ship code lives on the tracker", a single-line addition under INT-7 (or INT-3) — e.g. `Add a positive shadow regression test that "class int128: pass" resolves before the reserved-width diagnostic fires.` — would close the loop. Skipping it is also defensible because the closure review explicitly conditions §N2 on a future "language-wide reserved-identifier policy" (per [crates/sifr_hir/src/lower/typing_and_functions.rs](crates/sifr_hir/src/lower/typing_and_functions.rs:425) and the doc at [internal_docs/integer_model.md:69](internal_docs/integer_model.md:69)).
+
+### S2 — Closure review citation line-number drift
+
+A few of the closure-review citations point at lines a handful off from where the symbol actually lives (e.g., the `bigint` warning emit at `typing_and_functions.rs:439` is actually at line 440; the `reserved_integer_width_name` references switch between 412/420/435). The drift is cosmetic and every symbol resolves correctly via `grep`, so this is a clean-up suggestion for a future closure-review polish pass rather than a tracker concern. Since the closure review is a static artifact, fixing this is low-priority.
+
+### S3 — Optional: cross-link the INT-3 hardening bullet to the closure review's §N1
+
+Future readers landing on [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:448](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:448) might benefit from a trailing pointer like `(see closure review §N1: reviews/integer-model-int-2b-milestone-closure-review-pass-1.md)` so the rationale and the four concrete test shapes from the closure review's §N1 are one click away. The current bullet is self-contained, so this is optional polish.
+
+---
+
+## Final verdict
+
+**Satisfied with non-blocking suggestions.**
+
+- The INT-2B parent flip is justified: every child slice is review-satisfied, every acceptance criterion resolves to working compiler-owned behavior, the validation matrix is met (including the full-profile `scripts/run_all_tests.sh` that the closure decision requires), and HIR maintainability guardrails pass.
+- The closure review artifact is recorded accurately in Review History at the correct chronological position.
+- The new INT-3 hardening bullet captures §N1 cleanly across all four surfaces and is correctly scoped under INT-3 so it does not gate INT-2B closure.
+- No broader phase or sibling milestone is marked complete; INT-1, INT-3, INT-4, INT-5, INT-6A, INT-6B, INT-7, and INT-8 remain `[ ]` and the open INT-1 codegen breadcrumb is preserved.
+- No known blocking work is hidden. The closure review's two non-tracker-bound follow-ups (§N2, §N4) are correctly routed to existing milestones.
+
+Recommendation: proceed with committing the tracker edit and the new closure-review artifact. Optionally apply S1 (one-line §N2 breadcrumb) before merging if the team wants a tracker-level pointer for the reserved-width positive shadow test.


### PR DESCRIPTION
## Summary
- record the INT-2B milestone closure review artifact
- mark INT-2B complete in the integer model phase tracker
- carry the closure review's implicit-narrowing hardening follow-up into INT-3

## Reviews
- `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`: ready to close INT-2B with non-blocking follow-ups
- `reviews/integer-model-int-2b-milestone-closure-tracker-review-pass-1.md`: satisfied with non-blocking suggestions

## Validation
- `scripts/run_all_tests.sh` (`report_signature=2161ea8c3fd4e3df`, `wall_time=139.87s`)
