### PR TITLE
Promote exact-int function returns to SifrInt

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -10,6 +10,9 @@ BIG_LIMIT: int = 10 ** 20
 def circle_area(r: float) -> float:
     return PI * r * r
 
+def returned_big_limit() -> int:
+    return BIG_LIMIT + 1
+
 def main():
     assert str(circle_area(5.0)) == '78.53975'
     assert str(MAX_RETRIES) == '3'
@@ -17,6 +20,10 @@ def main():
     assert str(NEGATIVE_LIMIT) == '-13'
     assert str(BIG_LIMIT) == '100000000000000000000'
     assert str(BIG_LIMIT + 1) == '100000000000000000001'
+    returned_big: int = returned_big_limit()
+    returned_plus_one: int = returned_big_limit() + 1
+    assert str(returned_big) == '100000000000000000001'
+    assert str(returned_plus_one) == '100000000000000000002'
     oversized_local: int = BIG_LIMIT + LIMIT
     assert str(oversized_local) == '100000000000000000254'
     chained_oversized_local: int = oversized_local + 2

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -475,20 +475,19 @@ impl RustEmitter {
                 let value = self.rewrite_stdlib_constant_idents_in_expr(value);
                 let force_sifr_int = self.is_forced_sifr_int_local(&name);
                 let value_is_sifr_int = self.is_sifr_int_expr(&value);
-                let (ty, value) = if matches!(ty, Some(crate::RustType::I64))
-                    && (value_is_sifr_int || force_sifr_int)
-                {
-                    let value = self.coerce_expr_to_sifr_int_value(value);
-                    self.sifr_int_local_bindings
-                        .borrow_mut()
-                        .insert(name.clone());
-                    (Some(crate::RustType::Named("SifrInt".to_string())), value)
-                } else {
-                    if !force_sifr_int {
-                        self.sifr_int_local_bindings.borrow_mut().remove(&name);
-                    }
-                    (ty, value)
-                };
+                let (ty, value) =
+                    if is_legacy_i64_type(&ty) && (value_is_sifr_int || force_sifr_int) {
+                        let value = self.coerce_expr_to_sifr_int_value(value);
+                        self.sifr_int_local_bindings
+                            .borrow_mut()
+                            .insert(name.clone());
+                        (Some(crate::RustType::Named("SifrInt".to_string())), value)
+                    } else {
+                        if !force_sifr_int {
+                            self.sifr_int_local_bindings.borrow_mut().remove(&name);
+                        }
+                        (ty, value)
+                    };
                 crate::RustStmt::Let {
                     mutable,
                     name,
@@ -563,9 +562,17 @@ impl RustEmitter {
                 cond: self.rewrite_stdlib_constant_idents_in_expr(cond),
                 msg: msg.map(|msg| self.rewrite_stdlib_constant_idents_in_expr(msg)),
             },
-            crate::RustStmt::Return(expr) => crate::RustStmt::Return(
-                expr.map(|ret| self.rewrite_stdlib_constant_idents_in_expr(ret)),
-            ),
+            crate::RustStmt::Return(expr) => {
+                let value = expr.map(|ret| {
+                    let ret = self.rewrite_stdlib_constant_idents_in_expr(ret);
+                    if self.current_sifr_int_return {
+                        self.coerce_expr_to_sifr_int_value(ret)
+                    } else {
+                        ret
+                    }
+                });
+                crate::RustStmt::Return(value)
+            }
             crate::RustStmt::If {
                 cond,
                 then_body,
@@ -1366,6 +1373,7 @@ impl RustEmitter {
         match expr {
             crate::RustExpr::FnCall { func, args } if args.is_empty() => {
                 self.is_sifr_int_module_constant_func(func)
+                    || self.is_sifr_int_returning_function_call(func)
             }
             crate::RustExpr::FnCall { func, .. } => matches!(
                 func.as_ref(),
@@ -1394,6 +1402,14 @@ impl RustEmitter {
                     .strip_suffix("()")
                     .is_some_and(|const_func| const_func == func_name)
         })
+    }
+
+    fn is_sifr_int_returning_function_call(&self, func: &crate::RustExpr) -> bool {
+        rust_expr_identifier_path(func).is_some_and(|name| self.function_returns_sifr_int(&name))
+    }
+
+    pub(super) fn function_returns_sifr_int(&self, name: &str) -> bool {
+        self.sifr_int_function_returns.borrow().contains(name)
     }
 }
 
@@ -1453,6 +1469,11 @@ fn is_sifr_int_comparison_op(op: &str) -> bool {
 
 fn is_sifr_int_operand_coercion_op(op: &str) -> bool {
     is_sifr_int_arithmetic_op(op) || is_sifr_int_comparison_op(op)
+}
+
+fn is_legacy_i64_type(ty: &Option<crate::RustType>) -> bool {
+    matches!(ty, Some(crate::RustType::I64))
+        || matches!(ty, Some(crate::RustType::Named(name)) if name == "i64")
 }
 
 fn rust_expr_identifier_path(expr: &crate::RustExpr) -> Option<String> {
@@ -1831,5 +1852,59 @@ mod tests {
                 } if rewritten_op == op
             ));
         }
+    }
+
+    #[test]
+    fn rewrites_sifr_int_returning_function_call_let_type() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_function_returns
+            .borrow_mut()
+            .insert("make_big".to_string());
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Let {
+            mutable: false,
+            name: "value".to_string(),
+            ty: Some(RustType::I64),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Ident("make_big".to_string())),
+                args: vec![],
+            },
+        });
+
+        assert!(matches!(
+            rewritten,
+            RustStmt::Let {
+                ty: Some(RustType::Named(ref name)),
+                ..
+            } if name == "SifrInt"
+        ));
+    }
+
+    #[test]
+    fn rewrites_sifr_int_returning_function_call_named_i64_let_type() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_function_returns
+            .borrow_mut()
+            .insert("make_big".to_string());
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Let {
+            mutable: false,
+            name: "value".to_string(),
+            ty: Some(RustType::Named("i64".to_string())),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Ident("make_big".to_string())),
+                args: vec![],
+            },
+        });
+
+        assert!(matches!(
+            rewritten,
+            RustStmt::Let {
+                ty: Some(RustType::Named(ref name)),
+                ..
+            } if name == "SifrInt"
+        ));
     }
 }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -6,7 +6,7 @@ use crate::{
     helpers::collect_reassigned_vars,
     hir_analysis::traversal::{self, TraversalConfig},
 };
-use sifr_hir::{HirExpr, HirFunction, HirParam, HirStmt};
+use sifr_hir::{HirExpr, HirFunction, HirModule, HirParam, HirStmt};
 use sifr_type_system::{make_union, OwnershipKind, ParamConvention, Type};
 use std::collections::{HashMap, HashSet};
 
@@ -110,56 +110,56 @@ impl RustEmitter {
             return;
         }
 
-        let module_sifr_int_bindings = self
-            .module_constants
+        let module_sifr_int_bindings = self.module_sifr_int_bindings();
+        let function_sifr_int_returns = self.sifr_int_function_returns.borrow().clone();
+
+        let mut forced = self.sifr_int_forced_local_bindings.borrow().clone();
+        forced.extend(collect_sifr_int_forced_locals(
+            body,
+            &local_int_bindings,
+            &module_sifr_int_bindings,
+            &function_sifr_int_returns,
+        ));
+        *self.sifr_int_forced_local_bindings.borrow_mut() = forced;
+    }
+
+    pub(super) fn register_sifr_int_function_returns(&self, module: &HirModule) {
+        let module_sifr_int_bindings = self.module_sifr_int_bindings();
+        let mut function_returns = HashSet::new();
+        loop {
+            let before = function_returns.len();
+            let discovered = module
+                .functions
+                .iter()
+                .filter_map(|func| {
+                    (matches!(
+                        crate::resolve_alias_type_for_plain_call(&func.return_type),
+                        Type::Int
+                    ) && hir_function_returns_sifr_int(
+                        func,
+                        &module_sifr_int_bindings,
+                        &function_returns,
+                    ))
+                    .then(|| func.name.clone())
+                })
+                .collect::<Vec<_>>();
+            function_returns.extend(discovered);
+            if function_returns.len() == before {
+                break;
+            }
+        }
+        *self.sifr_int_function_returns.borrow_mut() = function_returns;
+    }
+
+    fn module_sifr_int_bindings(&self) -> HashSet<String> {
+        self.module_constants
             .iter()
             .filter_map(|(name, (ty, rust_name))| {
                 (matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
                     && rust_name.ends_with("()"))
                 .then(|| name.clone())
             })
-            .collect::<HashSet<_>>();
-
-        let mut forced = self.sifr_int_forced_local_bindings.borrow().clone();
-        loop {
-            let before = forced.len();
-            let mut on_stmt = |stmt: &HirStmt| match stmt {
-                HirStmt::Let { name, value, .. } | HirStmt::Assign { name, value }
-                    if local_int_bindings.contains(name)
-                        && hir_expr_needs_sifr_int_storage(
-                            value,
-                            &forced,
-                            &module_sifr_int_bindings,
-                        ) =>
-                {
-                    forced.insert(name.clone());
-                }
-                HirStmt::AugAssign { name, op, value }
-                    if local_int_bindings.contains(name)
-                        && is_sifr_int_augassign_op(op)
-                        && (forced.contains(name)
-                            || hir_expr_needs_sifr_int_storage(
-                                value,
-                                &forced,
-                                &module_sifr_int_bindings,
-                            )) =>
-                {
-                    forced.insert(name.clone());
-                }
-                _ => {}
-            };
-            let mut on_expr = |_expr: &HirExpr| {};
-            traversal::walk_stmts(
-                body,
-                TraversalConfig::LOCAL_SCOPE_ONLY,
-                &mut on_stmt,
-                &mut on_expr,
-            );
-            if forced.len() == before {
-                break;
-            }
-        }
-        *self.sifr_int_forced_local_bindings.borrow_mut() = forced;
+            .collect::<HashSet<_>>()
     }
 
     pub(super) fn try_lower_structured_nested_function_stmt(&mut self, stmt: &HirStmt) -> bool {
@@ -224,6 +224,7 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
+        let saved_current_sifr_int_return = self.current_sifr_int_return;
         let nested_binding_mutable = saved_mutated_vars.contains(&func.name);
 
         self.current_return_type = Some(func.return_type.clone());
@@ -268,6 +269,7 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+        self.current_sifr_int_return = saved_current_sifr_int_return;
 
         let lowered_stmt = if is_recursive {
             let params = func
@@ -431,6 +433,9 @@ impl RustEmitter {
 
         if func.return_type == Type::None {
             return None;
+        }
+        if self.function_returns_sifr_int(&func.name) {
+            return Some(RustType::Named("SifrInt".to_string()));
         }
         Some(self.rust_ir_type_with_generics(&func.return_type))
     }
@@ -598,6 +603,7 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
+        let saved_current_sifr_int_return = self.current_sifr_int_return;
 
         self.current_return_type = Some(func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
@@ -608,6 +614,7 @@ impl RustEmitter {
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
+        self.current_sifr_int_return = self.function_returns_sifr_int(&func.name);
         self.register_function_scope_params(&func.params);
         self.register_local_body_binding_types(&func.body);
 
@@ -710,18 +717,121 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+        self.current_sifr_int_return = saved_current_sifr_int_return;
     }
+}
+
+fn hir_function_returns_sifr_int(
+    func: &HirFunction,
+    module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
+) -> bool {
+    let local_int_bindings = func
+        .body
+        .iter()
+        .filter_map(|stmt| match stmt {
+            HirStmt::Let { name, ty, .. }
+                if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int) =>
+            {
+                Some(name.clone())
+            }
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let forced = collect_sifr_int_forced_locals(
+        &func.body,
+        &local_int_bindings,
+        module_sifr_int_bindings,
+        function_sifr_int_returns,
+    );
+
+    let mut returns_sifr_int = false;
+    let mut on_stmt = |stmt: &HirStmt| {
+        if let HirStmt::Return { value: Some(value) } = stmt {
+            returns_sifr_int |= hir_expr_needs_sifr_int_storage(
+                value,
+                &forced,
+                module_sifr_int_bindings,
+                function_sifr_int_returns,
+            );
+        }
+    };
+    let mut on_expr = |_expr: &HirExpr| {};
+    traversal::walk_stmts(
+        &func.body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    returns_sifr_int
+}
+
+fn collect_sifr_int_forced_locals(
+    body: &[HirStmt],
+    local_int_bindings: &HashSet<String>,
+    module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
+) -> HashSet<String> {
+    let mut forced = HashSet::new();
+    if local_int_bindings.is_empty() {
+        return forced;
+    }
+    loop {
+        let before = forced.len();
+        let mut on_stmt = |stmt: &HirStmt| match stmt {
+            HirStmt::Let { name, value, .. } | HirStmt::Assign { name, value }
+                if local_int_bindings.contains(name)
+                    && hir_expr_needs_sifr_int_storage(
+                        value,
+                        &forced,
+                        module_sifr_int_bindings,
+                        function_sifr_int_returns,
+                    ) =>
+            {
+                forced.insert(name.clone());
+            }
+            HirStmt::AugAssign { name, op, value }
+                if local_int_bindings.contains(name)
+                    && is_sifr_int_augassign_op(op)
+                    && (forced.contains(name)
+                        || hir_expr_needs_sifr_int_storage(
+                            value,
+                            &forced,
+                            module_sifr_int_bindings,
+                            function_sifr_int_returns,
+                        )) =>
+            {
+                forced.insert(name.clone());
+            }
+            _ => {}
+        };
+        let mut on_expr = |_expr: &HirExpr| {};
+        traversal::walk_stmts(
+            body,
+            TraversalConfig::LOCAL_SCOPE_ONLY,
+            &mut on_stmt,
+            &mut on_expr,
+        );
+        if forced.len() == before {
+            break;
+        }
+    }
+    forced
 }
 
 fn hir_expr_needs_sifr_int_storage(
     expr: &HirExpr,
     forced_locals: &HashSet<String>,
     module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
 ) -> bool {
     match expr {
         HirExpr::LargeIntLiteral(_) => true,
         HirExpr::Name { name, .. } => {
             forced_locals.contains(name) || module_sifr_int_bindings.contains(name)
+        }
+        HirExpr::Call { func, args, .. } => {
+            args.is_empty() && function_sifr_int_returns.contains(func)
         }
         HirExpr::BinOp {
             left,
@@ -732,14 +842,28 @@ fn hir_expr_needs_sifr_int_storage(
         } if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
             && matches!(op.as_str(), "+" | "-" | "*") =>
         {
-            hir_expr_needs_sifr_int_storage(left, forced_locals, module_sifr_int_bindings)
-                || hir_expr_needs_sifr_int_storage(right, forced_locals, module_sifr_int_bindings)
+            hir_expr_needs_sifr_int_storage(
+                left,
+                forced_locals,
+                module_sifr_int_bindings,
+                function_sifr_int_returns,
+            ) || hir_expr_needs_sifr_int_storage(
+                right,
+                forced_locals,
+                module_sifr_int_bindings,
+                function_sifr_int_returns,
+            )
         }
         HirExpr::UnaryOp { op, operand, ty }
             if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
                 && matches!(op.as_str(), "+" | "-") =>
         {
-            hir_expr_needs_sifr_int_storage(operand, forced_locals, module_sifr_int_bindings)
+            hir_expr_needs_sifr_int_storage(
+                operand,
+                forced_locals,
+                module_sifr_int_bindings,
+                function_sifr_int_returns,
+            )
         }
         _ => false,
     }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1213,6 +1213,10 @@ struct RustEmitter {
     sifr_int_local_bindings: RefCell<HashSet<String>>,
     /// Local names pre-promoted to `SifrInt` because a later assignment needs exact-int storage.
     sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
+    /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
+    sifr_int_function_returns: RefCell<HashSet<String>>,
+    /// Whether the active function-like body returns `SifrInt` for source-level `int`.
+    current_sifr_int_return: bool,
     /// Stack used to capture structured statement emission as IR nodes.
     stmt_capture_stack: Vec<Vec<RustStmt>>,
     /// Recursion guard for non-structured emitter paths.
@@ -1314,6 +1318,8 @@ impl RustEmitter {
             none_widened_local_bindings: HashSet::new(),
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
+            sifr_int_function_returns: RefCell::new(HashSet::new()),
+            current_sifr_int_return: false,
             stmt_capture_stack: Vec::new(),
             lowering_stats: LoweringStats::default(),
         }
@@ -1373,6 +1379,7 @@ impl RustEmitter {
         self.prescan_module_metadata(module);
 
         self.emit_module_constants(module, module_public);
+        self.register_sifr_int_function_returns(module);
         self.emit_module_body(module, module_public, test_mode);
     }
 

--- a/reviews/integer-model-int-1-sifrint-function-return-boundaries-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-function-return-boundaries-review-pass-1.md
@@ -1,0 +1,176 @@
+# Review: INT-1 SifrInt Function Return Boundaries Pass 1
+
+## Verdict
+
+Satisfied with non-blocking suggestions.
+
+The slice's stated narrow scope — promote module-level `-> int` functions whose returns transitively depend on SifrInt sources, coerce their return statements, and recognize zero-arg calls to them as SifrInt at call sites — is met cleanly. The pre-scan, scope save/restore for the primary `emit_function` path, and call-site detection are all sound. End-to-end and probe matrix verification confirms the load-bearing cases work and pre-existing i64 paths stay untouched.
+
+I do flag two non-blocking quality concerns (N1, N2 below) that surface in code shapes that were already broken pre-PR. Neither is a strict regression, and both are out of the slice's stated scope, but they're worth tracking explicitly in the next tracker so they don't get lost behind the function-return tick.
+
+## Findings
+
+None blocking.
+
+The implementation matches the design and phase-issue framing:
+
+### Pre-scan correctness
+
+[register_sifr_int_function_returns](crates/sifr_codegen/src/function_emitter.rs:131-156) walks `module.functions` in a fixed-point loop. Within each iteration, every function with `Type::Int` return is checked via `hir_function_returns_sifr_int`, which in turn computes a per-function forced-locals set and looks for any Return whose value `hir_expr_needs_sifr_int_storage` (now extended with the `function_sifr_int_returns` parameter). The fixed-point loop correctly handles transitive function dependencies — verified by probing:
+
+```sifr
+def inner() -> int:
+    return BIG_LIMIT + 1
+def outer() -> int:
+    return inner()
+```
+
+emits both `inner` and `outer` with `-> SifrInt`, the call site `let result: SifrInt = outer()` correctly retypes, runtime round-trips. ✓
+
+Mutual recursion (`f -> g -> f` with one side bringing a SifrInt source) also converges in two iterations because the fixed-point reads `function_returns` as a snapshot per iteration, then extends — verified by tracing.
+
+The pre-scan order is correct: [lib.rs:1379-1383](crates/sifr_codegen/src/lib.rs:1379) calls `prescan_module_metadata` → `emit_module_constants` (populates `module_constants`) → `register_sifr_int_function_returns` (reads `module_constants`) → `emit_module_body`. The data dependency on `module_constants` is honored. ✓
+
+The `register_local_body_binding_types` path now also extends `sifr_int_forced_local_bindings` via `collect_sifr_int_forced_locals`, threading the same `function_sifr_int_returns` set through the predicate. This means a local `let x: int = make_big()` gets pre-promoted to SifrInt because `Call{make_big, []}` with empty args and a promoted name now satisfies `hir_expr_needs_sifr_int_storage`. The walker descends through loop/if/match bodies via `TraversalConfig::LOCAL_SCOPE_ONLY` (excluding nested function bodies), which is the right scope for the per-function forced set.
+
+### Scope save/restore for primary emit_function
+
+`current_sifr_int_return` is saved at [function_emitter.rs:606](crates/sifr_codegen/src/function_emitter.rs:606), set via `self.current_sifr_int_return = self.function_returns_sifr_int(&func.name)` at [function_emitter.rs:617](crates/sifr_codegen/src/function_emitter.rs:617), and restored at [function_emitter.rs:720](crates/sifr_codegen/src/function_emitter.rs:720). This is the primary entry point called from `emit_module_body` for each module-level function. The save/restore correctly resets the flag for sibling functions in a module — verified by emitting the e2e fixture: `circle_area`, `returned_big_limit`, and `main` each have the flag set independently based on their own promotion status.
+
+### Call-site recognition
+
+[is_sifr_int_returning_function_call](crates/sifr_codegen/src/expr_render_helpers.rs:1406-1408) added to `is_sifr_int_expr`'s zero-arg `FnCall` arm. Verified end-to-end:
+
+| Probe                             | Emitted Rust                                                | Result |
+|-----------------------------------|-------------------------------------------------------------|--------|
+| `let v: int = make_big()`         | `let v: SifrInt = make_big();`                              | ✓ |
+| `let v: int = make_big() + 1`     | `let v: SifrInt = make_big() + SifrInt::from_i64(1);`       | ✓ |
+| `let v: int = -make_big()`        | `let v: SifrInt = -(make_big());`                           | ✓ |
+| `let v: int = make_big() * 2`     | `let v: SifrInt = make_big() * SifrInt::from_i64(2);`       | ✓ |
+| `let d: bool = make_big() > 100`  | `let d: bool = (&make_big() > &SifrInt::from_i64(100));`    | ✓ |
+| `let v: int = inner()` (transitive) | `let v: SifrInt = inner();` after `inner` itself promoted | ✓ |
+
+### Return statement coercion
+
+The Return arm at [expr_render_helpers.rs:565-575](crates/sifr_codegen/src/expr_render_helpers.rs:565) reads `current_sifr_int_return` and routes the expression through `coerce_expr_to_sifr_int_value` when promoted. Verified by emit:
+
+```rust
+fn returned_big_limit() -> SifrInt {
+    return __const_BIG_LIMIT() + SifrInt::from_i64(1);
+}
+```
+
+The value-position coerce is correct here: a registered local source would be cloned (not borrowed), helper FnCalls and BinOp results pass through, and small literals get `from_i64`-wrapped. Same semantics PRs #1825/#1827 established.
+
+### Both `RustType::I64` and `Named("i64")` shapes
+
+The new `is_legacy_i64_type` predicate at [expr_render_helpers.rs:1474-1477](crates/sifr_codegen/src/expr_render_helpers.rs:1474) handles both encodings. Reasonable: production codegen produces `RustType::Named("i64")` in some paths (e.g., `preamble.rs:502` for `Vec<i64>`-typed initializers and various `intrinsic_method_emitters.rs` paths). The `rewrites_sifr_int_returning_function_call_named_i64_let_type` test pins this defensive coverage. ✓
+
+### Tests
+
+- [rewrites_sifr_int_returning_function_call_let_type](crates/sifr_codegen/src/expr_render_helpers.rs:1858) — pins `Let { ty: Some(I64), value: FnCall{Ident("make_big"), []} }` retypes to `Some(SifrInt)`.
+- [rewrites_sifr_int_returning_function_call_named_i64_let_type](crates/sifr_codegen/src/expr_render_helpers.rs:1885) — same but for the `Named("i64")` encoding.
+- E2E fixture adds `returned_big_limit() -> int` plus four call-site uses (`returned_big`, `returned_plus_one` and their asserts), exercising both let-retype and operand-position recognition.
+
+Coverage gaps that didn't surface as bugs but would harden the slice (see N3 below).
+
+## Notes
+
+(Non-blocking observations only.)
+
+### N1 — Closure body Returns inherit `current_sifr_int_return` from a promoted outer function
+
+The flag is saved/restored at function-emit boundaries, but **not at closure-body boundaries**. The Closure and ClosureBlock arms in [rewrite_stdlib_constant_idents_in_expr](crates/sifr_codegen/src/expr_render_helpers.rs:380-400) descend into the body without touching `current_sifr_int_return`. Inside a promoted outer function, any `RustExpr::Closure { body: …Return(...) }` gets its return value coerced as if it returns SifrInt.
+
+Reproduction:
+
+```sifr
+BIG_LIMIT: int = 10 ** 20
+
+def outer() -> int:
+    def inner() -> int:
+        return 42
+    x: int = inner()
+    return BIG_LIMIT + x
+```
+
+Post-PR emits:
+
+```rust
+fn outer() -> SifrInt {
+    let inner = || {
+        return SifrInt::from_i64(42);   // <-- leaked coercion
+    };
+    let x: i64 = inner();              // E0308: expected i64, found SifrInt
+    return __const_BIG_LIMIT() + SifrInt::from_i64(x);
+}
+```
+
+`inner`'s body's `return 42` gets coerced to `SifrInt::from_i64(42)` because the rewrite arm reads the outer's `current_sifr_int_return = true`. This makes `inner`'s closure type `Fn() -> SifrInt`, mismatching the `let x: i64 = inner()` site.
+
+**Not a strict regression.** Pre-PR (commit `74bb52c5`) the same fixture failed at the outer's return statement (`return SifrInt + i64` against `-> i64`); post-PR it fails at the `let x: i64 = inner()`. Both versions fail to compile. I checked: shapes that don't trigger outer's promotion (no SifrInt source in the body) compile and run identically pre- and post-PR.
+
+But the leak is a real codegen bug, and the fix is small: save+restore (or save+clear+restore) `current_sifr_int_return` at the Closure and ClosureBlock arms, since closures have their own return semantics independent of the surrounding function. Worth tracking in the next open follow-up bullet alongside the broader function-boundary work, since both will likely be unblocked when full parameter+return migration lands.
+
+### N2 — Functions with parameters get promoted but call sites with arguments don't compile
+
+[register_sifr_int_function_returns](crates/sifr_codegen/src/function_emitter.rs:131) promotes any function whose return needs SifrInt storage, **regardless of parameter count**. But call-site recognition in [hir_expr_needs_sifr_int_storage](crates/sifr_codegen/src/function_emitter.rs:836) and [is_sifr_int_returning_function_call](crates/sifr_codegen/src/expr_render_helpers.rs:1406) requires `args.is_empty()`. So:
+
+```sifr
+def make_big_with_arg(x: int) -> int:
+    return x + BIG_LIMIT
+
+def main():
+    result: int = make_big_with_arg(5)
+    print(str(result))
+```
+
+emits
+
+```rust
+fn make_big_with_arg(x: i64) -> SifrInt {
+    return SifrInt::from_i64(x) + __const_BIG_LIMIT();
+}
+
+fn main() {
+    let result: i64 = make_big_with_arg(5 as i64);   // E0308
+    …
+}
+```
+
+The function definition compiles cleanly (the body's return coerces correctly). The call site fails because the let isn't pre-promoted to SifrInt — `args.is_empty()` is false.
+
+**Not a strict regression.** Pre-PR, the same fixture failed at the function body's return (`expected i64, found SifrInt`) — the function definition itself didn't compile. Post-PR, the function compiles but call sites with args fail. Strict improvement at the function-definition level.
+
+The slice description acknowledges the zero-arg call-site restriction. The asymmetry (broad promotion, narrow call-site recognition) is acceptable per scope, but it does mean a Sifr file that defines a parametrized SifrInt-returning helper can't be called via `int = f(arg)`. Two fix shapes for the next slice:
+
+1. Restrict the promotion criterion to `func.params.is_empty()` or to functions whose call sites are *all* zero-arg, mirroring the call-site predicate. This would leave parametrized functions broken at the body return (same as pre-PR), but consistent.
+2. Extend call-site recognition to non-zero-arg calls when the function name is in `sifr_int_function_returns`. This is what the broader function-boundary follow-up should do.
+
+Option 2 is the durable fix. Worth flagging in the open INT-1 follow-up so the asymmetry is explicit.
+
+### N3 — `current_sifr_int_return` save/restore not added to `function_like_lowering.rs`, `class_emitter.rs`, `class_method_emitter.rs`
+
+The slice adds save/restore at the two `function_emitter.rs` sites (the regular `emit_function` and `try_lower_structured_nested_function_stmt`) but not at the other three function-body emission paths. Currently benign because:
+
+- The other three paths emit class methods, Display impls, and operator-protocol bodies — none of which are in `module.functions` and so `current_sifr_int_return` is `false` when entering them.
+- These paths aren't typically invoked recursively from inside `emit_function`'s body emission, so the outer `true` value doesn't leak in.
+
+Verified by reading the call graph: [function_like_lowering.rs:21](crates/sifr_codegen/src/function_like_lowering.rs:21) is invoked from `type_emitters.rs:333` and `operator_protocol_emitters.rs:291`, both class/enum emission paths that run at module-emit-body time, with `current_sifr_int_return = false`.
+
+But this is a fragile invariant. A future feature (nested classes, inline operator overloads, etc.) could enter one of these paths while the flag is `true`, silently coercing class method or Display body returns. A defensive save+clear+restore at all three sites — symmetric to how PR #1825 added `sifr_int_forced_local_bindings` save/restore uniformly — would future-proof the code without behavioral change today. Optional polish.
+
+### N4 — Test coverage for pre-scan and Return coercion is e2e-only
+
+The two new unit tests cover let-retype shapes (`let result: I64/Named("i64") = make_big()` → SifrInt). What's not unit-tested:
+
+- **Pre-scan transitive dependency**: a unit test that constructs a small `HirModule` with two `Type::Int`-returning functions where one calls the other, and asserts both end up in `sifr_int_function_returns` after `register_sifr_int_function_returns`.
+- **Return coercion**: a unit test that stages `current_sifr_int_return = true` and rewrites a `RustStmt::Return(Some(Cast(Literal(0), I64)))` into `RustStmt::Return(Some(FnCall{from_i64, [Literal(0)]}))`.
+- **Operand-position zero-arg call recognition** in BinOp/UnaryOp/comparison shapes — currently only e2e-covered.
+- **"Should not promote"** sibling test for a Type::Int-returning function whose body doesn't need SifrInt — pins the deliberate gap.
+
+E2E coverage is sufficient for merge confidence, but the unit-level matrix mirrors prior slices' patterns (see PR #1825 pass-1 review's similar gap-flag).
+
+### N5 — Carry-forward open items
+
+Lexical shadowing, legacy-emission paths, fallible `//` and `%`, and the *broader* function argument/return boundary work all remain open from prior reviews. Not addressed by this slice. Specifically: this slice's scope explicitly preserves the broader function-boundary migration as still open — N2 above is one concrete shape that the broader work should close, and the open INT-1 follow-up bullet should be updated by the next tracker PR to reflect both that "module-level zero-arg `-> int` returns" is now closed and that "function arguments and call sites with arguments" remains open.


### PR DESCRIPTION
## Summary
- pre-scan module functions with source-level `-> int` returns and promote those that return exact-int values to Rust `SifrInt`
- coerce return statements in promoted functions through value-position SifrInt coercion
- treat zero-arg calls to promoted functions as SifrInt at downstream local/arithmetic use sites, including legacy `Named("i64")` typed lets
- extend `module_constants.sifr` coverage for exact-int function returns and arithmetic on the returned value

## Validation
- `cargo test -p sifr_codegen expr_render_helpers::tests:: -- --nocapture`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- standalone repro: `def make_big() -> int: return BIG_LIMIT + 1` run through `cargo run -q -p sifr -- run`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=67.67s`)
