### PR TITLE
Implement bytes uint8 surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/bytes_basics.sifr
+++ b/crates/sifr/tests/e2e/pass/bytes_basics.sifr
@@ -2,7 +2,7 @@
 def sum_bytes(data: bytes) -> int:
     total: int = 0
     for value in data:
-        total += value
+        total += int(value)
     return total
 
 def main() -> None:
@@ -11,8 +11,9 @@ def main() -> None:
     merged: bytes = left + right
 
     assert len(merged) == 4
-    first: int | None = merged[0]
-    assert first == 65
+    first: uint8 | None = merged[0]
+    expected_first: uint8 = 65
+    assert first == expected_first
 
     middle: bytes = merged[1:3]
     assert len(middle) == 2

--- a/crates/sifr/tests/e2e/pass/bytes_constructors.sifr
+++ b/crates/sifr/tests/e2e/pass/bytes_constructors.sifr
@@ -3,9 +3,10 @@ def main() -> None:
     size_ok: bool = False
     try:
         zeroes: bytes = bytes(4)
+        zero: uint8 = 0
         assert len(zeroes) == 4
-        assert zeroes[0] == 0
-        assert zeroes[3] == 0
+        assert zeroes[0] == zero
+        assert zeroes[3] == zero
         size_ok = True
     except ValueError as e:
         _ = str(e.message)
@@ -15,9 +16,12 @@ def main() -> None:
     try:
         ints: list[int] = [72, 105, 33]
         payload: bytes = bytes.from_ints(ints)
-        assert payload[0] == 72
-        assert payload[1] == 105
-        assert payload[2] == 33
+        h: uint8 = 72
+        i: uint8 = 105
+        bang: uint8 = 33
+        assert payload[0] == h
+        assert payload[1] == i
+        assert payload[2] == bang
         from_ints_ok = True
     except ValueError as e:
         _ = str(e.message)

--- a/crates/sifr/tests/e2e/pass/bytes_hex_and_binary_io.sifr
+++ b/crates/sifr/tests/e2e/pass/bytes_hex_and_binary_io.sifr
@@ -25,9 +25,10 @@ def main():
     utf8_guard_ok: bool = False
     hex_guard_ok: bool = False
 
-    idx: int | None = payload[1]
+    idx: uint8 | None = payload[1]
+    expected_idx: uint8 = 66
     if idx is not None:
-        index_ok = idx == 66
+        index_ok = idx == expected_idx
 
     iter_ok = sum_bytes(payload) == 266
     contains_ok = payload.contains(67) and (not payload.contains(300))

--- a/crates/sifr/tests/e2e/pass/bytes_uint8_surface.sifr
+++ b/crates/sifr/tests/e2e/pass/bytes_uint8_surface.sifr
@@ -1,0 +1,21 @@
+def main() -> None:
+    payload: bytes = b"A\xff"
+
+    first: uint8 | None = payload[0]
+    second: uint8 | None = payload[1]
+    missing: uint8 | None = payload[99]
+    expected_first: uint8 = 65
+    expected_second: uint8 = 255
+
+    assert first == expected_first
+    assert second == expected_second
+    assert missing is None
+
+    values: list[uint8] = []
+    for byte in payload:
+        values.append(byte)
+
+    expected_values: list[uint8] = []
+    expected_values.append(expected_first)
+    expected_values.append(expected_second)
+    assert values == expected_values

--- a/crates/sifr/tests/e2e/pass/iterator_integration.sifr
+++ b/crates/sifr/tests/e2e/pass/iterator_integration.sifr
@@ -35,8 +35,11 @@ def main():
     actual.append(str(materialize_iterable_from_return(iter([4, 5]))) == "[4, 5]")
 
     payload: bytes = b"ABC"
-    byte_iter: Iterator[int] = iter(payload)
-    actual.append(str(list(map(lambda b: b + 1, byte_iter))) == "[66, 67, 68]")
+    byte_iter: Iterator[uint8] = iter(payload)
+    incremented: list[int] = []
+    for b in byte_iter:
+        incremented.append(int(b) + 1)
+    actual.append(str(incremented) == "[66, 67, 68]")
 
     try:
         matches: Iterator[Match] = finditer("\\d+", "a12b345")

--- a/crates/sifr_codegen/src/expr_ref_emitter.rs
+++ b/crates/sifr_codegen/src/expr_ref_emitter.rs
@@ -79,7 +79,7 @@ fn display_option_inner_type(expr: &HirExpr) -> Option<Type> {
     if let HirExpr::Index { object, .. } = expr {
         match crate::resolve_alias_type_for_plain_call(object.ty()) {
             Type::List(elem) => return Some((**elem).clone()),
-            Type::Bytes => return Some(Type::Int),
+            Type::Bytes => return Some(Type::FixedInt(sifr_type_system::FixedIntType::U8)),
             Type::Dict(_, value) => return Some((**value).clone()),
             Type::Str => return Some(Type::Str),
             _ => {}

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1101,7 +1101,7 @@ impl RustEmitter {
                                         expr: Box::new(crate::RustExpr::Deref(Box::new(
                                             crate::RustExpr::Ident("__byte".to_string()),
                                         ))),
-                                        ty: crate::RustType::I64,
+                                        ty: crate::RustType::Named("u8".to_string()),
                                     }),
                                     is_move: false,
                                 }],

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -291,7 +291,7 @@ fn registry_iterable_to_owned_iter_expr_with_hint(
                     }],
                     body: Box::new(RustExpr::Cast {
                         expr: Box::new(RustExpr::Ident("__byte".to_string())),
-                        ty: crate::RustType::I64,
+                        ty: crate::RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],
@@ -312,7 +312,7 @@ fn registry_iterable_to_owned_iter_expr_with_hint(
                         expr: Box::new(RustExpr::Deref(Box::new(RustExpr::Ident(
                             "__byte".to_string(),
                         )))),
-                        ty: crate::RustType::I64,
+                        ty: crate::RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],
@@ -1422,7 +1422,7 @@ impl RustEmitter {
                                         expr: Box::new(crate::RustExpr::Deref(Box::new(
                                             crate::RustExpr::Ident("__byte".to_string()),
                                         ))),
-                                        ty: crate::RustType::I64,
+                                        ty: crate::RustType::Named("u8".to_string()),
                                     }),
                                     is_move: false,
                                 }],
@@ -1560,7 +1560,7 @@ impl RustEmitter {
                                     expr: Box::new(crate::RustExpr::Deref(Box::new(
                                         crate::RustExpr::Ident("__byte".to_string()),
                                     ))),
-                                    ty: crate::RustType::I64,
+                                    ty: crate::RustType::Named("u8".to_string()),
                                 }),
                                 is_move: false,
                             }],
@@ -2950,6 +2950,10 @@ impl RustEmitter {
                         else_expr: Some(Box::new(crate::RustExpr::Literal(
                             crate::RustLiteral::Int(0),
                         ))),
+                    }),
+                    Type::FixedInt(_) => Some(crate::RustExpr::Cast {
+                        expr: Box::new(lowered),
+                        ty: crate::RustType::I64,
                     }),
                     Type::BigInt => Some(crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::FnCall {

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -720,7 +720,7 @@ fn try_lower_simple_iter_source_expr(iter_expr: &HirExpr) -> Option<RustExpr> {
                     }],
                     body: Box::new(RustExpr::Cast {
                         expr: Box::new(RustExpr::Ident("__byte".to_string())),
-                        ty: RustType::I64,
+                        ty: RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],
@@ -741,7 +741,7 @@ fn try_lower_simple_iter_source_expr(iter_expr: &HirExpr) -> Option<RustExpr> {
                         expr: Box::new(RustExpr::Deref(Box::new(RustExpr::Ident(
                             "__byte".to_string(),
                         )))),
-                        ty: RustType::I64,
+                        ty: RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -2489,7 +2489,7 @@ fn try_lower_simple_for_iter_expr(iter: &HirExpr, target_ty: &Type) -> Option<Ru
                     }],
                     body: Box::new(RustExpr::Cast {
                         expr: Box::new(RustExpr::Ident("__byte".to_string())),
-                        ty: RustType::I64,
+                        ty: RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],
@@ -2510,7 +2510,7 @@ fn try_lower_simple_for_iter_expr(iter: &HirExpr, target_ty: &Type) -> Option<Ru
                         expr: Box::new(RustExpr::Deref(Box::new(RustExpr::Ident(
                             "__byte".to_string(),
                         )))),
-                        ty: RustType::I64,
+                        ty: RustType::Named("u8".to_string()),
                     }),
                     is_move: false,
                 }],

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -3406,7 +3406,7 @@ impl RustEmitter {
                                 expr: Box::new(crate::RustExpr::Deref(Box::new(
                                     crate::RustExpr::Ident("__byte".to_string()),
                                 ))),
-                                ty: crate::RustType::I64,
+                                ty: crate::RustType::Named("u8".to_string()),
                             }),
                             is_move: false,
                         }],
@@ -3555,7 +3555,7 @@ impl RustEmitter {
                                     expr: Box::new(crate::RustExpr::Deref(Box::new(
                                         crate::RustExpr::Ident("__byte".to_string()),
                                     ))),
-                                    ty: crate::RustType::I64,
+                                    ty: crate::RustType::Named("u8".to_string()),
                                 }),
                                 is_move: false,
                             }],
@@ -3566,7 +3566,7 @@ impl RustEmitter {
                             expr: Box::new(lowered_object),
                             index: Box::new(list_index),
                         }),
-                        ty: crate::RustType::I64,
+                        ty: crate::RustType::Named("u8".to_string()),
                     }));
                 }
                 Type::Str => {
@@ -5394,7 +5394,7 @@ impl RustEmitter {
                         ty: crate::RustType::Named("usize".to_string()),
                     }),
                 }),
-                ty: crate::RustType::I64,
+                ty: crate::RustType::Named("u8".to_string()),
             },
             Type::Str => {
                 let nth_expr = crate::RustExpr::MethodCall {
@@ -6929,7 +6929,7 @@ impl RustEmitter {
                         }],
                         body: Box::new(crate::RustExpr::Cast {
                             expr: Box::new(crate::RustExpr::Ident("__byte".to_string())),
-                            ty: crate::RustType::I64,
+                            ty: crate::RustType::Named("u8".to_string()),
                         }),
                         is_move: false,
                     }],
@@ -6950,7 +6950,7 @@ impl RustEmitter {
                             expr: Box::new(crate::RustExpr::Deref(Box::new(
                                 crate::RustExpr::Ident("__byte".to_string()),
                             ))),
-                            ty: crate::RustType::I64,
+                            ty: crate::RustType::Named("u8".to_string()),
                         }),
                         is_move: false,
                     }],

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -2280,6 +2280,39 @@ fn test_bytes_augmented_subscript_assignment_has_ownership_code() {
 }
 
 #[test]
+fn test_bytes_index_and_iteration_expose_uint8() {
+    let source =
+        "def main() -> None:\n    payload: bytes = b\"abc\"\n    first = payload[0]\n    for value in payload:\n        seen: uint8 = value\n";
+    let module = lower_source(source).expect("bytes uint8 lowering should succeed");
+    let function = module
+        .functions
+        .iter()
+        .find(|function| function.name == "main")
+        .expect("main function should exist");
+
+    let Some(HirStmt::Let { ty: first_ty, .. }) = function
+        .body
+        .iter()
+        .find(|stmt| matches!(stmt, HirStmt::Let { name, .. } if name == "first"))
+    else {
+        panic!("expected first binding");
+    };
+    assert_eq!(
+        first_ty,
+        &Type::Union(vec![Type::FixedInt(FixedIntType::U8), Type::None])
+    );
+
+    let Some(HirStmt::For { target_ty, .. }) = function
+        .body
+        .iter()
+        .find(|stmt| matches!(stmt, HirStmt::For { target, .. } if target == "value"))
+    else {
+        panic!("expected bytes for loop");
+    };
+    assert_eq!(target_ty, &Type::FixedInt(FixedIntType::U8));
+}
+
+#[test]
 fn test_bytes_codec_type_errors_have_structured_codes() {
     let encode_source = "def main() -> None:\n    _bad: bytes = \"abc\".encode(1)\n";
     let encode_result = lower_source(encode_source);

--- a/crates/sifr_hir/src/lower/guarded_index.rs
+++ b/crates/sifr_hir/src/lower/guarded_index.rs
@@ -22,6 +22,7 @@ pub(super) fn guarded_sequence_index_result_type(
                 }
             }
             Type::Str => guarded_string_index_type(sequence_name.as_str(), &sub.slice, ctx),
+            Type::Bytes => guarded_bytes_index_type(sequence_name.as_str(), &sub.slice, ctx),
             _ => None,
         };
     }
@@ -78,6 +79,18 @@ fn guarded_string_index_type(
 ) -> Option<Type> {
     if has_guarded_sequence_index(sequence_name, index_expr, ctx) {
         Some(Type::Str)
+    } else {
+        None
+    }
+}
+
+fn guarded_bytes_index_type(
+    sequence_name: &str,
+    index_expr: &Expr,
+    ctx: &LowerCtx,
+) -> Option<Type> {
+    if has_guarded_sequence_index(sequence_name, index_expr, ctx) {
+        Some(Type::FixedInt(sifr_type_system::FixedIntType::U8))
     } else {
         None
     }

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -890,7 +890,7 @@ impl Type {
             Self::Set(elem) => Some(*elem.clone()),
             Self::Tuple(elems) => Self::homogeneous_tuple_iter_element_type(elems),
             Self::Str => Some(Type::Str),
-            Self::Bytes => Some(Type::Int),
+            Self::Bytes => Some(Type::FixedInt(FixedIntType::U8)),
             Self::Dict(key, _) => Some(*key.clone()),
             Self::Iterable(elem) => Some(*elem.clone()),
             Self::Iterator(elem) => Some(*elem.clone()),
@@ -960,7 +960,7 @@ impl Type {
                 ],
             }),
             Self::Bytes => Some(IterationMetadata {
-                element_type: Type::Int,
+                element_type: Type::FixedInt(FixedIntType::U8),
                 capabilities: vec![
                     IterationCapability::MultiPass,
                     IterationCapability::DoubleEnded,
@@ -1077,8 +1077,11 @@ impl Type {
             }
             Self::Bytes => {
                 if index_ty == &Type::Int {
-                    // Safe indexing: returns Option[int] = int | None
-                    Some(Type::Union(vec![Type::Int, Type::None]))
+                    // Safe indexing: returns Option[uint8] = uint8 | None
+                    Some(Type::Union(vec![
+                        Type::FixedInt(FixedIntType::U8),
+                        Type::None,
+                    ]))
                 } else {
                     None
                 }
@@ -1133,7 +1136,7 @@ impl Type {
             Self::Dict(key, _) => Some(*key.clone()),
             Self::Range => Some(Type::Int),
             Self::Str => Some(Type::Str),
-            Self::Bytes => Some(Type::Int),
+            Self::Bytes => Some(Type::FixedInt(FixedIntType::U8)),
             Self::Union(members) => {
                 let non_none: Vec<&Type> = members
                     .iter()
@@ -1266,7 +1269,9 @@ impl Type {
             }
             (Self::Range, Self::Iterable(dst)) => return Type::Int.is_assignable_to(dst),
             (Self::Str, Self::Iterable(dst)) => return Type::Str.is_assignable_to(dst),
-            (Self::Bytes, Self::Iterable(dst)) => return Type::Int.is_assignable_to(dst),
+            (Self::Bytes, Self::Iterable(dst)) => {
+                return Type::FixedInt(FixedIntType::U8).is_assignable_to(dst);
+            }
             (Self::Dict(key, _), Self::Iterable(dst)) => return key.is_assignable_to(dst),
             (Self::Class { name, methods, .. }, Self::Iterator(dst)) => {
                 return Self::class_next_element_type(name, methods)
@@ -1494,6 +1499,25 @@ mod tests {
         assert_eq!(iterable_int.iterable_element_type(), Some(Type::Int));
         assert!(iter_int.is_assignable_to(&iterable_int));
         assert!(list_int.is_assignable_to(&iterable_int));
+    }
+
+    #[test]
+    fn test_bytes_iterable_and_index_contract_uses_uint8() {
+        let uint8 = Type::FixedInt(FixedIntType::U8);
+
+        assert_eq!(Type::Bytes.iterable_element_type(), Some(uint8.clone()));
+        assert_eq!(
+            Type::Bytes
+                .iteration_metadata()
+                .map(|metadata| metadata.element_type),
+            Some(uint8.clone())
+        );
+        assert_eq!(
+            Type::Bytes.index_result_type(&Type::Int),
+            Some(Type::Union(vec![uint8.clone(), Type::None]))
+        );
+        assert!(Type::Bytes.is_assignable_to(&Type::Iterable(Box::new(uint8))));
+        assert!(!Type::Bytes.is_assignable_to(&Type::Iterable(Box::new(Type::Int))));
     }
 
     #[test]

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -455,6 +455,8 @@ Validation:
 - [x] INT-3 fixed-width add API review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-add-apis-review-pass-1.md`.
 - [x] INT-3 fixed-width subtraction API review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-sub-apis-review-pass-1.md`.
 - [x] INT-3 fixed-width multiplication API review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-mul-apis-review-pass-1.md`.
+- [x] INT-4 bytes `uint8` surface review pass 1 satisfied with a non-blocking display-option fallback cleanup note: `reviews/integer-model-int-4-bytes-uint8-surface-review-pass-1.md`.
+- [x] INT-4 bytes `uint8` surface review pass 2 satisfied after addressing the pass 1 cleanup note: `reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -521,6 +523,7 @@ Validation:
   - [x] Fixed-width instance `checked_sub`, `wrapping_sub`, `saturating_sub`, and `overflowing_sub` now expose explicit representation-preserving subtraction for same-width operands, reject mixed-width operands, lower to Rust primitive no-panic APIs, and cover underflow/non-underflow behavior in e2e; review is satisfied and quick validation is passing: PR #1869.
   - [x] Fixed-width instance `checked_mul`, `wrapping_mul`, `saturating_mul`, and `overflowing_mul` now expose explicit representation-preserving multiplication for same-width operands, reject mixed-width operands, lower to Rust primitive no-panic APIs, and cover overflow/non-overflow behavior in e2e; review is satisfied and quick validation is passing: PR #1870.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
+  - [x] `bytes` indexing, guarded indexing, and iteration now expose `uint8`; ordinary indexes and lengths remain `int`, stdlib bytes helpers widen explicitly with `int(b)`, display fallback typing is aligned, and focused bytes fixtures cover the surface; review is satisfied and quick validation is passing: PR #1872.
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration

--- a/lib/sifr/bytes.sifr
+++ b/lib/sifr/bytes.sifr
@@ -28,7 +28,7 @@ def encode_utf8_result(s: str) -> Result[bytes, ParseError]:
 def count_byte(data: bytes, value: int) -> int:
     count: int = 0
     for b in data:
-        if b == value:
+        if int(b) == value:
             count = count + 1
     return count
 
@@ -36,7 +36,7 @@ def count_byte(data: bytes, value: int) -> int:
 def find_byte(data: bytes, value: int) -> int | None:
     idx: int = 0
     for b in data:
-        if b == value:
+        if int(b) == value:
             return idx
         idx = idx + 1
     return None
@@ -47,8 +47,8 @@ def starts_with(data: bytes, prefix: bytes) -> bool:
         return False
     i: int = 0
     while i < len(prefix):
-        a: int | None = data[i]
-        b: int | None = prefix[i]
+        a: uint8 | None = data[i]
+        b: uint8 | None = prefix[i]
         if a is None:
             return False
         if b is None:
@@ -65,8 +65,8 @@ def ends_with(data: bytes, suffix: bytes) -> bool:
     offset: int = len(data) - len(suffix)
     i: int = 0
     while i < len(suffix):
-        a: int | None = data[offset + i]
-        b: int | None = suffix[i]
+        a: uint8 | None = data[offset + i]
+        b: uint8 | None = suffix[i]
         if a is None:
             return False
         if b is None:

--- a/reviews/integer-model-int-4-bytes-uint8-surface-review-pass-1.md
+++ b/reviews/integer-model-int-4-bytes-uint8-surface-review-pass-1.md
@@ -1,0 +1,44 @@
+Now I have a complete picture. Let me provide my review.
+
+---
+
+## Review: INT-4 Bytes uint8 Surface Slice
+
+### 1. Blocking Findings
+
+**None.** The implementation correctly implements the INT-4 rule.
+
+### 2. Non-Blocking Observations
+
+**Pre-existing type system inconsistency (not introduced by this PR):**
+
+- **File:** `crates/sifr_codegen/src/expr_ref_emitter.rs:82`
+- **Code:** `Type::Bytes => return Some(Type::Int)`
+- **Issue:** The `display_option_inner_type` function returns `Type::Int` for bytes, but should return `Type::FixedInt(FixedIntType::U8)` per the INT-4 contract.
+
+**Analysis:** This branch is effectively unreachable for bytes indexing expressions because:
+1. Bytes indexing produces `uint8 | None` (confirmed at `types.rs:1078-1084`)
+2. The `option_inner_type` function correctly extracts `FixedInt(U8)` from unions (lines 44-52)
+3. `option_inner_type` returns `Some(Type::FixedInt(U8))` before the indexing branch is evaluated
+
+**No functional impact:** Both `Type::Int` and `Type::FixedInt(_)` return `false` from `uses_debug_display_format` (line 8), so the display format would be identical in either case.
+
+**Recommendation:** Fix as a follow-up cleanup for type system consistency. Not a blocker.
+
+### 3. Verification Summary
+
+| Area | Status | Evidence |
+|------|--------|----------|
+| Type system contract | ✓ | `types.rs:893, 960, 1078-1084, 1269-1271` — bytes element/iteration/index all use `FixedInt(U8)` |
+| Type system tests | ✓ | `types.rs:1505-1520` — 5 assertions covering all contract points |
+| HIR lowering | ✓ | `guarded_index.rs:87-96` — guarded bytes index returns `FixedInt(U8)` |
+| HIR unit test | ✓ | `expressions_tests.rs:2282-2313` — verifies index and iteration types |
+| Codegen (Rust types) | ✓ | 12 instances of `RustType::I64` → `RustType::Named("u8")` for bytes elements |
+| Codegen (widening) | ✓ | `intrinsic_method_emitters.rs:2954-2957` — `FixedInt(_)` widening to `i64` |
+| Standard library | ✓ | `bytes.sifr` — uses `int(b)` for widening, `uint8` for element types |
+| E2E tests | ✓ | 5 test files updated + new `bytes_uint8_surface.sifr` |
+| Local validation | ✓ | All quick profile tests pass |
+
+### 4. Final Verdict
+
+**Satisfied.** The INT-4 rule is correctly implemented: bytes indexing and iteration expose `uint8`, while ordinary indexes and lengths remain `int`. No regressions, no user-triggerable panic risks, no contract drift in changed code.

--- a/reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md
+++ b/reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md
@@ -1,0 +1,42 @@
+
+
+Now I have a complete picture. Here is my review:
+
+---
+
+## Review: INT-4 Bytes uint8 Surface Slice — Pass 2
+
+### 1. Blocking Findings
+
+**None.** The implementation is correct and consistent.
+
+### 2. Verification
+
+**Pass-1 consistency issue — resolved:**
+
+- `crates/sifr_codegen/src/expr_ref_emitter.rs:82`: `Type::Bytes => return Some(Type::FixedInt(sifr_type_system::FixedIntType::U8))` — now correctly returns `U8` instead of `Type::Int`. The `option_inner_type` path (lines 44–53) already handled the union correctly via the type system; this fix aligns the index-expression fallback path.
+
+**Contract enforcement — verified across all layers:**
+
+| Layer | File:Line | Change |
+|---|---|---|
+| Type system | `types.rs:893` | `Bytes.iterable_element_type()` → `FixedInt(U8)` |
+| Type system | `types.rs:963` | `Bytes.iteration_metadata().element_type` → `FixedInt(U8)` |
+| Type system | `types.rs:1080-1084` | `Bytes.index_result_type(Int)` → `FixedInt(U8) \| None` |
+| Type system | `types.rs:1139` | `Bytes.option_element_type()` → `FixedInt(U8)` |
+| Type system | `types.rs:1271-1273` | `Bytes → Iterable(T)` requires `T = FixedInt(U8)` |
+| Type system test | `types.rs:1501-1523` | 5 assertions covering all contract points |
+| HIR lowering | `guarded_index.rs:25,90-96` | Guarded bytes index → `FixedInt(U8)` |
+| HIR test | `expressions_tests.rs:2282-2318` | Verifies index/iteration types |
+| Codegen | 12 × `RustType::I64` → `RustType::Named("u8")` | Bytes element → `u8` |
+| Codegen widening | `intrinsic_method_emitters.rs:2954-2957` | `FixedInt(_)` cast to `i64` for arithmetic contexts |
+| Stdlib | `lib/sifr/bytes.sifr` | `int(b)` for widening, `uint8` annotations |
+| E2E | 5 existing tests + `bytes_uint8_surface.sifr` | New test covers surface behavior |
+
+**No regressions:** All local validation tests passed (quick profile, focused unit/E2E).
+
+**No user-triggerable panic risks:** No new `unwrap()`/`expect()` on data-dependent paths.
+
+### 3. Final Verdict
+
+**Satisfied.** The INT-4 rule is correctly implemented: bytes indexing and iteration expose `uint8`, ordinary indexes and lengths remain `int`. The pass-1 consistency issue is resolved without introducing new issues.


### PR DESCRIPTION
## Summary
- make bytes indexing, guarded indexing, iteration metadata, and iterable assignability expose uint8
- lower bytes iteration/index codegen as Rust u8 and add explicit int(uint8) widening for stdlib bytes helpers
- add focused HIR/type/e2e coverage plus review artifacts

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p sifr_type_system bytes_iterable_and_index_contract_uses_uint8 -- --nocapture
- cargo test -p sifr_hir bytes_index_and_iteration_expose_uint8 -- --nocapture
- cargo test -p sifr_codegen int -- --nocapture
- SIFR_E2E_FIXTURE_MANIFEST=... bytes_uint8_surface, bytes_basics, bytes_hex_and_binary_io, iterator_integration, bytes_helpers, cpython_bytes_subset, bytes_constructors: passed
- scripts/run_all_tests.sh --profile quick

## Reviews
- reviews/integer-model-int-4-bytes-uint8-surface-review-pass-1.md: satisfied with non-blocking cleanup note
- reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md: satisfied