### PR TITLE
Validate fixed-width match literals

### DIFF
--- a/crates/sifr/tests/e2e/fail/fixed_width_match_literal_out_of_range.sifr
+++ b/crates/sifr/tests/e2e/fail/fixed_width_match_literal_out_of_range.sifr
@@ -1,0 +1,9 @@
+# expect-error: SIFR-INT-0001
+
+def main():
+    value: uint8 = 1
+    match value:
+        case 256:
+            pass
+        case _:
+            pass

--- a/crates/sifr/tests/e2e/pass/fixed_width_match_literal_fitting.sifr
+++ b/crates/sifr/tests/e2e/pass/fixed_width_match_literal_fitting.sifr
@@ -1,0 +1,16 @@
+def classify(value: uint8) -> str:
+    match value:
+        case 255:
+            return "max"
+        case 0:
+            return "zero"
+        case _:
+            return "other"
+
+def main():
+    max_byte: uint8 = 255
+    zero: uint8 = 0
+    one: uint8 = 1
+    assert str(classify(max_byte)) == 'max'
+    assert str(classify(zero)) == 'zero'
+    assert str(classify(one)) == 'other'

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -264,6 +264,34 @@ fn test_fixed_width_literal_assignment_out_of_range_has_int_code() {
 }
 
 #[test]
+fn test_fixed_width_match_literal_out_of_range_has_int_code() {
+    let source = "def main():\n    value: uint8 = 1\n    match value:\n        case 256:\n            pass\n        case _:\n            pass\n";
+    let errors =
+        lower_source(source).expect_err("out-of-range fixed-width match literal should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)
+            && error.message
+                == "integer value 256 does not fit target type uint8; valid range is 0..=255"
+            && error.primary_range == Some(range_for(source, "256"))
+    }));
+    assert!(
+        errors
+            .iter()
+            .all(|error| error.code == Some(DiagnosticCode::INT_FIXED_WIDTH_OUT_OF_RANGE)),
+        "expected only fixed-width range diagnostics, got {errors:?}"
+    );
+}
+
+#[test]
+fn test_fixed_width_match_literal_in_range_lowers() {
+    lower_source(
+        "def main():\n    value: uint8 = 255\n    match value:\n        case 255:\n            pass\n        case _:\n            pass\n",
+    )
+    .expect("in-range fixed-width match literal should lower");
+}
+
+#[test]
 fn test_fixed_width_module_constant_out_of_range_has_int_code() {
     let source = "LIMIT: uint8 = 255\nTOO_HIGH: uint8 = 256\n\ndef main():\n    print(\"ok\")\n";
     let errors =

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -778,7 +778,17 @@ pub(super) fn lower_pattern(
             } else {
                 // Try to lower as a literal expression
                 let expr = lower_expr(val_pat.value.as_ref(), ctx)?;
-                Some(HirPattern::Literal { value: expr })
+                let value = match validate_fixed_width_initializer(
+                    ctx,
+                    subject_ty,
+                    &expr,
+                    val_pat.value.range(),
+                ) {
+                    FixedWidthInitializerFit::Fits(value) => value,
+                    FixedWidthInitializerFit::Rejected => return None,
+                    FixedWidthInitializerFit::NotConst => expr,
+                };
+                Some(HirPattern::Literal { value })
             }
         }
         Pattern::MatchOr(or_pat) => {

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -457,6 +457,8 @@ Validation:
 - [x] INT-3 fixed-width multiplication API review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-mul-apis-review-pass-1.md`.
 - [x] INT-4 bytes `uint8` surface review pass 1 satisfied with a non-blocking display-option fallback cleanup note: `reviews/integer-model-int-4-bytes-uint8-surface-review-pass-1.md`.
 - [x] INT-4 bytes `uint8` surface review pass 2 satisfied after addressing the pass 1 cleanup note: `reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md`.
+- [x] INT-4 fixed-width literal pattern fitting review pass 1 satisfied with a non-blocking positive-coverage note: `reviews/integer-model-int-4-fixed-width-match-literal-review-pass-1.md`.
+- [x] INT-4 fixed-width literal pattern fitting review pass 2 satisfied after adding positive in-range coverage: `reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -524,6 +526,7 @@ Validation:
   - [x] Fixed-width instance `checked_mul`, `wrapping_mul`, `saturating_mul`, and `overflowing_mul` now expose explicit representation-preserving multiplication for same-width operands, reject mixed-width operands, lower to Rust primitive no-panic APIs, and cover overflow/non-overflow behavior in e2e; review is satisfied and quick validation is passing: PR #1870.
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
   - [x] `bytes` indexing, guarded indexing, and iteration now expose `uint8`; ordinary indexes and lengths remain `int`, stdlib bytes helpers widen explicitly with `int(b)`, display fallback typing is aligned, and focused bytes fixtures cover the surface; review is satisfied and quick validation is passing: PR #1872.
+  - [x] Fixed-width match literal patterns now reuse the fixed-width fitting diagnostic path, so in-range `uint8` cases such as `case 255` lower and out-of-range cases such as `case 256` fail with `SIFR-INT-0001`; review is satisfied and quick validation is passing: PR #1873.
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration

--- a/reviews/integer-model-int-4-fixed-width-match-literal-review-pass-1.md
+++ b/reviews/integer-model-int-4-fixed-width-match-literal-review-pass-1.md
@@ -1,0 +1,52 @@
+
+
+All validation passed. Here's my review:
+
+---
+
+## Review: INT-4 Fixed-Width Match Literal Fitting
+
+### Implementation Summary
+
+**Code change** (`statements.rs:778-791`): In `lower_pattern` for `Pattern::MatchValue`, after lowering the value expression, the code now calls `validate_fixed_width_initializer(ctx, subject_ty, &expr, val_pat.value.range())` and handles all three outcomes:
+- `Fits` → use the folded value (const-evaluable, in range)
+- `Rejected` → return `None` (out-of-range, diagnostic already emitted)
+- `NotConst` → use the original expression (e.g., enum variant)
+
+### Findings
+
+**No blocking issues.**
+
+1. **Correctness** (`statements.rs:781-791`): The validation is applied to literal patterns against fixed-width subjects. When `256` is used against `uint8`, `validate_fixed_width_initializer` correctly emits `SIFR-INT-0001` with message "integer value 256 does not fit target type uint8; valid range is 0..=255". The `Rejected` branch returns `None`, which propagates up and suppresses that arm while the other arms (e.g., `case _:`) continue processing.
+
+2. **Recursive coverage**: `MatchOr` patterns (`statements.rs:794-799`) recursively call `lower_pattern` on each sub-pattern, so each alternative is independently validated against the subject type. `MatchClass` (`statements.rs:801-850`) passes the field type (not the subject type) to `lower_pattern`, which is correct.
+
+3. **No panic risk**: `return None` from `lower_pattern` is safe — the match lowering handles `None` by skipping the arm (`statements.rs:884-888`), and the diagnostic is already emitted before returning.
+
+4. **Test coverage**:
+   - Unit test: `test_fixed_width_match_literal_out_of_range_has_int_code` in `expressions_tests.rs:266-285` — verifies exact diagnostic code, message, and primary range
+   - E2E fail fixture: `fixed_width_match_literal_out_of_range.sifr` — verifies the failure propagates to exit code
+
+### Non-blocking observations
+
+- **Test for positive case missing** (not blocking): The validation matrix calls for both positive cases (in-range literal arms) and negative cases (out-of-range). No positive test exists yet, but this is a pre-existing gap — not a regression from this PR.
+
+- **E2E harness note**: The reviewer noted the fail harness runs the full corpus rather than honoring `SIFR_E2E_FIXTURE_MANIFEST`, and prints an unrelated CFG panic from the broader corpus. This is a pre-existing harness behavior, not caused by this change.
+
+### Contract compliance with `internal_docs/integer_model.md`
+
+Section "Pattern Matching, Enums, and Containers" (lines 415-434):
+> Matching a fixed-width subject with an out-of-range literal is a compile-time error.
+
+The implementation correctly rejects `case 256:` against `uint8` with `SIFR-INT-0001`. The diagnostic includes the value, target type, and valid range — matching the "fixed-width narrowing out of range" diagnostic spec (lines 440-443).
+
+### Validation results
+
+- `cargo fmt --check`: passed
+- `git diff --check`: passed  
+- `cargo test -p sifr_hir test_fixed_width_match_literal_out_of_range_has_int_code`: passed
+- `scripts/run_all_tests.sh --profile quick`: all lanes green (24 pass, 0 fail)
+
+---
+
+**Final verdict: satisfied**

--- a/reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md
+++ b/reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md
@@ -1,0 +1,63 @@
+
+
+## Review: INT-4 Fixed-Width Match Literal Fitting (Final Pass)
+
+---
+
+### Summary
+
+This slice extends the INT-4 fixed-width validation from variable assignments and module constants into the `lower_pattern` path for `Pattern::MatchValue` literal patterns. The pass-1 non-blocking gap (missing positive coverage) has been resolved.
+
+---
+
+### Findings
+
+**No blocking issues.**
+
+#### 1. Correctness (`statements.rs:781-791`)
+
+The validation path is sound. After lowering the literal value expression, `validate_fixed_width_initializer` is called with the subject type as the target. Three outcomes are handled correctly:
+- `Fits` → the in-range folded literal (`255`, `0`, etc.) is folded into the pattern, correct
+- `Rejected` → diagnostic already emitted inline; `return None` suppresses the arm, correct
+- `NotConst` → the original expression used (e.g., enum variant `Color.RED` is not const-evaluable so it passes through unchanged), correct
+
+#### 2. Negative case (`expressions_tests.rs:266-284`, `fixed_width_match_literal_out_of_range.sifr`)
+
+`case 256:` against `uint8` produces exactly one `SIFR-INT-0001` with message `"integer value 256 does not fit target type uint8; valid range is 0..=255"`. Primary range correctly points to `"256"`. No other diagnostics are emitted (the second `assert` guards this). E2E fail fixture uses `#expect-error: SIFR-INT-0001` which is clean.
+
+#### 3. Positive case (`expressions_tests.rs:286-292`, `fixed_width_match_literal_fitting.sifr`)
+
+`case 255:` against `uint8` lowers without error. The E2E pass fixture covers both boundary literals (`255`, `0`) and runtime assertions to verify the generated Rust code is correct end-to-end.
+
+#### 4. `NotConst` is correct
+
+`validate_fixed_width_initializer` returns `NotConst` when the value expression is not a const-integer (e.g., a module constant name resolved via `ctx.const_integer_values`, a binary expression with non-const operands, etc.). In all these cases, skipping range validation is correct — the value is validated at the point it was originally defined.
+
+#### 5. No panic risk
+
+`return None` from `lower_pattern` is the established mechanism for skipping arms (used by `Pattern::MatchClass` invalid-class-name path at `statements.rs:810`, `Pattern::MatchValue` invalid-attr path at `statements.rs:772`). The caller at `statements.rs:884-888` handles `None` by skipping the arm.
+
+#### 6. Contract compliance
+
+`internal_docs/integer_model.md` line 415-434: *"Matching a fixed-width subject with an out-of-range literal is a compile-time error."* — implemented. Diagnostic format matches the spec for range errors (value + type + valid range).
+
+---
+
+### Non-blocking observations
+
+None — the pass-1 notes are all resolved.
+
+---
+
+### Validation results
+
+All locally verified per user report:
+- `cargo fmt --check` ✓
+- `git diff --check` ✓  
+- Unit tests: 2 tests pass (`test_fixed_width_match_literal_out_of_range_has_int_code`, `test_fixed_width_match_literal_in_range_lowers`) ✓
+- E2E pass fixture ✓
+- E2E fail fixture fails cleanly with only `SIFR-INT-0001` ✓
+
+---
+
+**Final verdict: satisfied**


### PR DESCRIPTION
## Summary
- validate literal match patterns against fixed-width subject types through the existing fixed-width fitting diagnostic path
- reject out-of-range cases such as `case 256` for `uint8` with `SIFR-INT-0001`
- add in-range pass coverage and out-of-range fail coverage plus review artifacts

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p sifr_hir fixed_width_match_literal -- --nocapture
- SIFR_E2E_FIXTURE_MANIFEST=... fixed_width_match_literal_fitting: passed
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/fixed_width_match_literal_out_of_range.sifr: fails cleanly with only SIFR-INT-0001
- scripts/run_all_tests.sh --profile quick

## Reviews
- reviews/integer-model-int-4-fixed-width-match-literal-review-pass-1.md: satisfied with non-blocking positive-coverage note
- reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md: satisfied
