### PR TITLE
Promote fitting fixed-width scalar arithmetic

### DIFF
--- a/crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
+++ b/crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
@@ -1,0 +1,9 @@
+def main() -> None:
+    left: int32 = 2_000_000_000
+    right: int32 = 2_000_000_000
+    total: int = left + right
+    diff: int = right - left
+    product: int = 2 * right
+    assert str(total) == "4000000000"
+    assert str(diff) == "0"
+    assert str(product) == "4000000000"

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -2,7 +2,7 @@
 
 use crate::{CodegenError, RustExpr, RustLiteral, RustParam, RustStmt, RustType};
 use sifr_hir::{HirExpr, HirFStringPart, HirIteratorOp, HirParam};
-use sifr_type_system::Type;
+use sifr_type_system::{FixedIntType, Type};
 use std::cell::RefCell;
 
 thread_local! {
@@ -209,6 +209,13 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
                     left: Box::new(try_lower_mixed_float_operand_expr(left)?),
                     op: normalize_binop_op(op).to_string(),
                     right: Box::new(try_lower_mixed_float_operand_expr(right)?),
+                });
+            }
+            if is_promoted_fixed_width_integer_binop(op, left.ty(), right.ty(), ty) {
+                return Some(RustExpr::BinOp {
+                    left: Box::new(try_lower_promoted_integer_operand_expr(left)?),
+                    op: normalize_binop_op(op).to_string(),
+                    right: Box::new(try_lower_promoted_integer_operand_expr(right)?),
                 });
             }
             Some(RustExpr::BinOp {
@@ -1340,6 +1347,17 @@ fn is_int_like_simple(ty: &Type) -> bool {
     matches!(normalize_simple_numeric_scalar_type(ty), Some("int"))
 }
 
+fn is_fixed_width_int_like_simple(ty: &Type) -> bool {
+    matches!(
+        resolve_alias_type(ty),
+        Type::FixedInt(fixed) if fixed_width_promotes_to_current_int(*fixed)
+    )
+}
+
+fn fixed_width_promotes_to_current_int(fixed: FixedIntType) -> bool {
+    !matches!(fixed, FixedIntType::U64 | FixedIntType::USize)
+}
+
 fn is_float_like_simple(ty: &Type) -> bool {
     matches!(normalize_simple_numeric_scalar_type(ty), Some("float"))
 }
@@ -1464,6 +1482,19 @@ fn is_simple_int_true_division_binop(
         && is_int_like_simple(right_ty)
 }
 
+fn is_promoted_fixed_width_integer_binop(
+    op: &str,
+    left_ty: &Type,
+    right_ty: &Type,
+    result_ty: &Type,
+) -> bool {
+    matches!(op, "+" | "-" | "*")
+        && is_int_like_simple(result_ty)
+        && (is_fixed_width_int_like_simple(left_ty) || is_fixed_width_int_like_simple(right_ty))
+        && (is_int_like_simple(left_ty) || is_fixed_width_int_like_simple(left_ty))
+        && (is_int_like_simple(right_ty) || is_fixed_width_int_like_simple(right_ty))
+}
+
 fn is_safe_simple_compare(op: &str, left_ty: &Type, right_ty: &Type) -> bool {
     if !matches!(op, "==" | "!=" | "<" | "<=" | ">" | ">=") {
         return false;
@@ -1503,6 +1534,9 @@ fn is_safe_simple_binop(op: &str, left_ty: &Type, right_ty: &Type, result_ty: &T
     if matches!(op, "+" | "-" | "*" | "%")
         && is_mixed_simple_float_binop(op, left_ty, right_ty, result_ty)
     {
+        return true;
+    }
+    if is_promoted_fixed_width_integer_binop(op, left_ty, right_ty, result_ty) {
         return true;
     }
     if matches!(op, "&" | "|" | "^" | "<<" | ">>") {
@@ -1668,6 +1702,24 @@ fn try_lower_mixed_float_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
         return Some(RustExpr::Cast {
             expr: Box::new(lowered),
             ty: RustType::F64,
+        });
+    }
+    Some(lowered)
+}
+
+fn try_lower_promoted_integer_operand_expr(expr: &HirExpr) -> Option<RustExpr> {
+    let lowered = match expr {
+        HirExpr::Name { name, ty }
+            if is_int_like_simple(ty) || is_fixed_width_int_like_simple(ty) =>
+        {
+            RustExpr::Ident(name.clone())
+        }
+        _ => try_lower_simple_binop_operand_expr(expr)?,
+    };
+    if is_fixed_width_int_like_simple(expr.ty()) {
+        return Some(RustExpr::Cast {
+            expr: Box::new(lowered),
+            ty: RustType::I64,
         });
     }
     Some(lowered)

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -501,6 +501,34 @@ def main():
 }
 
 #[test]
+fn test_fixed_width_scalar_add_sub_mul_promote_to_int() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    left: int32 = 2
+    right: int32 = 3
+    total: int = left + right
+    diff: int = left - 1
+    product: int = 2 * right
+",
+    )
+    .expect("ordinary fixed-width scalar arithmetic should promote to int");
+
+    assert!(matches!(
+        function_let_value(&module, "total"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
+    assert!(matches!(
+        function_let_value(&module, "diff"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
+    assert!(matches!(
+        function_let_value(&module, "product"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
+}
+
+#[test]
 fn test_fixed_width_const_expression_out_of_range_has_int_code() {
     let source = "def main():\n    too_wide: uint8 = 2 ** 8\n";
     let errors =

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -1,6 +1,6 @@
 //! Type checking rules for Sifr operators and expressions.
 
-use crate::types::Type;
+use crate::types::{FixedIntType, Type};
 use crate::union::{remove_none_from_union, union_contains_none};
 use sifr_diagnostics::DiagnosticCode;
 
@@ -20,6 +20,15 @@ fn is_decimal_family_type(ty: &Type) -> bool {
 
 fn is_integral_numeric_type(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::LiteralInt(_) | Type::BigInt)
+}
+
+fn is_exact_or_fixed_integer_type(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::LiteralInt(_))
+        || matches!(ty, Type::FixedInt(fixed) if fixed_width_promotes_to_current_int(*fixed))
+}
+
+fn fixed_width_promotes_to_current_int(fixed: FixedIntType) -> bool {
+    !matches!(fixed, FixedIntType::U64 | FixedIntType::USize)
 }
 
 /// Type-check a binary operation (e.g., `a + b`, `a - b`).
@@ -95,6 +104,9 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> TypeCheckRes
             if left == &Type::Int && right == &Type::Int {
                 return Ok(Type::Int);
             }
+            if is_exact_or_fixed_integer_type(left) && is_exact_or_fixed_integer_type(right) {
+                return Ok(Type::Int);
+            }
             if left.is_numeric() && right.is_numeric() {
                 return Ok(Type::Float);
             }
@@ -144,6 +156,9 @@ pub fn type_check_binary_op(left: &Type, op: &str, right: &Type) -> TypeCheckRes
                 return Ok(Type::BigInt);
             }
             if left == &Type::Int && right == &Type::Int {
+                return Ok(Type::Int);
+            }
+            if is_exact_or_fixed_integer_type(left) && is_exact_or_fixed_integer_type(right) {
                 return Ok(Type::Int);
             }
             if left.is_numeric() && right.is_numeric() {
@@ -618,6 +633,32 @@ mod tests {
             type_check_binary_op(&Type::Float, "*", &Type::Int).unwrap(),
             Type::Float
         );
+    }
+
+    #[test]
+    fn test_fixed_width_integer_add_sub_mul_promote_to_int() {
+        let i32_ty = Type::FixedInt(crate::FixedIntType::I32);
+        let u8_ty = Type::FixedInt(crate::FixedIntType::U8);
+
+        assert_eq!(
+            type_check_binary_op(&i32_ty, "+", &i32_ty).unwrap(),
+            Type::Int
+        );
+        assert_eq!(
+            type_check_binary_op(&u8_ty, "-", &Type::Int).unwrap(),
+            Type::Int
+        );
+        assert_eq!(
+            type_check_binary_op(&Type::LiteralInt(2), "*", &u8_ty).unwrap(),
+            Type::Int
+        );
+    }
+
+    #[test]
+    fn test_uint64_integer_add_waits_for_sifrint_promotion() {
+        let u64_ty = Type::FixedInt(crate::FixedIntType::U64);
+
+        assert!(type_check_binary_op(&u64_ty, "+", &u64_ty).is_err());
     }
 
     #[test]

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -443,6 +443,7 @@ Validation:
 - [x] INT-2B fixed-width fail fixture marker cleanup review satisfied: `reviews/integer-model-int-2b-fixed-width-fail-fixture-markers-review-pass-1.md`.
 - [x] INT-2B module const/fixed-width fallback cleanup review pass 4 satisfied after addressing pass 2 and pass 3 blockers: `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md`.
 - [x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`.
+- [x] INT-3 fitting fixed-width scalar `+`/`-`/`*` promotion review satisfied with no blockers and non-blocking broader-width coverage follow-up: `reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -496,6 +497,9 @@ Validation:
   - [x] Fixed-width const-expression fail fixture markers are canonical top-level `expect-error` entries, so the e2e fail harness now enforces `SIFR-INT-0001` and `SIFR-INT-0004` columns; review is satisfied and quick validation is passing: PR #1812.
   - [x] Module constant integer fallback paths now preserve budget diagnostics for over-budget module `int`/fixed-width constants, support same-module `int` const reuse through names/unary/binops, reject mixed fixed-width-to-`int` const reuse before codegen, and smoke-test the new codegen shapes; review is satisfied and quick validation is passing: PR #1814.
 - [ ] INT-3 scalar arithmetic and numeric mixing
+  - [x] Ordinary fixed-width scalar `+`, `-`, and `*` now promote fitting fixed-width operands to source-level `int` and cast operands before generated Rust arithmetic, preserving `int32(2_000_000_000) + int32(2_000_000_000) -> int`; review is satisfied and quick validation is passing: PR #1860.
+  - [ ] Expand fixed-width scalar promotion coverage across `int8`, `int16`, `int64`, `uint16`, `uint32`, and `isize` before closing INT-3.
+  - [ ] Deduplicate the temporary `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands.
   - [ ] Add hardening tests that keep implicit `int`-to-fixed-width narrowing rejected in returns, list literals, dict literals, and generic specialization as scalar arithmetic and numeric mixing evolve.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries

--- a/reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md
+++ b/reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md
@@ -1,0 +1,101 @@
+# Review: INT-3 Fixed-Width Scalar Promotion (PR #1860)
+
+## 1. Verdict: APPROVED
+
+The PR correctly implements the conservative first INT-3 slice for ordinary fixed-width scalar `+`, `-`, and `*` promotion to source-level `int`. The implementation is sound, tests pass, and the design intent is followed.
+
+---
+
+## 2. Blocking Findings
+
+**None.** No blocking issues found.
+
+---
+
+## 3. Non-Blocking Follow-ups
+
+### 3.1 Test coverage gap for non-int32 fixed-width types
+
+The e2e pass fixture (`fixed_width_scalar_arithmetic_promotion.sifr`) and HIR lowering test (`test_fixed_width_scalar_add_sub_mul_promote_to_int`) only exercise `int32`. The type system test (`test_fixed_width_integer_add_sub_mul_promote_to_int`) covers `int32` and `uint8`.
+
+The implementation logic in `fixed_width_promotes_to_current_int` correctly includes all fixed-width families except `U64` and `USize`:
+- **Included**: `I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `ISize`
+- **Excluded**: `U64`, `USize` (per design: "uint64, usize ... remain later INT-3 work")
+
+**Gap**: No explicit positive test coverage for `int64`, `int16`, `int8`, `uint16`, `uint32`, or `isize` arithmetic promotion. Recommend adding a broader e2e pass fixture or expanding the existing one to cover all promoted fixed-width families before closing INT-3.
+
+**Files affected**:
+- `crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr`
+- `crates/sifr_hir/src/lower/expressions_tests.rs:504`
+- `crates/sifr_type_system/src/check.rs:639`
+
+### 3.2 Duplicate `fixed_width_promotes_to_current_int` function
+
+The same `fixed_width_promotes_to_current_int` logic appears in two crates:
+
+- `crates/sifr_type_system/src/check.rs:28` — type-system-level check
+- `crates/sifr_codegen/src/lower_expr.rs:1352` — codegen-level check
+
+Both return `!matches!(fixed, FixedIntType::U64 | FixedIntType::USize)` with identical semantics. This duplication is acceptable for now since the crates are separate and the logic is simple, but it creates a maintenance risk: if a new fixed-width type is added to `FixedIntType`, both copies must be updated in sync. Consider extracting to a shared constant or a minimal shared-types crate before INT-3 closure.
+
+### 3.3 Pre-existing clippy warnings unrelated to this PR
+
+`cargo clippy -p sifr_hir -- -D warnings` produces two errors in `crates/sifr_hir/src/lower/integer_nonzero_guards.rs` (lines 26 and 82). These exist on the base branch and are not introduced by this PR. They are mentioned here for awareness only and do not block this PR.
+
+---
+
+## 4. Validation Notes
+
+### 4.1 Local validation
+
+```bash
+scripts/run_all_tests.sh --profile quick
+```
+
+**Result**: All tests pass. Quick profile completed in ~54s with 24 e2e pass tests, 2 type system tests, and 14 HIR tests.
+
+### 4.2 Type system logic
+
+`is_exact_or_fixed_integer_type` in `check.rs:23` correctly identifies `Int`, `LiteralInt`, and all fixed-width types except `U64` and `USize` as promoting to `int`. The `type_check_binary_op` modifications for `+`, `-`, `*` return `Type::Int` when both operands satisfy this predicate. Logic is sound.
+
+### 4.3 Codegen logic
+
+`is_promoted_fixed_width_integer_binop` in `lower_expr.rs:1482` correctly detects `+`, `-`, `*` between int and promoted fixed-width types. `try_lower_promoted_integer_operand_expr` in `lower_expr.rs:1710` casts fixed-width operands to `RustType::I64` before the operation.
+
+Generated output for the pass fixture:
+```rust
+let left: i32 = 2000000000i32;
+let right: i32 = 2000000000i32;
+let total: i64 = (left as i64) + (right as i64);
+let diff: i64 = (right as i64) - (left as i64);
+let product: i64 = (2 as i64) * (right as i64);
+```
+
+This is consistent with the conservative slice: `int` is represented as `i64` in codegen, and fixed-width operands are explicitly cast before the operation.
+
+### 4.4 Excluded types
+
+`U64` and `USize` are correctly excluded from promotion. The type system test `test_uint64_integer_add_waits_for_sifrint_promotion` confirms `U64 + U64` produces an error. This matches the review scope: "uint64, usize ... remain later INT-3 work."
+
+### 4.5 Design consistency
+
+The implementation follows `internal_docs/integer_model.md`:
+
+- "Ordinary fixed-width scalar arithmetic promotes to exact `int`" — `int32 + int32 -> int` ✓
+- "`uint64`, `usize` remain later INT-3 work" — both are excluded ✓
+- "It intentionally only handles fixed-width integer families that are losslessly representable by the current generated int backend" — `i64` can represent all promoted fixed-width types except `U64` ✓
+
+---
+
+## 5. Summary
+
+| Area | Assessment |
+|------|-----------|
+| Correctness | ✓ Type rules and codegen lowering are correct |
+| Codegen soundness | ✓ Fixed-width operands cast to i64 before `+`, `-`, `*`; result type is `i64` which maps to `int` |
+| Test coverage | Partial — only int32/uint8 explicitly tested; other fixed-width types logically covered but not directly tested |
+| Design consistency | ✓ Follows the conservative first-slice intent |
+| Excluded types (U64, USize) | ✓ Correctly excluded per review scope |
+| Pre-existing issues | Clippy warnings in `integer_nonzero_guards.rs` are unrelated to this PR |
+
+**Recommendation**: Approve for merge. Address the non-blocking test coverage gap (3.1) before closing INT-3.


### PR DESCRIPTION
## Summary
- Promote ordinary fitting fixed-width scalar +, -, and * operations to source-level int in type checking and HIR.
- Lower promoted fixed-width operands with pre-operation i64 casts so generated Rust does not overflow in the original fixed-width representation.
- Add unit and e2e coverage for int32 overflow-past-int32 arithmetic and keep uint64/usize promotion blocked until the broader SifrInt backend path exists.

## Scope
This is the first conservative INT-3 scalar arithmetic slice. It only covers fixed-width integer families that are losslessly representable by the current generated int backend. uint64, usize, //, %, **, decimal/fixed mixing, and fallible arithmetic semantics remain follow-up INT-3 work.

## Validation
- cargo test -p sifr_type_system fixed_width_integer_add_sub_mul -- --nocapture
- cargo test -p sifr_type_system uint64_integer_add -- --nocapture
- cargo test -p sifr_hir fixed_width_scalar_add_sub_mul -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile quick (wall_time=66.31s, report_signature=e1bf653aaa770517)