### PR TITLE
Harden fixed-width promotion narrowing boundaries

### DIFF
--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -783,6 +783,99 @@ fn test_fixed_width_call_argument_literal_is_not_implicitly_narrowed() {
 }
 
 #[test]
+fn test_promoted_fixed_width_result_is_not_implicitly_narrowed_in_return() {
+    let source = "\
+def add(left: uint8, right: uint8) -> uint8:
+    return left + right
+";
+    let errors =
+        lower_source(source).expect_err("promoted fixed-width return narrowing should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.message == "return type mismatch: expected 'uint8', got 'int'"
+            && error.primary_range
+                == Some(range_for_after_anchor(source, "return ", "left + right"))
+    }));
+}
+
+#[test]
+fn test_promoted_fixed_width_result_is_not_implicitly_narrowed_in_list_literal() {
+    let source = "\
+def main() -> None:
+    left: uint8 = 1
+    right: uint8 = 2
+    values: list[uint8] = [left + right]
+";
+    let errors = lower_source(source).expect_err("promoted fixed-width list narrowing should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.message == "type mismatch: expected 'list[uint8]', got 'list[int]'"
+            && error.primary_range
+                == Some(range_for_after_anchor(
+                    source,
+                    "values: list[uint8] = ",
+                    "[left + right]",
+                ))
+    }));
+}
+
+#[test]
+fn test_promoted_fixed_width_result_is_not_implicitly_narrowed_in_dict_literal() {
+    let source = "\
+def main() -> None:
+    left: uint8 = 1
+    right: uint8 = 2
+    values: dict[str, uint8] = {\"sum\": left + right}
+";
+    let errors = lower_source(source).expect_err("promoted fixed-width dict narrowing should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error.message == "type mismatch: expected 'dict[str, uint8]', got 'dict[str, int]'"
+            && error.primary_range
+                == Some(range_for_after_anchor(
+                    source,
+                    "values: dict[str, uint8] = ",
+                    "{\"sum\": left + right}",
+                ))
+    }));
+}
+
+#[test]
+fn test_promoted_fixed_width_result_is_not_implicitly_narrowed_in_generic_specialization() {
+    let source = "\
+class Box[T]:
+    value: T
+
+    def __init__(self, value: T):
+        self.value = value
+
+def main() -> None:
+    left: uint8 = 1
+    right: uint8 = 2
+    box: Box[uint8] = Box(left + right)
+";
+    let errors =
+        lower_source(source).expect_err("promoted fixed-width generic narrowing should fail");
+
+    assert!(
+        errors.iter().any(|error| {
+            error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+                && error.message == "type mismatch: expected 'Box', got 'Box'"
+                && error.primary_range
+                    == Some(range_for_after_anchor(
+                        source,
+                        "box: Box[uint8] = ",
+                        "Box(left + right)",
+                    ))
+        }),
+        "{errors:?}"
+    );
+}
+
+#[test]
 fn test_reassignment_type_mismatch_has_primary_range() {
     let source = "def main():\n    value = 1\n    value = \"not an int\"\n";
     let result = lower_source(source);

--- a/crates/sifr_hir/src/lower/fixed_width_class_payload.rs
+++ b/crates/sifr_hir/src/lower/fixed_width_class_payload.rs
@@ -1,0 +1,137 @@
+use sifr_type_system::Type;
+
+fn type_mentions_class(ty: &Type, class_name: &str) -> bool {
+    match ty.resolve_alias() {
+        Type::Class { name, fields, .. } => {
+            name == class_name
+                || fields
+                    .iter()
+                    .any(|(_, field_ty)| type_mentions_class(field_ty, class_name))
+        }
+        Type::List(elem)
+        | Type::Set(elem)
+        | Type::Iterable(elem)
+        | Type::Iterator(elem)
+        | Type::Alias { body: elem, .. }
+        | Type::Newtype { inner: elem, .. } => type_mentions_class(elem, class_name),
+        Type::Dict(key, value) | Type::Result(key, value) => {
+            type_mentions_class(key, class_name) || type_mentions_class(value, class_name)
+        }
+        Type::Tuple(elems) | Type::Union(elems) | Type::Intersection(elems) => elems
+            .iter()
+            .any(|elem| type_mentions_class(elem, class_name)),
+        Type::Callable(params, _, ret) => {
+            params
+                .iter()
+                .any(|param| type_mentions_class(param, class_name))
+                || type_mentions_class(ret, class_name)
+        }
+        Type::Function(ft) => {
+            ft.params
+                .iter()
+                .any(|(_, param_ty, _)| type_mentions_class(param_ty, class_name))
+                || type_mentions_class(&ft.return_type, class_name)
+        }
+        Type::Protocol { methods, .. } => methods.iter().any(|(_, ft)| {
+            ft.params
+                .iter()
+                .any(|(_, param_ty, _)| type_mentions_class(param_ty, class_name))
+                || type_mentions_class(&ft.return_type, class_name)
+        }),
+        _ => false,
+    }
+}
+
+fn type_contains_fixed_width(ty: &Type) -> bool {
+    match ty.resolve_alias() {
+        Type::FixedInt(_) => true,
+        Type::Class {
+            fields, methods, ..
+        } => {
+            fields
+                .iter()
+                .any(|(_, field_ty)| type_contains_fixed_width(field_ty))
+                || methods.iter().any(|(_, ft)| {
+                    ft.params
+                        .iter()
+                        .any(|(_, param_ty, _)| type_contains_fixed_width(param_ty))
+                        || type_contains_fixed_width(&ft.return_type)
+                })
+        }
+        Type::List(elem)
+        | Type::Set(elem)
+        | Type::Iterable(elem)
+        | Type::Iterator(elem)
+        | Type::Alias { body: elem, .. }
+        | Type::Newtype { inner: elem, .. } => type_contains_fixed_width(elem),
+        Type::Dict(key, value) | Type::Result(key, value) => {
+            type_contains_fixed_width(key) || type_contains_fixed_width(value)
+        }
+        Type::Tuple(elems) | Type::Union(elems) | Type::Intersection(elems) => {
+            elems.iter().any(type_contains_fixed_width)
+        }
+        Type::Callable(params, _, ret) => {
+            params.iter().any(type_contains_fixed_width) || type_contains_fixed_width(ret)
+        }
+        Type::Function(ft) => {
+            ft.params
+                .iter()
+                .any(|(_, param_ty, _)| type_contains_fixed_width(param_ty))
+                || type_contains_fixed_width(&ft.return_type)
+        }
+        Type::Protocol { methods, .. } => methods.iter().any(|(_, ft)| {
+            ft.params
+                .iter()
+                .any(|(_, param_ty, _)| type_contains_fixed_width(param_ty))
+                || type_contains_fixed_width(&ft.return_type)
+        }),
+        _ => false,
+    }
+}
+
+fn class_payload_contains_fixed_width(fields: &[(String, Type)]) -> bool {
+    fields
+        .iter()
+        .any(|(_, field_ty)| type_contains_fixed_width(field_ty))
+}
+
+pub(super) fn class_specialization_payload_conflicts(source: &Type, target: &Type) -> bool {
+    let (
+        Type::Class {
+            name: source_name,
+            fields: source_fields,
+            ..
+        },
+        Type::Class {
+            name: target_name,
+            fields: target_fields,
+            ..
+        },
+    ) = (source.resolve_alias(), target.resolve_alias())
+    else {
+        return false;
+    };
+    if source_name != target_name || source_fields.len() != target_fields.len() {
+        return false;
+    }
+    if source_fields
+        .iter()
+        .any(|(_, field_ty)| type_mentions_class(field_ty, source_name))
+        || target_fields
+            .iter()
+            .any(|(_, field_ty)| type_mentions_class(field_ty, target_name))
+    {
+        return false;
+    }
+    if !class_payload_contains_fixed_width(source_fields)
+        && !class_payload_contains_fixed_width(target_fields)
+    {
+        return false;
+    }
+    source_fields.iter().any(|(source_field, source_ty)| {
+        target_fields
+            .iter()
+            .find(|(target_field, _)| target_field == source_field)
+            .is_some_and(|(_, target_ty)| !source_ty.is_assignable_to(target_ty))
+    })
+}

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -32,6 +32,7 @@ mod expression_sum_sorted;
 mod expressions;
 #[cfg(test)]
 mod expressions_tests;
+mod fixed_width_class_payload;
 mod fixed_width_fitting;
 mod flow_diagnostics;
 mod flow_helpers;

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -9,6 +9,7 @@ use super::container_literal_specialization::{
 use super::control_flow_conditions::validate_control_flow_condition;
 use super::diagnostics::{collect_raise_error_types, format_type_name, is_valid_error_type};
 use super::expressions::{lower_expr, lower_star_unpack_assign, lower_tuple_unpack_assign};
+use super::fixed_width_class_payload::class_specialization_payload_conflicts;
 use super::fixed_width_fitting::{validate_fixed_width_initializer, FixedWidthInitializerFit};
 use super::flow_helpers::then_body_always_exits;
 use super::for_loop_safety::{is_collection_backed_iter_source, loop_body_mutates_iter_source};
@@ -1062,7 +1063,11 @@ pub(super) fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Optio
         if let FixedWidthInitializerFit::Fits(folded_expr) = fixed_width_fit {
             expr = folded_expr;
         }
-        if !is_int_to_bigint && fixed_width_not_const && !final_ty.is_assignable_to(&declared_type)
+        let class_specialization_conflict =
+            class_specialization_payload_conflicts(&final_ty, &declared_type);
+        if !is_int_to_bigint
+            && ((fixed_width_not_const && !final_ty.is_assignable_to(&declared_type))
+                || class_specialization_conflict)
         {
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -445,6 +445,7 @@ Validation:
 - [x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`.
 - [x] INT-3 fitting fixed-width scalar `+`/`-`/`*` promotion review satisfied with no blockers and non-blocking broader-width coverage follow-up: `reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md`.
 - [x] INT-3 fitting fixed-width scalar promotion coverage review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-promotion-coverage-review-pass-1.md`.
+- [x] INT-3 fixed-width promotion narrowing-boundary hardening review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-narrowing-hardening-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -501,7 +502,7 @@ Validation:
   - [x] Ordinary fixed-width scalar `+`, `-`, and `*` now promote fitting fixed-width operands to source-level `int` and cast operands before generated Rust arithmetic, preserving `int32(2_000_000_000) + int32(2_000_000_000) -> int`; review is satisfied and quick validation is passing: PR #1860.
   - [x] Fixed-width scalar promotion coverage now spans all fitting fixed-width families (`int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, and `isize`) while keeping `uint64` and `usize` blocked until the broader `SifrInt` promotion path; review is satisfied and quick validation is passing: PR #1861.
   - [ ] Deduplicate the temporary `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands.
-  - [ ] Add hardening tests that keep implicit `int`-to-fixed-width narrowing rejected in returns, list literals, dict literals, and generic specialization as scalar arithmetic and numeric mixing evolve.
+  - [x] Promoted fixed-width arithmetic results are now hardened against implicit narrowing in fixed-width returns, list literals, dict literals, and generic class specialization; review is satisfied and quick validation is passing: PR #1862.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock

--- a/reviews/integer-model-int-3-fixed-width-narrowing-hardening-review-pass-1.md
+++ b/reviews/integer-model-int-3-fixed-width-narrowing-hardening-review-pass-1.md
@@ -1,0 +1,21 @@
+# INT-3 Fixed-Width Narrowing Hardening Review Pass 1
+
+## Findings
+
+1. The four new hardening tests cover return, list literal, dict literal, and generic class specialization positions. They correctly assert `TYPE_MISMATCH` with precise diagnostic ranges.
+2. `class_specialization_payload_conflicts` is correctly implemented: it gates on same class name and same field count, excludes self-recursive classes via `type_mentions_class` recursion, requires a `FixedInt` in at least one payload, and checks field-by-field assignability.
+3. The self-recursive exclusion preserves existing recursive narrowing behavior for recursive classes such as `Tree[T]` with recursive fields.
+4. The `lower_ann_assign` modification is minimal and additive, extending the existing error path rather than replacing it.
+5. The conservative behavior is safe and aligned with the integer model: the check rejects `Box[X]` to `Box[Y]` where the payloads differ across fixed-width-sensitive types.
+
+## Required Changes
+
+None.
+
+## Non-blocking Notes
+
+None.
+
+## Verdict
+
+Approved for this milestone. The implementation correctly hardens the stated boundaries while preserving recursive class behavior, as confirmed by the passing recursive class regression test.


### PR DESCRIPTION
## Summary
- Add HIR hardening tests that promoted fixed-width arithmetic results cannot implicitly narrow into fixed-width returns, list literals, dict literals, or generic class specialization.
- Add a fixed-width-only class payload specialization check for annotated assignments so inferred promoted payloads do not satisfy fixed-width generic payloads.
- Keep the check scoped away from self-recursive class payloads to preserve existing recursive narrowing behavior.

## Validation
- `cargo test -p sifr_hir promoted_fixed_width_result_is_not_implicitly_narrowed -- --nocapture`
- `cargo test -p sifr_hir while_not_none_narrows_optional_receiver_for_attribute_access -- --nocapture`
- `cargo test -p sifr_hir recursive_tree_attributes_narrow_after_truthiness_or_guard -- --nocapture`
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile quick` (wall_time=76.12s, report_signature=e1bf653aaa770517)

Issue: `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md`