### PR TITLE
Promote SifrInt function parameters

### DIFF
--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -16,6 +16,19 @@ def returned_big_limit() -> int:
 def returned_big_with_offset(offset: int) -> int:
     return BIG_LIMIT + offset
 
+def echo_int_parameter(value: int) -> int:
+    return value
+
+def add_to_exact_parameter(value: int, offset: int) -> int:
+    return value + offset
+
+def add_right_exact_parameter(prefix: int, value: int) -> int:
+    return value + prefix
+
+def alias_exact_parameter(value: int) -> int:
+    alias: int = value
+    return alias + 1
+
 def returned_big_with_nested_small() -> int:
     def small_inner() -> int:
         return 42
@@ -58,6 +71,11 @@ def main():
     returned_big: int = returned_big_limit()
     returned_plus_one: int = returned_big_limit() + 1
     returned_with_offset: int = returned_big_with_offset(3)
+    echoed_parameter: int = echo_int_parameter(BIG_LIMIT)
+    echoed_small_parameter: int = echo_int_parameter(5)
+    added_parameter: int = add_to_exact_parameter(BIG_LIMIT, 3)
+    added_right_parameter: int = add_right_exact_parameter(3, BIG_LIMIT)
+    aliased_parameter: int = alias_exact_parameter(BIG_LIMIT)
     returned_nested: int = returned_big_with_nested_small()
     returned_nested_helper: int = returned_big_from_nested_helper()
     returned_recursive_nested_helper: int = returned_big_from_recursive_nested_helper()
@@ -66,6 +84,11 @@ def main():
     assert str(returned_big) == '100000000000000000001'
     assert str(returned_plus_one) == '100000000000000000002'
     assert str(returned_with_offset) == '100000000000000000003'
+    assert str(echoed_parameter) == '100000000000000000000'
+    assert str(echoed_small_parameter) == '5'
+    assert str(added_parameter) == '100000000000000000003'
+    assert str(added_right_parameter) == '100000000000000000003'
+    assert str(aliased_parameter) == '100000000000000000001'
     assert str(returned_nested) == '100000000000000000042'
     assert str(returned_nested_helper) == '100000000000000000001'
     assert str(returned_recursive_nested_helper) == '100000000000000000003'

--- a/crates/sifr/tests/e2e/pass/module_constants.sifr
+++ b/crates/sifr/tests/e2e/pass/module_constants.sifr
@@ -104,10 +104,12 @@ def main():
     reuse_a: int = reusable_oversized_local + 1
     reuse_b: int = reusable_oversized_local + 2
     negated_reuse: int = -reusable_oversized_local
+    echoed_local_parameter: int = echo_int_parameter(reusable_oversized_local)
     assert str(reusable_oversized_local) == '100000000000000000001'
     assert str(reuse_a) == '100000000000000000002'
     assert str(reuse_b) == '100000000000000000003'
     assert str(negated_reuse) == '-100000000000000000001'
+    assert str(echoed_local_parameter) == '100000000000000000001'
     assert reusable_oversized_local < reuse_b
     assigned_total: int = 0
     assigned_total = assigned_total + reusable_oversized_local

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -256,13 +256,30 @@ impl RustEmitter {
                     .map(|arg| self.rewrite_stdlib_constant_idents_in_expr(arg))
                     .collect(),
             },
-            crate::RustExpr::FnCall { func, args } => crate::RustExpr::FnCall {
-                func: Box::new(self.rewrite_stdlib_constant_idents_in_expr(*func)),
-                args: args
-                    .into_iter()
-                    .map(|arg| self.rewrite_stdlib_constant_idents_in_expr(arg))
-                    .collect(),
-            },
+            crate::RustExpr::FnCall { func, args } => {
+                let func = self.rewrite_stdlib_constant_idents_in_expr(*func);
+                let args = if let Some(func_name) = rust_expr_identifier_path(&func) {
+                    args.into_iter()
+                        .enumerate()
+                        .map(|(idx, arg)| {
+                            let arg = self.rewrite_stdlib_constant_idents_in_expr(arg);
+                            if self.function_param_lowers_to_sifr_int(&func_name, idx) {
+                                self.coerce_expr_to_sifr_int_value(arg)
+                            } else {
+                                arg
+                            }
+                        })
+                        .collect()
+                } else {
+                    args.into_iter()
+                        .map(|arg| self.rewrite_stdlib_constant_idents_in_expr(arg))
+                        .collect()
+                };
+                crate::RustExpr::FnCall {
+                    func: Box::new(func),
+                    args,
+                }
+            }
             crate::RustExpr::MacroCall { name, args } => crate::RustExpr::MacroCall {
                 name,
                 args: args
@@ -1424,6 +1441,13 @@ impl RustEmitter {
 
     pub(super) fn function_returns_sifr_int(&self, name: &str) -> bool {
         self.sifr_int_function_returns.borrow().contains(name)
+    }
+
+    pub(super) fn function_param_lowers_to_sifr_int(&self, name: &str, idx: usize) -> bool {
+        self.sifr_int_function_params
+            .borrow()
+            .get(name)
+            .is_some_and(|params| params.contains(&idx))
     }
 }
 

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1419,6 +1419,7 @@ impl RustEmitter {
             crate::RustExpr::UnaryOp { op, operand } if op == "-" => self.is_sifr_int_expr(operand),
             crate::RustExpr::Paren(inner) => self.is_sifr_int_expr(inner),
             crate::RustExpr::Ref { expr, .. } => self.is_sifr_int_expr(expr),
+            crate::RustExpr::Clone(expr) => self.is_sifr_int_expr(expr),
             _ => false,
         }
     }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -61,9 +61,14 @@ impl RustEmitter {
             .insert(name.to_string(), ty.clone());
     }
 
-    fn register_function_scope_params(&mut self, params: &[HirParam]) {
-        for param in params {
+    fn register_function_scope_params(&mut self, func_name: &str, params: &[HirParam]) {
+        for (param_idx, param) in params.iter().enumerate() {
             self.register_function_scope_binding(&param.name, &param.ty, param.convention);
+            if self.function_param_lowers_to_sifr_int(func_name, param_idx) {
+                self.sifr_int_local_bindings
+                    .borrow_mut()
+                    .insert(param.name.clone());
+            }
         }
     }
 
@@ -129,29 +134,68 @@ impl RustEmitter {
     pub(super) fn register_sifr_int_function_returns(&self, module: &HirModule) {
         let module_sifr_int_bindings = self.module_sifr_int_bindings();
         let mut function_returns = HashSet::new();
+        let mut function_params: HashMap<String, HashSet<usize>> = HashMap::new();
+        let module_function_params = module
+            .functions
+            .iter()
+            .map(|func| {
+                (
+                    func.name.clone(),
+                    func.params
+                        .iter()
+                        .map(|param| param.ty.clone())
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
         loop {
             let before = function_returns.len();
+            let before_params = function_params.values().map(HashSet::len).sum::<usize>();
             let discovered = module
                 .functions
                 .iter()
                 .filter_map(|func| {
+                    let extra_forced_params =
+                        collect_sifr_int_function_param_names(func, &function_params);
                     (matches!(
                         crate::resolve_alias_type_for_plain_call(&func.return_type),
                         Type::Int
-                    ) && hir_function_returns_sifr_int(
+                    ) && hir_function_returns_sifr_int_with_extra_forced(
                         func,
                         &module_sifr_int_bindings,
                         &function_returns,
+                        &extra_forced_params,
                     ))
                     .then(|| func.name.clone())
                 })
                 .collect::<Vec<_>>();
             function_returns.extend(discovered);
-            if function_returns.len() == before {
+            for func in &module.functions {
+                let extra_forced_params =
+                    collect_sifr_int_function_param_names(func, &function_params);
+                let forced = collect_function_sifr_int_forced_locals_with_extra(
+                    func,
+                    &module_sifr_int_bindings,
+                    &function_returns,
+                    &extra_forced_params,
+                );
+                for (name, indexes) in collect_sifr_int_call_arg_function_params(
+                    &func.body,
+                    &module_function_params,
+                    &forced,
+                    &module_sifr_int_bindings,
+                    &function_returns,
+                ) {
+                    function_params.entry(name).or_default().extend(indexes);
+                }
+            }
+            let after_params = function_params.values().map(HashSet::len).sum::<usize>();
+            if function_returns.len() == before && after_params == before_params {
                 break;
             }
         }
         *self.sifr_int_function_returns.borrow_mut() = function_returns;
+        *self.sifr_int_function_params.borrow_mut() = function_params;
     }
 
     fn module_sifr_int_bindings(&self) -> HashSet<String> {
@@ -494,6 +538,23 @@ impl RustEmitter {
         }
     }
 
+    fn lower_module_function_param_type(
+        &self,
+        func_name: &str,
+        param_idx: usize,
+        param: &HirParam,
+    ) -> RustType {
+        if self.function_param_lowers_to_sifr_int(func_name, param_idx)
+            && matches!(
+                crate::resolve_alias_type_for_plain_call(&param.ty),
+                Type::Int
+            )
+        {
+            return RustType::Named("SifrInt".to_string());
+        }
+        self.lower_function_param_type(&param.ty, param.convention)
+    }
+
     fn lower_function_return_type(
         &self,
         func: &HirFunction,
@@ -691,7 +752,7 @@ impl RustEmitter {
             .set(self.function_returns_sifr_int(&func.name));
         let active_function_returns = self.function_sifr_int_returns_for_body(&func.body);
         *self.sifr_int_function_returns.borrow_mut() = active_function_returns;
-        self.register_function_scope_params(&func.params);
+        self.register_function_scope_params(&func.name, &func.params);
         self.register_local_body_binding_types(&func.body);
 
         let visibility = if !test_mode && module_public && func.name != "main" {
@@ -712,8 +773,9 @@ impl RustEmitter {
         let params = func
             .params
             .iter()
-            .map(|param| {
-                let rust_ty = self.lower_function_param_type(&param.ty, param.convention);
+            .enumerate()
+            .map(|(param_idx, param)| {
+                let rust_ty = self.lower_module_function_param_type(&func.name, param_idx, param);
                 if param.convention.is_owned() && param.convention.is_mutable() {
                     RustParam::NamedMut {
                         name: param.name.clone(),
@@ -864,39 +926,19 @@ fn hir_function_returns_sifr_int_with_extra_forced(
     function_sifr_int_returns: &HashSet<String>,
     extra_forced_locals: &HashSet<String>,
 ) -> bool {
+    let forced = collect_function_sifr_int_forced_locals_with_extra(
+        func,
+        module_sifr_int_bindings,
+        function_sifr_int_returns,
+        extra_forced_locals,
+    );
     let mut function_sifr_int_returns = function_sifr_int_returns.clone();
-    let local_int_bindings = func
-        .body
-        .iter()
-        .filter_map(|stmt| match stmt {
-            HirStmt::Let { name, ty, .. }
-                if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int) =>
-            {
-                Some(name.clone())
-            }
-            _ => None,
-        })
-        .collect::<HashSet<_>>();
-    let mut forced;
-    loop {
-        forced = collect_sifr_int_forced_locals(
-            &func.body,
-            &local_int_bindings,
-            module_sifr_int_bindings,
-            &function_sifr_int_returns,
-        );
-        forced.extend(extra_forced_locals.iter().cloned());
-        let before = function_sifr_int_returns.len();
-        function_sifr_int_returns.extend(collect_nested_sifr_int_function_returns(
-            &func.body,
-            module_sifr_int_bindings,
-            &function_sifr_int_returns,
-            &forced,
-        ));
-        if function_sifr_int_returns.len() == before {
-            break;
-        }
-    }
+    function_sifr_int_returns.extend(collect_nested_sifr_int_function_returns(
+        &func.body,
+        module_sifr_int_bindings,
+        &function_sifr_int_returns,
+        &forced,
+    ));
 
     let mut returns_sifr_int = false;
     let mut on_stmt = |stmt: &HirStmt| {
@@ -917,6 +959,104 @@ fn hir_function_returns_sifr_int_with_extra_forced(
         &mut on_expr,
     );
     returns_sifr_int
+}
+
+fn collect_function_sifr_int_forced_locals_with_extra(
+    func: &HirFunction,
+    module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
+    extra_forced_locals: &HashSet<String>,
+) -> HashSet<String> {
+    let mut function_sifr_int_returns = function_sifr_int_returns.clone();
+    let local_int_bindings = func
+        .body
+        .iter()
+        .filter_map(|stmt| match stmt {
+            HirStmt::Let { name, ty, .. }
+                if matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int) =>
+            {
+                Some(name.clone())
+            }
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let mut forced;
+    loop {
+        forced = collect_sifr_int_forced_locals_with_seed(
+            &func.body,
+            &local_int_bindings,
+            module_sifr_int_bindings,
+            &function_sifr_int_returns,
+            extra_forced_locals,
+        );
+        let before = function_sifr_int_returns.len();
+        function_sifr_int_returns.extend(collect_nested_sifr_int_function_returns(
+            &func.body,
+            module_sifr_int_bindings,
+            &function_sifr_int_returns,
+            &forced,
+        ));
+        if function_sifr_int_returns.len() == before {
+            break;
+        }
+    }
+    forced
+}
+
+fn collect_sifr_int_function_param_names(
+    func: &HirFunction,
+    function_params: &HashMap<String, HashSet<usize>>,
+) -> HashSet<String> {
+    let Some(indexes) = function_params.get(&func.name) else {
+        return HashSet::new();
+    };
+    func.params
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .collect()
+}
+
+fn collect_sifr_int_call_arg_function_params(
+    body: &[HirStmt],
+    module_function_params: &HashMap<String, Vec<Type>>,
+    forced_locals: &HashSet<String>,
+    module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
+) -> HashMap<String, HashSet<usize>> {
+    let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
+    let mut on_stmt = |_stmt: &HirStmt| {};
+    let mut on_expr = |expr: &HirExpr| {
+        let HirExpr::Call { func, args, .. } = expr else {
+            return;
+        };
+        let Some(params) = module_function_params.get(func) else {
+            return;
+        };
+        for (idx, arg) in args.iter().enumerate() {
+            let Some(param_ty) = params.get(idx) else {
+                continue;
+            };
+            if matches!(
+                crate::resolve_alias_type_for_plain_call(param_ty),
+                Type::Int
+            ) && hir_expr_needs_sifr_int_storage(
+                arg,
+                forced_locals,
+                module_sifr_int_bindings,
+                function_sifr_int_returns,
+            ) {
+                discovered.entry(func.clone()).or_default().insert(idx);
+            }
+        }
+    };
+    traversal::walk_stmts(
+        body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    discovered
 }
 
 fn collect_nested_sifr_int_function_returns(
@@ -1000,7 +1140,23 @@ fn collect_sifr_int_forced_locals(
     module_sifr_int_bindings: &HashSet<String>,
     function_sifr_int_returns: &HashSet<String>,
 ) -> HashSet<String> {
-    let mut forced = HashSet::new();
+    collect_sifr_int_forced_locals_with_seed(
+        body,
+        local_int_bindings,
+        module_sifr_int_bindings,
+        function_sifr_int_returns,
+        &HashSet::new(),
+    )
+}
+
+fn collect_sifr_int_forced_locals_with_seed(
+    body: &[HirStmt],
+    local_int_bindings: &HashSet<String>,
+    module_sifr_int_bindings: &HashSet<String>,
+    function_sifr_int_returns: &HashSet<String>,
+    seed: &HashSet<String>,
+) -> HashSet<String> {
+    let mut forced = seed.clone();
     if local_int_bindings.is_empty() {
         return forced;
     }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1215,6 +1215,8 @@ struct RustEmitter {
     sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
     /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_returns: RefCell<HashSet<String>>,
+    /// Module-level function `int` parameters promoted from legacy `i64` to `SifrInt`.
+    sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
     current_sifr_int_return: Cell<bool>,
     /// Stack used to capture structured statement emission as IR nodes.
@@ -1319,6 +1321,7 @@ impl RustEmitter {
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_function_returns: RefCell::new(HashSet::new()),
+            sifr_int_function_params: RefCell::new(HashMap::new()),
             current_sifr_int_return: Cell::new(false),
             stmt_capture_stack: Vec::new(),
             lowering_stats: LoweringStats::default(),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -5213,6 +5213,12 @@ impl RustEmitter {
                 );
             }
 
+            if self.function_param_lowers_to_sifr_int(func, idx) {
+                let lowered_arg = self.rewrite_stdlib_constant_idents_in_expr(lowered_arg);
+                adapted.push(self.coerce_expr_to_sifr_int_value(lowered_arg));
+                continue;
+            }
+
             let param_rust_type = param_ty.rust_type();
             if param_rust_type.starts_with("Box<")
                 && !Self::is_box_new_call_expr_for_ir(&lowered_arg)

--- a/reviews/integer-model-int-1-sifrint-function-parameter-boundaries-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-function-parameter-boundaries-review-pass-1.md
@@ -1,0 +1,196 @@
+# Review: INT-1 SifrInt Function Parameter Boundaries Pass 1
+
+**Verdict: Blockers remain. Changes requested.**
+
+The slice's pre-scan correctly discovers which module-level function parameters need promotion, the `lower_module_function_param_type` correctly emits `SifrInt` for promoted positions, and `register_function_scope_params` correctly registers promoted parameter names as inner SifrInt locals so the body coerces uses of them. The e2e fixture's module-helper-and-literal call shapes round-trip cleanly.
+
+But the slice has one reachable correctness blocker: when a call site passes a **registered SifrInt local** (e.g., `big: int = BIG_LIMIT + 1` then `echo(big)`) to a promoted parameter, the codegen emits `echo(SifrInt::from_i64(big.clone()))` — a `from_i64` wrap around an already-`SifrInt` value, which fails rustc with `expected i64, found SifrInt`. This is the slice's stated primary case ("function argument expressions that are already `SifrInt` need uniform parameter lowering"), and it's broken for the load-bearing local-source shape.
+
+The cause is double-application of `coerce_expr_to_sifr_int_value` across two code paths, with the intermediate `Clone(Ident)` shape unrecognized by `is_sifr_int_expr`. Fix is small (one match arm).
+
+## Findings
+
+### B1 — Blocker: `echo(big)` for registered SifrInt local emits invalid Rust
+
+**Reproduction:**
+
+```sifr
+BIG_LIMIT: int = 10 ** 20
+
+def echo(value: int) -> int:
+    return value
+
+def main():
+    big: int = BIG_LIMIT + 1
+    a: int = echo(big)
+    print(str(a))
+```
+
+Post-PR emits:
+
+```rust
+fn echo(value: SifrInt) -> SifrInt {
+    return value.clone();
+}
+
+fn main() {
+    let big: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+    let a: SifrInt = echo(SifrInt::from_i64(big.clone()));   // E0308: expected i64, found SifrInt
+    …
+}
+```
+
+`rustc` rejects the call site:
+
+```
+error[E0308]: mismatched types
+  --> src/main.rs:20:45
+   |
+20 |     let a: SifrInt = echo(SifrInt::from_i64(big.clone()));
+   |                           ----------------- ^^^^^^^^^^^ expected `i64`, found `SifrInt`
+```
+
+Same shape repros with chained locals (`big1: int = BIG_LIMIT + 1; big2: int = big1 + 1; echo(big2)` → `echo(SifrInt::from_i64(big2.clone()))`).
+
+**Pre-PR-#1841 baseline:** `fn echo(value: i64) -> i64 { return value; }` and `echo(big)` failed with `expected i64, found SifrInt` at the call site. Both versions fail to compile, so this is **not a strict regression** — but the slice's stated primary scope is "function argument expressions that are already `SifrInt` need uniform parameter lowering instead of legacy `i64`", and the fix doesn't deliver for the registered-local case.
+
+**Cause — double-application of `coerce_expr_to_sifr_int_value`:**
+
+For a stmt like `let a: int = echo(big)`, the call goes through two coerce passes:
+
+1. **First pass** at [adapt_plain_call_args_with_signature_for_ir](crates/sifr_codegen/src/stmt_support_emitter.rs:5216-5219):
+
+   ```rust
+   if self.function_param_lowers_to_sifr_int(func, idx) {
+       let lowered_arg = self.rewrite_stdlib_constant_idents_in_expr(lowered_arg);
+       adapted.push(self.coerce_expr_to_sifr_int_value(lowered_arg));
+       continue;
+   }
+   ```
+
+   For `Ident("big")` (registered SifrInt local), this produces `Clone(Ident("big"))` via the value-position coerce's first match arm.
+
+2. **Second pass** at [the FnCall arm in rewrite_stdlib_constant_idents_in_expr](crates/sifr_codegen/src/expr_render_helpers.rs:259-279):
+
+   ```rust
+   crate::RustExpr::FnCall { func, args } => {
+       let func = self.rewrite_stdlib_constant_idents_in_expr(*func);
+       let args = if let Some(func_name) = rust_expr_identifier_path(&func) {
+           args.into_iter()
+               .enumerate()
+               .map(|(idx, arg)| {
+                   let arg = self.rewrite_stdlib_constant_idents_in_expr(arg);
+                   if self.function_param_lowers_to_sifr_int(&func_name, idx) {
+                       self.coerce_expr_to_sifr_int_value(arg)
+                   } else {
+                       arg
+                   }
+               })
+               .collect()
+       …
+   }
+   ```
+
+   This runs on the already-coerced `Clone(Ident("big"))`. `coerce_expr_to_sifr_int_value(Clone(Ident("big")))`:
+
+   - Doesn't match `Ident` arm (it's `Clone`, not `Ident`).
+   - Doesn't match `Paren`, `BinOp` arms.
+   - Falls to `other if is_sifr_int_expr(&other)` — but [is_sifr_int_expr](crates/sifr_codegen/src/expr_render_helpers.rs:1392-1410) has no `Clone(...)` arm, so it returns false (wildcard).
+   - Falls to `Cast { ty: I64, expr } => from_i64(...)` — doesn't match (it's Clone).
+   - Falls to `other => sifr_int_from_i64_expr(other)` — wraps `Clone(Ident("big"))` in `SifrInt::from_i64(...)`.
+
+   Result: `SifrInt::from_i64(big.clone())` — invalid because `from_i64` expects `i64`.
+
+**Why module-helper and literal call shapes work** (and the e2e fixture passes):
+
+- `echo(BIG_LIMIT)`: arg is `__const_BIG_LIMIT()` (FnCall to module helper). First coerce: `is_sifr_int_expr(FnCall)` → true via `is_sifr_int_module_constant_func` → pass through. Second coerce: same → pass through. ✓
+- `echo(5)`: arg is `Cast(Literal(5), I64)`. First coerce: matches `Cast { ty: I64 }` → `from_i64(5)`. Second coerce: `is_sifr_int_expr(FnCall(SifrInt::from_i64))` → true via the from_i64 path arm → pass through. ✓
+- `echo(echo(BIG_LIMIT))`: nested SifrInt-returning call. First coerce passes through (FnCall to promoted echo). Second coerce same. ✓
+
+Only the **registered local** (Ident) case hits the Clone shape, which the wildcard path mishandles.
+
+**Suggested fix** (smallest, most local):
+
+Add a `Clone(expr)` arm to `is_sifr_int_expr` that recurses on the inner expression:
+
+```rust
+// In is_sifr_int_expr, add:
+crate::RustExpr::Clone(expr) => self.is_sifr_int_expr(expr),
+```
+
+With this arm, `Clone(Ident(registered_local))` recurses into `Ident("big")` → registered → true. Then the second coerce's `other if is_sifr_int_expr(&other)` arm fires and passes the `Clone(Ident)` through unchanged. The final emit would be `echo(big.clone())`, which is well-typed because `big.clone()` is `SifrInt` and `echo` takes `SifrInt`.
+
+Alternative fix (slightly more involved): unify the call-arg coercion to fire in only one path. Currently the rewriter's FnCall arm and `adapt_plain_call_args_with_signature_for_ir` both apply `coerce_expr_to_sifr_int_value`. Choose one.
+
+A **regression test** for the load-bearing shape would also be needed — e.g., add to `module_constants.sifr`:
+
+```sifr
+echoed_local_parameter: int = echo_int_parameter(big_local_already_in_fixture)
+assert str(echoed_local_parameter) == '...'
+```
+
+This would have caught the bug.
+
+## Notes
+
+(Non-blocking observations only — these can be addressed alongside or after the B1 fix.)
+
+### N1 — Pre-scan structure is sound
+
+[register_sifr_int_function_returns](crates/sifr_codegen/src/function_emitter.rs:135-200) now does a fixed-point loop that interleaves return-type discovery and parameter-promotion discovery. The structure is correct:
+
+1. Discover SifrInt-returning functions (using the current `function_params` map to seed forced-locals analysis via `extra_forced_params`).
+2. For each function, discover which call-site arguments are SifrInt-shaped, mark the corresponding callee's parameter index as promoted.
+3. Loop until both `function_returns` and `function_params` converge.
+
+The combined termination check `if function_returns.len() == before && after_params == before_params` correctly waits for both maps to stabilize.
+
+I traced `echo_int_parameter(BIG_LIMIT)` and `add_to_exact_parameter(BIG_LIMIT, 3)`:
+- iter 1: `echo_int_parameter` and `add_to_exact_parameter` analyzed for returns. `value` (echo's idx 0) and `value` (add's idx 0) marked promoted via call-arg detection in main's body (since `BIG_LIMIT` is module SifrInt source).
+- iter 2: With promoted params seeded into forced, `echo_int_parameter`'s return `value` is now SifrInt-forced, so echo gets added to function_returns. Same for add.
+- iter 3: function_returns stable, function_params stable. Break.
+
+✓ Fixed-point converges correctly.
+
+### N2 — Per-position parameter promotion is precise
+
+`add_to_exact_parameter(BIG_LIMIT, 3)` correctly promotes only `value` (idx 0), leaving `offset` (idx 1) as `i64`:
+
+```rust
+fn add_to_exact_parameter(value: SifrInt, offset: i64) -> SifrInt {
+    return &value + SifrInt::from_i64(offset);
+}
+```
+
+Same for `add_right_exact_parameter(3, BIG_LIMIT)` which promotes only `value` (idx 1). ✓ The slice doesn't over-promote when only a subset of args at a call site are SifrInt-shaped.
+
+### N3 — Body coercion of promoted parameter uses works
+
+For `add_to_exact_parameter`'s body `return value + offset`, the body emit produces `&value + SifrInt::from_i64(offset)`. `value` is registered (via `register_function_scope_params`'s new SifrInt-aware branch at [function_emitter.rs:65-69](crates/sifr_codegen/src/function_emitter.rs:65)), so the BinOp arm coerces `value` to `&value` and wraps `offset` in `from_i64`. ✓
+
+For `alias_exact_parameter`'s body `alias: int = value; return alias + 1`, the Let retypes `alias` to SifrInt (via `coerce_expr_to_sifr_int_value` of registered-local `Ident("value")` → `Clone(Ident)` → `value.clone()`), and the return BinOp coerces `alias` correctly. ✓
+
+### N4 — Return-boundary, nested-helper, capture, and closure-return-state behavior preserved
+
+I re-ran the e2e fixture in full. All 14 expr_render_helpers tests pass; all earlier milestone shapes (BinOp arithmetic, BinOp comparison, AugAssign, value-semantic alias, function returns, nested helpers, recursive captures, closure return-state) still emit correctly. No regression in those areas.
+
+### N5 — Carry-forward open items unchanged
+
+Lexical shadowing, legacy-emission paths, fallible `//` and `%` — all stay tracked. Once B1 is closed, this slice closes the "function argument expressions that are already `SifrInt` need uniform parameter lowering" residual; the next tracker should mark that complete.
+
+### N6 — No focused unit tests added
+
+The e2e fixture covers four parameter-promotion shapes (`echo_int_parameter`, `add_to_exact_parameter`, `add_right_exact_parameter`, `alias_exact_parameter`) but **not** the failing shape (passing a registered SifrInt local). Adding both:
+
+- A unit test that pre-stages `function_param_lowers_to_sifr_int` and `sifr_int_local_bindings`, then asserts the call rewriter emits `func(big.clone())` instead of `func(SifrInt::from_i64(big.clone()))`.
+- An e2e fixture line: `echoed_local_parameter: int = echo_int_parameter(reusable_oversized_local)` (using an already-defined registered local from the fixture) plus a matching assert.
+
+…would have caught B1 and would harden against future regressions.
+
+## What I'd accept
+
+- B1 fix: add `Clone(expr) => self.is_sifr_int_expr(expr)` arm to `is_sifr_int_expr` in [crates/sifr_codegen/src/expr_render_helpers.rs](crates/sifr_codegen/src/expr_render_helpers.rs:1392). This makes `Clone(Ident registered)` recognized as SifrInt-shape, so the second coerce pass-through arm fires instead of the from_i64 fallback.
+- Add a regression e2e assertion exercising the registered-local-arg case (e.g., `echo_int_parameter(reusable_oversized_local)` with an `assert str(...) == '100000000000000000001'`).
+- The N1/N2/N3 mechanisms are sound and don't need changes.
+
+Once B1 is addressed and a regression test pins it, I'd flip the verdict to "Satisfied".

--- a/reviews/integer-model-int-1-sifrint-function-parameter-boundaries-review-pass-2.md
+++ b/reviews/integer-model-int-1-sifrint-function-parameter-boundaries-review-pass-2.md
@@ -1,0 +1,144 @@
+# Review: INT-1 SifrInt Function Parameter Boundaries Pass 2
+
+**Verdict: Satisfied. No blockers.**
+
+The pass-1 B1 blocker is closed by the minimum fix I suggested in pass-1's "What I'd accept" section. The pass-2 delta is exactly two changes: one match arm added to `is_sifr_int_expr` to recognize `Clone(expr)` as SifrInt-shape when the inner is SifrInt, and one regression assertion added to the e2e fixture exercising the registered-local-argument shape. Both are minimal, focused, and preserve all earlier milestone shapes.
+
+## Findings
+
+None blocking.
+
+### B1 — Closed
+
+The pass-1 B1 reproducer (`echo(big)` for a registered SifrInt local `big`) was emitting `echo(SifrInt::from_i64(big.clone()))` because `coerce_expr_to_sifr_int_value` was applied twice — first by `adapt_plain_call_args_with_signature_for_ir` (producing `Clone(Ident("big"))`) and then by the FnCall arm in `rewrite_stdlib_constant_idents_in_expr` (where the wildcard fallback wrapped `Clone(Ident)` in `from_i64` because `is_sifr_int_expr` didn't recognize `Clone`).
+
+Pass-2 closes B1 with a one-line addition at [expr_render_helpers.rs:1422](crates/sifr_codegen/src/expr_render_helpers.rs:1422):
+
+```rust
+crate::RustExpr::Clone(expr) => self.is_sifr_int_expr(expr),
+```
+
+This makes `is_sifr_int_expr(Clone(Ident registered))` recurse into the inner Ident, recognize it as registered → true. Then the second coerce's `other if is_sifr_int_expr(&other)` arm fires and passes the `Clone(Ident)` through unchanged. The final emit is `echo(big.clone())`, which is well-typed because `big.clone()` is `SifrInt` and `echo`'s parameter is `SifrInt` (promoted by the slice's pre-scan).
+
+I reproduced the pass-1 B1 case post-fix:
+
+```sifr
+def echo(value: int) -> int:
+    return value
+
+def main():
+    big: int = BIG_LIMIT + 1
+    a: int = echo(big)
+    print(str(a))
+    print(str(big))
+```
+
+Post-PR-#1841-pass-2 emits:
+
+```rust
+fn echo(value: SifrInt) -> SifrInt {
+    return value.clone();
+}
+
+fn main() {
+    let big: SifrInt = __const_BIG_LIMIT() + SifrInt::from_i64(1);
+    let a: SifrInt = echo(big.clone());      // <-- single-coerced, well-typed
+    println!("{}", format!("{}", a));
+    println!("{}", format!("{}", big));      // <-- big still usable
+}
+```
+
+Compiles and runs, prints `100000000000000000001` twice. ✓ `big` retains source-level value semantics (the clone produces an independent SifrInt; `big` is still observable).
+
+The chained-local case (`big1 = BIG_LIMIT + 1; big2 = big1 + 1; echo(big2)`) also works post-fix, emitting `echo(big2.clone())`. ✓
+
+### Probe matrix verified
+
+| Probe                                                                | Result |
+|----------------------------------------------------------------------|--------|
+| Registered SifrInt local passed to promoted parameter — fixture line | ✓ `echo_int_parameter(reusable_oversized_local.clone())` |
+| Chained registered locals (`big1 → big2` → call)                     | ✓ `echo(big2.clone())` |
+| Multiple promoted parameters with mixed args (`add_two(big, BIG_LIMIT)`) | ✓ `add_two(big.clone(), __const_BIG_LIMIT())` |
+| Same registered local at multiple promoted positions (`add_two(big, big)`) | ✓ `add_two(big.clone(), big.clone())` |
+| Nested calls with promoted params (`echo(echo(BIG_LIMIT))`)          | ✓ helper FnCall pass-through |
+| Module helper as arg (`echo(BIG_LIMIT)`)                             | ✓ unchanged from pass-1 |
+| Literal as arg (`echo(5)`)                                           | ✓ `echo(SifrInt::from_i64(5))` unchanged |
+| Source local still usable after `echo(big.clone())` call             | ✓ value-semantic preservation |
+
+`scripts/run_all_tests.sh --profile quick` reproduces `report_signature=e1bf653aaa770517` (same as #1817–#1839), confirming no test deltas elsewhere.
+
+### Soundness check on the new `Clone(expr)` arm
+
+The new `is_sifr_int_expr` arm recurses into the inner expression. I verified there are no false positives:
+
+- `Clone(Ident("not_registered"))` — recurse → Ident not in `sifr_int_local_bindings` → false. ✓
+- `Clone(FnCall(non_promoted_function))` — recurse → FnCall arm checks against module helpers, promoted functions, and from_i64 paths; for an unrelated function name, all three fail → false. ✓
+- `Clone(Cast(literal, I64))` — Cast doesn't match any arm → wildcard → false. ✓ Correct because `Clone(literal_cast)` doesn't represent a SifrInt value.
+
+And no false negatives for the load-bearing case:
+
+- `Clone(Ident registered)` — recurse → registered → true. ✓
+- `Clone(FnCall to module helper)` — recurse → helper recognized → true. ✓
+- `Clone(FnCall to promoted function)` — recurse → promoted-function-call recognized → true. ✓
+
+The arm is sound and correctly minimal.
+
+### Regression test coverage
+
+The new e2e fixture line at [crates/sifr/tests/e2e/pass/module_constants.sifr:107](crates/sifr/tests/e2e/pass/module_constants.sifr:107):
+
+```sifr
+echoed_local_parameter: int = echo_int_parameter(reusable_oversized_local)
+```
+
+…with the matching assert at line 112:
+
+```sifr
+assert str(echoed_local_parameter) == '100000000000000000001'
+```
+
+…exercises exactly the pass-1 B1 reproducer: a registered SifrInt local (`reusable_oversized_local`, set at fixture line 102 via `BIG_LIMIT + 1`) passed to a promoted parameter (`echo_int_parameter`'s `value`). The emitted Rust shows `echo_int_parameter(reusable_oversized_local.clone())` — single-coerced, well-typed. The trailing `assert str(reusable_oversized_local) == '100000000000000000001'` (already in the fixture) pins that the source local stays usable after the call.
+
+This regression test would have caught B1 if it had existed in pass-1.
+
+### Prior pass-1 N1–N6 observations remain accurate
+
+- **N1** Pre-scan structure: still sound, still correctly converges `function_returns` and `function_params` via fixed-point.
+- **N2** Per-position promotion: still precise (verified by `add_to_exact_parameter` and `add_right_exact_parameter` in the fixture).
+- **N3** Body coercion of promoted parameter uses: still works (verified by `alias_exact_parameter`'s body shape).
+- **N4** Return-boundary, nested-helper, capture, and closure-return-state behavior preserved: confirmed by 14 expr_render_helpers tests passing and full e2e fixture round-tripping.
+- **N5** Carry-forward open items unchanged.
+- **N6** Test coverage now includes the registered-local case (B1 fix paired with regression assertion).
+
+### Notable structural observation
+
+After this slice, the open INT-1 follow-up loses its "function argument expressions that are already `SifrInt`" item. The remaining open items are:
+- Lexical shadowing and legacy-emission paths.
+- Unsupported augmented assignment / fallible `//` and `%`.
+
+These are non-function-boundary concerns, signaling that the function-boundary sub-phase of INT-1 is now fully closed across return types, parameter types, captures (recursive and non-recursive, module-source and local-source), and call-site coercion.
+
+## Notes
+
+(Non-blocking observations only.)
+
+- **N1 — The minimum-cost fix matches pass-1's "What I'd accept" suggestion.** Adding `Clone(expr) => self.is_sifr_int_expr(expr)` is the smallest possible change that closes B1 without touching the double-coercion path (which would have been more invasive). The diff is two lines (one in production, one in fixture plus assertion). Good targeted change.
+
+- **N2 — The Clone arm sits adjacent to the Ref arm in `is_sifr_int_expr`** ([expr_render_helpers.rs:1421-1422](crates/sifr_codegen/src/expr_render_helpers.rs:1421)), forming a small group of "wrapper" arms that recurse into their inner. Both arms have the same shape (`recurse into inner`), so the pairing reads naturally.
+
+- **N3 — No focused unit test added for the Clone-recognition arm.** The e2e fixture covers the load-bearing shape, but a focused unit test asserting `is_sifr_int_expr(Clone(Ident registered))` returns true (and `is_sifr_int_expr(Clone(Ident unregistered))` returns false) would harden against future regressions to the arm. Optional.
+
+- **N4 — Carry-forward open items unchanged.** Lexical shadowing, legacy-emission, fallible `//` and `%` — all stay tracked under the open INT-1 follow-up. Once a tracker PR records this slice complete, the open follow-up bullet should remove "function argument expressions that are already `SifrInt`" since this slice closes that residual.
+
+- **N5 — Pass-pattern observation.** PR #1841 follows the dual-pass pattern of #1825 and #1827 — an initial implementation with a B1 blocker, then a small focused fix in pass 2. The history pattern accommodates this.
+
+- **N6 — Quick validation.** `report_signature=e1bf653aaa770517` matches all prior milestone PRs, and the cited `wall_time=65.65s` is in the normal range for tracker-only or small implementation deltas.
+
+## What I'd accept (resolved)
+
+Pass-1 asked for:
+
+- **B1 fix**: add `Clone(expr) => self.is_sifr_int_expr(expr)` arm to `is_sifr_int_expr`. ✓ Done at [expr_render_helpers.rs:1422](crates/sifr_codegen/src/expr_render_helpers.rs:1422).
+- **Regression e2e assertion** exercising the registered-local-arg case. ✓ Done at [crates/sifr/tests/e2e/pass/module_constants.sifr:107,112](crates/sifr/tests/e2e/pass/module_constants.sifr:107) with `echoed_local_parameter`.
+
+Both items are addressed. Verdict flips to Satisfied.


### PR DESCRIPTION
## Summary
- Add a fixed-point SifrInt function-boundary pre-scan that promotes module-level `int` parameter positions when call sites pass SifrInt-shaped arguments.
- Lower promoted parameters as `SifrInt`, register them as exact-int locals inside function bodies, and coerce promoted call-argument positions on both structured and rewritten call paths.
- Extend `module_constants.sifr` with exact-int parameter, small-argument coercion, right-hand parameter, and alias-through-parameter coverage.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p sifr_codegen`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/module_constants.sifr`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/module_constants.sifr` (verified promoted `SifrInt` parameter signatures and coerced call args)
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_constants.sifr`
- `scripts/run_all_tests.sh --profile quick` (`report_signature=e1bf653aaa770517`, `wall_time=70.27s`)
