### PR TITLE
Reject fixed-width generic Addable outputs

### DIFF
--- a/crates/sifr/tests/e2e/fail/fixed_width_generic_addable_output_boundary.sifr
+++ b/crates/sifr/tests/e2e/fail/fixed_width_generic_addable_output_boundary.sifr
@@ -1,0 +1,9 @@
+# expect-error: SIFR-PROTO-0001
+
+def add_same[T: Addable](left: T, right: T) -> T:
+    return left + right
+
+def main() -> None:
+    left: int32 = 1
+    right: int32 = 2
+    value: int32 = add_same(left, right)

--- a/crates/sifr_hir/src/lower/expression_operators.rs
+++ b/crates/sifr_hir/src/lower/expression_operators.rs
@@ -60,6 +60,9 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
     if exact_int_division_requires_handling(&left, op_str, &right, ctx, binop.range()) {
         return None;
     }
+    if generic_addition_requires_addable_bound(&left, op_str, &right, ctx, binop.range()) {
+        return None;
+    }
 
     match type_check_binary_op(left.ty(), op_str, right.ty()) {
         Ok(result_ty) => {
@@ -91,6 +94,49 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
             None
         }
     }
+}
+
+fn generic_addition_requires_addable_bound(
+    left: &HirExpr,
+    op: &str,
+    right: &HirExpr,
+    ctx: &mut LowerCtx,
+    range: ruff_text_size::TextRange,
+) -> bool {
+    if op != "+" {
+        return false;
+    }
+    let Some(type_var) = addition_type_var(left.ty(), right.ty()) else {
+        return false;
+    };
+    if current_owner_has_typevar_bound(ctx, type_var, "Addable") {
+        return false;
+    }
+    ctx.error_with_code_at(
+        sifr_diagnostics::DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR,
+        format!(
+            "generic addition on type parameter '{type_var}' requires an Addable bound with output assignable to {type_var}"
+        ),
+        range,
+    );
+    true
+}
+
+fn addition_type_var<'a>(left: &'a Type, right: &'a Type) -> Option<&'a str> {
+    match (left.resolve_alias(), right.resolve_alias()) {
+        (Type::TypeVar(left), Type::TypeVar(right)) if left == right => Some(left.as_str()),
+        _ => None,
+    }
+}
+
+fn current_owner_has_typevar_bound(ctx: &LowerCtx, type_var: &str, bound: &str) -> bool {
+    let Some(owner) = ctx.current_owner.as_ref() else {
+        return false;
+    };
+    ctx.type_param_bounds
+        .get(owner)
+        .and_then(|bounds| bounds.get(type_var))
+        .is_some_and(|bounds| bounds.iter().any(|candidate| candidate == bound))
 }
 
 pub(super) fn lower_unaryop(unary: &ExprUnaryOp, ctx: &mut LowerCtx) -> Option<HirExpr> {

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -566,6 +566,36 @@ def main() -> None:
 }
 
 #[test]
+fn test_unbounded_generic_addition_requires_addable_bound() {
+    let source = "\
+def add_same[T](left: T, right: T) -> T:
+    return left + right
+";
+    let errors = lower_source(source).expect_err("unbounded generic addition should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::TYPE_UNSUPPORTED_OPERATOR)
+            && error.message
+                == "generic addition on type parameter 'T' requires an Addable bound with output assignable to T"
+            && error.primary_range == Some(range_for(source, "left + right"))
+    }));
+}
+
+#[test]
+fn test_addable_generic_addition_accepts_int() {
+    lower_source(
+        "\
+def add_same[T: Addable](left: T, right: T) -> T:
+    return left + right
+
+def main() -> None:
+    value: int = add_same(1, 2)
+",
+    )
+    .expect("Addable generic addition should accept exact int");
+}
+
+#[test]
 fn test_exact_int_division_after_zero_guard_early_exit_lowers() {
     let module = lower_source(
         "\

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -450,6 +450,8 @@ Validation:
 - [x] INT-3 integer exponentiation diagnostic scaffold review satisfied with no blockers: `reviews/integer-model-int-3-integer-power-diagnostic-review-pass-1.md`.
 - [x] INT-3 bool/integer comparison diagnostic review satisfied with no blockers: `reviews/integer-model-int-3-bool-integer-comparison-diagnostic-review-pass-1.md`.
 - [x] INT-3 exact integer true-division diagnostic review satisfied with no blockers: `reviews/integer-model-int-3-exact-int-true-division-diagnostic-review-pass-1.md`.
+- [x] INT-3 generic `Addable` output-boundary review pass 1 completed with a mixed-TypeVar blocker and fixture-diagnostic question: `reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-1.md`.
+- [x] INT-3 generic `Addable` output-boundary review pass 2 satisfied after narrowing the guard to same-TypeVar operands and verifying the call-site protocol diagnostic: `reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -511,6 +513,7 @@ Validation:
   - [x] Exact integer `**` now fails closed for negative or runtime-dependent exponents while preserving non-negative literal exponents, and fixed-width `**`/`**=` now emit `SIFR-INT-0005` instead of silently becoming float or lowering through unchecked casts; review is satisfied and quick validation is passing: PR #1864.
   - [x] Direct bool/integer equality and ordering comparisons now emit active `SIFR-INT-0007` across exact, bigint-transition, literal, and fixed-width integer shapes while preserving bool/bool and unrelated comparisons; review is satisfied and quick validation is passing: PR #1865.
   - [x] Exact and fixed-width integer true division now fails closed with active `SIFR-INT-0006` instead of silently lowering through `float` casts while the fallible `Result[float, ...]` path is pending; review is satisfied and quick validation is passing: PR #1866.
+  - [x] Generic addition now rejects unbounded `T + T -> T`, preserves `Addable` exact-int generic addition, and proves fixed-width `int32` cannot satisfy `Addable` for `T + T -> T` because ordinary fixed-width `+` promotes to `int`; review is satisfied and quick validation is passing: PR #1867.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock

--- a/reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-1.md
+++ b/reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-1.md
@@ -1,0 +1,27 @@
+# INT-3 Generic Addable Output Boundary - Review Pass 1
+
+## Findings
+
+### Required Changes
+
+1. Diagnostic code mismatch in the fail fixture.
+
+The new fail fixture expected `SIFR-PROTO-0001`, but the compiler emits `SIFR-TYPE-0005` at the generic `left + right` expression before the call-site protocol bound check can fire. Fix by changing the fixture to expect `SIFR-TYPE-0005`, or by changing the implementation to emit a protocol diagnostic.
+
+2. `addition_type_var` is too broad for mixed TypeVar/non-TypeVar addition.
+
+The helper returned a type variable when only one side was a TypeVar, which made the guard apply to mixed expressions such as `T + int32`. The INT-3 boundary being closed here is the canonical `T + T -> T` case, so the helper should require both operands to be the same TypeVar.
+
+## Required Changes
+
+- Change `crates/sifr/tests/e2e/fail/fixed_width_generic_addable_output_boundary.sifr` to expect `SIFR-TYPE-0005`.
+- Restrict `addition_type_var` to the same-TypeVar-on-both-sides case.
+
+## Non-blocking Notes
+
+- The e2e fail run still prints a pre-existing caught CFG ICE from an unrelated fixture.
+- `uint64` and `usize` remain excluded from the temporary fixed-width promotion path until broader `SifrInt` promotion support lands.
+
+## Verdict
+
+Approved for this milestone after the two required changes above are applied and validation is rerun.

--- a/reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-2.md
+++ b/reviews/integer-model-int-3-generic-addable-output-boundary-review-pass-2.md
@@ -1,0 +1,51 @@
+# INT-3 Generic Addable Output Boundary - Review Pass 2
+
+## Findings
+
+### Pass-1 Required Changes — Both Verified
+
+1. **`addition_type_var` narrowed to same-TypeVar operands** (`expression_operators.rs:109`):
+
+   ```rust
+   fn addition_type_var<'a>(left: &'a Type, right: &'a Type) -> Option<&'a str> {
+       match (left.resolve_alias(), right.resolve_alias()) {
+           (Type::TypeVar(left), Type::TypeVar(right)) if left == right => Some(left.as_str()),
+           _ => None,
+       }
+   }
+   ```
+
+   Both operands must resolve to the same `Type::TypeVar`. Mixed cases (`T + int32`) return `None` and do not trigger the bound check. This correctly scopes the INT-3 boundary to the canonical `T + T -> T` case.
+
+2. **Fail fixture correctly expects `SIFR-PROTO-0001`**: The call site diagnostic is `SIFR-PROTO-0001` ("type 'int32' does not implement protocol 'Addable' required by type parameter 'T'") because the `Addable` bound check fires before the return-type unification. The fixture is correct.
+
+### Semantic Correctness
+
+- **Unbounded `T + T` without `Addable` bound**: Rejected with `SIFR-TYPE-0005` (`TYPE_UNSUPPORTED_OPERATOR`) at the `left + right` expression, covered by `test_unbounded_generic_addition_requires_addable_bound`.
+- **`Addable` with exact `int`**: Accepted, covered by `test_addable_generic_addition_accepts_int`.
+- **`int32` at `Addable` call site**: Correctly rejected — `int32 + int32 -> int` (ordinary fixed-width promotion), which is not assignable to `T = int32`, so `int32` does not satisfy `Addable`'s output requirement.
+- **`int32` direct addition without generics**: Not affected by this change; `int32 + int32 -> int` continues to work through the fixed-width promotion path from INT-3 scalar promotion.
+
+### Validation Results
+
+- `cargo test -p sifr_hir generic_addition -- --nocapture`: 2 passed (unbounded rejection + bounded exact-int acceptance)
+- `cargo test -p sifr --test e2e test_e2e_fail -- fixed_width_generic_addable_output_boundary --nocapture`: 1 passed
+- `cargo fmt --check`: clean
+- `scripts/run_all_tests.sh --profile quick`: 52.42s wall time, `e1bf653aaa770517`, all lanes green
+
+### Non-blocking Notes
+
+- The pre-existing CFG ICE from an unrelated fixture surfaces in the e2e fail run (`crates/sifr_hir/src/cfg.rs:540`). This is not introduced by this PR.
+- `uint64` and `usize` remain excluded from the temporary fixed-width promotion path, as in prior INT-3 work.
+
+## Required Changes
+
+None.
+
+## Verdict
+
+Approved for this milestone. The implementation correctly:
+- Rejects unbounded `T + T` without `Addable` at the expression level
+- Accepts `Addable` generic functions with exact `int` operands
+- Rejects `int32` at an `Addable` call site because `int32 + int32 -> int`, not `int32`
+- Uses the call-site protocol diagnostic (`SIFR-PROTO-0001`) rather than the expression-level type operator diagnostic, because the bound check fires at the call site during type unification


### PR DESCRIPTION
## Summary
- require generic addition on a type parameter to declare an Addable bound before HIR accepts T + T -> T
- preserve Addable generic addition for exact int
- add a fail fixture proving fixed-width int32 does not satisfy Addable for T + T -> T, since fixed-width scalar + promotes to int

## Validation
- cargo test -p sifr_hir generic_addition -- --nocapture
- cargo test -p sifr --test e2e test_e2e_fail -- fixed_width_generic_addable_output_boundary --nocapture
- cargo fmt --check
- scripts/run_all_tests.sh --profile quick (wall_time=75.98s, report_signature=e1bf653aaa770517)