### PR TITLE
Cover exact int literal augassign diagnostics

### DIFF
--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -366,6 +366,37 @@ def main() -> None:
 }
 
 #[test]
+fn test_exact_int_augassign_by_nonzero_literal_still_lowers() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    value: int = 28
+    value //= 3
+    value %= -5
+",
+    )
+    .expect("proven non-zero literal augassign divisors should lower");
+
+    let main_fn = &module.functions[0];
+    assert!(matches!(
+        &main_fn.body[1],
+        HirStmt::AugAssign {
+            name,
+            op,
+            value: HirExpr::IntLiteral(3),
+        } if name == "value" && op == "//="
+    ));
+    assert!(matches!(
+        &main_fn.body[2],
+        HirStmt::AugAssign {
+            name,
+            op,
+            value: HirExpr::UnaryOp { ty: Type::Int, .. },
+        } if name == "value" && op == "%="
+    ));
+}
+
+#[test]
 fn test_fixed_width_const_expression_uses_module_integer_constants() {
     let module = lower_source(
         "BASE: int = 250 + 4\n\ndef main() -> uint8:\n    value: uint8 = BASE + 1\n    return value\n",

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -418,6 +418,7 @@ Validation:
 - [x] INT-1 proven exact-int floor/modulo literal-divisor codegen review satisfied with non-blocking naming and coverage hardening notes: `reviews/integer-model-int-1-proven-floor-mod-codegen-review-pass-1.md`.
 - [x] INT-1 proven exact-int floor/modulo augmented-assignment review satisfied with no blockers: `reviews/integer-model-int-1-proven-floor-mod-augassign-review-pass-1.md`.
 - [x] INT-1 exact-int division/modulo diagnostic scaffold review satisfied with non-blocking direct `//=` literal coverage follow-up: `reviews/integer-model-int-1-exact-int-division-diagnostic-scaffold-review-pass-1.md`.
+- [x] INT-1 exact-int augmented-assignment literal suppression coverage review satisfied with no blockers: `reviews/integer-model-int-1-exact-int-augassign-literal-coverage-review-pass-1.md`.
 - [x] INT-2A reserved-width diagnostic review pass 1 completed with doc-code normalization blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-1.md`.
 - [x] INT-2A reserved-width diagnostic review pass 2 satisfied after addressing blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-2b.md`.
 - [x] INT-2A large integer literal HIR review pass 1 completed with canonical-representation blocker: `reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md`.
@@ -470,6 +471,7 @@ Validation:
   - [x] `SifrInt`-shaped `//` and `%` expressions with syntactically non-zero integer literal divisors now lower through compiler-proven non-zero floor division/modulo runtime helpers, preserving oversized exact-int module constants, unary receivers, and derived local values without `i64` fallback; review is satisfied and quick validation is passing: PR #1855.
   - [x] `SifrInt`-shaped `//=` and `%=` augmented assignments with syntactically non-zero integer literal right-hand sides now rewrite to plain assignments through compiler-proven non-zero floor division/modulo runtime helpers, preserving promoted exact-int locals without Rust `/=` or `%=` fallback; review is satisfied and quick validation is passing: PR #1856.
   - [x] User-code exact-int `//`, `%`, `//=`, and `%=` with unproven exact-int divisors now fail closed with active `SIFR-INT-0005` diagnostics unless the divisor is a syntactically non-zero integer literal; trusted stdlib lowering remains exempt until broader guard/proof tracking covers its internal non-zero loops; review is satisfied and quick validation is passing: PR #1857.
+  - [x] Direct HIR coverage now proves exact-int `//=` and `%=` with syntactically non-zero integer literal divisors still lower successfully, closing the scaffold review hardening note; review is satisfied and quick validation is passing: PR #1858.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: full `Result[int, DivisionError]` expression/codegen integration and non-literal proven-nonzero analysis still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-augassign-literal-coverage-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-augassign-literal-coverage-review-pass-1.md
@@ -1,0 +1,21 @@
+# Review: INT-1 exact-int augassign literal coverage PR #1858
+
+## Verdict
+APPROVED
+
+## Blocking Findings
+none
+
+## Non-Blocking Findings
+none
+
+## Validation Notes
+Single-test follow-up PR. Validation suite is appropriate:
+- `cargo fmt --check` — style pass.
+- `cargo test -p sifr_hir exact_int_augassign -- --nocapture` — targeted unit test covering the new suppression path.
+- `scripts/run_all_tests.sh --profile quick` — full quick profile, same signature as parent PR.
+
+The suppression path being tested (`//=` and `%=` with syntactically non-zero integer literals) is exercised directly. The negative counterparts (`//=`/`%=` with an unproven variable divisor) already have coverage in `test_exact_int_mod_augassign_by_unproven_divisor_has_int0005` (lines 331–345) from PR #1857. Together the two tests form a complete positive/negative pair for augassign divisors.
+
+## Residual Risks
+Acceptable. This is a narrow hardening PR with a single test that closes a non-blocking reviewer note. The risk of regression is minimal — the test is inline in `expressions_tests.rs` and the suppression logic in `lower_augassign_expr` is exercised by multiple existing tests.


### PR DESCRIPTION
## Summary
- add direct HIR coverage proving exact-int //= and %= with syntactically non-zero literal divisors continue to lower instead of emitting SIFR-INT-0005
- closes the non-blocking reviewer note from PR #1857

## Validation
- cargo fmt --check
- cargo test -p sifr_hir exact_int_augassign -- --nocapture
- scripts/run_all_tests.sh --profile quick (report_signature=e1bf653aaa770517, wall_time=83.46s)
