### PR TITLE
Implement fixed-width sum and abs widening

### DIFF
--- a/crates/sifr/tests/e2e/pass/fixed_width_sum_abs_builtins.sifr
+++ b/crates/sifr/tests/e2e/pass/fixed_width_sum_abs_builtins.sifr
@@ -1,0 +1,14 @@
+def main():
+    left: int32 = 2000000000
+    right: int32 = 2000000000
+    values: list[int32] = [left, right]
+    total: int = sum(values)
+    assert str(total) == '4000000000'
+
+    minimum: int8 = -128
+    magnitude: int = abs(minimum)
+    assert str(magnitude) == '128'
+
+    byte: uint8 = 255
+    widened_byte_abs: int = abs(byte)
+    assert str(widened_byte_abs) == '255'

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -2134,18 +2134,42 @@ impl RustEmitter {
                 }
             }
             "sum" if args.len() == 1 => {
-                let sum_method = if let Some(elem_ty) =
-                    crate::resolve_alias_type_for_plain_call(args[0].ty()).iterable_element_type()
-                {
-                    format!(
-                        "sum::<{}>",
-                        crate::render_type(&crate::sifr_type_to_rust_type(&elem_ty))
-                    )
+                let elem_ty =
+                    crate::resolve_alias_type_for_plain_call(args[0].ty()).iterable_element_type();
+                let mut iter_expr = registry_iterable_to_owned_iter_expr(self, &args[0])?;
+                if matches!(
+                    elem_ty.as_ref().map(Type::resolve_alias),
+                    Some(Type::FixedInt(fixed)) if fixed.supports_current_int_builtin_widening()
+                ) {
+                    iter_expr = crate::RustExpr::MethodCall {
+                        receiver: Box::new(iter_expr),
+                        method: "map".to_string(),
+                        args: vec![crate::RustExpr::Closure {
+                            params: vec![crate::RustParam::Named {
+                                name: "__sum_item".to_string(),
+                                ty: crate::RustType::Named("_".to_string()),
+                            }],
+                            body: Box::new(crate::RustExpr::Cast {
+                                expr: Box::new(crate::RustExpr::Ident("__sum_item".to_string())),
+                                ty: crate::RustType::I64,
+                            }),
+                            is_move: false,
+                        }],
+                    };
+                }
+                let sum_method = if let Some(elem_ty) = elem_ty {
+                    let sum_ty = match elem_ty.resolve_alias() {
+                        Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening() => {
+                            crate::RustType::I64
+                        }
+                        _ => crate::sifr_type_to_rust_type(&elem_ty),
+                    };
+                    format!("sum::<{}>", crate::render_type(&sum_ty))
                 } else {
                     "sum".to_string()
                 };
                 let iter_chain = crate::RustExpr::MethodCall {
-                    receiver: Box::new(registry_iterable_to_owned_iter_expr(self, &args[0])?),
+                    receiver: Box::new(iter_expr),
                     method: sum_method,
                     args: vec![],
                 };
@@ -2615,6 +2639,17 @@ impl RustEmitter {
             }
             "abs" if args.len() == 1 => {
                 let lowered = self.try_lower_registry_expr_strict(&args[0])?;
+                let lowered = if matches!(
+                    crate::resolve_alias_type_for_plain_call(args[0].ty()),
+                    Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening()
+                ) {
+                    crate::RustExpr::Cast {
+                        expr: Box::new(lowered),
+                        ty: crate::RustType::I64,
+                    }
+                } else {
+                    lowered
+                };
                 Some(crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered))),
                     method: "abs".to_string(),

--- a/crates/sifr_hir/src/lower/expression_abs.rs
+++ b/crates/sifr_hir/src/lower/expression_abs.rs
@@ -1,0 +1,71 @@
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_python_ast::ExprCall;
+use sifr_type_system::Type;
+
+use super::expression_diagnostics;
+use super::expressions::lower_expr;
+use super::LowerCtx;
+
+fn first_call_keyword_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .keywords
+        .first()
+        .map_or_else(|| call.func.range(), |keyword| keyword.range)
+}
+
+fn call_arity_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .args
+        .last()
+        .map_or_else(|| call.func.range(), Ranged::range)
+}
+
+pub(super) fn lower_abs_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "abs() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return None;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            format!(
+                "abs() takes exactly 1 argument, got {}",
+                call.arguments.args.len()
+            ),
+            call_arity_range(call),
+        );
+        return None;
+    }
+    let arg = lower_expr(&call.arguments.args[0], ctx)?;
+    let ty = arg.ty().clone();
+    let fixed_width_abs_widens = matches!(
+        ty.resolve_alias(),
+        Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening()
+    );
+    if !ty.is_numeric() && !fixed_width_abs_widens {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "abs() argument must be numeric, got '{}'",
+                ty.display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return None;
+    }
+    let ty = if fixed_width_abs_widens {
+        Type::Int
+    } else {
+        ty
+    };
+    Some(HirExpr::Call {
+        func: "abs".to_string(),
+        args: vec![arg],
+        ty,
+    })
+}

--- a/crates/sifr_hir/src/lower/expression_sum_sorted.rs
+++ b/crates/sifr_hir/src/lower/expression_sum_sorted.rs
@@ -54,10 +54,14 @@ pub(super) fn lower_sum_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirE
         );
         return None;
     };
+    let result_ty = match elem_ty.resolve_alias() {
+        Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening() => Type::Int,
+        _ => elem_ty,
+    };
     Some(HirExpr::Call {
         func: "sum".to_string(),
         args: vec![arg],
-        ty: elem_ty,
+        ty: result_ty,
     })
 }
 

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -22,6 +22,7 @@ use super::diagnostics::list_append_argument_type_mismatch;
 use super::empty_collection_refinement::{
     refine_empty_list_binding_expr, refine_empty_set_binding_expr,
 };
+use super::expression_abs::lower_abs_call;
 use super::expression_diagnostics;
 use super::expression_functional_builtins::{
     lower_any_all_call, lower_filter_call, lower_map_call, lower_zip_call,
@@ -621,43 +622,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
 
         // Special handling for abs() built-in
         if func_name == "abs" {
-            if !call.arguments.keywords.is_empty() {
-                expression_diagnostics::call_unexpected_keyword(
-                    ctx,
-                    "abs() does not accept keyword arguments".to_string(),
-                    first_call_keyword_range(call),
-                );
-                return None;
-            }
-            if call.arguments.args.len() != 1 {
-                expression_diagnostics::call_wrong_positional_count(
-                    ctx,
-                    format!(
-                        "abs() takes exactly 1 argument, got {}",
-                        call.arguments.args.len()
-                    ),
-                    call_arity_range(call),
-                );
-                return None;
-            }
-            let arg = lower_expr(&call.arguments.args[0], ctx)?;
-            let ty = arg.ty().clone();
-            if !ty.is_numeric() {
-                expression_diagnostics::type_mismatch(
-                    ctx,
-                    format!(
-                        "abs() argument must be numeric, got '{}'",
-                        ty.display_name()
-                    ),
-                    call.arguments.args[0].range(),
-                );
-                return None;
-            }
-            return Some(HirExpr::Call {
-                func: "abs".to_string(),
-                args: vec![arg],
-                ty,
-            });
+            return lower_abs_call(call, ctx);
         }
 
         // Special handling for hash() built-in

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1942,6 +1942,22 @@ fn test_scalar_builtin_type_mismatches_have_type_code() {
 }
 
 #[test]
+fn test_abs_fixed_width_builtin_widens_to_int() {
+    let module =
+        lower_source("def main():\n    value: int8 = -128\n    widened: int = abs(value)\n")
+            .expect("fixed-width abs should widen to int");
+    let main_fn = module
+        .functions
+        .iter()
+        .find(|func| func.name == "main")
+        .expect("main should lower");
+    let HirStmt::Let { ty, .. } = &main_fn.body[1] else {
+        panic!("expected widened let");
+    };
+    assert_eq!(ty, &Type::Int);
+}
+
+#[test]
 fn test_hash_unhashable_argument_has_proto_code() {
     let result = lower_source(
         "class Measurement:\n    value: float\n\n    def __init__(self, value: float):\n        self.value = value\n\ndef main():\n    m: Measurement = Measurement(3.14)\n    print(hash(m))\n",
@@ -4318,6 +4334,23 @@ fn test_sum_keyword_and_type_errors_have_codes() {
             && error.code == Some(DiagnosticCode::TYPE_MISMATCH)
             && error.primary_range == Some(range_for_after_anchor(type_source, "sum(", "1"))
     }));
+}
+
+#[test]
+fn test_sum_fixed_width_iterable_widens_to_int() {
+    let module = lower_source(
+        "def main():\n    left: int32 = 2000000000\n    right: int32 = 2000000000\n    values: list[int32] = [left, right]\n    total: int = sum(values)\n",
+    )
+    .expect("fixed-width sum should widen to int");
+    let main_fn = module
+        .functions
+        .iter()
+        .find(|func| func.name == "main")
+        .expect("main should lower");
+    let HirStmt::Let { ty, .. } = &main_fn.body[3] else {
+        panic!("expected total let");
+    };
+    assert_eq!(ty, &Type::Int);
 }
 
 #[test]

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -24,6 +24,7 @@ mod default_args;
 mod defaultdict_refinement;
 mod diagnostics;
 mod empty_collection_refinement;
+mod expression_abs;
 mod expression_diagnostics;
 mod expression_functional_builtins;
 mod expression_iter_builtins;

--- a/crates/sifr_hir/src/lower/nested_function_inference.rs
+++ b/crates/sifr_hir/src/lower/nested_function_inference.rs
@@ -1131,13 +1131,19 @@ fn infer_call_type(
                 return Type::List(Box::new(elem_ty));
             }
             if name.id == "sum" {
-                return call
+                let elem_ty = call
                     .arguments
                     .args
                     .first()
                     .map(|arg| infer_expr_type(arg, env, states, current_function, ctx))
                     .and_then(|arg_ty| arg_ty.iterable_element_type())
                     .unwrap_or(Type::Unknown);
+                return match elem_ty.resolve_alias() {
+                    Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening() => {
+                        Type::Int
+                    }
+                    _ => elem_ty,
+                };
             }
             if name.id == "Counter" {
                 let key_ty = call
@@ -1156,12 +1162,18 @@ fn infer_call_type(
                 return Type::Int;
             }
             if name.id == "abs" {
-                return call
+                let arg_ty = call
                     .arguments
                     .args
                     .first()
                     .map(|arg| infer_expr_type(arg, env, states, current_function, ctx))
                     .unwrap_or(Type::Unknown);
+                return match arg_ty.resolve_alias() {
+                    Type::FixedInt(fixed) if fixed.supports_current_int_builtin_widening() => {
+                        Type::Int
+                    }
+                    _ => arg_ty,
+                };
             }
             if name.id == "max" || name.id == "min" {
                 let mut result = Type::Unknown;

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -132,6 +132,14 @@ pub enum FixedIntType {
 
 impl FixedIntType {
     #[must_use]
+    pub const fn supports_current_int_builtin_widening(self) -> bool {
+        matches!(
+            self,
+            Self::I8 | Self::I16 | Self::I32 | Self::U8 | Self::U16 | Self::U32
+        )
+    }
+
+    #[must_use]
     pub const fn source_name(self) -> &'static str {
         match self {
             Self::I8 => "int8",
@@ -1449,6 +1457,29 @@ mod tests {
         let fixed = Type::FixedInt(FixedIntType::U32);
         assert_eq!(fixed.display_name(), "uint32");
         assert_eq!(fixed.union_variant_name(), "Uint32");
+    }
+
+    #[test]
+    fn test_fixed_width_current_int_builtin_widening_policy() {
+        for fixed in [
+            FixedIntType::I8,
+            FixedIntType::I16,
+            FixedIntType::I32,
+            FixedIntType::U8,
+            FixedIntType::U16,
+            FixedIntType::U32,
+        ] {
+            assert!(fixed.supports_current_int_builtin_widening());
+        }
+
+        for fixed in [
+            FixedIntType::I64,
+            FixedIntType::U64,
+            FixedIntType::ISize,
+            FixedIntType::USize,
+        ] {
+            assert!(!fixed.supports_current_int_builtin_widening());
+        }
     }
 
     #[test]

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -459,6 +459,8 @@ Validation:
 - [x] INT-4 bytes `uint8` surface review pass 2 satisfied after addressing the pass 1 cleanup note: `reviews/integer-model-int-4-bytes-uint8-surface-review-pass-2.md`.
 - [x] INT-4 fixed-width literal pattern fitting review pass 1 satisfied with a non-blocking positive-coverage note: `reviews/integer-model-int-4-fixed-width-match-literal-review-pass-1.md`.
 - [x] INT-4 fixed-width literal pattern fitting review pass 2 satisfied after adding positive in-range coverage: `reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md`.
+- [x] INT-4 fixed-width `sum`/`abs` builtin review pass 1 completed with guardrail and duplicate-policy blockers: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-1.md`.
+- [x] INT-4 fixed-width `sum`/`abs` builtin review pass 2 satisfied after extracting `abs` lowering and sharing the widening policy: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -527,6 +529,7 @@ Validation:
 - [ ] INT-4 builtins, indexing, bytes, ranges, and pattern matching
   - [x] `bytes` indexing, guarded indexing, and iteration now expose `uint8`; ordinary indexes and lengths remain `int`, stdlib bytes helpers widen explicitly with `int(b)`, display fallback typing is aligned, and focused bytes fixtures cover the surface; review is satisfied and quick validation is passing: PR #1872.
   - [x] Fixed-width match literal patterns now reuse the fixed-width fitting diagnostic path, so in-range `uint8` cases such as `case 255` lower and out-of-range cases such as `case 256` fail with `SIFR-INT-0001`; review is satisfied and quick validation is passing: PR #1873.
+  - [x] `sum(list[int32])` and `abs(int8.MIN)` now widen to `int` for the currently safe fixed-width builtin families, with shared policy coverage, focused e2e coverage, review satisfied, and quick validation passing: PR #1874.
 - [ ] INT-5 serialization, web, and schema boundaries
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration

--- a/reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-1.md
+++ b/reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-1.md
@@ -1,0 +1,74 @@
+
+
+# Code Review: INT-4 Fixed-Width Sum/Abs Builtins
+
+## Severity 1 — Blocking
+
+### 1. `expressions.rs` now exceeds the HIR maintainability guardrail
+The guardrail limit is 3800 lines; the file is now **3821 lines** (21 lines over). The `scripts/check_hir_maintainability_guardrails.py` check explicitly fails:
+```
+HIR maintainability guardrails: FAIL
+- crates/sifr_hir/src/lower/expressions.rs is 3821 lines (limit 3800)
+```
+
+The 15 lines added (`fixed_width_abs_widens_to_current_int` helper + ~6 lines of widening logic in `lower_call`) pushed it over the limit. This blocks the local validation gate.
+
+**Fix:** Move the helper function to a shared location (e.g., `super::builtin_calls` or a new `expressions_helpers.rs`) and keep only the call-site logic in `expressions.rs`. The widening decision in `lower_call` is small enough to stay inline.
+
+---
+
+## Severity 2 — Code Quality / Internal Consistency
+
+### 2. Four identical `fixed_width_*_widens_to_current_int` helpers
+The same `matches!(FixedIntType::I8|I16|I32|U8|U16|U32)` predicate is copy-pasted in four locations:
+
+| Location | Function name |
+|---|---|
+| `expressions.rs` | `fixed_width_abs_widens_to_current_int` |
+| `expression_sum_sorted.rs` | `fixed_width_sum_widens_to_current_int` |
+| `nested_function_inference.rs` | `fixed_width_builtin_widens_to_current_int` |
+| `intrinsic_method_emitters.rs` | `fixed_width_builtin_widens_to_current_int` |
+
+These are byte-for-byte identical except for the function name. With the conservative fixed-width set being a deliberate implementation choice (not expected to change per-slice), this duplication is a maintenance hazard: when the set expands in a future slice, all four must be kept in sync.
+
+**Fix:** Extract to a shared helper. Since `sifr_type_system` already has `FixedIntType`, this could live as `pub fn fixed_width_widens_to_int(fixed: FixedIntType) -> bool` in `sifr_type_system` or in a shared `hir::lower::builtin_helpers` module. The function name should be generic (`*_widens_to_int`) since it applies to both `sum` and `abs`.
+
+---
+
+## Severity 3 — Diagnostics
+
+### 3. `abs(int8.MIN)` edge case is handled correctly in codegen but not reflected in the error message
+
+The codegen correctly widens fixed-width to `i64` before calling `.abs()`, so `abs(-128i8)` generates `(-128i8 as i64).abs()` which produces `128i64`. This matches the contract.
+
+However, the current error message for `abs()` on non-numeric types says `"abs() argument must be numeric, got 'X'"`. This is slightly imprecise for fixed-width integers — they *are* numeric, they just don't pass the `ty.is_numeric()` check. The widened types are technically valid, so the error path for `abs()` with a fixed-width type is unreachable. But if a user somehow triggers the old path (shouldn't happen), the message is misleading.
+
+**Verdict:** Not blocking — the widening is correct and the guard `!ty.is_numeric() && !fixed_width_abs_widens` correctly lets in fixed-width types. No action needed.
+
+---
+
+## Severity 4 — Test Coverage (Informational)
+
+### 4. The e2e fixture is not registered in the test harness
+The file `crates/sifr/tests/e2e/pass/fixed_width_sum_abs_builtins.sifr` exists but is not included in the e2e test runner's discovery mechanism. Running `scripts/run_e2e_pass.sh` with fixture selection fails because the harness doesn't discover untracked fixtures. The unit tests in `expressions_tests.rs` cover the HIR lowering correctly, but the e2e fixture would never run in CI.
+
+**Fix:** Register the fixture or confirm it's intentionally a manual-only test. Given the unit test coverage, this is low urgency, but the fixture won't serve its purpose if it can't run in CI.
+
+---
+
+## Contract Alignment Assessment
+
+The implementation correctly implements the slice's stated acceptance criteria:
+
+- **`sum(list[int32])` returns source-level `int`**: ✓ Widening via `.map(|x| x as i64).sum::<i64>()` and HIR type set to `Type::Int`. The `expressions_tests.rs` test confirms the inferred type is `Type::Int`.
+- **`abs(int8.MIN)` returns source-level `int`**: ✓ Widen-to-i64 before `.abs()` prevents overflow. The e2e fixture asserts `abs(-128)` yields `128` and the codegen confirms the generated Rust is `(-128i8 as i64).abs()`.
+
+The conservative set (`I8/I16/I32/U8/U16/U32`) is correctly scoped — `int64`/`uint64`/`isize`/`usize` would overflow an i64-backed accumulator and are correctly excluded.
+
+---
+
+## Verdict
+
+**Another pass is required after fixes.**
+
+The guardrail violation in `expressions.rs` is a blocking failure — the local validation gate does not pass. The duplicate helpers are a code quality issue that should be addressed before merging, as they create a synchronization hazard for future widening set expansion.

--- a/reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md
+++ b/reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md
@@ -1,0 +1,82 @@
+
+
+---
+
+# Code Review: INT-4 Fixed-Width Sum/Abs Builtins — Pass 2
+
+## Pass 1 Blocker Status
+
+| Pass 1 Finding | Status |
+|---|---|
+| 1. `expressions.rs` exceeded HIR maintainability guardrail (3821 > 3800 lines) | **FIXED** — `abs()` lowering extracted to `expression_abs.rs`, module declared in `mod.rs` line 27. Guardrail now passes. |
+| 2. Four identical widening predicates | **FIXED** — Single policy method `FixedIntType::supports_current_int_builtin_widening()` added to `sifr_type_system/src/types.rs:135-140`. HIR, codegen, and nested function inference all call this shared method. |
+| 3. e2e fixture not discoverable | **FIxt** — Fixture exists at `crates/sifr/tests/e2e/pass/fixed_width_sum_abs_builtins.sifr`. E2E discovery confirmed: passes when manifest is correctly structured (`{"fixture_names": ["fixed_width_sum_abs_builtins"]}`). |
+
+---
+
+## Validation Results
+
+All local validation steps passed:
+
+| Check | Result |
+|---|---|
+| `cargo fmt --check` | PASS |
+| `scripts/check_hir_maintainability_guardrails.py` | PASS |
+| `cargo test -p sifr_type_system test_fixed_width_current_int_builtin_widening_policy` | PASS |
+| `cargo test -p sifr_hir test_abs_fixed_width_builtin_widens_to_int` | PASS |
+| `cargo test -p sifr_hir test_sum_fixed_width_iterable_widens_to_int` | PASS |
+| `cargo test -p sifr_codegen sum` | PASS (4 tests) |
+| `git diff --check` | PASS |
+| E2E fixture `fixed_width_sum_abs_builtins` | PASS |
+
+---
+
+## Contract Alignment
+
+The implementation correctly implements the canonical design from `internal_docs/integer_model.md`:
+
+| Contract Rule | Implementation | Status |
+|---|---|---|
+| `sum(list[int8/int16/int32/uint8/uint16/uint32])` returns `int` | HIR widening + codegen `.map(\|x\| x as i64).sum::<i64>()` | ✓ |
+| `sum(list[int64/uint64/isize/usize])` returns fixed-width | No widening applied | ✓ |
+| `abs(int8.MIN)` returns `int` (not `int8`) | Codegen widens to `i64` before `.abs()`, e2e fixture asserts `abs(-128) == 128` | ✓ |
+| Conservative set correctly scoped | `I8/I16/I32/U8/U16/U32` included; `I64/U64/ISize/USize` excluded | ✓ |
+
+---
+
+## Codegen Safety Assessment
+
+No user-triggerable panics identified:
+
+| Codegen Path | Analysis |
+|---|---|
+| `sum` for widening types (line 2136–2176) | Uses `sum::<i64>()` with map cast. Iterator consumed and accumulated. No panics. |
+| `sum` for non-widening types (line 2165) | Falls through to element type's native `sum`. No additional wrapping. |
+| `abs` for widening types (line 2640–2657) | Cast to `i64` before `.abs()`. Prevents `int8::MIN.abs()` overflow. |
+| `abs` for non-widening types (line 2651) | Pass-through to native `.abs()`. No additional wrapping. |
+
+---
+
+## Architecture Quality
+
+**Shared policy**: `FixedIntType::supports_current_int_builtin_widening()` in `sifr_type_system` is the canonical source of truth. One call site in each of:
+- `expression_abs.rs:48` — HIR `abs()` lowering
+- `expression_sum_sorted.rs:58` — HIR `sum()` lowering
+- `nested_function_inference.rs:1142,1172` — Nested function type inference
+- `intrinsic_method_emitters.rs:2142,2162,2644` — Codegen (all three occurrences are necessary: two in `sum` for element type check, one in `abs`)
+
+**File decomposition**: `expression_abs.rs` is 72 lines, well-scoped. No monolithic files.
+
+---
+
+## Minor Note (Not a Blocker)
+
+The `--fixture-manifest` usage in the review request specified just the file stem (`fixed_width_sum_abs_builtins`) but the actual manifest format requires a JSON object: `{"fixture_names": ["fixed_width_sum_abs_builtins"]}`. The script's help text could be clearer. Not blocking since the fixture is discoverable via normal e2e discovery when no manifest is specified.
+
+---
+
+## Verdict
+
+**All pass 1 blockers resolved. Review satisfied — no further passes required.**
+
+The implementation is correct, contract-aligned, guardrail-compliant, and codegen-safe. The shared policy method eliminates the duplication that was the primary code quality concern.


### PR DESCRIPTION
## Summary
- widen fixed-width sum/abs builtin HIR and nested inference results to source-level int for the currently safe fixed-width families
- cast fixed-width sum and abs codegen through i64 to avoid int8::MIN abs overflow and int32 sum overflow
- extract abs lowering from expressions.rs and share the builtin widening policy on FixedIntType
- add HIR/type-system/e2e coverage and record Claude review pass artifacts

## Validation
- scripts/run_all_tests.sh --profile quick
- reviewer satisfied: reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md