### PR TITLE
Wire oversized module int constants through SifrInt

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -5,6 +5,7 @@ MAX_RETRIES: int = 3
 BASE_LIMIT: int = 250
 LIMIT: int = BASE_LIMIT + 4
 NEGATIVE_LIMIT: int = -(MAX_RETRIES + 10)
+BIG_LIMIT: int = 10 ** 20
 
 def circle_area(r: float) -> float:
     return PI * r * r
@@ -14,3 +15,4 @@ def main():
     assert str(MAX_RETRIES) == '3'
     assert str(LIMIT) == '254'
     assert str(NEGATIVE_LIMIT) == '-13'
+    assert str(BIG_LIMIT) == '100000000000000000000'

--- a/crates/sifr_codegen/src/lower_item.rs
+++ b/crates/sifr_codegen/src/lower_item.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     try_lower_leaf_expr, try_lower_leaf_expr_result, CodegenError, RustExpr, RustItem, RustLiteral,
-    RustStmt, RustType, Visibility,
+    RustMatchArm, RustStmt, RustType, Visibility,
 };
 use sifr_hir::HirExpr;
 use sifr_type_system::Type;
@@ -32,6 +32,10 @@ fn is_simple_module_string_const_type(ty: &Type) -> bool {
 
 fn is_simple_module_none_const_type(ty: &Type) -> bool {
     matches!(resolve_alias_type(ty), Type::None)
+}
+
+fn is_exact_module_int_type(ty: &Type) -> bool {
+    matches!(resolve_alias_type(ty), Type::Int)
 }
 
 pub fn try_lower_simple_module_constant_item_result(
@@ -83,6 +87,10 @@ fn try_lower_simple_module_constant_item_result_impl(
     ty: &Type,
     value: &HirExpr,
 ) -> Result<Option<(RustItem, String)>, CodegenError> {
+    if let Some(decimal_text) = large_module_int_literal_decimal(ty, value) {
+        return Ok(Some(lower_large_module_int_const_item(name, &decimal_text)));
+    }
+
     if is_simple_module_primitive_const_type(ty) {
         let lowered_value =
             if let Some(lowered) = crate::fixed_width_literal_expr_for_target(ty, value) {
@@ -172,16 +180,92 @@ fn try_lower_simple_module_constant_item_result_impl(
     )))
 }
 
+fn large_module_int_literal_decimal(ty: &Type, value: &HirExpr) -> Option<String> {
+    if !is_exact_module_int_type(ty) {
+        return None;
+    }
+    match value {
+        HirExpr::LargeIntLiteral(value) => Some(value.clone()),
+        HirExpr::UnaryOp { op, operand, .. } if op == "+" => {
+            large_module_int_literal_decimal(ty, operand)
+        }
+        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
+            let value = large_module_int_literal_decimal(ty, operand)?;
+            Some(format!("-{value}"))
+        }
+        _ => None,
+    }
+}
+
+fn sifr_int_parse_decimal_call(decimal_text: &str) -> RustExpr {
+    RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            "SifrInt".to_string(),
+            "parse_decimal".to_string(),
+        ])),
+        args: vec![
+            RustExpr::Ident(format!("\"{}\"", decimal_text.escape_default())),
+            RustExpr::Path(vec![
+                "sifr_runtime".to_string(),
+                "DEFAULT_MAX_INTEGER_DIGITS".to_string(),
+            ]),
+        ],
+    }
+}
+
 /// Conservative dispatcher for simple module-constant item lowering.
 pub fn try_lower_simple_module_constant_item(
     name: &str,
     ty: &Type,
     value: &HirExpr,
 ) -> Option<(RustItem, String)> {
+    if let Some(decimal_text) = large_module_int_literal_decimal(ty, value) {
+        return Some(lower_large_module_int_const_item(name, &decimal_text));
+    }
     try_lower_simple_module_const_item(name, ty, value)
         .or_else(|| try_lower_simple_module_string_const_item(name, ty, value))
         .or_else(|| try_lower_simple_module_none_const_item(name, ty, value))
         .or_else(|| try_lower_simple_module_helper_const_item(name, ty, value))
+}
+
+fn lower_large_module_int_const_item(name: &str, decimal_text: &str) -> (RustItem, String) {
+    let rust_name = format!("__const_{name}");
+    (
+        RustItem::Fn {
+            name: rust_name.clone(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![],
+            ret: Some(RustType::Named("SifrInt".to_string())),
+            body: vec![RustStmt::Match {
+                expr: sifr_int_parse_decimal_call(decimal_text),
+                arms: vec![
+                    RustMatchArm {
+                        pattern: "Ok(value)".to_string(),
+                        bindings: vec![],
+                        guard: None,
+                        body: vec![RustStmt::Return(Some(RustExpr::Ident(
+                            "value".to_string(),
+                        )))],
+                    },
+                    RustMatchArm {
+                        pattern: "Err(err)".to_string(),
+                        bindings: vec![],
+                        guard: None,
+                        body: vec![RustStmt::Expr(RustExpr::FormatMacro {
+                            name: "panic".to_string(),
+                            format_str: format!(
+                                "compiler emitted invalid integer literal for module constant {name}: {{}}"
+                            ),
+                            args: vec![RustExpr::Ident("err".to_string())],
+                        })],
+                    },
+                ],
+            }],
+            is_async: false,
+        },
+        format!("{rust_name}()"),
+    )
 }
 
 /// Conservatively lowers module-level primitive constants via IR.
@@ -389,6 +473,36 @@ mod tests {
                 ..
             } if name == "ANSWER"
         ));
+    }
+
+    #[test]
+    fn dispatcher_result_lowers_large_module_int_const_as_sifr_int_helper() {
+        let (item, rust_name_call) = try_lower_simple_module_constant_item_result(
+            "limit",
+            &Type::Int,
+            &HirExpr::LargeIntLiteral("100000000000000000000".to_string()),
+        )
+        .expect("large exact int module const should validate")
+        .expect("large exact int module const should lower");
+
+        assert_eq!(rust_name_call, "__const_limit()");
+        assert!(matches!(
+            item,
+            RustItem::Fn {
+                ref name,
+                visibility: Visibility::Private,
+                ret: Some(RustType::Named(ref ret)),
+                ..
+            } if name == "__const_limit" && ret == "SifrInt"
+        ));
+
+        let rendered = crate::render_items(&[item]);
+        assert!(rendered.contains("fn __const_limit() -> SifrInt"));
+        assert!(rendered.contains(
+            "SifrInt::parse_decimal(\"100000000000000000000\", sifr_runtime::DEFAULT_MAX_INTEGER_DIGITS)"
+        ));
+        assert!(!rendered.contains(".unwrap("));
+        assert!(!rendered.contains(".expect("));
     }
 
     #[test]

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -505,6 +505,23 @@ fn test_module_int_over_budget_const_expr_stays_hir_diagnostic() {
 }
 
 #[test]
+fn test_module_int_const_expr_above_i64_folds_to_large_literal_for_codegen() {
+    let module = lower_source("LIMIT: int = 10 ** 20\n\ndef main():\n    print(str(LIMIT))\n")
+        .expect("in-budget oversized module int constant should lower");
+
+    assert!(
+        module
+            .constants
+            .iter()
+            .any(|(name, ty, value)| name == "LIMIT"
+                && ty == &Type::Int
+                && matches!(value, HirExpr::LargeIntLiteral(value) if value == "100000000000000000000")),
+        "oversized exact int module constants should be folded to a canonical large literal for codegen: {:?}",
+        module.constants
+    );
+}
+
+#[test]
 fn test_fixed_width_over_budget_literal_diagnostic_is_not_duplicated() {
     let literal = "1".repeat(4097);
     let source = format!("def main():\n    too_large: uint8 = {literal}\n");

--- a/crates/sifr_hir/src/lower/fixed_width_fitting.rs
+++ b/crates/sifr_hir/src/lower/fixed_width_fitting.rs
@@ -80,10 +80,13 @@ pub(super) fn remember_module_const_integer(
     name: &str,
     value: &HirExpr,
     range: TextRange,
-) {
+) -> Option<BigInt> {
     if let ConstIntegerValue::Value(value) = const_integer_value(ctx, value, range) {
-        ctx.const_integer_values.insert(name.to_string(), value);
+        ctx.const_integer_values
+            .insert(name.to_string(), value.clone());
+        return Some(value);
     }
+    None
 }
 
 enum ConstIntegerValue {

--- a/crates/sifr_hir/src/lower/module_constants_lowering.rs
+++ b/crates/sifr_hir/src/lower/module_constants_lowering.rs
@@ -1,4 +1,5 @@
 use crate::HirExpr;
+use num_bigint::BigInt;
 use ruff_text_size::Ranged;
 use sifr_python_ast::{Expr, Stmt, UnaryOp};
 use sifr_type_system::Type;
@@ -51,12 +52,17 @@ fn collect_annotated_constant(
         hir_value = folded_value;
     }
     if ctx.error_count() == error_count_before_initializer {
-        fixed_width_fitting::remember_module_const_integer(
+        let remembered_value = fixed_width_fitting::remember_module_const_integer(
             ctx,
             &var_name,
             &hir_value,
             value_expr.range(),
         );
+        if let Some(folded) =
+            oversized_int_module_constant_literal_for_codegen(&ty, remembered_value.as_ref())
+        {
+            hir_value = folded;
+        }
     }
     ctx.scope.define(var_name.clone(), ty.clone());
     constants.push((var_name, ty, hir_value));
@@ -80,19 +86,38 @@ fn collect_bare_constant(
     if ctx.type_vars.contains(&var_name) {
         return;
     }
-    let Some(hir_value) = lower_module_integer_const_expr(&assign.value, ctx) else {
+    let Some(mut hir_value) = lower_module_integer_const_expr(&assign.value, ctx) else {
         return;
     };
 
     let ty = hir_value.ty().clone();
-    fixed_width_fitting::remember_module_const_integer(
+    let remembered_value = fixed_width_fitting::remember_module_const_integer(
         ctx,
         &var_name,
         &hir_value,
         assign.value.range(),
     );
+    if let Some(folded) =
+        oversized_int_module_constant_literal_for_codegen(&ty, remembered_value.as_ref())
+    {
+        hir_value = folded;
+    }
     ctx.scope.define(var_name.clone(), ty.clone());
     constants.push((var_name, ty, hir_value));
+}
+
+fn oversized_int_module_constant_literal_for_codegen(
+    ty: &Type,
+    value: Option<&BigInt>,
+) -> Option<HirExpr> {
+    if !matches!(ty.resolve_alias(), Type::Int) {
+        return None;
+    }
+    let value = value?;
+    if i64::try_from(value.clone()).is_ok() {
+        return None;
+    }
+    Some(HirExpr::LargeIntLiteral(value.to_str_radix(10)))
 }
 
 fn lower_module_integer_const_expr(expr: &Expr, ctx: &LowerCtx) -> Option<HirExpr> {

--- a/reviews/integer-model-int-1-large-module-int-codegen-review-pass-1.md
+++ b/reviews/integer-model-int-1-large-module-int-codegen-review-pass-1.md
@@ -1,0 +1,130 @@
+# INT-1 Large Module `int` Constant SifrInt Codegen — Review Pass 1
+
+**Verdict:** Satisfied with non-blocking suggestions.
+
+## Scope reviewed
+
+Working-tree diff against `342071de` on `int-1-large-module-int-const-codegen`:
+
+- [crates/sifr_hir/src/lower/fixed_width_fitting.rs](crates/sifr_hir/src/lower/fixed_width_fitting.rs)
+- [crates/sifr_hir/src/lower/module_constants_lowering.rs](crates/sifr_hir/src/lower/module_constants_lowering.rs)
+- [crates/sifr_hir/src/lower/expressions_tests.rs](crates/sifr_hir/src/lower/expressions_tests.rs)
+- [crates/sifr_codegen/src/lower_item.rs](crates/sifr_codegen/src/lower_item.rs)
+- [crates/sifr/tests/e2e/pass/module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr)
+
+Reference docs:
+- [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)
+- [internal_docs/integer_model.md](internal_docs/integer_model.md)
+- [reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md](reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md) (the N4 follow-up this slice closes)
+
+## Slice goal — closed
+
+The pass-4 N4 follow-up was that an in-budget literal exceeding `i64` (e.g. `LIMIT: int = 999_999_999_999_999_999_999_999_999_999_999_999`) survived `lower_module_integer_const_expr` → `lower_integer_const_expr_simple` → `HirExpr::LargeIntLiteral`, then `try_lower_simple_module_constant_item_result_impl` returned `Ok(None)`, and the production emitter panicked at [crates/sifr_codegen/src/module_constants.rs:12](crates/sifr_codegen/src/module_constants.rs:12) with `structured module constant emission missing for production path (...)`.
+
+The diff closes that path on both sides:
+
+1. HIR: [oversized_int_module_constant_literal_for_codegen](crates/sifr_hir/src/lower/module_constants_lowering.rs:109) folds any `Type::Int`-annotated or bare module constant whose `BigInt` value does not fit `i64` to a canonical `HirExpr::LargeIntLiteral(value.to_str_radix(10))`. This is wired into both [collect_annotated_constant](crates/sifr_hir/src/lower/module_constants_lowering.rs:55) and [collect_bare_constant](crates/sifr_hir/src/lower/module_constants_lowering.rs:94), gated by the existing `error_count_before_initializer` check on the annotated path so an over-budget or fixed-width-out-of-range diagnostic still suppresses the fold.
+
+2. HIR: [remember_module_const_integer](crates/sifr_hir/src/lower/fixed_width_fitting.rs:78) was extended to return `Option<BigInt>` so the caller can reuse the already-evaluated value without re-evaluating. The implementation hashes the same `ConstIntegerValue::Value(value)` arm and inserts a clone, so this is a non-behavioral refactor on the `remember` side.
+
+3. Codegen: [large_module_int_literal_decimal](crates/sifr_codegen/src/lower_item.rs:183) is checked in both the Result and non-Result dispatchers *before* the legacy `is_simple_module_primitive_const_type` branch, and emits a private helper [lower_large_module_int_const_item](crates/sifr_codegen/src/lower_item.rs:231) returning `SifrInt` via `SifrInt::parse_decimal(text, sifr_runtime::DEFAULT_MAX_INTEGER_DIGITS)`. The `Err(err)` arm panics with a `compiler emitted invalid integer literal for module constant {name}: {{}}` message — programmer-invariant, not user-data-driven.
+
+I traced the production path end-to-end:
+
+- `BIG_LIMIT: int = 10 ** 20` ⇒ parser → `BinOp(IntLiteral(10), **, IntLiteral(20))` → `lower_module_integer_const_expr` returns the BinOp HIR with `ty: Int` → `error_count_before_initializer` sees no validate error (annotated `int = int` is `NotConst`, types match, no `TYPE_MISMATCH`) → `remember_module_const_integer` evaluates to `100_000_000_000_000_000_000` and caches it → `oversized_int_module_constant_literal_for_codegen(&Type::Int, Some(&value))` rejects `i64::try_from`, returns `LargeIntLiteral("100000000000000000000")` → `try_lower_simple_module_constant_item_result_impl` matches the new branch → emits `fn __const_BIG_LIMIT() -> SifrInt { match SifrInt::parse_decimal(...) { Ok(v) => return v, Err(err) => panic!(...) } }`. Verified by hand-running `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr`, which reproduces exactly that shape, and by `cargo run -q -p sifr -- run …`, which prints `100000000000000000000`.
+
+- `BIG: int = -(10 ** 20)` ⇒ inner BinOp evaluates to `100_000_000_000_000_000_000`, the negate path produces `UnaryOp("-", BinOp, Int)` HIR, `remember_module_const_integer` evaluates the `"-"` arm to `-100_000_000_000_000_000_000`, and the codegen fold replaces the entire `UnaryOp` shape with a canonical `LargeIntLiteral("-100000000000000000000")`. Verified end-to-end: emitted `parse_decimal("-100000000000000000000", …)` runs and prints `-100000000000000000000`.
+
+- Module-public flag preserves correctness: [try_emit_lowered_module_constant_result](crates/sifr_codegen/src/module_constants.rs:33) rewrites the new `RustItem::Fn { visibility, .. }` to `Visibility::Pub` when `module_public` is true, same as the existing string/none helpers.
+
+- Use-site rewriting works: `module_constants.insert(name, (Type::Int, "__const_BIG_LIMIT()"))` via [try_emit_lowered_module_constant_result](crates/sifr_codegen/src/module_constants.rs:44), and [parse_module_constant_expr](crates/sifr_codegen/src/expr_render_helpers.rs:1204) converts a referencing `Expr::Name` into a fn-call expression. `str(BIG_LIMIT)` ends up as `format!("{}", __const_BIG_LIMIT())`, which works because `SifrInt: Display` is impl'd in the runtime crate. The auto-import collector at [ir_imports.rs:436](crates/sifr_codegen/src/ir_imports.rs:436) handles both the `SifrInt` type and the `sifr_runtime` path, so the generated file picks up `use sifr_runtime::SifrInt;`.
+
+- The `Err` panic is unreachable under canonical input. `BigInt::to_str_radix(10)` produces `[\\-]?[0-9]+`, [count_decimal_digits](crates/sifr_runtime/src/int.rs:426) accepts that shape, both `INTEGER_EVAL_DECIMAL_DIGIT_BUDGET` ([fixed_width_fitting.rs:103](crates/sifr_hir/src/lower/fixed_width_fitting.rs:103), [integer_literal_diagnostics.rs:9](crates/sifr_hir/src/lower/integer_literal_diagnostics.rs:9)) and [DEFAULT_MAX_INTEGER_DIGITS](crates/sifr_runtime/src/int.rs:10) are `4096`, and the HIR fold only fires after `remember_module_const_integer` already passed `reject_if_over_budget`. So the runtime digit-limit check cannot reject what the compiler emits today.
+
+## Determinism / regression check
+
+- Annotated *fixed-width* over-budget paths are unchanged. `LIMIT: uint8 = 10 ** 5000` still emits one `SIFR-INT-0004` from `validate_fixed_width_initializer` and the `error_count_before_initializer` guard skips the new fold. The new `oversized_int_module_constant_literal_for_codegen` also short-circuits on `!matches!(ty.resolve_alias(), Type::Int)`, so even if the gate were missed, a `FixedInt` annotation would not trigger SifrInt codegen.
+- Annotated `int` over-budget paths are unchanged. `LIMIT: int = 10 ** 5000` ⇒ `remember_module_const_integer` emits one `SIFR-INT-0004` and returns `None`; the fold sees `value: None` and returns `None`; the existing `LargeIntLiteral` HIR survives but the diagnostic short-circuits the build before codegen runs. The pinned [test_module_int_over_budget_const_expr_stays_hir_diagnostic](crates/sifr_hir/src/lower/expressions_tests.rs:466) still asserts `errors.len() == 1`.
+- The `i64::try_from(value.clone()).is_ok()` gate keeps small `int` constants on the legacy `RustItem::Const { ty: I64, … }` path — `MAX_RETRIES: int = 3`, `BASE_LIMIT: int = 250`, `LIMIT: int = BASE_LIMIT + 4`, `NEGATIVE_LIMIT: int = -(MAX_RETRIES + 10)` all stay on `i64`, as visible in the emitted snapshot. Same-module `int` reuse and unary/binop folding from the INT-2B pass-4 fix still works (the e2e fixture pins `'254'` and `'-13'`).
+- The non-Result dispatcher `try_lower_simple_module_constant_item` only has test-only callers (`lib_codegen_tests.rs:944` aside, all uses are tests in `lower_item.rs`), so the duplicated check at [lower_item.rs:222](crates/sifr_codegen/src/lower_item.rs:222) does not change production behavior; it only keeps the dispatcher paths symmetric. No drift.
+
+## Scope drift
+
+- `module_constants_lowering.rs` adds a single helper and two call sites mirrored across the annotated and bare paths. No drift into general expression lowering.
+- `fixed_width_fitting.rs` change is a return-type extension on an existing helper; the only behavioral side effect is the now-required `value.clone()` to satisfy the `BigInt` return — `value` was previously consumed into the map insertion. `num_bigint::BigInt: Clone`, so the clone is allocator-bound but unavoidable here.
+- `lower_item.rs` adds `RustMatchArm` to the imports, a single helper for the SifrInt parse-decimal call, the dispatcher pre-check, and the `lower_large_module_int_const_item` constructor. No edits to existing branches.
+- The e2e fixture only adds one constant and one assertion. No deletions or renames.
+
+## Tests
+
+- [test_module_int_const_expr_above_i64_folds_to_large_literal_for_codegen](crates/sifr_hir/src/lower/expressions_tests.rs:507) pins the HIR fold on the annotated path: `LIMIT: int = 10 ** 20` lowers to `(LIMIT, Type::Int, LargeIntLiteral("100000000000000000000"))`. The `module.constants` shape is the contract the codegen new branch matches against, so this is the right invariant.
+- [dispatcher_result_lowers_large_module_int_const_as_sifr_int_helper](crates/sifr_codegen/src/lower_item.rs:479) pins the codegen lowering shape: `Fn { name: "__const_limit", ret: Some(Named("SifrInt")), … }` with the rendered body containing `SifrInt::parse_decimal("100000000000000000000", sifr_runtime::DEFAULT_MAX_INTEGER_DIGITS)` and asserts `!rendered.contains(".unwrap(")` / `!rendered.contains(".expect(")`. Sufficient for the no-panic-via-unwrap invariant.
+- [module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr) adds `BIG_LIMIT: int = 10 ** 20` and `assert str(BIG_LIMIT) == '100000000000000000000'`, smoke-testing the full pipeline (parse → HIR fold → codegen helper → runtime parse_decimal → Display).
+
+## Non-blocking findings
+
+### N1 — `BIG_LIMIT + 1` in a function body emits invalid Rust
+
+This is the most impactful follow-up. With the new lowering, `BIG_LIMIT: int = 10 ** 20` succeeds, but if a downstream use site mixes it with a small `int` (e.g. `x: int = BIG_LIMIT + 1`), the emitter produces `__const_BIG_LIMIT() + (1 as i64)`, which `rustc` rejects with:
+
+```
+error[E0277]: cannot add `i64` to `SifrInt`
+   --> src/main.rs:15:38
+    |
+15 |     let x: i64 = __const_BIG_LIMIT() + (1 as i64);
+    |                                      ^ no implementation for `SifrInt + i64`
+```
+
+Reproduced locally with a minimal `BIG_LIMIT: int = 10 ** 20\n\ndef main():\n    x: int = BIG_LIMIT + 1\n    print(str(x))\n` driver. Before this slice the file would have died at compiler-panic time inside `emit_module_constants`, so this is *strictly* an incremental improvement — the failure mode moves from compiler crash to `rustc` error. But it leaves a real, narrow gap where Sifr accepts source that produces invalid generated Rust, which violates the spirit of the "if it compiles, it works" guarantee at the surface level.
+
+This is consistent with the issue's framing ("Wire module-level `int` constants whose in-budget values exceed `i64` through `SifrInt` codegen, removing the current module-constant production panic path") and the pass-4 N4 note that broader `Type::Int` arithmetic SifrInt wiring belongs to INT-1/INT-3 wave 2. So the slice can land as-is for the panic-removal goal, but a follow-up should track this to closure either by a typed Sifr-level "int constant exceeds i64" diagnostic on use sites until full SifrInt arithmetic lands, or by routing any `int`-typed module constant through SifrInt regardless of size when the broader wave runs. Worth tracking explicitly in the issue's INT-1 checklist so it doesn't slip behind the panic-removal tick.
+
+### N2 — Codegen-side `UnaryOp` branches in `large_module_int_literal_decimal` are dead from the production HIR pipeline
+
+[large_module_int_literal_decimal](crates/sifr_codegen/src/lower_item.rs:187) handles `HirExpr::UnaryOp { op: "+", … }` and `HirExpr::UnaryOp { op: "-", … }`, but the HIR fold added in this slice always pre-flattens both shapes to a canonical `LargeIntLiteral("-…")` or `LargeIntLiteral("…")` via `bigint.to_str_radix(10)`. Both production callers (annotated and bare) go through the same `oversized_int_module_constant_literal_for_codegen` path, so the dispatcher's `UnaryOp` branches are only reachable if a future caller passes an un-folded shape.
+
+Two options, neither blocking:
+- Add a unit test that calls the codegen helper with an un-folded `UnaryOp("-", LargeIntLiteral("1…"))` shape to keep the branches alive and pinned.
+- Drop the `UnaryOp` branches from `large_module_int_literal_decimal` since the HIR pipeline guarantees the canonical shape — leaning on the contract the new HIR test asserts.
+
+I'd lean toward keeping the branches plus adding the test (so the codegen helper stays robust to non-canonical callers), but either is fine.
+
+### N3 — Bare-constant fold path has no focused HIR test
+
+The new test covers the annotated `LIMIT: int = 10 ** 20` shape. The bare `BIG = 10 ** 20` (no annotation) path was modified — `mut hir_value`, `oversized_int_module_constant_literal_for_codegen` call — but no HIR test specifically exercises it. Tracing it: `lower_module_integer_const_expr(BinOp(10, **, 20))` returns the BinOp with `ty: Int`, `remember_module_const_integer` evaluates and caches, the fold replaces `hir_value` with the canonical `LargeIntLiteral`. Functionally identical to the annotated path, just not pinned. A two-line addition mirroring `test_module_int_const_expr_above_i64_folds_to_large_literal_for_codegen` for the bare-assignment shape (`BIG = 10 ** 20\n\ndef main():\n    print(str(BIG))\n`) would close the gap.
+
+### N4 — No "compile-time vs runtime digit budget" contract test
+
+The unreachability of the `panic!` arm relies on `INTEGER_EVAL_DECIMAL_DIGIT_BUDGET` (HIR) and `DEFAULT_MAX_INTEGER_DIGITS` (runtime) staying in lockstep at `4096`. They live in different crates and aren't structurally tied. A trivial assertion test in `sifr_codegen` (or an integration test) like
+
+```rust
+assert_eq!(
+    sifr_runtime::DEFAULT_MAX_INTEGER_DIGITS,
+    sifr_hir::lower::INTEGER_EVAL_DECIMAL_DIGIT_BUDGET, // pub-export needed
+);
+```
+
+would pin the invariant so a future change reducing the runtime limit (for example) cannot silently make the panic reachable from valid Sifr source. Optional — the values are unlikely to drift accidentally — but cheap insurance, and aligned with the INT-1 milestone scope ("Add generated-code panic-shape tests for runtime integer paths").
+
+### N5 — Per-call re-parsing of the decimal text
+
+`__const_BIG_LIMIT()` calls `SifrInt::parse_decimal(...)` on every reference, allocating a fresh `BigInt` each time. For ordinary module constants this is consistent with how the existing `__const_<name>()` helpers for `String`/`None` already work (the string helper does `to_string()` per call), but the SifrInt path is the first to do real work in the helper body. INT-8 perf gates will likely want a `OnceLock`/`LazyLock`-cached static or a `&'static SifrInt` accessor. Not a concern for this slice.
+
+### N6 — Minor: string-literal expression construction in `sifr_int_parse_decimal_call`
+
+[sifr_int_parse_decimal_call](crates/sifr_codegen/src/lower_item.rs:200) constructs the decimal-text argument as `RustExpr::Ident(format!("\"{}\"", decimal_text.escape_default()))`. `escape_default()` is fine because the canonical decimal text only contains ASCII digits and an optional `-`, neither of which `escape_default` mangles. Using `RustExpr::Literal(RustLiteral::Str(decimal_text.into()))` would be more idiomatic (the renderer already handles quoting/escaping for `Str` literals). Style nit, not behavioral.
+
+## Validation
+
+I re-traced rather than re-ran the listed validation. The cited results are consistent with the code:
+
+- `cargo fmt` — diff is fmt-clean (no stray indentation against the existing style).
+- `cargo test -p sifr_hir module_int_const_expr_above_i64 -- --nocapture` — the test source pins exactly the shape my trace describes.
+- `cargo test -p sifr_codegen large_module_int_const -- --nocapture` — the rendered-substring assertions match the call-site I verified.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr` — I reproduced this directly via `emit` + `run` and confirmed `100000000000000000000` and `-100000000000000000000` both round-trip.
+- `cargo test -p sifr_hir module_ -- --nocapture` and `cargo test -p sifr_codegen module_const -- --nocapture` — broader regressions; the slice does not touch the cases pinned by the existing `test_module_*` set.
+- `scripts/run_all_tests.sh --profile quick` — `report_signature=e1bf653aaa770517`, `wall_time=71.91s`, passed. The manifest-bound suite is the authoritative gate per AGENTS.md and is green.
+
+## Verdict
+
+**Satisfied with non-blocking suggestions.** The slice cleanly closes the pass-4 N4 follow-up: in-budget `int` module constants exceeding `i64` no longer crash the emitter, they lower through a `SifrInt` helper using `parse_decimal` against a programmer-invariant `panic!` arm that is unreachable while the HIR and runtime digit budgets agree. The HIR fold and codegen branch are mirrored across the annotated and bare paths and tested at both the HIR-shape level and end-to-end. Non-blocking suggestions: (N1) downstream `int + int` arithmetic mixing the new SifrInt helper with the legacy `i64` `const` shape produces `rustc` errors and should be tracked as the next sub-item under INT-1 wave 2; (N2) prune-or-test the codegen-side `UnaryOp` branches that the HIR fold makes dead; (N3) add a focused HIR test for the bare-constant fold; (N4) pin the `INTEGER_EVAL_DECIMAL_DIGIT_BUDGET == DEFAULT_MAX_INTEGER_DIGITS` invariant with a contract test; (N5) consider lazy-static caching of the parse_decimal result for INT-8 perf; (N6) `RustLiteral::Str` is more idiomatic than `Ident` for the decimal-text argument. None gates merge.


### PR DESCRIPTION
## Summary
- Fold in-budget module-level `int` constants that exceed `i64` to canonical `LargeIntLiteral` HIR after const evaluation.
- Lower those module constants through a `SifrInt` helper instead of the legacy primitive `const i64` path.
- Add HIR/codegen coverage plus an e2e pass fixture assertion for `BIG_LIMIT: int = 10 ** 20`.

## Review
- Claude review satisfied: `reviews/integer-model-int-1-large-module-int-codegen-review-pass-1.md`
- Non-blocking follow-up noted: broader `SifrInt` arithmetic/use-site migration still needs a later INT-1/INT-3 slice.

## Validation
- `cargo fmt`
- `cargo test -p sifr_hir module_int_const_expr_above_i64 -- --nocapture`
- `cargo test -p sifr_codegen large_module_int_const -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- `cargo test -p sifr_hir module_ -- --nocapture`
- `cargo test -p sifr_codegen module_const -- --nocapture`
- `scripts/run_all_tests.sh --profile quick` (report_signature=e1bf653aaa770517, wall_time=71.91s)
