### PR TITLE
Handle SifrInt function calls with args

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -13,6 +13,15 @@ def circle_area(r: float) -> float:
 def returned_big_limit() -> int:
     return BIG_LIMIT + 1
 
+def returned_big_with_offset(offset: int) -> int:
+    return BIG_LIMIT + offset
+
+def returned_big_with_nested_small() -> int:
+    def small_inner() -> int:
+        return 42
+    value: int = small_inner()
+    return BIG_LIMIT + value
+
 def main():
     assert str(circle_area(5.0)) == '78.53975'
     assert str(MAX_RETRIES) == '3'
@@ -22,8 +31,12 @@ def main():
     assert str(BIG_LIMIT + 1) == '100000000000000000001'
     returned_big: int = returned_big_limit()
     returned_plus_one: int = returned_big_limit() + 1
+    returned_with_offset: int = returned_big_with_offset(3)
+    returned_nested: int = returned_big_with_nested_small()
     assert str(returned_big) == '100000000000000000001'
     assert str(returned_plus_one) == '100000000000000000002'
+    assert str(returned_with_offset) == '100000000000000000003'
+    assert str(returned_nested) == '100000000000000000042'
     oversized_local: int = BIG_LIMIT + LIMIT
     assert str(oversized_local) == '100000000000000000254'
     chained_oversized_local: int = oversized_local + 2

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -399,23 +399,37 @@ impl RustEmitter {
                 params,
                 body,
                 is_move,
-            } => crate::RustExpr::Closure {
-                params,
-                body: Box::new(self.rewrite_stdlib_constant_idents_in_expr(*body)),
-                is_move,
-            },
+            } => {
+                let saved_current_sifr_int_return = self.current_sifr_int_return.get();
+                self.current_sifr_int_return.set(false);
+                let body = Box::new(self.rewrite_stdlib_constant_idents_in_expr(*body));
+                self.current_sifr_int_return
+                    .set(saved_current_sifr_int_return);
+                crate::RustExpr::Closure {
+                    params,
+                    body,
+                    is_move,
+                }
+            }
             crate::RustExpr::ClosureBlock {
                 params,
                 body,
                 is_move,
-            } => crate::RustExpr::ClosureBlock {
-                params,
-                body: body
+            } => {
+                let saved_current_sifr_int_return = self.current_sifr_int_return.get();
+                self.current_sifr_int_return.set(false);
+                let body = body
                     .into_iter()
                     .map(|stmt| self.rewrite_stdlib_constant_idents_in_stmt(stmt))
-                    .collect(),
-                is_move,
-            },
+                    .collect();
+                self.current_sifr_int_return
+                    .set(saved_current_sifr_int_return);
+                crate::RustExpr::ClosureBlock {
+                    params,
+                    body,
+                    is_move,
+                }
+            }
             crate::RustExpr::StructInit { name, fields } => crate::RustExpr::StructInit {
                 name,
                 fields: fields
@@ -565,7 +579,7 @@ impl RustEmitter {
             crate::RustStmt::Return(expr) => {
                 let value = expr.map(|ret| {
                     let ret = self.rewrite_stdlib_constant_idents_in_expr(ret);
-                    if self.current_sifr_int_return {
+                    if self.current_sifr_int_return.get() {
                         self.coerce_expr_to_sifr_int_value(ret)
                     } else {
                         ret
@@ -1371,16 +1385,16 @@ impl RustEmitter {
 
     fn is_sifr_int_expr(&self, expr: &crate::RustExpr) -> bool {
         match expr {
-            crate::RustExpr::FnCall { func, args } if args.is_empty() => {
-                self.is_sifr_int_module_constant_func(func)
+            crate::RustExpr::FnCall { func, args } => {
+                (args.is_empty() && self.is_sifr_int_module_constant_func(func))
                     || self.is_sifr_int_returning_function_call(func)
+                    || matches!(
+                        func.as_ref(),
+                        crate::RustExpr::Path(path)
+                            if string_path_matches(path, &["SifrInt", "from_i64"])
+                                || string_path_matches(path, &["sifr_runtime", "SifrInt", "from_i64"])
+                    )
             }
-            crate::RustExpr::FnCall { func, .. } => matches!(
-                func.as_ref(),
-                crate::RustExpr::Path(path)
-                    if string_path_matches(path, &["SifrInt", "from_i64"])
-                        || string_path_matches(path, &["sifr_runtime", "SifrInt", "from_i64"])
-            ),
             crate::RustExpr::Ident(name) => self.is_registered_sifr_int_local(name),
             crate::RustExpr::BinOp { left, op, right } if is_sifr_int_arithmetic_op(op) => {
                 self.is_sifr_int_expr(left) || self.is_sifr_int_expr(right)
@@ -1906,5 +1920,62 @@ mod tests {
                 ..
             } if name == "SifrInt"
         ));
+    }
+
+    #[test]
+    fn rewrites_sifr_int_returning_function_call_with_args_let_type() {
+        let emitter = RustEmitter::new();
+        emitter
+            .sifr_int_function_returns
+            .borrow_mut()
+            .insert("make_big_with_arg".to_string());
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_stmt(RustStmt::Let {
+            mutable: false,
+            name: "value".to_string(),
+            ty: Some(RustType::Named("i64".to_string())),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Ident("make_big_with_arg".to_string())),
+                args: vec![RustExpr::Cast {
+                    expr: Box::new(RustExpr::Literal(RustLiteral::Int(3))),
+                    ty: RustType::I64,
+                }],
+            },
+        });
+
+        assert!(matches!(
+            rewritten,
+            RustStmt::Let {
+                ty: Some(RustType::Named(ref name)),
+                ..
+            } if name == "SifrInt"
+        ));
+    }
+
+    #[test]
+    fn closure_block_returns_do_not_inherit_sifr_int_return_state() {
+        let emitter = RustEmitter::new();
+        emitter.current_sifr_int_return.set(true);
+
+        let rewritten = emitter.rewrite_stdlib_constant_idents_in_expr(RustExpr::ClosureBlock {
+            params: vec![],
+            body: vec![RustStmt::Return(Some(RustExpr::Cast {
+                expr: Box::new(RustExpr::Literal(RustLiteral::Int(42))),
+                ty: RustType::I64,
+            }))],
+            is_move: false,
+        });
+
+        let RustExpr::ClosureBlock { body, .. } = rewritten else {
+            panic!("expected closure block");
+        };
+        assert!(matches!(
+            body.as_slice(),
+            [RustStmt::Return(Some(RustExpr::Cast {
+                ty: RustType::I64,
+                ..
+            }))]
+        ));
+        assert!(emitter.current_sifr_int_return.get());
     }
 }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -224,7 +224,7 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
-        let saved_current_sifr_int_return = self.current_sifr_int_return;
+        let saved_current_sifr_int_return = self.current_sifr_int_return.get();
         let nested_binding_mutable = saved_mutated_vars.contains(&func.name);
 
         self.current_return_type = Some(func.return_type.clone());
@@ -235,6 +235,7 @@ impl RustEmitter {
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
+        self.current_sifr_int_return.set(false);
         self.callable_var_conventions
             .clone_from(&post_stmt_callable_conventions);
         for param in &func.params {
@@ -269,7 +270,8 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
-        self.current_sifr_int_return = saved_current_sifr_int_return;
+        self.current_sifr_int_return
+            .set(saved_current_sifr_int_return);
 
         let lowered_stmt = if is_recursive {
             let params = func
@@ -603,7 +605,7 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
-        let saved_current_sifr_int_return = self.current_sifr_int_return;
+        let saved_current_sifr_int_return = self.current_sifr_int_return.get();
 
         self.current_return_type = Some(func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
@@ -614,7 +616,8 @@ impl RustEmitter {
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
-        self.current_sifr_int_return = self.function_returns_sifr_int(&func.name);
+        self.current_sifr_int_return
+            .set(self.function_returns_sifr_int(&func.name));
         self.register_function_scope_params(&func.params);
         self.register_local_body_binding_types(&func.body);
 
@@ -717,7 +720,8 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
-        self.current_sifr_int_return = saved_current_sifr_int_return;
+        self.current_sifr_int_return
+            .set(saved_current_sifr_int_return);
     }
 }
 
@@ -830,9 +834,7 @@ fn hir_expr_needs_sifr_int_storage(
         HirExpr::Name { name, .. } => {
             forced_locals.contains(name) || module_sifr_int_bindings.contains(name)
         }
-        HirExpr::Call { func, args, .. } => {
-            args.is_empty() && function_sifr_int_returns.contains(func)
-        }
+        HirExpr::Call { func, .. } => function_sifr_int_returns.contains(func),
         HirExpr::BinOp {
             left,
             op,

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) use lib_support::{
 };
 use sifr_hir::{HirExpr, HirFunction, HirModule, HirStmt};
 use sifr_type_system::{ParamConvention, Type};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::Write as _;
@@ -1216,7 +1216,7 @@ struct RustEmitter {
     /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_returns: RefCell<HashSet<String>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
-    current_sifr_int_return: bool,
+    current_sifr_int_return: Cell<bool>,
     /// Stack used to capture structured statement emission as IR nodes.
     stmt_capture_stack: Vec<Vec<RustStmt>>,
     /// Recursion guard for non-structured emitter paths.
@@ -1319,7 +1319,7 @@ impl RustEmitter {
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_function_returns: RefCell::new(HashSet::new()),
-            current_sifr_int_return: false,
+            current_sifr_int_return: Cell::new(false),
             stmt_capture_stack: Vec::new(),
             lowering_stats: LoweringStats::default(),
         }

--- a/reviews/integer-model-int-1-sifrint-function-call-args-and-closure-return-state-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-function-call-args-and-closure-return-state-review-pass-1.md
@@ -1,0 +1,155 @@
+# Review: INT-1 SifrInt Function Call Args and Closure Return State Pass 1
+
+## Verdict
+
+Satisfied.
+
+The slice closes both pass-1 follow-ups from the function-return-boundaries review (#1829's pass-1 N1 closure leak and N2 parametrized-fn call-site asymmetry) cleanly, with three coordinated changes that fit the slice's stated narrow scope. End-to-end and probe matrix verification confirm the load-bearing cases work, prior cases stay correct, and the broader function-boundary migration remains explicitly open.
+
+## Findings
+
+None blocking.
+
+### 1. `Cell<bool>` conversion is appropriate
+
+Changing `current_sifr_int_return: bool` to `Cell<bool>` ([lib.rs:1219](crates/sifr_codegen/src/lib.rs:1219), [lib.rs:1322](crates/sifr_codegen/src/lib.rs:1322)) is the right interior-mutability primitive:
+
+- `bool` is `Copy`, so `Cell::get()`/`set()` work without overhead. No `RefCell` runtime borrow tracking needed.
+- The motivation is that `rewrite_stdlib_constant_idents_in_*` helpers take `&self`, so the new closure save/clear/restore in their Closure/ClosureBlock arms needs to mutate the flag without escalating to `&mut self`. `Cell` localizes the mutability without propagating up the entire rewrite call chain.
+- All call sites in `function_emitter.rs` updated consistently from direct field access to `.get()`/`.set()` ([function_emitter.rs:227](crates/sifr_codegen/src/function_emitter.rs:227), [function_emitter.rs:238](crates/sifr_codegen/src/function_emitter.rs:238), [function_emitter.rs:273-274](crates/sifr_codegen/src/function_emitter.rs:273), [function_emitter.rs:608](crates/sifr_codegen/src/function_emitter.rs:608), [function_emitter.rs:619-620](crates/sifr_codegen/src/function_emitter.rs:619), [function_emitter.rs:723-724](crates/sifr_codegen/src/function_emitter.rs:723)).
+- Read sites in the rewriter at [expr_render_helpers.rs:582](crates/sifr_codegen/src/expr_render_helpers.rs:582) updated to `.get()`.
+
+### 2. Closure save/clear/restore is sound
+
+The Closure and ClosureBlock arms ([expr_render_helpers.rs:399-431](crates/sifr_codegen/src/expr_render_helpers.rs:399)) save the outer's flag, set `false` while emitting the closure body, and restore the saved value. This addresses pass-1 N1 (closure-body Return stmts inheriting promoted outer-function state) by ensuring closure return semantics are independent of the surrounding function.
+
+Setting to `false` unconditionally inside closures is correct because:
+- Closures (lambdas, lowered nested `def`) are never in `sifr_int_function_returns` — that set tracks only `module.functions`.
+- A closure body's Return stmts return *from the closure*, not from the outer function. The closure's actual return type is inferred from its body, so if the body produces a SifrInt expression naturally (via BinOp/UnaryOp coercion), the closure ends up `Fn() -> SifrInt`. The flag is only used to decide whether to additionally route Return values through `coerce_expr_to_sifr_int_value`, which is a value-position coerce that wraps registered locals in `Clone(...)` — that wrap is correct for outer-function promotion semantics, not for closure semantics.
+
+I verified the pass-1 N1 reproducer is now fixed:
+
+```sifr
+def outer() -> int:
+    def inner() -> int:
+        return 42
+    x: int = inner()
+    return BIG_LIMIT + x
+```
+
+emits
+
+```rust
+fn outer() -> SifrInt {
+    let inner = || {
+        return 42 as i64;          // <-- not coerced, closure flag set to false
+    };
+    let x: i64 = inner();
+    return __const_BIG_LIMIT() + SifrInt::from_i64(x);
+}
+```
+
+Compiles, runs, prints `100000000000000000042`. ✓
+
+Nested closures cascade the save/restore correctly. Tracing: outer (`true`) → closure A enters (save `true`, set `false`) → closure B enters within A (save `false`, set `false`) → B body emits → restore to `false` → A body emits → restore to `true` → outer continues. Each level's restore is symmetric.
+
+The `RustExpr::Closure` (single-expr) arm save/restore is defensive — a single-expr closure has no explicit Return stmt, so the flag wouldn't be read inside its body. Including the save/restore symmetric with ClosureBlock is harmless and future-proof.
+
+### 3. Recognizing all calls to promoted SifrInt-returning functions
+
+Two changes drop the `args.is_empty()` guard:
+
+- [hir_expr_needs_sifr_int_storage](crates/sifr_codegen/src/function_emitter.rs:836-839) at the HIR pre-scan: now `function_sifr_int_returns.contains(func)` regardless of args.
+- [is_sifr_int_expr](crates/sifr_codegen/src/expr_render_helpers.rs:1385-1399) at the Rust IR rewrite: the merged `RustExpr::FnCall` arm now checks `is_sifr_int_returning_function_call` for any args count, while keeping `args.is_empty()` guarding `is_sifr_int_module_constant_func` (which is only correct for zero-arg helpers).
+
+This is sound: a promoted function returns `SifrInt` at the Rust level regardless of how many arguments it takes. Recognizing the call as SifrInt-shaped at the rewriter just informs downstream coercion paths. The arguments themselves are still passed by their existing types (i64 for `int` parameters that haven't been migrated), which is the slice's explicitly-deferred boundary.
+
+I verified end-to-end with several probes:
+
+| Probe                                                       | Emitted Rust                                                                | Result |
+|-------------------------------------------------------------|-----------------------------------------------------------------------------|--------|
+| `make_big_with_arg(x: int) -> int: return BIG_LIMIT + x`    | `fn make_big_with_arg(x: i64) -> SifrInt { return __const_BIG_LIMIT() + SifrInt::from_i64(x); }` | ✓ |
+| Call site `let v: int = make_big_with_arg(5)`               | `let v: SifrInt = make_big_with_arg(5 as i64);`                             | ✓ |
+| Multi-arg `make_big_multi(a, b)`                            | `fn make_big_multi(a: i64, b: i64) -> SifrInt { ... }` + `let v: SifrInt = make_big_multi(...);` | ✓ |
+| Recursive `promoted_recursive(n)` returning BIG_LIMIT base + recursive case | `fn promoted_recursive(n: i64) -> SifrInt { ... return promoted_recursive(n - 1) + SifrInt::from_i64(1); }` | ✓ |
+
+All compile and round-trip at runtime.
+
+### 4. Scope truthfulness — argument expressions still legacy
+
+The slice description explicitly acknowledges:
+
+> "This is still not a full function-argument migration: function parameters remain legacy-lowered where applicable, so argument expressions that themselves require SifrInt may remain future work."
+
+I verified this is accurate:
+
+```sifr
+def make_big_with_arg(x: int) -> int:
+    return BIG_LIMIT + x
+
+def main():
+    big: int = BIG_LIMIT + 1
+    v: int = make_big_with_arg(big)   # passing SifrInt local to int param
+```
+
+emits `make_big_with_arg(big)` (no coercion on the arg) which fails rustc because `big: SifrInt` doesn't unify with `x: i64`. **Not a regression** — pre-PR-#1831 (with #1829 in place) the same code failed at *both* the call's arg type *and* the let's return type; post-PR fails only at the arg type. Strict improvement at the call-site recognition level. The slice does not claim to fix this, and the open follow-up bullet at [issues/…/checklist:442](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md) correctly tracks "function arguments/non-zero-argument call sites".
+
+### 5. Pre-existing scenarios preserved
+
+I re-emitted the e2e fixture and probed the prior milestone slices' shapes:
+
+- `BIG_LIMIT + 1` still emits `__const_BIG_LIMIT() + SifrInt::from_i64(1)`.
+- `reusable_oversized_local + 1` still emits `&reusable_oversized_local + SifrInt::from_i64(1)`.
+- `total += big` still emits `total = &total + &big;`.
+- `b: int = a` (alias) still emits `let b: SifrInt = a.clone();`.
+- Comparison `a < b` still emits `&a < &b`.
+- Pure i64 paths (no SifrInt source anywhere) untouched.
+
+All pre-existing assertions in `module_constants.sifr` round-trip.
+
+### 6. Tests
+
+- [rewrites_sifr_int_returning_function_call_with_args_let_type](crates/sifr_codegen/src/expr_render_helpers.rs:1925) — pins the new behavior: a `RustStmt::Let { ty: Some(Named("i64")), value: FnCall{Ident("make_big_with_arg"), [Cast(Literal(3), I64)]} }` rewrites to a SifrInt-typed Let. The choice to use `Named("i64")` (rather than `RustType::I64`) exercises the existing `is_legacy_i64_type` predicate from #1829 against the slice's new arm. ✓
+
+- [closure_block_returns_do_not_inherit_sifr_int_return_state](crates/sifr_codegen/src/expr_render_helpers.rs:1953) — pins both that the ClosureBlock body's `Return(Cast(Literal(42), I64))` stays uncoerced (no `from_i64` wrap) when the outer flag is `true`, AND that the flag is properly restored after the closure rewrite (`assert!(emitter.current_sifr_int_return.get())`). The double assertion is the right pattern — it catches both the local-coerce and the restore-leak shapes simultaneously.
+
+E2E coverage adds:
+- `returned_big_with_offset(offset: int) -> int` + call site `returned_big_with_offset(3)` → exercises non-zero-arg call recognition end-to-end.
+- `returned_big_with_nested_small() -> int` with a nested `def small_inner() -> int: return 42` → exercises the closure save/restore end-to-end (small_inner's body's `return 42` stays as `return 42 as i64`, and outer's `return BIG_LIMIT + value` coerces correctly).
+
+Both fixture additions round-trip the assertions.
+
+## Notes
+
+(Non-blocking observations only.)
+
+### N-pass2-1 — Pass-1 N3 (defensive save/restore in three other emitter paths) still applies
+
+The slice doesn't add `current_sifr_int_return` save/restore in `function_like_lowering.rs`, `class_emitter.rs`, or `class_method_emitter.rs`. The conversion to `Cell<bool>` makes the future fix even easier (no `&mut self` propagation needed), but it remains a defensive future-proofing note. Currently benign because those paths are entered with `current_sifr_int_return = false` from module emit and don't recursively invoke `emit_function`. Worth tracking, not blocking.
+
+### N-pass2-2 — Nested function with naturally SifrInt-shaped return doesn't propagate to non-promoted outer
+
+A subtle remaining gap surfaced by my probe matrix:
+
+```sifr
+def outer() -> int:
+    def helper() -> int:
+        return BIG_LIMIT + 1
+    return helper()
+```
+
+The pre-scan walks `module.functions` only, so `helper` (nested inside `outer`) is never checked for promotion. `outer`'s body has `return helper()` which the pre-scan checks via `hir_expr_needs_sifr_int_storage(Call{helper, ...})` → `function_sifr_int_returns.contains("helper")` → `false` (helper isn't in `module.functions`). Outer doesn't get promoted, stays `-> i64`. But helper's closure body has `return BIG_LIMIT + 1` which the BinOp coerces to a SifrInt expression, making helper's inferred type `Fn() -> SifrInt`. Outer's `return helper()` then mismatches `-> i64`.
+
+Pre-PR-#1831 was also broken here (same shape). **Not a regression.** This is the inverse of pass-1 N1 — instead of the outer flag leaking into the closure, the closure's natural SifrInt-shape doesn't propagate up to promote the outer. Both directions need broader function-boundary work to fully close. Worth flagging in the next tracker as a sibling concern alongside the open follow-up's "function arguments/non-zero-argument call sites" bullet.
+
+### N-pass2-3 — Single-expr `Closure` arm save/restore is defensive
+
+The single-expr `Closure` body has no explicit Return stmts, so the flag wouldn't be read inside its body. Including the save/restore symmetric with ClosureBlock is harmless and protects against future shapes (e.g., if a single-expr closure body becomes a Block expression containing stmts), but currently it's dead code. Worth a one-line comment explaining "symmetric with ClosureBlock for future-proofing; single-expr bodies don't currently read the flag". Optional polish.
+
+### N-pass2-4 — Single-expr Closure case isn't unit-tested
+
+The new `closure_block_returns_do_not_inherit_sifr_int_return_state` test pins the ClosureBlock variant. A sibling test for the single-expr `Closure` variant (asserting it also save/restores) would harden against a future regression where someone removes the single-expr arm's save/restore thinking it's unused. Optional.
+
+### N-pass2-5 — Carry-forward open items unchanged
+
+Lexical shadowing, legacy-emission paths, fallible `//` and `%`, and the broader function argument / non-zero-arg call-site migration all stay tracked under the open INT-1 follow-up at [issues/…/checklist:442](issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md). The next tracker PR should update that bullet to reflect that the closure-leak gap and the parametrized-fn call-site recognition gap are now closed, while keeping the function-argument / arg-expression-with-SifrInt-source gap explicitly open (per N-pass2-2 above).


### PR DESCRIPTION
## Summary
- recognize calls to promoted `SifrInt`-returning functions at call sites even when the call has ordinary arguments
- carry that recognition into the HIR forced-local pre-scan so `result: int = make_big_with_arg(3)` stores as `SifrInt`
- make `current_sifr_int_return` interior-mutable so closure/nested-function boundaries can clear and restore it while rewriting returns
- extend `module_constants.sifr` with an argument-taking promoted return helper and a nested small helper inside a promoted outer function

## Validation
- `cargo test -p sifr_codegen expr_render_helpers::tests:: -- --nocapture`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- standalone repro for `make_big_with_arg(x: int) -> int` and nested small helper inside promoted outer function
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=78.80s`)
