### PR TITLE
Promote exact-int assignment targets to SifrInt

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -36,3 +36,9 @@ def main():
     assigned_total = assigned_total + reusable_oversized_local
     assigned_total = assigned_total + 2
     assert str(assigned_total) == '100000000000000000003'
+    alias_reuse: int = reusable_oversized_local
+    alias_assign: int = 0
+    alias_assign = reusable_oversized_local
+    assert str(alias_reuse) == '100000000000000000001'
+    assert str(alias_assign) == '100000000000000000001'
+    assert str(reusable_oversized_local) == '100000000000000000001'

--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -32,3 +32,7 @@ def main():
     assert str(reuse_b) == '100000000000000000003'
     assert str(negated_reuse) == '-100000000000000000001'
     assert reusable_oversized_local < reuse_b
+    assigned_total: int = 0
+    assigned_total = assigned_total + reusable_oversized_local
+    assigned_total = assigned_total + 2
+    assert str(assigned_total) == '100000000000000000003'

--- a/crates/sifr_codegen/src/class_emitter.rs
+++ b/crates/sifr_codegen/src/class_emitter.rs
@@ -162,12 +162,15 @@ impl RustEmitter {
         let saved_mutated = self.mutated_vars.clone();
         let saved_local_binding_types = self.local_binding_types.clone();
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
+        let saved_sifr_int_forced_local_bindings =
+            self.sifr_int_forced_local_bindings.borrow().clone();
 
         self.emission_ctx.in_display_impl = true;
         self.current_return_type = Some(str_func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&str_func.body, &self.func_signatures);
         self.local_binding_types.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
+        self.sifr_int_forced_local_bindings.borrow_mut().clear();
         self.register_local_body_binding_types(&str_func.body);
 
         let mut body = Vec::new();
@@ -188,6 +191,7 @@ impl RustEmitter {
         self.mutated_vars = saved_mutated;
         self.local_binding_types = saved_local_binding_types;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
+        *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
         body
     }
 

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -490,6 +490,8 @@ impl RustEmitter {
         let saved_callable_var_conventions = self.callable_var_conventions.clone();
         let saved_local_binding_types = self.local_binding_types.clone();
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
+        let saved_sifr_int_forced_local_bindings =
+            self.sifr_int_forced_local_bindings.borrow().clone();
 
         self.current_return_type = Some(method.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&method.body, &self.func_signatures);
@@ -498,6 +500,7 @@ impl RustEmitter {
         self.callable_var_conventions.clear();
         self.local_binding_types.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
+        self.sifr_int_forced_local_bindings.borrow_mut().clear();
 
         for param in &method.params {
             let effective_convention = if method.name == "new" {
@@ -597,6 +600,7 @@ impl RustEmitter {
         self.callable_var_conventions = saved_callable_var_conventions;
         self.local_binding_types = saved_local_binding_types;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
+        *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
 
         RustItem::Fn {
             name: method.name.clone(),

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -478,7 +478,7 @@ impl RustEmitter {
                 let (ty, value) = if matches!(ty, Some(crate::RustType::I64))
                     && (value_is_sifr_int || force_sifr_int)
                 {
-                    let value = self.coerce_expr_to_sifr_int(value);
+                    let value = self.coerce_expr_to_sifr_int_value(value);
                     self.sifr_int_local_bindings
                         .borrow_mut()
                         .insert(name.clone());
@@ -523,7 +523,7 @@ impl RustEmitter {
                         self.sifr_int_local_bindings
                             .borrow_mut()
                             .insert(name.clone());
-                        self.coerce_expr_to_sifr_int(value)
+                        self.coerce_expr_to_sifr_int_value(value)
                     }
                     _ => value,
                 };
@@ -1294,6 +1294,33 @@ impl RustEmitter {
         }
     }
 
+    fn coerce_expr_to_sifr_int_value(&self, expr: crate::RustExpr) -> crate::RustExpr {
+        match expr {
+            crate::RustExpr::Ident(name) if self.is_registered_sifr_int_local(&name) => {
+                crate::RustExpr::Clone(Box::new(crate::RustExpr::Ident(name)))
+            }
+            crate::RustExpr::Paren(inner) => {
+                crate::RustExpr::Paren(Box::new(self.coerce_expr_to_sifr_int_value(*inner)))
+            }
+            crate::RustExpr::BinOp { left, op, right }
+                if is_sifr_int_arithmetic_op(&op)
+                    && (self.is_sifr_int_expr(&left) || self.is_sifr_int_expr(&right)) =>
+            {
+                crate::RustExpr::BinOp {
+                    left: Box::new(self.coerce_expr_to_sifr_int(*left)),
+                    op,
+                    right: Box::new(self.coerce_expr_to_sifr_int(*right)),
+                }
+            }
+            other if self.is_sifr_int_expr(&other) => other,
+            crate::RustExpr::Cast {
+                expr,
+                ty: crate::RustType::I64,
+            } => sifr_int_from_i64_expr(*expr),
+            other => sifr_int_from_i64_expr(other),
+        }
+    }
+
     fn coerce_expr_to_sifr_int_comparison_operand(&self, expr: crate::RustExpr) -> crate::RustExpr {
         let coerced = self.coerce_expr_to_sifr_int(expr);
         if matches!(coerced, crate::RustExpr::Ref { .. }) {
@@ -1640,6 +1667,48 @@ mod tests {
             } if name == "total"
                 && args.len() == 1
                 && matches!(func.as_ref(), RustExpr::Path(path) if path.as_slice() == ["SifrInt", "from_i64"])
+        ));
+    }
+
+    #[test]
+    fn rewrites_sifr_int_value_position_aliases_to_clone() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_local_bindings
+            .borrow_mut()
+            .insert("source".to_string());
+        emitter
+            .sifr_int_forced_local_bindings
+            .borrow_mut()
+            .insert("target".to_string());
+
+        let rewritten_let = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Let {
+            mutable: false,
+            name: "target".to_string(),
+            ty: Some(RustType::I64),
+            value: RustExpr::Ident("source".to_string()),
+        });
+        assert!(matches!(
+            rewritten_let,
+            RustStmt::Let {
+                ty: Some(RustType::Named(ref name)),
+                value: RustExpr::Clone(inner),
+                ..
+            } if name == "SifrInt"
+                && matches!(inner.as_ref(), RustExpr::Ident(source) if source == "source")
+        ));
+
+        let rewritten_assign = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Assign {
+            target: RustExpr::Ident("target".to_string()),
+            value: RustExpr::Ident("source".to_string()),
+        });
+        assert!(matches!(
+            rewritten_assign,
+            RustStmt::Assign {
+                target: RustExpr::Ident(ref target),
+                value: RustExpr::Clone(inner),
+            } if target == "target"
+                && matches!(inner.as_ref(), RustExpr::Ident(source) if source == "source")
         ));
     }
 }

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -473,15 +473,21 @@ impl RustEmitter {
                 value,
             } => {
                 let value = self.rewrite_stdlib_constant_idents_in_expr(value);
+                let force_sifr_int = self.is_forced_sifr_int_local(&name);
                 let value_is_sifr_int = self.is_sifr_int_expr(&value);
-                let ty = if matches!(ty, Some(crate::RustType::I64)) && value_is_sifr_int {
+                let (ty, value) = if matches!(ty, Some(crate::RustType::I64))
+                    && (value_is_sifr_int || force_sifr_int)
+                {
+                    let value = self.coerce_expr_to_sifr_int(value);
                     self.sifr_int_local_bindings
                         .borrow_mut()
                         .insert(name.clone());
-                    Some(crate::RustType::Named("SifrInt".to_string()))
+                    (Some(crate::RustType::Named("SifrInt".to_string())), value)
                 } else {
-                    self.sifr_int_local_bindings.borrow_mut().remove(&name);
-                    ty
+                    if !force_sifr_int {
+                        self.sifr_int_local_bindings.borrow_mut().remove(&name);
+                    }
+                    (ty, value)
                 };
                 crate::RustStmt::Let {
                     mutable,
@@ -506,10 +512,23 @@ impl RustEmitter {
                     .map(|stmt| self.rewrite_stdlib_constant_idents_in_stmt(stmt))
                     .collect(),
             },
-            crate::RustStmt::Assign { target, value } => crate::RustStmt::Assign {
-                target: self.rewrite_stdlib_constant_idents_in_expr(target),
-                value: self.rewrite_stdlib_constant_idents_in_expr(value),
-            },
+            crate::RustStmt::Assign { target, value } => {
+                let target = self.rewrite_stdlib_constant_idents_in_expr(target);
+                let value = self.rewrite_stdlib_constant_idents_in_expr(value);
+                let value = match &target {
+                    crate::RustExpr::Ident(name)
+                        if self.is_registered_sifr_int_local(name)
+                            || self.is_forced_sifr_int_local(name) =>
+                    {
+                        self.sifr_int_local_bindings
+                            .borrow_mut()
+                            .insert(name.clone());
+                        self.coerce_expr_to_sifr_int(value)
+                    }
+                    _ => value,
+                };
+                crate::RustStmt::Assign { target, value }
+            }
             crate::RustStmt::AugAssign { target, op, value } => crate::RustStmt::AugAssign {
                 target: self.rewrite_stdlib_constant_idents_in_expr(target),
                 op,
@@ -1256,6 +1275,16 @@ impl RustEmitter {
             crate::RustExpr::Paren(inner) => {
                 crate::RustExpr::Paren(Box::new(self.coerce_expr_to_sifr_int(*inner)))
             }
+            crate::RustExpr::BinOp { left, op, right }
+                if is_sifr_int_arithmetic_op(&op)
+                    && (self.is_sifr_int_expr(&left) || self.is_sifr_int_expr(&right)) =>
+            {
+                crate::RustExpr::BinOp {
+                    left: Box::new(self.coerce_expr_to_sifr_int(*left)),
+                    op,
+                    right: Box::new(self.coerce_expr_to_sifr_int(*right)),
+                }
+            }
             other if self.is_sifr_int_expr(&other) => other,
             crate::RustExpr::Cast {
                 expr,
@@ -1278,6 +1307,10 @@ impl RustEmitter {
 
     fn is_registered_sifr_int_local(&self, name: &str) -> bool {
         self.sifr_int_local_bindings.borrow().contains(name)
+    }
+
+    fn is_forced_sifr_int_local(&self, name: &str) -> bool {
+        self.sifr_int_forced_local_bindings.borrow().contains(name)
     }
 
     fn is_sifr_int_expr(&self, expr: &crate::RustExpr) -> bool {
@@ -1560,7 +1593,53 @@ mod tests {
                     RustExpr::FnCall { func, args }
                         if args.is_empty()
                             && matches!(func.as_ref(), RustExpr::Ident(name) if name == "__const_BIG_LIMIT")
-                )
+            )
+        ));
+    }
+
+    #[test]
+    fn rewrites_forced_sifr_int_assignment_target_storage() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_forced_local_bindings
+            .borrow_mut()
+            .insert("total".to_string());
+
+        let rewritten_let = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Let {
+            mutable: true,
+            name: "total".to_string(),
+            ty: Some(RustType::I64),
+            value: RustExpr::Cast {
+                expr: Box::new(RustExpr::Literal(RustLiteral::Int(0))),
+                ty: RustType::I64,
+            },
+        });
+
+        assert!(matches!(
+            rewritten_let,
+            RustStmt::Let {
+                ty: Some(RustType::Named(ref name)),
+                value: RustExpr::FnCall { .. },
+                ..
+            } if name == "SifrInt"
+        ));
+
+        let rewritten_assign = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Assign {
+            target: RustExpr::Ident("total".to_string()),
+            value: RustExpr::Cast {
+                expr: Box::new(RustExpr::Literal(RustLiteral::Int(2))),
+                ty: RustType::I64,
+            },
+        });
+
+        assert!(matches!(
+            rewritten_assign,
+            RustStmt::Assign {
+                target: RustExpr::Ident(ref name),
+                value: RustExpr::FnCall { func, args },
+            } if name == "total"
+                && args.len() == 1
+                && matches!(func.as_ref(), RustExpr::Path(path) if path.as_slice() == ["SifrInt", "from_i64"])
         ));
     }
 }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -94,6 +94,60 @@ impl RustEmitter {
             self.local_binding_types.entry(name).or_insert(ty);
         }
         self.none_widened_local_bindings.extend(widened_bindings);
+        self.register_sifr_int_forced_local_bindings(body);
+    }
+
+    fn register_sifr_int_forced_local_bindings(&self, body: &[HirStmt]) {
+        let local_int_bindings = self
+            .local_binding_types
+            .iter()
+            .filter_map(|(name, ty)| {
+                matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
+                    .then(|| name.clone())
+            })
+            .collect::<HashSet<_>>();
+        if local_int_bindings.is_empty() {
+            return;
+        }
+
+        let module_sifr_int_bindings = self
+            .module_constants
+            .iter()
+            .filter_map(|(name, (ty, rust_name))| {
+                (matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
+                    && rust_name.ends_with("()"))
+                .then(|| name.clone())
+            })
+            .collect::<HashSet<_>>();
+
+        let mut forced = self.sifr_int_forced_local_bindings.borrow().clone();
+        loop {
+            let before = forced.len();
+            let mut on_stmt = |stmt: &HirStmt| match stmt {
+                HirStmt::Let { name, value, .. } | HirStmt::Assign { name, value }
+                    if local_int_bindings.contains(name)
+                        && hir_expr_needs_sifr_int_storage(
+                            value,
+                            &forced,
+                            &module_sifr_int_bindings,
+                        ) =>
+                {
+                    forced.insert(name.clone());
+                }
+                _ => {}
+            };
+            let mut on_expr = |_expr: &HirExpr| {};
+            traversal::walk_stmts(
+                body,
+                TraversalConfig::LOCAL_SCOPE_ONLY,
+                &mut on_stmt,
+                &mut on_expr,
+            );
+            if forced.len() == before {
+                break;
+            }
+        }
+        *self.sifr_int_forced_local_bindings.borrow_mut() = forced;
     }
 
     pub(super) fn try_lower_structured_nested_function_stmt(&mut self, stmt: &HirStmt) -> bool {
@@ -156,6 +210,8 @@ impl RustEmitter {
         let saved_local_binding_types = self.local_binding_types.clone();
         let saved_none_widened_local_bindings = self.none_widened_local_bindings.clone();
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
+        let saved_sifr_int_forced_local_bindings =
+            self.sifr_int_forced_local_bindings.borrow().clone();
         let nested_binding_mutable = saved_mutated_vars.contains(&func.name);
 
         self.current_return_type = Some(func.return_type.clone());
@@ -165,6 +221,7 @@ impl RustEmitter {
         self.local_binding_types.clear();
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
+        self.sifr_int_forced_local_bindings.borrow_mut().clear();
         self.callable_var_conventions
             .clone_from(&post_stmt_callable_conventions);
         for param in &func.params {
@@ -198,6 +255,7 @@ impl RustEmitter {
         self.local_binding_types = saved_local_binding_types;
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
+        *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
 
         let lowered_stmt = if is_recursive {
             let params = func
@@ -526,6 +584,8 @@ impl RustEmitter {
         let saved_local_binding_types = self.local_binding_types.clone();
         let saved_none_widened_local_bindings = self.none_widened_local_bindings.clone();
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
+        let saved_sifr_int_forced_local_bindings =
+            self.sifr_int_forced_local_bindings.borrow().clone();
 
         self.current_return_type = Some(func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
@@ -535,6 +595,7 @@ impl RustEmitter {
         self.local_binding_types.clear();
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
+        self.sifr_int_forced_local_bindings.borrow_mut().clear();
         self.register_function_scope_params(&func.params);
         self.register_local_body_binding_types(&func.body);
 
@@ -636,5 +697,38 @@ impl RustEmitter {
         self.local_binding_types = saved_local_binding_types;
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
+        *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+    }
+}
+
+fn hir_expr_needs_sifr_int_storage(
+    expr: &HirExpr,
+    forced_locals: &HashSet<String>,
+    module_sifr_int_bindings: &HashSet<String>,
+) -> bool {
+    match expr {
+        HirExpr::LargeIntLiteral(_) => true,
+        HirExpr::Name { name, .. } => {
+            forced_locals.contains(name) || module_sifr_int_bindings.contains(name)
+        }
+        HirExpr::BinOp {
+            left,
+            op,
+            right,
+            ty,
+            ..
+        } if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
+            && matches!(op.as_str(), "+" | "-" | "*") =>
+        {
+            hir_expr_needs_sifr_int_storage(left, forced_locals, module_sifr_int_bindings)
+                || hir_expr_needs_sifr_int_storage(right, forced_locals, module_sifr_int_bindings)
+        }
+        HirExpr::UnaryOp { op, operand, ty }
+            if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
+                && matches!(op.as_str(), "+" | "-") =>
+        {
+            hir_expr_needs_sifr_int_storage(operand, forced_locals, module_sifr_int_bindings)
+        }
+        _ => false,
     }
 }

--- a/crates/sifr_codegen/src/function_like_lowering.rs
+++ b/crates/sifr_codegen/src/function_like_lowering.rs
@@ -22,6 +22,8 @@ impl RustEmitter {
         let saved_mut_borrowed_params = self.mut_borrowed_params.clone();
         let saved_local_binding_types = self.local_binding_types.clone();
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
+        let saved_sifr_int_forced_local_bindings =
+            self.sifr_int_forced_local_bindings.borrow().clone();
 
         self.current_return_type = Some(func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
@@ -29,6 +31,7 @@ impl RustEmitter {
         self.mut_borrowed_params.clear();
         self.local_binding_types.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
+        self.sifr_int_forced_local_bindings.borrow_mut().clear();
         for param in &func.params {
             if param.convention.is_shared_borrow()
                 && param.ty.ownership() != sifr_type_system::OwnershipKind::Copy
@@ -101,6 +104,7 @@ impl RustEmitter {
         self.mut_borrowed_params = saved_mut_borrowed_params;
         self.local_binding_types = saved_local_binding_types;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
+        *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
         lowered_body
     }
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1211,6 +1211,8 @@ struct RustEmitter {
     none_widened_local_bindings: HashSet<String>,
     /// Local names whose generated Rust binding has been promoted from legacy `i64` to `SifrInt`.
     sifr_int_local_bindings: RefCell<HashSet<String>>,
+    /// Local names pre-promoted to `SifrInt` because a later assignment needs exact-int storage.
+    sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
     /// Stack used to capture structured statement emission as IR nodes.
     stmt_capture_stack: Vec<Vec<RustStmt>>,
     /// Recursion guard for non-structured emitter paths.
@@ -1311,6 +1313,7 @@ impl RustEmitter {
             local_binding_types: HashMap::new(),
             none_widened_local_bindings: HashSet::new(),
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
+            sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
             stmt_capture_stack: Vec::new(),
             lowering_stats: LoweringStats::default(),
         }
@@ -1494,7 +1497,7 @@ impl RustEmitter {
                 }
             };
 
-            self.push_captured_stmt(&RustStmt::Let {
+            let lowered_stmt = RustStmt::Let {
                 mutable: self.mutated_vars.contains(name)
                     || matches!(
                         &effective_ty,
@@ -1507,8 +1510,10 @@ impl RustEmitter {
                     || is_generic_class
                     || match (&effective_ty, value) {
                         (resolved_ty, HirExpr::Call { func, args, .. })
-                            if matches!(resolve_alias_type_for_plain_call(resolved_ty), Type::Set(_))
-                                && func == "set"
+                            if matches!(
+                                resolve_alias_type_for_plain_call(resolved_ty),
+                                Type::Set(_)
+                            ) && func == "set"
                                 && args.is_empty() =>
                         {
                             true
@@ -1520,10 +1525,9 @@ impl RustEmitter {
                                 ..
                             },
                             HirExpr::Call { func, args, .. },
-                        )
-                            if func == alias_name
-                                && args.is_empty()
-                                && alias_name.starts_with("__compat_defaultdict_") =>
+                        ) if func == alias_name
+                            && args.is_empty()
+                            && alias_name.starts_with("__compat_defaultdict_") =>
                         {
                             if let Type::Dict(key_ty, value_ty) = body.resolve_alias() {
                                 matches!(key_ty.as_ref(), Type::Any | Type::Unknown)
@@ -1534,14 +1538,15 @@ impl RustEmitter {
                             }
                         }
                         _ => false,
-                    }
-                {
+                    } {
                     None
                 } else {
                     Some(self.rust_ir_type_with_generics(&effective_ty))
                 },
                 value: lowered_value,
-            });
+            };
+            let lowered_stmt = self.rewrite_stdlib_constant_idents_in_stmt(lowered_stmt);
+            self.push_captured_stmt(&lowered_stmt);
             self.lowering_stats.stmt_structured += 1;
             self.lowering_stats.stmt_candidate_structured += 1;
             return Ok(true);
@@ -1595,10 +1600,12 @@ impl RustEmitter {
             } else {
                 return Ok(false);
             };
-            self.push_captured_stmt(&RustStmt::Assign {
+            let lowered_stmt = RustStmt::Assign {
                 target: RustExpr::Ident(name.clone()),
                 value: lowered_value,
-            });
+            };
+            let lowered_stmt = self.rewrite_stdlib_constant_idents_in_stmt(lowered_stmt);
+            self.push_captured_stmt(&lowered_stmt);
             self.lowering_stats.stmt_structured += 1;
             self.lowering_stats.stmt_candidate_structured += 1;
             return Ok(true);

--- a/reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-1.md
@@ -1,0 +1,296 @@
+# INT-1 SifrInt Assignment Targets — Review Pass 1
+
+**Verdict:** Changes requested.
+
+A small, narrow-shape regression on a natural and previously-working code pattern (`b: int = a` where `a` is a registered SifrInt local) gates merge. The slice's stated goal — making `total = total + big` compile — is achieved, and most other shapes I probed work. The regression is mechanically simple to fix and the rest of the implementation is sound, so I expect a quick turnaround. Details below.
+
+## Scope reviewed
+
+PR #1825, branch `int-1-sifrint-assignment-targets` (head `32c5c818`), `main..HEAD` diff:
+
+- [crates/sifr_codegen/src/lib.rs](crates/sifr_codegen/src/lib.rs)
+- [crates/sifr_codegen/src/function_emitter.rs](crates/sifr_codegen/src/function_emitter.rs)
+- [crates/sifr_codegen/src/function_like_lowering.rs](crates/sifr_codegen/src/function_like_lowering.rs)
+- [crates/sifr_codegen/src/class_emitter.rs](crates/sifr_codegen/src/class_emitter.rs)
+- [crates/sifr_codegen/src/class_method_emitter.rs](crates/sifr_codegen/src/class_method_emitter.rs)
+- [crates/sifr_codegen/src/expr_render_helpers.rs](crates/sifr_codegen/src/expr_render_helpers.rs)
+- [crates/sifr/tests/e2e/pass/module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr)
+
+Reference docs:
+- [issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)
+- [internal_docs/integer_model.md](internal_docs/integer_model.md) — value-semantic rule at [line 474](internal_docs/integer_model.md:474).
+- [reviews/integer-model-int-1-sifrint-local-value-semantics-review-pass-1.md](reviews/integer-model-int-1-sifrint-local-value-semantics-review-pass-1.md) — the prior review whose N2 ("`total = total + big` still emits invalid Rust") this slice closes.
+- Pre-PR baseline behavior verified by checking out commit `7da872e0` (PR #1823's tracker, equivalent to PR #1823's implementation state) into a worktree and re-emitting probes.
+
+## Slice goal — partially closed
+
+The pass-1 N2 follow-up was that `total: int = 0; total = total + big` (with `big` a registered SifrInt local) emitted `total = SifrInt::from_i64(total) + &big`, failing rustc because `total: i64`. This slice closes that case.
+
+### Pre-scan: `register_sifr_int_forced_local_bindings`
+
+A new pass at [function_emitter.rs:97-148](crates/sifr_codegen/src/function_emitter.rs:97) runs during `register_local_body_binding_types`. It walks the function body once with `TraversalConfig::LOCAL_SCOPE_ONLY` (so nested function bodies are not visited — their own emit calls handle them) and identifies `int`-typed local bindings whose initializers or assignment values transitively require SifrInt storage. The fixed-point loop adds new names until convergence; transitive cases like `a = BIG_LIMIT + 1; b = a; c = b` all converge to forced.
+
+The visitor only matches `HirStmt::Let` and `HirStmt::Assign` (with `name` directly on the stmt) — so function parameters, AugAssign targets, tuple-unpack targets, and class-attr assignments are not pre-scanned. This is consistent with the slice description ("avoid changing function parameter/signature boundaries") and with the prior tracker's split between local-codegen migration (this slice) and signature migration (deferred).
+
+`hir_expr_needs_sifr_int_storage` at [function_emitter.rs:707-737](crates/sifr_codegen/src/function_emitter.rs:707) recognizes:
+
+- `LargeIntLiteral` — true.
+- `Name` — true if the name is in `forced` or in `module_sifr_int_bindings` (Type::Int helpers with a `()` rust_name).
+- Type::Int `BinOp { +, -, * }` — true if either operand needs SifrInt.
+- Type::Int `UnaryOp { +, - }` — true if operand needs SifrInt.
+- Anything else — false.
+
+The set of operators is appropriately restricted to the operators the codegen rewriter actually coerces. That keeps the pre-scan from forcing locals on operator shapes the BinOp coercion path doesn't handle (e.g., `<<`, `>>`, `//`, `%`).
+
+### Per-function scope save/restore
+
+All five emitter entry points save/clear/restore `sifr_int_forced_local_bindings`:
+
+- [function_emitter.rs:213/256](crates/sifr_codegen/src/function_emitter.rs:213) and [function_emitter.rs:587/700](crates/sifr_codegen/src/function_emitter.rs:587) (regular and alt function emitter)
+- [function_like_lowering.rs:25/107](crates/sifr_codegen/src/function_like_lowering.rs:25) (operator/protocol lowering)
+- [class_emitter.rs:165/194](crates/sifr_codegen/src/class_emitter.rs:165) (Display impl)
+- [class_method_emitter.rs:493/603](crates/sifr_codegen/src/class_method_emitter.rs:493) (class methods)
+
+Each site mirrors the existing `saved_sifr_int_local_bindings` plumbing one-for-one. `RefCell::borrow().clone()` save, `borrow_mut().clear()` post-save, body emit, then `*borrow_mut() = saved` restore. Verified by grep: every save site for `saved_sifr_int_local_bindings` has a matching save for `saved_sifr_int_forced_local_bindings`. ✓
+
+### Let/Assign rewrite
+
+The `RustStmt::Let` arm at [expr_render_helpers.rs:473-499](crates/sifr_codegen/src/expr_render_helpers.rs:473) is amended:
+
+```rust
+let value = self.rewrite_stdlib_constant_idents_in_expr(value);
+let force_sifr_int = self.is_forced_sifr_int_local(&name);
+let value_is_sifr_int = self.is_sifr_int_expr(&value);
+let (ty, value) = if matches!(ty, Some(crate::RustType::I64))
+    && (value_is_sifr_int || force_sifr_int)
+{
+    let value = self.coerce_expr_to_sifr_int(value);   // <-- new
+    self.sifr_int_local_bindings.borrow_mut().insert(name.clone());
+    (Some(crate::RustType::Named("SifrInt".to_string())), value)
+} else {
+    if !force_sifr_int {
+        self.sifr_int_local_bindings.borrow_mut().remove(&name);
+    }
+    (ty, value)
+};
+```
+
+Three changes:
+- Forcing-aware retype gate (`value_is_sifr_int || force_sifr_int`).
+- The value gets passed through `coerce_expr_to_sifr_int` so a forced local with a small-literal initializer (`assigned_total: int = 0`) gets `SifrInt::from_i64(0)` instead of leaving the literal as `i64`.
+- The else branch only removes from `sifr_int_local_bindings` when not force-flagged, preserving the registry for forced locals across re-Lets with non-SifrInt-valued sources.
+
+The `RustStmt::Assign` arm at [expr_render_helpers.rs:514-530](crates/sifr_codegen/src/expr_render_helpers.rs:514) gains a target-aware coerce: when the rewritten target is `Ident(name)` and the name is registered or forced, the rewritten value is run through `coerce_expr_to_sifr_int`, then the name is re-inserted into the registry (idempotent for already-registered names; load-bearing for transitive forcing where the registry might not have been populated yet).
+
+Together, these make `assigned_total: int = 0; assigned_total = assigned_total + reusable_oversized_local; assigned_total = assigned_total + 2` emit:
+
+```rust
+let mut assigned_total: SifrInt = SifrInt::from_i64(0);
+assigned_total = &assigned_total + &reusable_oversized_local;
+assigned_total = &assigned_total + SifrInt::from_i64(2);
+```
+
+…which compiles and round-trips at runtime. The fixture's final assert `str(assigned_total) == '100000000000000000003'` passes.
+
+### `coerce_expr_to_sifr_int`'s new BinOp arm
+
+A new arm in [coerce_expr_to_sifr_int](crates/sifr_codegen/src/expr_render_helpers.rs:1278-1287) handles `BinOp { +/-/* }` whose operands include a SifrInt-shaped side, recursively re-coercing each side. This is needed because the Assign target-aware coerce runs over an already-rewritten BinOp from `rewrite_stdlib_constant_idents_in_expr`, and without this arm the outer coerce would fall to the `other if is_sifr_int_expr(&other)` pass-through and miss the recursive structure. The recursion is bounded by the AST and the operands quickly hit the `Ref { Ident }` or pass-through terminators. ✓
+
+I verified the working cases via `cargo run -q -p sifr -- emit` against several probes:
+
+| Probe                                            | Emitted Rust                                           | Result |
+|--------------------------------------------------|--------------------------------------------------------|--------|
+| `total: int = 0; total = total + big; …`         | `let mut total: SifrInt = …; total = &total + &big;`   | ✓      |
+| `total: int = 0; total = a + 0` (BinOp source)   | `total = &a + SifrInt::from_i64(0)`                    | ✓      |
+| `total: int = 0; total = -a` (UnaryOp source)    | `total = -&a`                                          | ✓      |
+| `b: int = BIG_LIMIT` (helper)                    | `let b: SifrInt = __const_BIG_LIMIT()`                 | ✓      |
+| `total: int = 0; total = total + 1; …` (small-only) | stays `i64`                                          | ✓      |
+| Transitive force `a → b → c` through chained arithmetic | each retyped to SifrInt where SifrInt source flows | ✓ |
+
+Quick validation reproduces `report_signature=e1bf653aaa770517` and the e2e fixture round-trips.
+
+## Blocker
+
+### B1 — Bare `Ident` (registered SifrInt local) in Let or Assign value position emits invalid Rust
+
+The new `coerce_expr_to_sifr_int(value)` calls in the Let arm and the Assign arm are unconditional whenever the target is registered/forced. But `coerce_expr_to_sifr_int`'s first match arm — added in PR #1823 — wraps a registered Ident in `Ref { mutable: false, expr: Ident }` ([expr_render_helpers.rs:1271-1276](crates/sifr_codegen/src/expr_render_helpers.rs:1271)). That borrow shape was designed for **operand position** (BinOp/UnaryOp), where `Add<&SifrInt> for SifrInt` and friends accept it. In **value position** (the RHS of a `let _: SifrInt = …` or a `total = …` assign), `&local` produces `&SifrInt`, which does not unify with the target's `SifrInt` type.
+
+#### Reproduction (post-this-PR)
+
+```sifr
+BIG_LIMIT: int = 10 ** 20
+
+def main():
+    a: int = BIG_LIMIT + 1
+    b: int = a            # bare-Name alias
+    print(str(b))
+```
+
+`cargo run -q -p sifr -- emit` produces:
+
+```rust
+let a: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+let b: SifrInt = &a;          // E0308: expected `SifrInt`, found `&SifrInt`
+println!("{}", format!("{}", b));
+```
+
+`cargo run -q -p sifr -- run` fails compilation with rustc error E0308. Same shape via Assign:
+
+```sifr
+def main():
+    a: int = BIG_LIMIT + 1
+    total: int = 0
+    total = a              # bare-Name alias on assign
+```
+
+emits:
+
+```rust
+let mut total: SifrInt = SifrInt::from_i64(0);
+total = &a;                   // E0308
+```
+
+#### Pre-PR baseline (PR #1823, commit `7da872e0`)
+
+I checked out the previous file states for the six changed `sifr_codegen` files and re-ran emit on the same `b: int = a` probe:
+
+```rust
+let a: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+let b: SifrInt = a;           // compiles, prints "100000000000000000001"
+```
+
+So pre-PR the bare-Name alias compiled (with move semantics for `a`). Post-PR it fails outright. **This is a real regression on a natural, common Sifr pattern** (renaming/aliasing an `int` local).
+
+#### Why it happens
+
+The pre-PR Let arm (introduced in PR #1819, refined in #1821 / #1823) only **retyped** the binding — `value` was passed through unchanged whenever `value_is_sifr_int` was true. Pre-PR-#1825 emission for `Let { name: "b", value: Ident("a") }` was `let b: SifrInt = a;`. Compiles via direct assignment (move).
+
+This PR adds `let value = self.coerce_expr_to_sifr_int(value);` ([expr_render_helpers.rs:480](crates/sifr_codegen/src/expr_render_helpers.rs:480)). For the Ident-registered case, that walks the first match arm of `coerce_expr_to_sifr_int` and wraps in `Ref`. The wrap was correct in PR #1823's operand-position contexts but is incorrect in value-position contexts.
+
+The new test `rewrites_forced_sifr_int_assignment_target_storage` covers the literal-source forcing case (`Cast(Literal(0), I64)` → `SifrInt::from_i64(0)`), which works correctly. There is no test for the bare-Name registered-source case, which is exactly why the regression slipped through. The e2e fixture also uses a literal source (`assigned_total: int = 0`) and never aliases a SifrInt local through a bare Name in Let/Assign position, so it likewise misses the regression.
+
+#### Suggested fix
+
+The minimum change that closes B1 is to skip the value-position coerce when `value_is_sifr_int` is already true. That preserves PR #1823's pre-existing pass-through for already-SifrInt-shaped values, while still applying the wrap for the forced-but-not-yet-SifrInt-shaped case (small literal initializers, which is the new path the slice needs to enable):
+
+```rust
+let (ty, value) = if matches!(ty, Some(crate::RustType::I64))
+    && (value_is_sifr_int || force_sifr_int)
+{
+    let value = if value_is_sifr_int {
+        value                                    // already SifrInt; preserve PR #1823 behavior
+    } else {
+        self.coerce_expr_to_sifr_int(value)      // forced + non-SifrInt: wrap small literal / cast
+    };
+    self.sifr_int_local_bindings.borrow_mut().insert(name.clone());
+    (Some(crate::RustType::Named("SifrInt".to_string())), value)
+} else {
+    …
+};
+```
+
+The same gate applies to the Assign arm: only run the target-aware coerce when the rewritten value isn't already SifrInt-shaped (i.e., when it's a literal/cast). For the BinOp/UnaryOp shapes the slice claims (`total = total + big`, `total = -big`), the value rewrite already produces a SifrInt-shaped expression via the BinOp/UnaryOp coerce path; the post-rewrite coerce is then a no-op pass-through.
+
+If the team wants `b: int = a` to also preserve source-level value semantics (so `a` stays usable after `b: int = a`, per [integer_model.md:474](internal_docs/integer_model.md:474)), a value-position-specific coerce that emits `a.clone()` for a registered Ident — instead of `a` (move) or `&a` (borrow) — would be the durable fix. That is strictly an improvement over the pre-PR move behavior. Either fix unblocks merge; the minimum fix above just restores the pre-PR working shape.
+
+A regression test pinning the bare-Name case (e.g., a unit test asserting `Let { ty: Some(I64), value: Ident("registered") }` rewrites to `Let { ty: Some(SifrInt), value: Ident or Clone, … }` rather than `Ref`) would prevent re-introduction.
+
+## Determinism / regression check (other paths)
+
+I probed several other shapes; all produce correct Rust:
+
+- **i64-only paths untouched**: `total: int = 0; total += 1; total = total + 1` — pre-scan correctly does not force `total` because no SifrInt source flows in. Emits `let mut total: i64 = 0 as i64; total += (1 as i64); total = total + (1 as i64);`. ✓
+- **Helper-only Let**: `b: int = BIG_LIMIT` — emits `let b: SifrInt = __const_BIG_LIMIT();`. The helper FnCall passes through the new coerce arms (it's `is_sifr_int_expr`-true and not Ident, not Paren, not BinOp). ✓
+- **BinOp source Let**: `b: int = a + 0` — emits `let b: SifrInt = &a + SifrInt::from_i64(0);`. ✓
+- **UnaryOp source Let**: `b: int = -a` — emits `let b: SifrInt = -&a;`. ✓
+- **Transitive forcing**: `a = BIG_LIMIT + 1; b = a + 1; c = b + 1` (no bare-Name aliases) — all retyped, all use `&a`/`&b` operand borrows. ✓
+- **Existing operand cases from #1819/#1821/#1823** (`reuse_a`, `reuse_b`, `negated_reuse`, `reusable_oversized_local < reuse_b`, `BIG_LIMIT > 100`) — all unchanged in shape and round-trip the e2e fixture asserts.
+- **`scripts/run_all_tests.sh --profile quick`** reports `report_signature=e1bf653aaa770517` (same as #1817–#1823), confirming no snapshot/test deltas across the rest of the suite.
+
+## Tests
+
+- [rewrites_large_int_module_const_arithmetic_to_sifr_int_operands](crates/sifr_codegen/src/expr_render_helpers.rs:1486) (carried) — still passes.
+- [rewrites_large_int_module_const_let_type_to_sifr_int](crates/sifr_codegen/src/expr_render_helpers.rs:1516) (carried) — still passes.
+- [rewrites_registered_sifr_int_local_arithmetic_to_sifr_int_operands](crates/sifr_codegen/src/expr_render_helpers.rs:1526) (carried) — still passes.
+- [rewrites_large_int_module_const_comparison_to_sifr_int_operands](crates/sifr_codegen/src/expr_render_helpers.rs:1554) (carried) — still passes.
+- [rewrites_registered_sifr_int_local_comparison_to_borrowed_operands](crates/sifr_codegen/src/expr_render_helpers.rs:1598) (carried) — still passes.
+- [rewrites_forced_sifr_int_assignment_target_storage](crates/sifr_codegen/src/expr_render_helpers.rs:1620) (new) — covers the literal-source forcing case (Let with `0_i64` value retyping to `SifrInt::from_i64(0)`, then Assign with `2_i64` value rewriting to `total = SifrInt::from_i64(2)`). The structural assertions are correct for the case they cover.
+
+E2E coverage in [module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr) adds:
+
+- `assigned_total: int = 0` (literal-source forced Let)
+- `assigned_total = assigned_total + reusable_oversized_local` (BinOp-source forced Assign)
+- `assigned_total = assigned_total + 2` (BinOp-source forced Assign)
+- `assert str(assigned_total) == '100000000000000000003'` (round-trip)
+
+These pin the load-bearing shapes for the slice's stated scope. Coverage gaps that contributed to B1 slipping through:
+
+- **No test for `let b: int = a` where `a` is a registered SifrInt local.** The bare-Name value-position case.
+- **No test for `total = a` (Assign with bare-Name value).** Same shape on the Assign side.
+- **No test asserting the i64-only shape stays untouched** when `register_sifr_int_forced_local_bindings` runs and finds nothing forceable. Useful as a guard against future widening of the pre-scan rules.
+
+Adding any of these as unit tests would have caught B1.
+
+## Scope drift
+
+- Stays inside `sifr_codegen`. No HIR, type system, runtime, or driver changes. No public API growth.
+- The new helpers (`register_sifr_int_forced_local_bindings`, `is_forced_sifr_int_local`, `hir_expr_needs_sifr_int_storage`) are private. The new `RustEmitter` field `sifr_int_forced_local_bindings: RefCell<HashSet<String>>` is private.
+- The fixed-point pre-scan loop terminates because each iteration either adds a name (monotonic) or breaks. Bounded by the local int binding count. ✓
+- Function parameters are correctly excluded from the pre-scan because the visitor only walks Let/Assign targets — not parameters or pattern-bound names. The slice description's claim "avoid changing function parameter/signature boundaries" is honored. ✓
+- AugAssign (`total += a`) is not pre-scanned and not rewrite-coerced. Same shape was broken pre-PR (`total: i64 += a: SifrInt` failed rustc) and stays broken. Worth an explicit follow-up note (see N1 below).
+
+## Non-blocking findings
+
+(Once B1 is fixed, the items below remain.)
+
+### N1 — `AugAssign` is unhandled
+
+`total += a` (with `a` a SifrInt local) emits `let mut total: i64 = …; total += a;` regardless of forcing, because the pre-scan visitor at [function_emitter.rs:122](crates/sifr_codegen/src/function_emitter.rs:122) only matches `HirStmt::Let` and `HirStmt::Assign`. The rewrite path for `RustStmt::AugAssign` ([expr_render_helpers.rs:530-534](crates/sifr_codegen/src/expr_render_helpers.rs:530)) also doesn't apply target-aware coerce.
+
+This is not a regression — pre-PR the same code emitted the same broken Rust. But the slice description ("assignment targets such as `total = total + big`") implies broad coverage of mutating statements, and the most common shorthand for it is `total += big`. Worth either:
+
+- Extending the pre-scan visitor to include `HirStmt::AugAssign { name, value }` with the same predicate.
+- Or explicitly carving it out in the open follow-up bullet so a future reader doesn't think it's covered.
+
+### N2 — Pre-scan walker uses `LOCAL_SCOPE_ONLY`, which is correct
+
+`TraversalConfig::LOCAL_SCOPE_ONLY` skips nested function bodies — which is what we want, because nested-fn emission has its own per-function pre-scan. Other constructs (loops, if branches, match arms, blocks) are descended. I confirmed no nested-fn leakage by reading [hir_analysis/traversal.rs:1-19](crates/sifr_codegen/src/hir_analysis/traversal.rs:1). ✓
+
+### N3 — `coerce_expr_to_sifr_int`'s arm order is now even more load-bearing
+
+After this PR, `coerce_expr_to_sifr_int` has five match arms in a specific order:
+
+1. `Ident` registered → `Ref` (operand-position borrow).
+2. `Paren` → recurse.
+3. `BinOp { +/-/* }` with SifrInt operands → recurse and re-coerce both sides.
+4. `other if is_sifr_int_expr(&other)` → pass through.
+5. `Cast { ty: I64 }` → `from_i64`.
+6. `other` → `from_i64`.
+
+The arm-1 placement before arm-4 is load-bearing: arm-4 would also match a registered Ident (since `is_sifr_int_expr` was extended in PR #1821 to recognize them) and would pass it through, losing the borrow needed for operand position. PR #1823's review already noted this; the new BinOp arm (arm-3) has analogous ordering sensitivity. A short comment block explaining "arms 1 and 3 must precede arm 4 to ensure operand-position semantics" would protect future contributors from refactoring.
+
+This is a documentation suggestion, not a correctness concern. Optional.
+
+### N4 — Carry-over follow-ups still apply
+
+Lexical shadowing, legacy-emission-path coverage, fallible `//` and `%`, and function argument/return boundaries remain open from prior reviews. Not introduced or affected by this slice. Already tracked in [issues/…/checklist:434](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md).
+
+## Validation
+
+I re-traced rather than re-ran all of the listed validation. The cited results are consistent with the code:
+
+- `cargo test -p sifr_codegen rewrites_forced_sifr_int_assignment_target_storage -- --nocapture` — I ran this; passes.
+- `cargo test -p sifr_codegen rewrites_registered_sifr_int_local -- --nocapture` — I ran this; both passes.
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr | rg "assigned_total|reusable_oversized_local"` — I reproduced; the new fixture lines emit cleanly.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr` — round-trips.
+- `scripts/run_all_tests.sh --profile quick` — `report_signature=e1bf653aaa770517`, `wall_time=68.55s`. Same signature as #1817–#1823.
+
+The validation matrix passes because **none of the listed validations exercise the bare-Name aliasing shape that B1 is about**. The regression is silent against the current test suite.
+
+## Verdict
+
+**Changes requested.** The slice's stated goal — making `total: int = 0; total = total + big` compile — is met cleanly: a pre-scan walks Let/Assign targets and forces SifrInt storage on locals reachable from a SifrInt source, scope save/restore is correctly applied at all five emission entry points, the Let arm retypes both forced-with-literal and SifrInt-valued initializers, and the Assign arm coerces the value when the target is registered or forced. Most shapes I probed work, including the slice's e2e fixture.
+
+The blocker (B1) is that the new `coerce_expr_to_sifr_int(value)` calls in the Let arm and Assign arm produce `let _: SifrInt = &a;` for a registered-Ident value, where pre-PR they emitted `let _: SifrInt = a;`. This is a strict regression on a natural and previously-working code shape (`b: int = a` aliasing). The fix is small — skip the value-position coerce when `value_is_sifr_int` is already true (so already-SifrInt-shaped values pass through unchanged, matching PR #1823's behavior), or introduce a value-position coerce that clones registered Idents instead of borrowing them. A regression test for the bare-Name case should be added at the same time.
+
+Once B1 is closed, the remaining non-blocking findings (N1 AugAssign coverage gap, N3 documentation polish) can land separately.

--- a/reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-2.md
+++ b/reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-2.md
@@ -1,0 +1,212 @@
+# INT-1 SifrInt Assignment Targets — Review Pass 2
+
+**Verdict:** Satisfied. No blockers. The pass-1 B1 regression is fully fixed.
+
+## Scope reviewed
+
+PR #1825 pass-2, head `3a708c0b` ("Fix SifrInt assignment value aliases"), `32c5c818..HEAD` diff (the increment over pass-1):
+
+- [crates/sifr_codegen/src/expr_render_helpers.rs](crates/sifr_codegen/src/expr_render_helpers.rs)
+- [crates/sifr/tests/e2e/pass/module_constants.sifr](crates/sifr/tests/e2e/pass/module_constants.sifr)
+
+Reference docs:
+- [reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-1.md](reviews/integer-model-int-1-sifrint-assignment-targets-review-pass-1.md) — the pass-1 review whose B1 this revision closes.
+- [internal_docs/integer_model.md](internal_docs/integer_model.md) — value-semantic rule at [line 474](internal_docs/integer_model.md:474).
+- Pre-fix baseline (commit `32c5c818`, pass-1 state) confirmed broken on the bare-Name aliasing shape; post-fix (commit `3a708c0b`) confirmed working via direct probes.
+
+## B1 — fully closed
+
+The pass-1 finding was that the new `coerce_expr_to_sifr_int(value)` calls in the Let arm and Assign arm wrapped registered `Ident` locals in `Ref { mutable: false, expr: Ident(name) }` — correct for operand position (where `Add<&SifrInt>` etc. accept the borrow) but invalid for value position (where the LHS expects an owned `SifrInt`, not `&SifrInt`).
+
+The fix introduces a sibling helper [coerce_expr_to_sifr_int_value](crates/sifr_codegen/src/expr_render_helpers.rs:1297-1322):
+
+```rust
+fn coerce_expr_to_sifr_int_value(&self, expr: crate::RustExpr) -> crate::RustExpr {
+    match expr {
+        crate::RustExpr::Ident(name) if self.is_registered_sifr_int_local(&name) => {
+            crate::RustExpr::Clone(Box::new(crate::RustExpr::Ident(name)))
+        }
+        crate::RustExpr::Paren(inner) => {
+            crate::RustExpr::Paren(Box::new(self.coerce_expr_to_sifr_int_value(*inner)))
+        }
+        crate::RustExpr::BinOp { left, op, right }
+            if is_sifr_int_arithmetic_op(&op)
+                && (self.is_sifr_int_expr(&left) || self.is_sifr_int_expr(&right)) =>
+        {
+            crate::RustExpr::BinOp {
+                left: Box::new(self.coerce_expr_to_sifr_int(*left)),    // operand-position
+                op,
+                right: Box::new(self.coerce_expr_to_sifr_int(*right)),  // operand-position
+            }
+        }
+        other if self.is_sifr_int_expr(&other) => other,
+        crate::RustExpr::Cast {
+            expr,
+            ty: crate::RustType::I64,
+        } => sifr_int_from_i64_expr(*expr),
+        other => sifr_int_from_i64_expr(other),
+    }
+}
+```
+
+The structural design is sound:
+
+- **Arm 1** (the load-bearing change): registered `Ident` → `Clone(Ident)`, producing `local.clone()` instead of `&local`. This is the durable fix the pass-1 review suggested as the value-semantic-preserving option, not the simpler "leave the move alone" option. Cloning matches the [design rule](internal_docs/integer_model.md:474) that source-level `int` is value-semantic and non-consuming, so `b: int = a` now leaves `a` usable afterwards.
+- **Arm 2**: `Paren` recurses into the value-position coerce — keeps the value-position semantics inside parentheses.
+- **Arm 3**: A `BinOp` whose result *is* a value-position SifrInt expression. The result of an addition is itself a fresh-owned SifrInt that doesn't need cloning. But the operands of that `BinOp` are still in **operand position**, so the recursion delegates to the existing `coerce_expr_to_sifr_int` (operand-position coerce). This is the correct asymmetry: a Let-RHS that happens to be `a + b` should clone neither side and instead borrow them as `&a + &b`. Verified by my probe — `let s1: SifrInt = &a + SifrInt::from_i64(1)` (no clone on the BinOp itself).
+- **Arms 4–6**: identical to operand-position — pass through already-SifrInt-shaped helper calls and BinOp results, wrap `Cast(I64)` and other non-SifrInt expressions in `from_i64`.
+
+The two call sites at [expr_render_helpers.rs:481](crates/sifr_codegen/src/expr_render_helpers.rs:481) (Let arm) and [expr_render_helpers.rs:526](crates/sifr_codegen/src/expr_render_helpers.rs:526) (Assign arm) are the only changes needed; the existing pre-scan and scope save/restore plumbing is unchanged.
+
+### Pass-1 reproducers — fixed
+
+`b: int = a` (the original B1 case):
+
+```sifr
+BIG_LIMIT: int = 10 ** 20
+
+def main():
+    a: int = BIG_LIMIT + 1
+    b: int = a
+    print(str(b))
+    print(str(a))   # <-- now legal, value semantics preserved
+```
+
+emits
+
+```rust
+let a: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+let b: SifrInt = a.clone();
+println!("{}", format!("{}", b));
+println!("{}", format!("{}", a));
+```
+
+Compiles and prints `100000000000000000001` twice. Both `b` and `a` are usable independently after the let, satisfying the design rule. ✓
+
+`total = a` (the Assign-side B1 case):
+
+```sifr
+def main():
+    a: int = BIG_LIMIT + 1
+    total: int = 0
+    total = a
+    print(str(total))
+    print(str(a))
+```
+
+emits
+
+```rust
+let a: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+let mut total: SifrInt = SifrInt::from_i64(0);
+total = a.clone();
+…
+```
+
+Compiles and runs. ✓
+
+`b = a` with no annotation (a parallel inference path):
+
+```rust
+let b: SifrInt = a.clone();
+```
+
+…also works because the codegen-level inference still gives `Some(RustType::I64)` from `Type::Int`, so the Let arm's gate fires identically. ✓
+
+### Operand-position cases — preserved
+
+I re-probed the operand shapes from the prior PRs to confirm no regression from extending `coerce_expr_to_sifr_int_value`:
+
+| Probe                                                | Emitted Rust                                    | Result |
+|------------------------------------------------------|-------------------------------------------------|--------|
+| `s1: int = a + 1`                                    | `let s1: SifrInt = &a + SifrInt::from_i64(1);`  | ✓ borrowed |
+| `s2: int = -a`                                       | `let s2: SifrInt = -&a;`                        | ✓ borrowed |
+| `s4: bool = a < a + 1`                               | `let s4: bool = &a < &(&a + SifrInt::from_i64(1));` | ✓ borrowed |
+| `total: int = 0` (forced)                            | `let mut total: SifrInt = SifrInt::from_i64(0);` | ✓ from_i64 |
+| `total = total + a` (forced + BinOp source)          | `total = &total + &a;`                          | ✓ borrowed |
+| `total = total + 5` (forced + small literal in BinOp) | `total = &total + SifrInt::from_i64(5);`       | ✓ from_i64 |
+| `b: int = BIG_LIMIT` (helper alias)                  | `let b: SifrInt = __const_BIG_LIMIT();`         | ✓ pass-through |
+
+The asymmetry of arms 1 and 3 in `coerce_expr_to_sifr_int_value` keeps these working: BinOp value-position routes operands back through the *operand* coerce, which is what produces the `&a` shapes for sibling/UnaryOp operand cases.
+
+### Source value semantics
+
+The new e2e fixture lines specifically pin the value-semantic guarantee:
+
+```sifr
+alias_reuse: int = reusable_oversized_local
+alias_assign: int = 0
+alias_assign = reusable_oversized_local
+assert str(alias_reuse) == '100000000000000000001'
+assert str(alias_assign) == '100000000000000000001'
+assert str(reusable_oversized_local) == '100000000000000000001'   # <-- still usable
+```
+
+Emitted as:
+
+```rust
+let alias_reuse: SifrInt = reusable_oversized_local.clone();
+let mut alias_assign: SifrInt = SifrInt::from_i64(0);
+alias_assign = reusable_oversized_local.clone();
+…
+assert!((format!("{}", reusable_oversized_local) == "…".to_string()));   // <-- compiles, runs
+```
+
+The trailing `assert str(reusable_oversized_local)` is the load-bearing assertion that catches any future regression to move-by-default — if the codegen reverted to bare `Ident` (move) or stayed at `&Ident` (borrow), this assert would either fail to compile (use-after-move on a previous SifrInt local that was supposed to be cloned) or fail to compile from `&SifrInt` mismatch. ✓
+
+## Tests
+
+The new unit test [rewrites_sifr_int_value_position_aliases_to_clone](crates/sifr_codegen/src/expr_render_helpers.rs:1674-1714) is the missing pass-1 N4 coverage:
+
+- Stages `source` in `sifr_int_local_bindings` and `target` in `sifr_int_forced_local_bindings`.
+- Asserts `Let { ty: Some(I64), value: Ident("source") }` rewrites to `Let { ty: Some(SifrInt), value: Clone(Ident("source")) }`.
+- Asserts `Assign { target: Ident("target"), value: Ident("source") }` rewrites to `Assign { target: Ident("target"), value: Clone(Ident("source")) }`.
+
+Both assertions match the expected post-fix shape. The structural test would have caught B1 if it had existed in pass-1.
+
+The e2e fixture additions (`alias_reuse`, `alias_assign`, three asserts) close the same gap at the integration level.
+
+I ran:
+
+- `cargo test -p sifr_codegen rewrites_sifr_int_value_position_aliases_to_clone` — passes.
+- `cargo test -p sifr_codegen rewrites_forced_sifr_int_assignment_target_storage` — passes (pass-1's literal-source forcing test, unchanged).
+- `cargo test -p sifr_codegen rewrites_registered_sifr_int_local` — both arithmetic and comparison tests pass (the operand-position tests from PRs #1821/#1823 are unaffected).
+
+`cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr` round-trips all 18 asserts (the 9 from #1817–#1823, the 4 from pass-1 of #1825, and the 3 new value-position assertions added in pass-2).
+
+`scripts/run_all_tests.sh --profile quick` reports `report_signature=e1bf653aaa770517`, identical to the signature recorded across #1817–#1823.
+
+(Note: `cargo test -p sifr_codegen` shows 22 unrelated failures in `lib_codegen_tests::*` and `lower_*::tests::*` modules. I verified by checking out `main` and re-running — these failures pre-exist on `main` (parse errors on test class definitions) and are *not* introduced by this PR. The canonical validation gate per AGENTS.md is `scripts/run_all_tests.sh --profile quick`, which passes.)
+
+## Determinism / scope drift
+
+- Diff is +56/-2 lines: one new helper function (~26 lines), two call-site swaps (1 line each), one new unit test (~26 lines), and 6 lines of e2e fixture growth. Tightly scoped to the pass-1 fix.
+- All edits live in `expr_render_helpers.rs` and the e2e fixture. No HIR, type system, runtime, or driver changes. No public API growth.
+- The pass-1 plumbing (pre-scan, per-function scope save/restore for `sifr_int_forced_local_bindings`, retype gate, post-rewrite Assign coerce site) is unchanged. The only behavioral change is *which* coerce function the Let and Assign arms call.
+- The previous `coerce_expr_to_sifr_int` (operand-position) is unchanged and continues to be called from BinOp arms (in `rewrite_stdlib_constant_idents_in_expr`'s arm and recursively from the new `coerce_expr_to_sifr_int_value`'s BinOp arm) and from comparison-position via `coerce_expr_to_sifr_int_comparison_operand`.
+
+## Non-blocking observations
+
+(All carry forward from pass-1; none gate merge.)
+
+### N-pass2-1 — AugAssign still unhandled (pass-1 N1)
+
+`total += a` (with `a` a SifrInt local) emits `let mut total: i64 = …; total += a;` regardless of forcing. The pre-scan visitor only matches `HirStmt::Let | HirStmt::Assign`. The rewriter's `RustStmt::AugAssign` arm doesn't apply target-aware coerce. Pre-existing gap; same shape was broken pre-this-PR. The slice description doesn't claim AugAssign coverage, but it's the obvious next sub-slice.
+
+### N-pass2-2 — Coerce arm-ordering documentation (pass-1 N3)
+
+`coerce_expr_to_sifr_int_value` and `coerce_expr_to_sifr_int` now share the same arm-ordering invariant: arms 1 and 3 (Ident-registered, BinOp-with-SifrInt-operand) must precede arm 4 (`other if is_sifr_int_expr(&other)`). A short comment block explaining "arms 1 and 3 must precede arm 4 to ensure the value-position clone / operand-position borrow happens before the generic SifrInt pass-through" would protect future contributors who try to refactor either function. Optional polish, not a correctness concern.
+
+### N-pass2-3 — `Clone` chains for repeated bare-Name aliases
+
+Each `b: int = a; c: int = a; d: int = a;` produces three `a.clone()` calls. Each clone is allocator-bound for the `Big` variant of `SifrInt`. For the typical small-int case the `Small(i64)` variant clones cheaply, but for arbitrary-precision values the cost adds up. This is consistent with the design's "value-semantic" guarantee but worth noting as an INT-8 perf gate concern. Not in slice scope.
+
+### N-pass2-4 — Open follow-ups still apply
+
+Lexical shadowing, legacy-emission-path coverage, fallible `//` and `%`, function argument/return boundaries — all carried-forward open items at [issues/…/checklist:434](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md). Not affected by this slice.
+
+## Verdict
+
+**Satisfied. No blockers.** The pass-1 B1 regression is closed via a tightly-scoped fix: a sibling `coerce_expr_to_sifr_int_value` helper that clones registered Idents in value position while delegating to the operand-position helper for BinOp sub-operands. Both Let-RHS and Assign-RHS shapes for bare-Name aliases now compile and preserve the [design's value-semantic guarantee for `int` locals](internal_docs/integer_model.md:474) — verified by both the new unit test (`rewrites_sifr_int_value_position_aliases_to_clone`) and the new e2e assertions (`alias_reuse`, `alias_assign`, with the trailing `str(reusable_oversized_local)` assert pinning that the source local stays usable).
+
+Operand-position semantics from #1819/#1821/#1823 are preserved: arithmetic still emits `&a + …`, comparisons still emit `&a < &b`, unary negation still emits `-&a`, helper FnCalls still pass through unborrowed, small-literal forced storage still uses `from_i64`. Quick validation reproduces `report_signature=e1bf653aaa770517`. Non-blocking carry-forwards (N-pass2-1 AugAssign, N-pass2-2 arm-ordering doc comment, N-pass2-3 clone chain perf, N-pass2-4 broader migration) stay in the open INT-1 follow-up.


### PR DESCRIPTION
## Summary
- pre-scan function-like local `int` bindings and assignments to force SifrInt storage when later assignment expressions require exact-int values
- rewrite forced SifrInt lets and assignments through the same SifrInt coercion path, including arithmetic RHS operand normalization
- cover `assigned_total = assigned_total + reusable_oversized_local` and reassignment with small literals in the module constants e2e fixture

## Validation
- `cargo test -p sifr_codegen rewrites_forced_sifr_int_assignment_target_storage -- --nocapture`
- `cargo test -p sifr_codegen rewrites_registered_sifr_int_local -- --nocapture`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr | rg "assigned_total|reusable_oversized_local" -n`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=68.55s`)