### PR TITLE
Extend exact-int nonzero guard proof

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_nonzero_elif_and_nested_guards.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_nonzero_elif_and_nested_guards.sifr
@@ -1,0 +1,17 @@
+def guarded_elif(flag: bool, divisor: int) -> int:
+    if flag:
+        return 0
+    elif divisor == 0:
+        return 0
+    return 10 // divisor
+
+
+def guarded_nested(left: int, right: int) -> int:
+    if not (left == 0 or right == 0):
+        return (10 // left) + (10 % right)
+    return 0
+
+
+def main():
+    assert str(guarded_elif(False, 3)) == '3'
+    assert str(guarded_nested(2, 3)) == '6'

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -666,6 +666,54 @@ def main() -> None:
 }
 
 #[test]
+fn test_exact_int_division_after_elif_zero_guard_early_exit_lowers() {
+    let module = lower_source(
+        "\
+def main(flag: bool) -> None:
+    divisor: int = 3
+    if flag:
+        return
+    elif divisor == 0:
+        return
+    value: int = 10 // divisor
+",
+    )
+    .expect("elif early-exit zero guard should prove the divisor is non-zero after the chain");
+
+    assert!(matches!(
+        function_let_value(&module, "value"),
+        HirExpr::BinOp { ty: Type::Int, .. }
+    ));
+}
+
+#[test]
+fn test_exact_int_division_inside_nested_nonzero_guard_lowers() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    left: int = 3
+    right: int = 2
+    if not (left == 0 or right == 0):
+        a: int = 10 // left
+        b: int = 10 % right
+",
+    )
+    .expect("nested boolean zero guard should prove both divisors are non-zero inside the branch");
+
+    let HirStmt::If { then_body, .. } = &module.functions[0].body[2] else {
+        panic!("expected if statement");
+    };
+    let HirStmt::Let { value: a, .. } = &then_body[0] else {
+        panic!("expected first guarded let");
+    };
+    let HirStmt::Let { value: b, .. } = &then_body[1] else {
+        panic!("expected second guarded let");
+    };
+    assert!(matches!(a, HirExpr::BinOp { ty: Type::Int, .. }));
+    assert!(matches!(b, HirExpr::BinOp { ty: Type::Int, .. }));
+}
+
+#[test]
 fn test_exact_int_nonzero_guard_is_cleared_after_reassignment() {
     let source = "\
 def main() -> None:

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1737,6 +1737,12 @@ pub(super) fn lower_if(
 
     let mut branch_moved_states: Vec<_> = vec![then_moved];
     let mut branch_sequence_states = vec![then_sequence_guards];
+    let mut post_if_false_nonzero_guards = Vec::new();
+    let mut all_previous_branches_exit = then_body_always_exits(&then_body);
+    if all_previous_branches_exit {
+        post_if_false_nonzero_guards
+            .extend(detect_false_nonzero_integer_guards(&if_stmt.test, ctx));
+    }
 
     let mut elif_clauses = Vec::new();
     for clause in &if_stmt.elif_else_clauses {
@@ -1767,6 +1773,11 @@ pub(super) fn lower_if(
             ctx.scope.push();
             let body = lower_stmts(&clause.body, func_type, ctx);
             ctx.scope.pop();
+            let elif_body_exits = then_body_always_exits(&body);
+            if all_previous_branches_exit && elif_body_exits {
+                post_if_false_nonzero_guards.extend(detect_false_nonzero_integer_guards(test, ctx));
+            }
+            all_previous_branches_exit &= elif_body_exits;
             elif_clauses.push((cond, body));
 
             branch_moved_states.push(ctx.scope.save_moved_state());
@@ -1831,9 +1842,9 @@ pub(super) fn lower_if(
         for guard in detect_false_exit_sequence_guards(&if_stmt.test, ctx) {
             ctx.add_sequence_guard(guard);
         }
-        for name in detect_false_nonzero_integer_guards(&if_stmt.test, ctx) {
-            ctx.add_proven_nonzero_integer_binding(name);
-        }
+    }
+    for name in post_if_false_nonzero_guards {
+        ctx.add_proven_nonzero_integer_binding(name);
     }
     ctx.clear_sequence_pointers();
     Some(HirStmt::If {

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -420,6 +420,7 @@ Validation:
 - [x] INT-1 exact-int division/modulo diagnostic scaffold review satisfied with non-blocking direct `//=` literal coverage follow-up: `reviews/integer-model-int-1-exact-int-division-diagnostic-scaffold-review-pass-1.md`.
 - [x] INT-1 exact-int augmented-assignment literal suppression coverage review satisfied with no blockers: `reviews/integer-model-int-1-exact-int-augassign-literal-coverage-review-pass-1.md`.
 - [x] INT-1 exact-int non-zero guard proof review satisfied with non-blocking `elif`/nested-logic coverage follow-ups: `reviews/integer-model-int-1-exact-int-nonzero-guards-review-pass-1.md`.
+- [x] INT-1 exact-int non-zero guard follow-up review satisfied after adding `elif` early-exit and nested boolean guard coverage: `reviews/integer-model-int-1-exact-int-nonzero-guards-review-pass-2.md`.
 - [x] INT-2A reserved-width diagnostic review pass 1 completed with doc-code normalization blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-1.md`.
 - [x] INT-2A reserved-width diagnostic review pass 2 satisfied after addressing blocker: `reviews/integer-model-int-2a-reserved-width-diagnostic-review-pass-2b.md`.
 - [x] INT-2A large integer literal HIR review pass 1 completed with canonical-representation blocker: `reviews/integer-model-int-2a-large-literal-hir-review-pass-1b.md`.
@@ -492,6 +493,7 @@ Validation:
   - [x] User-code exact-int `//`, `%`, `//=`, and `%=` with unproven exact-int divisors now fail closed with active `SIFR-INT-0005` diagnostics unless the divisor is a syntactically non-zero integer literal; trusted stdlib lowering remains exempt until broader guard/proof tracking covers its internal non-zero loops; review is satisfied and quick validation is passing: PR #1857.
   - [x] Direct HIR coverage now proves exact-int `//=` and `%=` with syntactically non-zero integer literal divisors still lower successfully, closing the scaffold review hardening note; review is satisfied and quick validation is passing: PR #1858.
   - [x] Conservative non-literal exact-int non-zero facts now suppress `SIFR-INT-0005` for guarded divisors in `x != 0` true branches, `if x == 0: return/raise` early-exit false paths, and `while x != 0` bodies; reassignment and augmented assignment clear those facts, and the guarded `DivisionError` pass fixture now uses the checked parameter divisor again; review is satisfied and quick validation is passing: PR #1859.
+  - [x] Exact-int non-zero proof now covers early-exit `elif` zero guards and nested boolean guard composition such as `not (left == 0 or right == 0)`, with focused HIR/e2e coverage, review satisfied, and quick validation passing: PR #1875.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: full `Result[int, DivisionError]` expression/codegen integration and non-literal proven-nonzero analysis still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-nonzero-guards-review-pass-2.md
+++ b/reviews/integer-model-int-1-exact-int-nonzero-guards-review-pass-2.md
@@ -1,0 +1,79 @@
+
+
+---
+
+## Review: INT-1 exact-int nonzero guard follow-up (elif + nested guards)
+
+**Verdict: APPROVED**
+
+No blocking findings. The implementation is sound.
+
+---
+
+### Blocking Findings
+none
+
+---
+
+### Non-Blocking Findings
+
+**1. No test for `elif` with `else` clause when all guards exit**
+
+The current test `test_exact_int_division_after_elif_zero_guard_early_exit_lowers` uses `elif` with no `else`. A variant with a bare `else:` clause where all guards exit would exercise the else-body save/restore cycle in addition to the elif chain:
+
+```python
+if flag: return
+elif divisor == 0: return
+else: pass
+result = 10 // divisor
+```
+
+This is minor — the save/restore pattern is identical to the existing code and the e2e fixture covers similar shapes.
+
+**2. `all_previous_branches_exit` mutation during elif iteration**
+
+At lines 1777–1780, `all_previous_branches_exit` is both read (`if all_previous_branches_exit && elif_body_exits`) and written (`all_previous_branches_exit &= elif_body_exits`). This is correct but worth noting: the flag must be updated *after* the condition check so the current branch's exit status does not influence its own guard collection. The ordering is sound because `elif_body_exits` is computed from the body, and the guard collection uses `all_previous_branches_exit` (pre-update) to determine whether to propagate. No issue — just worth a comment for future maintainers.
+
+**3. Guard collection in elif uses `saved_nonzero_integer_bindings` not `elif_saved`**
+
+At line 1753, each elif iteration restores from `saved_nonzero_integer_bindings` (the pre-if snapshot) rather than the elif-specific save. This is correct — the elif is building on the false-branch of the if (and all previous elifs), so it must start from the original state. The elif-specific `elif_saved` (line 1762) is used only for narrowing within that elif's true branch, not for the outer restore. Confirmed correct.
+
+---
+
+### Soundness Analysis
+
+| Property | Analysis | Status |
+|---|---|---|
+| **elif chain propagation** | `all_previous_branches_exit` initialized from `then_body_always_exits(&then_body)` and updated with `&=` per elif. Guards collected only when previous branches all exit. | ✓ |
+| **Nested guard composition** | `detect_true_nonzero_integer_guards` handles `not (X or Y)` by delegating to `detect_false_nonzero_integer_guards`, which propagates through `BoolOp::Or` to collect both operands. | ✓ |
+| **Save/restore discipline** | Every branch (if, elif, else) properly saves before body and restores after. | ✓ |
+| **Post-chain application** | `post_if_false_nonzero_guards` accumulated during processing, applied once at end (line 1846). | ✓ |
+| **Reassignment invalidation** | `invalidate_rebound_binding_facts` calls `clear_proven_nonzero_integer_binding` (line 992). Unit test validates. | ✓ |
+| **Augassign unconditional clear** | Correct — clearing a non-member is a no-op; no incorrect suppression. | ✓ |
+| **Diagnostic suppression surface** | Only `HirExpr::Name` nodes reach `is_proven_nonzero_integer_binding`; literals are handled separately via `is_proven_nonzero_integer_expr` matching on `IntLiteral`/`LargeIntLiteral`. | ✓ |
+| **Path sensitivity for if/elif/else** | Guard is applied after the full chain, not after the if alone. Nested guard marks both operands non-zero inside the branch. Correct. | ✓ |
+
+---
+
+### Validation Notes
+
+All validation commands passed:
+- `cargo test -p sifr_hir exact_int -- --nocapture`: 13 tests pass
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_nonzero_elif_and_nested_guards.sifr`: correct Rust codegen
+- `scripts/run_all_tests.sh --profile quick`: 24 e2e pass tests, report signature `e1bf653aaa770517`
+
+The e2e fixture exercises the two new shapes:
+- `guarded_elif`: `if flag: return` + `elif divisor == 0: return` proves `divisor` non-zero after chain
+- `guarded_nested`: `not (left == 0 or right == 0)` proves both `left` and `right` non-zero inside branch
+
+---
+
+### Residual Risks
+
+Acceptable. The proven-nonzero binding set is a `HashSet<String>` with save/restore at every if/elif/else/while boundary. The follow-up correctly handles sequential guards in elif chains and logical composition in nested guards. The save/restore pattern is consistent with the prior pass.
+
+---
+
+### Recommendation
+
+**This review is satisfied.** The implementation is sound and the coverage is adequate. Proceed to PR.


### PR DESCRIPTION
## Summary
- propagate exact-int nonzero facts after early-exit if/elif chains
- add nested boolean guard coverage for `not (x == 0 or y == 0)`
- add focused HIR/e2e coverage and record Claude review

## Validation
- scripts/run_all_tests.sh --profile quick
- reviewer satisfied: reviews/integer-model-int-1-exact-int-nonzero-guards-review-pass-2.md