### PR TITLE
Add checked SifrInt floor division primitives

### DIFF
--- a/crates/sifr_runtime/src/int.rs
+++ b/crates/sifr_runtime/src/int.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigInt;
 use num_bigint::Sign;
-use num_traits::{Signed, ToPrimitive};
+use num_traits::{Signed, ToPrimitive, Zero};
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -174,6 +174,24 @@ impl SifrInt {
         }
     }
 
+    #[must_use]
+    pub fn checked_floor_div(&self, rhs: &Self) -> Option<Self> {
+        let rhs = rhs.as_bigint();
+        if rhs.is_zero() {
+            return None;
+        }
+        Some(Self::from_bigint(floor_div_bigint(&self.as_bigint(), &rhs)))
+    }
+
+    #[must_use]
+    pub fn checked_floor_mod(&self, rhs: &Self) -> Option<Self> {
+        let rhs = rhs.as_bigint();
+        if rhs.is_zero() {
+            return None;
+        }
+        Some(Self::from_bigint(floor_mod_bigint(&self.as_bigint(), &rhs)))
+    }
+
     try_to_fixed_width!(try_to_i8, i8, "i8", to_i8);
     try_to_fixed_width!(try_to_i16, i16, "i16", to_i16);
     try_to_fixed_width!(try_to_i32, i32, "i32", to_i32);
@@ -190,6 +208,29 @@ impl SifrInt {
     fn range_error(&self, target: &'static str) -> IntegerRangeError {
         IntegerRangeError::new(target, self.to_string())
     }
+}
+
+fn floor_div_bigint(left: &BigInt, right: &BigInt) -> BigInt {
+    let quotient = left / right;
+    let remainder = left % right;
+    if needs_floor_adjustment(&remainder, right) {
+        quotient - BigInt::from(1_i8)
+    } else {
+        quotient
+    }
+}
+
+fn floor_mod_bigint(left: &BigInt, right: &BigInt) -> BigInt {
+    let remainder = left % right;
+    if needs_floor_adjustment(&remainder, right) {
+        remainder + right
+    } else {
+        remainder
+    }
+}
+
+fn needs_floor_adjustment(remainder: &BigInt, divisor: &BigInt) -> bool {
+    !remainder.is_zero() && (remainder.is_negative() != divisor.is_negative())
 }
 
 impl From<i64> for SifrInt {
@@ -548,6 +589,73 @@ mod tests {
             (SifrInt::from_i64(i64::MAX) + SifrInt::from_i64(1)) - SifrInt::from_i64(i64::MAX);
 
         assert!(matches!(result, SifrInt::Small(1)));
+    }
+
+    #[test]
+    fn checked_floor_division_matches_exact_integer_semantics() {
+        let cases = [
+            (7, 3, 2),
+            (-7, 3, -3),
+            (7, -3, -3),
+            (-7, -3, 2),
+            (6, 3, 2),
+            (-6, 3, -2),
+        ];
+
+        for (left, right, expected) in cases {
+            let result = SifrInt::from_i64(left)
+                .checked_floor_div(&SifrInt::from_i64(right))
+                .expect("non-zero divisor should divide");
+            assert_eq!(result, SifrInt::from_i64(expected));
+        }
+    }
+
+    #[test]
+    fn checked_floor_modulo_matches_exact_integer_semantics() {
+        let cases = [
+            (7, 3, 1),
+            (-7, 3, 2),
+            (7, -3, -2),
+            (-7, -3, -1),
+            (6, 3, 0),
+            (-6, 3, 0),
+        ];
+
+        for (left, right, expected) in cases {
+            let result = SifrInt::from_i64(left)
+                .checked_floor_mod(&SifrInt::from_i64(right))
+                .expect("non-zero divisor should produce a remainder");
+            assert_eq!(result, SifrInt::from_i64(expected));
+        }
+    }
+
+    #[test]
+    fn checked_floor_division_and_modulo_return_none_for_zero_divisor() {
+        let left = SifrInt::from_i64(7);
+        let zero = SifrInt::from_i64(0);
+
+        assert_eq!(left.checked_floor_div(&zero), None);
+        assert_eq!(left.checked_floor_mod(&zero), None);
+    }
+
+    #[test]
+    fn checked_floor_division_and_modulo_normalize_large_results() {
+        let left = SifrInt::parse_decimal("100000000000000000000", DEFAULT_MAX_INTEGER_DIGITS)
+            .unwrap_or_else(|err| panic!("{err}"));
+        let divisor = SifrInt::from_i64(3);
+
+        assert_eq!(
+            left.checked_floor_div(&divisor)
+                .expect("non-zero divisor")
+                .to_string(),
+            "33333333333333333333"
+        );
+        assert_eq!(
+            left.checked_floor_mod(&divisor)
+                .expect("non-zero divisor")
+                .to_string(),
+            "1"
+        );
     }
 
     #[test]

--- a/reviews/integer-model-int-1-sifrint-checked-floor-mod-runtime-review-pass-1.md
+++ b/reviews/integer-model-int-1-sifrint-checked-floor-mod-runtime-review-pass-1.md
@@ -1,0 +1,144 @@
+# INT-1: SifrInt checked floor division/modulo runtime primitives
+## Review pass 1 — PR #1853 (`int-1-sifrint-floor-mod-support`)
+
+**Author:** Yaser Alnajjar
+**Commit:** `6ac7d7ef` ("Add checked SifrInt floor division primitives")
+**Files changed:** `crates/sifr_runtime/src/int.rs` (+109, -1)
+
+---
+
+## Summary
+
+Adds `checked_floor_div` and `checked_floor_mod` to `SifrInt` returning `Option<Self>`,
+with zero-divisor guard returning `None`. No codegen wiring. No HIR typed-failure
+behavior. Scope is intentionally limited to the runtime substrate slice.
+
+---
+
+## Blocking findings
+
+None.
+
+---
+
+## Non-blocking notes
+
+### 1. `MIN // -1` / `MIN % -1` i64 overflow not exercised
+
+`i64::MIN / -1` overflows i64 (produces `i64::MAX + 1 = 9223372036854775808`), and
+`num_bigint::BigInt` handles this without issue. The test suite does not include a
+case like `SifrInt::from_i64(i64::MIN).checked_floor_div(&SifrInt::from_i64(-1))`.
+Since `SifrInt::from_bigint` upcasts to `Big` when the value does not fit `Small(i64)`,
+this is safe in practice, but adding an explicit test case would harden the
+coverage boundary.
+
+**Recommendation (non-blocking):** Add a test case:
+```rust
+#[test]
+fn checked_floor_div_min_int_overflow() {
+    let result = SifrInt::from_i64(i64::MIN)
+        .checked_floor_div(&SifrInt::from_i64(-1))
+        .expect("should succeed with Big result");
+    assert_eq!(result.to_string(), "9223372036854775808");
+}
+```
+
+### 2. `#[must_use]` on private helpers
+
+`floor_div_bigint`, `floor_mod_bigint`, and `needs_floor_adjustment` are private
+non-`#[must_use]` functions. This is fine and consistent — callers are always
+within the same module. No action needed.
+
+### 3. `as_bigint()` clone cost on `Big` variant
+
+Both `checked_floor_div` and `checked_floor_mod` call `rhs.as_bigint()` and
+`self.as_bigint()`, each cloning the `BigInt` for the `Big` variant. This is the
+established pattern in the crate (e.g., existing arithmetic ops), so it is not a
+new concern. If performance becomes relevant later, a borrowing API could be
+introduced, but that is out of scope for this slice.
+
+### 4. `num_traits::Zero` import
+
+The PR adds `Zero` to the `num_traits` import but only uses `is_zero()`.
+`num_bigint::BigInt` also has an inherent `is_zero()` method, so the `Zero` trait
+import is unnecessary for the current call sites. It may be intended for future
+use. No action required.
+
+---
+
+## Design alignment check
+
+| Concern | Design rule | Implementation | Status |
+|---|---|---|---|
+| Floor semantics for negative operands | Python/exact-integer floor div/mod identity | `needs_floor_adjustment` checks remainder/divisor sign mismatch | Correct |
+| Zero divisor | Return typed failure, not panic | `None` on `is_zero()` | Correct |
+| API shape | Fallible division returns Option or Result | `Option<Self>` | Correct |
+| No codegen wiring | Scope is runtime only | No HIR/codegen changes | Correct |
+| `#[must_use]` | Fallible APIs must warn on discard | On both public methods | Correct |
+| `num_bigint` for arbitrary precision | `BigInt` handles overflow | `BigInt` division used | Correct |
+
+Python floor division/modulo semantics verified directly against Python interpreter:
+- `7 // 3 = 2`, `7 % 3 = 1` — matches test expectation
+- `-7 // 3 = -3`, `-7 % 3 = 2` — matches test expectation
+- `7 // -3 = -3`, `7 % -3 = -2` — matches test expectation
+- `-7 // -3 = 2`, `-7 % -3 = -1` — matches test expectation
+- `6 // 3 = 2`, `-6 // 3 = -2` — matches test expectation
+- Floor identity `q * divisor + r == dividend` holds for all cases
+- Remainder sign always matches divisor sign (or remainder is zero)
+
+---
+
+## Test coverage assessment
+
+| Scenario | Covered | Notes |
+|---|---|---|
+| Positive div/mod positive | Yes | `7 // 3`, `7 % 3` |
+| Negative div/mod positive | Yes | `-7 // 3`, `-7 % 3` |
+| Positive div/mod negative | Yes | `7 // -3`, `7 % -3` |
+| Negative div/mod negative | Yes | `-7 // -3`, `-7 % -3` |
+| Divisible cases | Yes | `6 // 3`, `-6 // 3` |
+| Zero divisor div | Yes | Returns `None` |
+| Zero divisor mod | Yes | Returns `None` |
+| Large BigInt normalization | Yes | 20-digit number |
+
+Missing (see note 1 above): `MIN // -1` overflow case.
+
+---
+
+## Scope alignment
+
+This PR is the **runtime substrate slice only** — `checked_floor_div` and
+`checked_floor_mod` are added to `SifrInt` with no HIR changes, no codegen
+emission, and no typed-failure wiring. The PR description explicitly states that
+codegen and HIR typed-failure behavior is the next slice. The implementation
+matches this boundary precisely.
+
+From INT-1 milestone description:
+> "Add canonical `SifrInt` runtime type with `Small(i64)` and `Big(Box<num_bigint::BigInt>)`"
+
+This PR adds floor division/modulo runtime primitives to that canonical type.
+
+---
+
+## Validation status
+
+Author reported:
+- `cargo fmt --check` — passed
+- `git diff --check` — passed
+- `cargo test -p sifr_runtime checked_floor -- --nocapture` — passed
+- `scripts/run_all_tests.sh --profile quick` — report `e1bf653aaa770517`, wall time 54.03s — passed
+
+Quick validation was run by the author. No independent re-run was performed as part
+of this review.
+
+---
+
+## Verdict
+
+**APPROVED** — no blocking findings.
+
+The implementation correctly implements Python/exact-integer floor division and
+floor modulo semantics, safely handles zero divisors via `Option`, and is
+correctly scoped to runtime only. One non-blocking note recommends adding an
+explicit `MIN // -1` test case for defensive coverage, but the current behavior
+is sound.


### PR DESCRIPTION
## Summary
- add checked SifrInt floor-division and floor-modulo runtime primitives that return None for zero divisors
- preserve Python/exact-integer floor semantics for negative operands
- cover small, large, and zero-divisor cases in runtime unit tests

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p sifr_runtime checked_floor -- --nocapture
- scripts/run_all_tests.sh --profile quick (report_signature=e1bf653aaa770517, wall_time=54.03s)