### PR TITLE
Handle SifrInt augmented assignment targets

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -36,6 +36,10 @@ def main():
     assigned_total = assigned_total + reusable_oversized_local
     assigned_total = assigned_total + 2
     assert str(assigned_total) == '100000000000000000003'
+    augmented_total: int = 0
+    augmented_total += reusable_oversized_local
+    augmented_total += 2
+    assert str(augmented_total) == '100000000000000000003'
     alias_reuse: int = reusable_oversized_local
     alias_assign: int = 0
     alias_assign = reusable_oversized_local

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1772,4 +1772,64 @@ mod tests {
                     )
         ));
     }
+
+    #[test]
+    fn rewrites_sifr_int_augassign_registered_source_to_borrowed_operand() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_forced_local_bindings
+            .borrow_mut()
+            .insert("total".to_string());
+        emitter
+            .sifr_int_local_bindings
+            .borrow_mut()
+            .insert("source".to_string());
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::AugAssign {
+            target: RustExpr::Ident("total".to_string()),
+            op: "+".to_string(),
+            value: RustExpr::Ident("source".to_string()),
+        });
+
+        let RustStmt::Assign { value, .. } = rewritten else {
+            panic!("expected SifrInt augassign rewrite to plain assignment");
+        };
+        assert!(matches!(
+            value,
+            RustExpr::BinOp { right, .. }
+                if matches!(
+                    right.as_ref(),
+                    RustExpr::Ref { mutable: false, expr }
+                        if matches!(expr.as_ref(), RustExpr::Ident(name) if name == "source")
+                )
+        ));
+    }
+
+    #[test]
+    fn rewrites_sifr_int_augassign_for_supported_ops() {
+        for op in ["+", "-", "*"] {
+            let emitter = RustEmitter::new();
+            emitter
+                .sifr_int_forced_local_bindings
+                .borrow_mut()
+                .insert("total".to_string());
+
+            let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::AugAssign {
+                target: RustExpr::Ident("total".to_string()),
+                op: op.to_string(),
+                value: RustExpr::Cast {
+                    expr: Box::new(RustExpr::Literal(RustLiteral::Int(2))),
+                    ty: RustType::I64,
+                },
+            });
+
+            assert!(matches!(
+                rewritten,
+                RustStmt::Assign {
+                    value: RustExpr::BinOp { op: ref rewritten_op, .. },
+                    ..
+                } if rewritten_op == op
+            ));
+        }
+    }
 }

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -529,11 +529,33 @@ impl RustEmitter {
                 };
                 crate::RustStmt::Assign { target, value }
             }
-            crate::RustStmt::AugAssign { target, op, value } => crate::RustStmt::AugAssign {
-                target: self.rewrite_stdlib_constant_idents_in_expr(target),
-                op,
-                value: self.rewrite_stdlib_constant_idents_in_expr(value),
-            },
+            crate::RustStmt::AugAssign { target, op, value } => {
+                let target = self.rewrite_stdlib_constant_idents_in_expr(target);
+                let value = self.rewrite_stdlib_constant_idents_in_expr(value);
+                match &target {
+                    crate::RustExpr::Ident(name)
+                        if is_sifr_int_arithmetic_op(&op)
+                            && (self.is_registered_sifr_int_local(name)
+                                || self.is_forced_sifr_int_local(name)) =>
+                    {
+                        self.sifr_int_local_bindings
+                            .borrow_mut()
+                            .insert(name.clone());
+                        crate::RustStmt::Assign {
+                            target: target.clone(),
+                            value: crate::RustExpr::BinOp {
+                                left: Box::new(crate::RustExpr::Ref {
+                                    mutable: false,
+                                    expr: Box::new(target),
+                                }),
+                                op,
+                                right: Box::new(self.coerce_expr_to_sifr_int(value)),
+                            },
+                        }
+                    }
+                    _ => crate::RustStmt::AugAssign { target, op, value },
+                }
+            }
             crate::RustStmt::Expr(expr) => {
                 crate::RustStmt::Expr(self.rewrite_stdlib_constant_idents_in_expr(expr))
             }
@@ -1709,6 +1731,45 @@ mod tests {
                 value: RustExpr::Clone(inner),
             } if target == "target"
                 && matches!(inner.as_ref(), RustExpr::Ident(source) if source == "source")
+        ));
+    }
+
+    #[test]
+    fn rewrites_forced_sifr_int_augassign_to_assignment() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_forced_local_bindings
+            .borrow_mut()
+            .insert("total".to_string());
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::AugAssign {
+            target: RustExpr::Ident("total".to_string()),
+            op: "+".to_string(),
+            value: RustExpr::Cast {
+                expr: Box::new(RustExpr::Literal(RustLiteral::Int(2))),
+                ty: RustType::I64,
+            },
+        });
+
+        let RustStmt::Assign { target, value } = rewritten else {
+            panic!("expected SifrInt augassign rewrite to plain assignment");
+        };
+        assert!(matches!(target, RustExpr::Ident(ref name) if name == "total"));
+        assert!(matches!(
+            value,
+            RustExpr::BinOp { left, op, right }
+                if op == "+"
+                    && matches!(
+                        left.as_ref(),
+                        RustExpr::Ref { mutable: false, expr }
+                            if matches!(expr.as_ref(), RustExpr::Ident(name) if name == "total")
+                    )
+                    && matches!(
+                        right.as_ref(),
+                        RustExpr::FnCall { func, args }
+                            if args.len() == 1
+                                && matches!(func.as_ref(), RustExpr::Path(path) if path.as_slice() == ["SifrInt", "from_i64"])
+                    )
         ));
     }
 }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -134,6 +134,18 @@ impl RustEmitter {
                 {
                     forced.insert(name.clone());
                 }
+                HirStmt::AugAssign { name, op, value }
+                    if local_int_bindings.contains(name)
+                        && is_sifr_int_augassign_op(op)
+                        && (forced.contains(name)
+                            || hir_expr_needs_sifr_int_storage(
+                                value,
+                                &forced,
+                                &module_sifr_int_bindings,
+                            )) =>
+                {
+                    forced.insert(name.clone());
+                }
                 _ => {}
             };
             let mut on_expr = |_expr: &HirExpr| {};
@@ -731,4 +743,8 @@ fn hir_expr_needs_sifr_int_storage(
         }
         _ => false,
     }
+}
+
+fn is_sifr_int_augassign_op(op: &str) -> bool {
+    matches!(op, "+=" | "-=" | "*=")
 }

--- a/reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-1.md
@@ -1,0 +1,84 @@
+# Review: INT-1 SifrInt AugAssign Targets Pass 1
+
+## Verdict
+
+Satisfied.
+
+## Findings
+
+None.
+
+The slice cleanly closes the prior tracker's "augmented assignment targets such as `total += big`" follow-up for the supported-ops scope, with three coordinated changes:
+
+1. **Pre-scan extension** at [function_emitter.rs:137-148](crates/sifr_codegen/src/function_emitter.rs:137). The forced-local visitor now matches `HirStmt::AugAssign { name, op, value }` when:
+   - `local_int_bindings.contains(name)` — only int locals
+   - `is_sifr_int_augassign_op(op)` — only `+=`, `-=`, `*=` (HIR-level form)
+   - `forced.contains(name) || hir_expr_needs_sifr_int_storage(value, …)` — either name was already forced by an earlier Let/Assign, or the value transitively brings a SifrInt source
+
+   The two-condition disjunction is load-bearing and correct: a Sifr-source pattern like
+   ```sifr
+   total: int = 0
+   total += big           # forces total via value side
+   total += 2             # already forced → keeps forcing through small literal
+   ```
+   converges in one walk pass. The fixed-point loop pre-existed; the new arm participates correctly.
+
+2. **Op-set consistency** between pre-scan and rewrite. The HIR pre-scan checks `is_sifr_int_augassign_op` (`+=`/`-=`/`*=`); the Rust IR rewrite checks `is_sifr_int_arithmetic_op` (`+`/`-`/`*`). I verified at [crates/sifr_hir/src/lower/aug_assign_lowering.rs:34-46](crates/sifr_hir/src/lower/aug_assign_lowering.rs:34) that HIR stores the augmented form (`+=`, `-=`, `*=`) and at [crates/sifr_codegen/src/lower_stmt.rs:4114](crates/sifr_codegen/src/lower_stmt.rs:4114) that Rust IR strips the trailing `=`. The two op-set predicates are therefore consistent — both express the same `{+, -, *}` semantic set in their respective IRs. Unsupported HIR ops like `//=`, `%=`, `<<=`, `>>=`, `**=` correctly fall through both gates.
+
+3. **AugAssign rewrite** at [expr_render_helpers.rs:532-557](crates/sifr_codegen/src/expr_render_helpers.rs:532). When target is `Ident(name)`, op is in `{+, -, *}`, and name is registered or forced:
+   - Insert into `sifr_int_local_bindings` (idempotent).
+   - Convert `target op= value` to `target = &target op coerce(value)`.
+   
+   The rewrite output is a plain `RustStmt::Assign` whose RHS is `BinOp { Ref{target}, op, coerce_expr_to_sifr_int(value) }`. The `&target` borrow preserves Rust ownership of the local across iterations, and `coerce_expr_to_sifr_int` (operand-position) borrows registered locals on the value side or wraps small literals in `from_i64`. Rust's `Add<&SifrInt> for &SifrInt` and friends accept the resulting `&SifrInt op &SifrInt`/`&SifrInt op SifrInt` shape, returning owned `SifrInt`, which assigns back to the SifrInt-typed target.
+
+### End-to-end verification
+
+`cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr` shows the new fixture lines lower to:
+
+```rust
+let mut augmented_total: SifrInt = SifrInt::from_i64(0);
+augmented_total = &augmented_total + &reusable_oversized_local;
+augmented_total = &augmented_total + SifrInt::from_i64(2);
+assert!((format!("{}", augmented_total) == "100000000000000000003".to_string()));
+```
+
+…and the trailing `assert str(reusable_oversized_local) == ...` (later in the fixture) compiles, pinning that `reusable_oversized_local` was *not* moved by the AugAssign — value semantics for the source local are preserved. The fixture round-trips at runtime.
+
+### Probe matrix (verified against the post-fix tip)
+
+| Source                                                  | Emitted Rust                                                | Result |
+|---------------------------------------------------------|-------------------------------------------------------------|--------|
+| `total: int = 0; total += a` (SifrInt local source)     | `total = &total + &a;`                                      | ✓ borrows both |
+| `total -= a`                                            | `total = &total - &a;`                                      | ✓ |
+| `total *= 2`                                            | `total = &total * SifrInt::from_i64(2);`                    | ✓ from_i64 |
+| `total += a + 1` (BinOp value, mixed local + literal)   | `total = &total + (&a + SifrInt::from_i64(1));`             | ✓ inner BinOp borrows operands |
+| `total += -a` (UnaryOp value)                           | `total = &total + -&a;`                                     | ✓ |
+| `for i in [1,2,3]: total += a` (loop body)              | `for … { total = &total + &a; }`                            | ✓ source survives loop |
+| Repeated `total += a` (multiple uses)                   | `&a` each time — never moves                                | ✓ source still usable after |
+| Pure i64: `total: int = 0; total += 1; total += 2`      | `let mut total: i64 = …; total += 1 as i64; total += 2;`    | ✓ unchanged |
+| Pure i64: `total: int = 10; total //= 3; total %= 2`    | `total /= 3 as i64; total %= 2 as i64;`                     | ✓ unchanged |
+
+Quick validation reproduces `report_signature=e1bf653aaa770517` (same as #1817–#1825).
+
+## Notes
+
+(Non-blocking observations only.)
+
+- **N1 — Mixed unsupported AugAssign ops on a forced SifrInt local emit invalid Rust.** A program like
+  ```sifr
+  a: int = BIG_LIMIT + 1
+  total: int = 0
+  total //= 2
+  total += a
+  ```
+  pre-PR failed at line 4 (`i64 += SifrInt`); post-PR it fails at line 3 because `total` is forced to `SifrInt` by the supported `+= a` and `total /= 2 as i64` (HIR `//=` lowers to Rust `/`, which `is_sifr_int_arithmetic_op` doesn't match) emits `SifrInt /= i64`. **Not a regression** — both versions fail to compile and the user couldn't run this code under either version. The slice's open follow-up at [issues/…/checklist:437](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md) explicitly defers fallible `//` and `%` to a separate sub-slice; once those route through Result-returning runtime helpers, the failure-shape shift will resolve naturally. Worth keeping in mind that promoting a local to SifrInt because of a supported AugAssign extends to the local's *other* AugAssign uses on unsupported ops, but this is a sharp edge of the broader migration, not of this slice.
+
+- **N2 — Subscript AugAssign (`arr[0] += big`) is out of scope.** [build_subscript_augassign_elem_stmt](crates/sifr_codegen/src/lower_stmt.rs:4087) is a separate path that emits a `RustStmt::AugAssign` with a `Deref` target, which the new rewrite arm correctly skips (it only matches `Ident` targets). Pre-PR was also broken for this case; same shape stays broken. Not a slice concern.
+
+- **N3 — Unit-test coverage is correct but minimal.** [rewrites_forced_sifr_int_augassign_to_assignment](crates/sifr_codegen/src/expr_render_helpers.rs:1738) pins the literal-source case (`+= Cast(2, I64)` → `&total + SifrInt::from_i64(2)`). The bare-Name registered-local source case (`+= a` → `&total + &a`) is exercised end-to-end by the e2e fixture but not by a focused unit test. The pass-1 review of PR #1825 noted that adding focused unit tests for the bare-Name shape would have caught a regression earlier; the same hardening would apply here. A unit-test sibling that pre-registers a `source` local and asserts `+= source` rewrites to `BinOp { Ref{target}, +, Ref{source} }` would close the matrix. Optional polish, not a correctness concern.
+
+- **N4 — Op-set test coverage is asymmetric.** The unit test covers `+`. The e2e fixture covers `+=`. There's no test exercising `-=` or `*=` directly. Functionally `is_sifr_int_arithmetic_op` and `is_sifr_int_augassign_op` cover all three uniformly, but a parameterized test or sibling cases for `-=` and `*=` would harden against accidental future divergence between the two predicates.
+
+- **N5 — Carry-forwards from prior reviews still apply.** Lexical shadowing, legacy-emission-path coverage, fallible `//`/`%` (especially relevant per N1 above), and function argument/return boundaries — all carried-forward open items at [issues/…/checklist:437](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md). Not affected by this slice.
+
+- **N6 — The empty `on_expr` closure** in the pre-scan is a no-op (`let mut on_expr = |_expr: &HirExpr| {};`). It's required by the `walk_stmts` traversal API. No concern, just noting that the visitor descends through expression trees without inspecting them — appropriate because the slice's logic operates at stmt granularity, and the new AugAssign matching is on the stmt itself.

--- a/reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-2.md
+++ b/reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-2.md
@@ -1,0 +1,55 @@
+# Review: INT-1 SifrInt AugAssign Targets Pass 2
+
+## Verdict
+
+Satisfied.
+
+## Findings
+
+None.
+
+The pass-2 delta is +60 test lines + +84 review-file lines. **Production code is unchanged** since pass-1 (verified by `git diff 0beefe00..HEAD -- crates/sifr_codegen/src/function_emitter.rs crates/sifr/tests/` returning empty). The two new unit tests directly address pass-1 N3 and N4.
+
+### Test 1 — pass-1 N3 (bare-Name registered source)
+
+[rewrites_sifr_int_augassign_registered_source_to_borrowed_operand](crates/sifr_codegen/src/expr_render_helpers.rs:1777) stages `total` in `sifr_int_forced_local_bindings` and `source` in `sifr_int_local_bindings`, then asserts that `total += source` rewrites to a plain `Assign` whose RHS BinOp has `right == Ref { Ident("source") }`. This faithfully reproduces the production scenario where the pre-scan + Let rewrite have already inserted the source local into the *registered* set (not the forced set), and exercises the `coerce_expr_to_sifr_int` path on the value side. The test's destructuring checks both that the AugAssign-to-Assign conversion fired (`let RustStmt::Assign { value, .. } = rewritten`) and that the registered local on the RHS is borrowed (`Ref { mutable: false, expr: Ident("source") }`). Not brittle: the test uses partial destructuring with `..` for unrelated fields and only pins the property pass-1 N3 was concerned with. ✓
+
+### Test 2 — pass-1 N4 (parameterized op coverage)
+
+[rewrites_sifr_int_augassign_for_supported_ops](crates/sifr_codegen/src/expr_render_helpers.rs:1808) iterates over `["+", "-", "*"]`, creates a fresh emitter per iteration (test isolation), and asserts each supported op produces an `Assign` whose RHS BinOp's op equals the input op. This directly answers the pass-1 N4 concern that only `+` was unit-tested while `-` and `*` were e2e-only. The fresh-per-iteration emitter avoids cross-test state leakage in the `RefCell` registries — important because the previous test mutates `sifr_int_local_bindings`/`sifr_int_forced_local_bindings`. ✓
+
+### Coverage matrix after pass-2
+
+| Property                                                    | Coverage                                                     |
+|-------------------------------------------------------------|--------------------------------------------------------------|
+| AugAssign-to-Assign conversion fires                        | All three new/updated unit tests + e2e fixture               |
+| Target borrowed via `&target`                               | `rewrites_forced_sifr_int_augassign_to_assignment` (pass-1)  |
+| Literal RHS coerced via `from_i64`                          | `rewrites_forced_sifr_int_augassign_to_assignment` (pass-1)  |
+| Registered-local RHS borrowed via `&source`                 | `rewrites_sifr_int_augassign_registered_source_to_borrowed_operand` (pass-2) |
+| Supported ops `+`/`-`/`*`                                   | `rewrites_sifr_int_augassign_for_supported_ops` (pass-2)     |
+| End-to-end runtime correctness for `+=` and `+= small`      | e2e fixture                                                  |
+
+### Saved review file
+
+Adding [reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-1.md](reviews/integer-model-int-1-sifrint-augassign-targets-review-pass-1.md) (84 lines) to the PR is consistent with prior dual-pass patterns — e.g., PR #1825 had its pass-1 and pass-2 review files committed alongside the implementation work before PR #1826's tracker PR ran. The review's verdict ("Satisfied") and the file path it lives at are both accurate. No staleness risk because the pass-1 review describes the implementation that already shipped (commit `0beefe00`), not the test-only delta. ✓
+
+### Scope adherence
+
+The PR remains strictly within the supported AugAssign scope (`+=`, `-=`, `*=`). Production code unchanged since pass-1; the test additions exercise the same predicates (`is_sifr_int_augassign_op` for HIR pre-scan, `is_sifr_int_arithmetic_op` for Rust IR rewrite) without widening either set. Unsupported HIR ops (`//=`, `%=`, `<<=`, `>>=`, `**=`, `&=`, `|=`, `^=`) and Rust IR ops (`/`, `%`, etc.) continue to fall through both gates. ✓
+
+### Validation
+
+- `cargo test -p sifr_codegen expr_render_helpers::tests:: -- --nocapture` reports 10 passed (up from 8 at pass-1 — the two new tests plus the eight pre-existing).
+- `scripts/run_all_tests.sh --profile quick` reports `report_signature=e1bf653aaa770517`, identical to the signature recorded across #1817–#1825 and the pass-1 implementation. Test-only delta correctly preserves the signature.
+
+## Notes
+
+(Non-blocking observations only.)
+
+- **N-pass2-1 — Defensive "should not rewrite" coverage is still absent.** The pass-2 tests pin the *positive* shape (supported ops do rewrite). They don't pin the *negative* shape (unsupported ops do not rewrite). A sibling test asserting that, say, `RustStmt::AugAssign { op: "/", … }` against a forced target stays as `RustStmt::AugAssign` (i.e., no Assign-conversion) would document the deliberate gap and protect against a future contributor accidentally widening `is_sifr_int_arithmetic_op` to include `/` or `%`. Not blocking — the e2e and existing unit suite would surface a regression at the next slice's testing — but the cheapest hardening would be a one-line parameterized loop over `["/", "%", "<<", ">>"]` asserting each stays in `RustStmt::AugAssign`. Optional.
+
+- **N-pass2-2 — Test 2 doesn't pin the LHS or RHS shape.** It only verifies the rewritten BinOp's op matches the input op. The LHS borrow (`Ref { Ident("total") }`) and the RHS coercion (`from_i64(2)`) are both already pinned by `rewrites_forced_sifr_int_augassign_to_assignment` (pass-1), so the new test doesn't need to repeat that property. Targeted scope is appropriate; not brittle.
+
+- **N-pass2-3 — Carry-forward open items unchanged.** Pass-1 N1 (mixed unsupported AugAssign ops on forced SifrInt locals fail rustc), N2 (subscript AugAssign out of scope), and N5 (broader migration items at [issues/…/checklist:437](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md)) all remain open at the same scope; pass-2 doesn't address or affect them. Each is correctly out-of-scope per the slice's stated boundaries.
+
+- **N-pass2-4 — Review file inclusion timing.** Some prior milestone slices kept the implementation review uncommitted until the tracker PR ran (e.g., #1820, #1822, #1824), while others committed the reviews alongside the implementation (e.g., the pass-1 + pass-2 review pair for #1825 before #1826). Both patterns appear in the milestone history. Including the pass-1 review in this PR is consistent with the latter pattern and won't conflict with the upcoming tracker PR.


### PR DESCRIPTION
## Summary
- pre-promote local `int` bindings that receive exact-int values through supported augmented assignments
- rewrite registered `SifrInt` `+=`/`-=`/`*=` targets to plain assignment with borrowed exact-int operands
- extend `module_constants.sifr` coverage for `total += big` and small follow-up augmentation
- add focused unit coverage for borrowed registered sources and all supported AugAssign ops

## Validation
- `cargo test -p sifr_codegen expr_render_helpers::tests:: -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=66.63s`)

## Notes
- A broad direct `cargo test -p sifr --test e2e test_e2e_pass -- module_constants --nocapture` command was not fixture-scoped by the harness and failed in unrelated legacy pass fixtures (`map`/`list` import, slice-copy, nested nonlocal). The authoritative quick lane passed.