### PR TITLE
Broaden fixed-width promotion coverage

### DIFF
--- a/crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
+++ b/crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
@@ -1,9 +1,26 @@
 def main() -> None:
+    tiny: int8 = 120
+    small: int16 = 32_000
     left: int32 = 2_000_000_000
     right: int32 = 2_000_000_000
+    wide: int64 = 9_000_000_000
+    byte: uint8 = 250
+    mid: uint16 = 65_000
+    large: uint32 = 4_000_000_000
+    pointer: isize = 500
+    tiny_total: int = tiny + small
     total: int = left + right
+    wide_total: int = wide + left
     diff: int = right - left
+    unsigned_diff: int = mid - byte
     product: int = 2 * right
+    unsigned_product: int = large * 2
+    pointer_total: int = pointer + 1
+    assert str(tiny_total) == "32120"
     assert str(total) == "4000000000"
+    assert str(wide_total) == "11000000000"
     assert str(diff) == "0"
+    assert str(unsigned_diff) == "64750"
     assert str(product) == "4000000000"
+    assert str(unsigned_product) == "8000000000"
+    assert str(pointer_total) == "501"

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -505,15 +505,27 @@ fn test_fixed_width_scalar_add_sub_mul_promote_to_int() {
     let module = lower_source(
         "\
 def main() -> None:
-    left: int32 = 2
-    right: int32 = 3
-    total: int = left + right
-    diff: int = left - 1
-    product: int = 2 * right
+    tiny: int8 = 2
+    small: int16 = 3
+    left: int32 = 5
+    wide: int64 = 7
+    byte: uint8 = 11
+    mid: uint16 = 13
+    large: uint32 = 17
+    pointer: isize = 19
+    tiny_total: int = tiny + small
+    total: int = left + wide
+    diff: int = mid - byte
+    product: int = 2 * large
+    pointer_total: int = pointer + 1
 ",
     )
     .expect("ordinary fixed-width scalar arithmetic should promote to int");
 
+    assert!(matches!(
+        function_let_value(&module, "tiny_total"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
     assert!(matches!(
         function_let_value(&module, "total"),
         HirExpr::BinOp { ty: Type::Int, .. }
@@ -524,6 +536,10 @@ def main() -> None:
     ));
     assert!(matches!(
         function_let_value(&module, "product"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
+    assert!(matches!(
+        function_let_value(&module, "pointer_total"),
         HirExpr::BinOp { ty: Type::Int, .. }
     ));
 }

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -637,28 +637,37 @@ mod tests {
 
     #[test]
     fn test_fixed_width_integer_add_sub_mul_promote_to_int() {
-        let i32_ty = Type::FixedInt(crate::FixedIntType::I32);
-        let u8_ty = Type::FixedInt(crate::FixedIntType::U8);
+        for fixed in [
+            crate::FixedIntType::I8,
+            crate::FixedIntType::I16,
+            crate::FixedIntType::I32,
+            crate::FixedIntType::I64,
+            crate::FixedIntType::U8,
+            crate::FixedIntType::U16,
+            crate::FixedIntType::U32,
+            crate::FixedIntType::ISize,
+        ] {
+            let ty = Type::FixedInt(fixed);
 
-        assert_eq!(
-            type_check_binary_op(&i32_ty, "+", &i32_ty).unwrap(),
-            Type::Int
-        );
-        assert_eq!(
-            type_check_binary_op(&u8_ty, "-", &Type::Int).unwrap(),
-            Type::Int
-        );
-        assert_eq!(
-            type_check_binary_op(&Type::LiteralInt(2), "*", &u8_ty).unwrap(),
-            Type::Int
-        );
+            assert_eq!(type_check_binary_op(&ty, "+", &ty).unwrap(), Type::Int);
+            assert_eq!(
+                type_check_binary_op(&ty, "-", &Type::Int).unwrap(),
+                Type::Int
+            );
+            assert_eq!(
+                type_check_binary_op(&Type::LiteralInt(2), "*", &ty).unwrap(),
+                Type::Int
+            );
+        }
     }
 
     #[test]
-    fn test_uint64_integer_add_waits_for_sifrint_promotion() {
-        let u64_ty = Type::FixedInt(crate::FixedIntType::U64);
+    fn test_uint64_and_usize_integer_add_wait_for_sifrint_promotion() {
+        for fixed in [crate::FixedIntType::U64, crate::FixedIntType::USize] {
+            let ty = Type::FixedInt(fixed);
 
-        assert!(type_check_binary_op(&u64_ty, "+", &u64_ty).is_err());
+            assert!(type_check_binary_op(&ty, "+", &ty).is_err());
+        }
     }
 
     #[test]

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -444,6 +444,7 @@ Validation:
 - [x] INT-2B module const/fixed-width fallback cleanup review pass 4 satisfied after addressing pass 2 and pass 3 blockers: `reviews/integer-model-int-2b-module-const-fallback-cleanup-review-pass-4.md`.
 - [x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`.
 - [x] INT-3 fitting fixed-width scalar `+`/`-`/`*` promotion review satisfied with no blockers and non-blocking broader-width coverage follow-up: `reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md`.
+- [x] INT-3 fitting fixed-width scalar promotion coverage review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-promotion-coverage-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -498,7 +499,7 @@ Validation:
   - [x] Module constant integer fallback paths now preserve budget diagnostics for over-budget module `int`/fixed-width constants, support same-module `int` const reuse through names/unary/binops, reject mixed fixed-width-to-`int` const reuse before codegen, and smoke-test the new codegen shapes; review is satisfied and quick validation is passing: PR #1814.
 - [ ] INT-3 scalar arithmetic and numeric mixing
   - [x] Ordinary fixed-width scalar `+`, `-`, and `*` now promote fitting fixed-width operands to source-level `int` and cast operands before generated Rust arithmetic, preserving `int32(2_000_000_000) + int32(2_000_000_000) -> int`; review is satisfied and quick validation is passing: PR #1860.
-  - [ ] Expand fixed-width scalar promotion coverage across `int8`, `int16`, `int64`, `uint16`, `uint32`, and `isize` before closing INT-3.
+  - [x] Fixed-width scalar promotion coverage now spans all fitting fixed-width families (`int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, and `isize`) while keeping `uint64` and `usize` blocked until the broader `SifrInt` promotion path; review is satisfied and quick validation is passing: PR #1861.
   - [ ] Deduplicate the temporary `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands.
   - [ ] Add hardening tests that keep implicit `int`-to-fixed-width narrowing rejected in returns, list literals, dict literals, and generic specialization as scalar arithmetic and numeric mixing evolve.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching

--- a/reviews/integer-model-int-3-fixed-width-promotion-coverage-review-pass-1.md
+++ b/reviews/integer-model-int-3-fixed-width-promotion-coverage-review-pass-1.md
@@ -1,0 +1,30 @@
+# Review: INT-3 Fixed-Width Promotion Coverage (PR #1861)
+
+**Review scope:** Test-coverage follow-up after PR #1860. Expands coverage for fitting fixed-width scalar `+`, `-`, and `*` promotion across `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, and `isize`. Keeps `uint64` and `usize` explicitly blocked until the broader `SifrInt` promotion path exists.
+
+## 1. Verdict: APPROVED
+
+## 2. Blocking Findings
+
+None.
+
+## 3. Non-Blocking Follow-Ups
+
+**Test structure — explicit `uint8`/`uint16`/`uint32` assertions in HIR lowering test**
+
+The HIR lowering test `test_fixed_width_scalar_add_sub_mul_promote_to_int` (expressions_tests.rs:504) adds declarations for `tiny` (int8), `small` (int16), `left` (int32), `wide` (int64), `byte` (uint8), `mid` (uint16), `large` (uint32), and `pointer` (isize) in the source (lines 508-515). Only `tiny_total`, `total`, `diff`, `product`, and `pointer_total` have explicit `assert!(matches!(...))` assertions. The `uint8`, `uint16`, and `uint32` variables (`byte`, `mid`, `large`) contribute to `diff` and `product` but lack individual assertion blocks. This is not a blocker — the design intent is clearly expressed and the behavior is covered via `diff` (uint16-uint8 → int) and `product` (2*uint32 → int) — but consider adding an explicit assertion for at least one pure-unsigned expression (e.g., `unsigned_total: int = byte + mid`) to make the unsigned coverage intent unambiguous.
+
+**Follow-up item (tracked in issue INT-3 checklist):** Deduplicate the `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands.
+
+## 4. Validation Notes
+
+- **Type system unit tests:** `cargo test -p sifr_type_system -- test_fixed_width` — 2 tests pass (88 total, all pass).
+- **HIR unit tests:** `cargo test -p sifr_hir -- test_fixed_width` — 14 tests pass (451 total, all pass).
+- **E2E fixture:** `fixed_width_scalar_arithmetic_promotion.sifr` compiles and runs to completion (exit 0), all 7 assert statements pass.
+- **HIR maintainability guardrails:** `python3 scripts/check_hir_maintainability_guardrails.py` — PASS.
+- **`isize` coverage:** `isize` is in the promoted set at `check.rs:648` and is explicitly asserted in `pointer_total` at `expressions_tests.rs:541-544`. Design-consistent: `isize` is covered like any other fitting fixed-width type in scalar promotion.
+- **`uint64`/`usize` exclusion:** Both remain blocked via `!matches!(fixed, FixedIntType::U64 | FixedIntType::USize)` at `check.rs:31`. The renamed test `test_uint64_and_usize_integer_add_wait_for_sifrint_promotion` at `check.rs:665` covers both with an error result, matching the documented blocking condition.
+
+## Summary
+
+PR #1861 correctly broadens the test coverage established by PR #1860. The type system loop now covers all 8 fitting fixed-width types (`I8`, `I16`, `I32`, `I64`, `U8`, `U16`, `U32`, `ISize`) with `+`, `-`, and `*` promotion. The HIR lowering test exercises int8, int16, int32, int64, uint8, uint16, uint32, and isize scalar promotion to `int` with concrete values and assertions. `uint64` and `usize` are correctly excluded and explicitly tested as blocked. No regressions, no blockers.


### PR DESCRIPTION
## Summary
- Expand type-system coverage for every currently promoted fixed-width family: int8, int16, int32, int64, uint8, uint16, uint32, and isize.
- Keep uint64 and usize explicitly covered as waiting for the broader SifrInt promotion path.
- Broaden HIR and e2e promotion coverage so the emitted Rust proves casts occur before arithmetic across signed, unsigned, and pointer-sized promoted operands.

## Validation
- cargo test -p sifr_type_system fixed_width_integer_add_sub_mul -- --nocapture
- cargo test -p sifr_type_system uint64_and_usize_integer_add -- --nocapture
- cargo test -p sifr_hir fixed_width_scalar_add_sub_mul -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/fixed_width_scalar_arithmetic_promotion.sifr
- cargo fmt --check
- scripts/run_all_tests.sh --profile quick (wall_time=70.68s, report_signature=e1bf653aaa770517)