### PR TITLE
Lower exact int floor mod to Result

### DIFF
--- a/crates/sifr/tests/e2e/fail/exact_int_division_requires_handling.sifr
+++ b/crates/sifr/tests/e2e/fail/exact_int_division_requires_handling.sifr
@@ -1,4 +1,4 @@
-# expect-error: SIFR-INT-0005
+# expect-error: SIFR-TYPE-0002
 
 def main() -> None:
     divisor: int = 3

--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result.sifr
@@ -1,0 +1,11 @@
+def main():
+    divisor: int = 0
+    try:
+        value: int = 10 // divisor
+        _ = value
+    except DivisionError as e:
+        assert str(e.message) == 'division by zero'
+
+    mod_divisor: int = 3
+    remainder: Result[int, DivisionError] = 10 % mod_divisor
+    _ = remainder

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -512,6 +512,7 @@ impl RustEmitter {
                 let value = self.rewrite_stdlib_constant_idents_in_expr(value);
                 let force_sifr_int = self.is_forced_sifr_int_local(&name);
                 let value_is_sifr_int = self.is_sifr_int_expr(&value);
+                let value_is_sifr_int_result = self.is_sifr_int_result_expr(&value);
                 let (ty, value) =
                     if is_legacy_i64_type(&ty) && (value_is_sifr_int || force_sifr_int) {
                         let value = self.coerce_expr_to_sifr_int_value(value);
@@ -519,6 +520,8 @@ impl RustEmitter {
                             .borrow_mut()
                             .insert(name.clone());
                         (Some(crate::RustType::Named("SifrInt".to_string())), value)
+                    } else if is_result_legacy_i64_type(&ty) && value_is_sifr_int_result {
+                        (ty.map(result_i64_type_to_sifr_int), value)
                     } else {
                         if !force_sifr_int {
                             self.sifr_int_local_bindings.borrow_mut().remove(&name);
@@ -1466,7 +1469,7 @@ impl RustEmitter {
         self.sifr_int_forced_local_bindings.borrow().contains(name)
     }
 
-    fn is_sifr_int_expr(&self, expr: &crate::RustExpr) -> bool {
+    pub(super) fn is_sifr_int_expr(&self, expr: &crate::RustExpr) -> bool {
         match expr {
             crate::RustExpr::FnCall { func, args } => {
                 (args.is_empty() && self.is_sifr_int_module_constant_func(func))
@@ -1495,8 +1498,32 @@ impl RustEmitter {
             crate::RustExpr::Paren(inner) => self.is_sifr_int_expr(inner),
             crate::RustExpr::Ref { expr, .. } => self.is_sifr_int_expr(expr),
             crate::RustExpr::Clone(expr) => self.is_sifr_int_expr(expr),
+            crate::RustExpr::Try(expr) => self.is_sifr_int_result_expr(expr),
             _ => false,
         }
+    }
+
+    pub(super) fn is_sifr_int_result_expr(&self, expr: &crate::RustExpr) -> bool {
+        match expr {
+            crate::RustExpr::Block {
+                expr: Some(inner), ..
+            } => self.is_sifr_int_result_expr(inner),
+            crate::RustExpr::MethodCall {
+                receiver, method, ..
+            } if method == "ok_or_else" => self.is_sifr_int_checked_floor_option_expr(receiver),
+            crate::RustExpr::Paren(inner) => self.is_sifr_int_result_expr(inner),
+            _ => false,
+        }
+    }
+
+    fn is_sifr_int_checked_floor_option_expr(&self, expr: &crate::RustExpr) -> bool {
+        matches!(
+            expr,
+            crate::RustExpr::MethodCall {
+                method,
+                ..
+            } if matches!(method.as_str(), "checked_floor_div" | "checked_floor_mod")
+        )
     }
 
     fn is_sifr_int_module_constant_func(&self, func: &crate::RustExpr) -> bool {
@@ -1592,6 +1619,28 @@ fn is_sifr_int_operand_coercion_op(op: &str) -> bool {
 fn is_legacy_i64_type(ty: &Option<crate::RustType>) -> bool {
     matches!(ty, Some(crate::RustType::I64))
         || matches!(ty, Some(crate::RustType::Named(name)) if name == "i64")
+}
+
+fn is_result_legacy_i64_type(ty: &Option<crate::RustType>) -> bool {
+    matches!(ty, Some(crate::RustType::Result(ok, _)) if is_legacy_i64_rust_type(ok))
+        || matches!(ty, Some(crate::RustType::Named(name)) if name.starts_with("Result<i64, "))
+}
+
+fn is_legacy_i64_rust_type(ty: &crate::RustType) -> bool {
+    matches!(ty, crate::RustType::I64)
+        || matches!(ty, crate::RustType::Named(name) if name == "i64")
+}
+
+fn result_i64_type_to_sifr_int(ty: crate::RustType) -> crate::RustType {
+    match ty {
+        crate::RustType::Result(ok, err) if is_legacy_i64_rust_type(&ok) => {
+            crate::RustType::Result(Box::new(crate::RustType::Named("SifrInt".to_string())), err)
+        }
+        crate::RustType::Named(name) if name.starts_with("Result<i64, ") => {
+            crate::RustType::Named(name.replacen("Result<i64, ", "Result<SifrInt, ", 1))
+        }
+        other => other,
+    }
 }
 
 fn is_proven_nonzero_integer_expr(expr: &crate::RustExpr) -> bool {

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -626,6 +626,9 @@ pub(crate) fn try_lower_simple_stmt_with_ctx_and_bindings(
                 name: name.clone(),
                 ty: if name == "_" || should_omit_local_type_annotation(effective_ty, value) {
                     None
+                } else if let Some(ty) = exact_int_floor_result_local_rust_type(effective_ty, value)
+                {
+                    Some(ty)
                 } else {
                     Some(crate::sifr_type_to_rust_type(effective_ty))
                 },
@@ -914,6 +917,51 @@ fn should_omit_local_type_annotation(ty: &Type, value: &HirExpr) -> bool {
         }
         _ => false,
     }
+}
+
+fn exact_int_floor_result_local_rust_type(ty: &Type, value: &HirExpr) -> Option<RustType> {
+    if matches!(
+        crate::resolve_alias_type_for_plain_call(ty),
+        Type::Int | Type::LiteralInt(_)
+    ) && matches!(
+        value,
+        HirExpr::QuestionMark { expr, .. } if is_exact_int_floor_result_expr(expr)
+    ) {
+        return Some(RustType::Named("SifrInt".to_string()));
+    }
+
+    if is_result_int_division_error_type(ty) && is_exact_int_floor_result_expr(value) {
+        let Type::Result(_, err_ty) = ty else {
+            return None;
+        };
+        return Some(RustType::Result(
+            Box::new(RustType::Named("SifrInt".to_string())),
+            Box::new(crate::sifr_type_to_rust_type(err_ty)),
+        ));
+    }
+
+    None
+}
+
+fn is_exact_int_floor_result_expr(value: &HirExpr) -> bool {
+    matches!(
+        value,
+        HirExpr::BinOp { op, ty, .. }
+            if matches!(op.as_str(), "//" | "%") && is_result_int_division_error_type(ty)
+    )
+}
+
+fn is_result_int_division_error_type(ty: &Type) -> bool {
+    let Type::Result(ok_ty, err_ty) = crate::resolve_alias_type_for_plain_call(ty) else {
+        return false;
+    };
+    matches!(
+        crate::resolve_alias_type_for_plain_call(ok_ty.as_ref()),
+        Type::Int | Type::LiteralInt(_)
+    ) && matches!(
+        crate::resolve_alias_type_for_plain_call(err_ty.as_ref()),
+        Type::Class { name, .. } if name == "DivisionError"
+    )
 }
 
 fn should_force_mutable_binding(ty: &Type) -> bool {

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -3968,6 +3968,62 @@ impl RustEmitter {
             let resolved_left_ty = crate::resolve_alias_type_for_plain_call(left.ty());
             let resolved_right_ty = crate::resolve_alias_type_for_plain_call(right.ty());
 
+            if matches!(op.as_str(), "//" | "%")
+                && matches!(resolved_left_ty, Type::Int | Type::LiteralInt(_))
+                && matches!(resolved_right_ty, Type::Int | Type::LiteralInt(_))
+                && is_result_int_division_error_type(resolved_result_ty)
+            {
+                let method = if op == "//" {
+                    "checked_floor_div"
+                } else {
+                    "checked_floor_mod"
+                };
+                return Ok(Some(crate::RustExpr::Block {
+                    stmts: vec![
+                        crate::RustStmt::Let {
+                            mutable: false,
+                            name: "__sifr_floor_left".to_string(),
+                            ty: Some(crate::RustType::Named("SifrInt".to_string())),
+                            value: self.coerce_expr_to_sifr_int_value(lowered_left),
+                        },
+                        crate::RustStmt::Let {
+                            mutable: false,
+                            name: "__sifr_floor_right".to_string(),
+                            ty: Some(crate::RustType::Named("SifrInt".to_string())),
+                            value: self.coerce_expr_to_sifr_int_value(lowered_right),
+                        },
+                    ],
+                    expr: Some(Box::new(crate::RustExpr::MethodCall {
+                        receiver: Box::new(crate::RustExpr::MethodCall {
+                            receiver: Box::new(crate::RustExpr::Ident(
+                                "__sifr_floor_left".to_string(),
+                            )),
+                            method: method.to_string(),
+                            args: vec![crate::RustExpr::Ref {
+                                mutable: false,
+                                expr: Box::new(crate::RustExpr::Ident(
+                                    "__sifr_floor_right".to_string(),
+                                )),
+                            }],
+                        }),
+                        method: "ok_or_else".to_string(),
+                        args: vec![crate::RustExpr::Closure {
+                            params: vec![],
+                            body: Box::new(crate::RustExpr::FnCall {
+                                func: Box::new(crate::RustExpr::Path(vec![
+                                    "DivisionError".to_string(),
+                                    "new".to_string(),
+                                ])),
+                                args: vec![crate::RustExpr::Literal(crate::RustLiteral::Str(
+                                    "division by zero".to_string(),
+                                ))],
+                            }),
+                            is_move: false,
+                        }],
+                    })),
+                }));
+            }
+
             if op == "*" && matches!(resolved_result_ty, Type::Str) {
                 let (string_expr, count_expr) = match (
                     matches!(resolved_left_ty, Type::Str),
@@ -5633,19 +5689,30 @@ impl RustEmitter {
                     };
                     self.coerce_local_value_for_target_type_for_ir(&effective_ty, value, lowered)?
                 };
+                let lowered_ty = if name == "_"
+                    || is_generic_class
+                    || should_omit_local_type_annotation(&effective_ty, value)
+                {
+                    None
+                } else if matches!(
+                    crate::resolve_alias_type_for_plain_call(&effective_ty),
+                    Type::Int | Type::LiteralInt(_)
+                ) && self.is_sifr_int_expr(&lowered_value)
+                {
+                    Some(crate::RustType::Named("SifrInt".to_string()))
+                } else if is_result_int_division_error_type(&effective_ty)
+                    && self.is_sifr_int_result_expr(&lowered_value)
+                {
+                    Some(result_int_to_sifr_int_rust_type(&effective_ty))
+                } else {
+                    Some(self.rust_ir_type_with_generics(&effective_ty))
+                };
                 (
                     vec![RustStmt::Let {
                         mutable: self.mutated_vars.contains(name)
                             || should_force_mutable_binding(&effective_ty),
                         name: name.clone(),
-                        ty: if name == "_"
-                            || is_generic_class
-                            || should_omit_local_type_annotation(&effective_ty, value)
-                        {
-                            None
-                        } else {
-                            Some(self.rust_ir_type_with_generics(&effective_ty))
-                        },
+                        ty: lowered_ty,
                         value: lowered_value,
                     }],
                     true,
@@ -8944,4 +9011,27 @@ impl RustEmitter {
         self.emit_lowered_stmts(std::slice::from_ref(&lowered));
         Ok(true)
     }
+}
+
+fn is_result_int_division_error_type(ty: &Type) -> bool {
+    let Type::Result(ok_ty, err_ty) = ty else {
+        return false;
+    };
+    matches!(
+        crate::resolve_alias_type_for_plain_call(ok_ty.as_ref()),
+        Type::Int | Type::LiteralInt(_)
+    ) && matches!(
+        crate::resolve_alias_type_for_plain_call(err_ty.as_ref()),
+        Type::Class { name, .. } if name == "DivisionError"
+    )
+}
+
+fn result_int_to_sifr_int_rust_type(ty: &Type) -> crate::RustType {
+    let Type::Result(_, err_ty) = ty else {
+        return crate::RustType::Named(ty.rust_type());
+    };
+    crate::RustType::Result(
+        Box::new(crate::RustType::Named("SifrInt".to_string())),
+        Box::new(crate::sifr_type_to_rust_type(err_ty)),
+    )
 }

--- a/crates/sifr_hir/src/lower/expression_operators.rs
+++ b/crates/sifr_hir/src/lower/expression_operators.rs
@@ -63,6 +63,14 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
     if generic_addition_requires_addable_bound(&left, op_str, &right, ctx, binop.range()) {
         return None;
     }
+    if let Some(result_ty) = exact_int_floor_result_type(&left, op_str, &right, ctx) {
+        return Some(HirExpr::BinOp {
+            left: Box::new(left),
+            op: op_str.to_string(),
+            right: Box::new(right),
+            ty: result_ty,
+        });
+    }
 
     match type_check_binary_op(left.ty(), op_str, right.ty()) {
         Ok(result_ty) => {
@@ -93,6 +101,58 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
             ctx.error_with_code_at(code, message, binop.range());
             None
         }
+    }
+}
+
+fn exact_int_floor_result_type(
+    left: &HirExpr,
+    op: &str,
+    right: &HirExpr,
+    ctx: &LowerCtx,
+) -> Option<Type> {
+    if ctx.is_stdlib_lowering() {
+        return None;
+    }
+    if !matches!(op, "//" | "%") {
+        return None;
+    }
+    if !is_exact_int_like(left.ty()) || !is_exact_int_like(right.ty()) {
+        return None;
+    }
+    if is_proven_nonzero_integer_expr(right, ctx) {
+        return None;
+    }
+    Some(Type::Result(
+        Box::new(Type::Int),
+        Box::new(division_error_type(ctx)),
+    ))
+}
+
+fn division_error_type(ctx: &LowerCtx) -> Type {
+    ctx.class_types
+        .get("DivisionError")
+        .cloned()
+        .unwrap_or(Type::Class {
+            name: "DivisionError".to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: vec![],
+            parent_class: Some("Error".to_string()),
+        })
+}
+
+fn is_exact_int_like(ty: &Type) -> bool {
+    matches!(ty, Type::Int | Type::LiteralInt(_))
+}
+
+fn is_proven_nonzero_integer_expr(expr: &HirExpr, ctx: &LowerCtx) -> bool {
+    match expr {
+        HirExpr::IntLiteral(value) => *value != 0,
+        HirExpr::LargeIntLiteral(value) => value != "0",
+        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
+            is_proven_nonzero_integer_expr(operand, ctx)
+        }
+        HirExpr::Name { name, .. } => ctx.is_proven_nonzero_integer_binding(name),
+        _ => false,
     }
 }
 

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -339,20 +339,46 @@ fn test_fixed_width_const_expression_assignment_fits_and_folds() {
 }
 
 #[test]
-fn test_exact_int_division_by_unproven_divisor_has_int0005() {
+fn test_exact_int_division_by_unproven_divisor_requires_result_target() {
     let source = "\
 def main() -> None:
     divisor: int = 3
     value: int = 10 // divisor
 ";
-    let errors = lower_source(source).expect_err("unproven exact-int divisor should fail");
+    let errors =
+        lower_source(source).expect_err("unproven exact-int divisor should produce Result[int]");
 
     assert!(errors.iter().any(|error| {
-        error.code == Some(DiagnosticCode::INT_EXACT_DIVISION_REQUIRES_HANDLING)
-            && error.message
-                == "integer division, modulo, or exponentiation requires handling a typed integer failure unless the compiler can prove this operation is safe"
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error
+                .message
+                .contains("expected 'int', got 'Result[int, DivisionError]'")
             && error.primary_range == Some(range_for(source, "10 // divisor"))
     }));
+}
+
+#[test]
+fn test_exact_int_division_by_unproven_divisor_lowers_as_result() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    divisor: int = 3
+    value: Result[int, DivisionError] = 10 // divisor
+",
+    )
+    .expect("unproven exact-int divisor should lower as Result[int, DivisionError]");
+
+    let HirStmt::Let { value, .. } = &module.functions[0].body[1] else {
+        panic!("expected result let");
+    };
+    assert!(matches!(
+        value,
+        HirExpr::BinOp {
+            ty: Type::Result(ok, err),
+            ..
+        } if matches!(ok.as_ref(), Type::Int)
+            && matches!(err.as_ref(), Type::Class { name, .. } if name == "DivisionError")
+    ));
 }
 
 #[test]
@@ -725,7 +751,10 @@ def main() -> None:
     let errors = lower_source(source).expect_err("reassignment should clear non-zero proof");
 
     assert!(errors.iter().any(|error| {
-        error.code == Some(DiagnosticCode::INT_EXACT_DIVISION_REQUIRES_HANDLING)
+        error.code == Some(DiagnosticCode::TYPE_MISMATCH)
+            && error
+                .message
+                .contains("expected 'int', got 'Result[int, DivisionError]'")
             && error.primary_range == Some(range_for(source, "10 // divisor"))
     }));
 }

--- a/crates/sifr_hir/src/lower/integer_failure_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/integer_failure_diagnostics.rs
@@ -31,14 +31,6 @@ pub(super) fn exact_int_division_requires_handling(
         emit_exact_int_division_requires_handling(ctx, range);
         return true;
     }
-    if is_exact_int_like(left.ty())
-        && is_exact_int_like(right.ty())
-        && is_exact_int_division_or_modulo(op)
-        && !is_proven_nonzero_integer_expr(right, ctx)
-    {
-        emit_exact_int_division_requires_handling(ctx, range);
-        return true;
-    }
     false
 }
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -462,6 +462,7 @@ Validation:
 - [x] INT-4 fixed-width literal pattern fitting review pass 2 satisfied after adding positive in-range coverage: `reviews/integer-model-int-4-fixed-width-match-literal-review-pass-2.md`.
 - [x] INT-4 fixed-width `sum`/`abs` builtin review pass 1 completed with guardrail and duplicate-policy blockers: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-1.md`.
 - [x] INT-4 fixed-width `sum`/`abs` builtin review pass 2 satisfied after extracting `abs` lowering and sharing the widening policy: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` review satisfied after adding HIR typing, local/try `SifrInt` codegen, and focused e2e coverage: `reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -494,7 +495,8 @@ Validation:
   - [x] Direct HIR coverage now proves exact-int `//=` and `%=` with syntactically non-zero integer literal divisors still lower successfully, closing the scaffold review hardening note; review is satisfied and quick validation is passing: PR #1858.
   - [x] Conservative non-literal exact-int non-zero facts now suppress `SIFR-INT-0005` for guarded divisors in `x != 0` true branches, `if x == 0: return/raise` early-exit false paths, and `while x != 0` bodies; reassignment and augmented assignment clear those facts, and the guarded `DivisionError` pass fixture now uses the checked parameter divisor again; review is satisfied and quick validation is passing: PR #1859.
   - [x] Exact-int non-zero proof now covers early-exit `elif` zero guards and nested boolean guard composition such as `not (left == 0 or right == 0)`, with focused HIR/e2e coverage, review satisfied, and quick validation passing: PR #1875.
-  - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: full `Result[int, DivisionError]` expression/codegen integration and non-literal proven-nonzero analysis still need support.
+  - [x] Unproven exact-int `//` and `%` now lower as `Result[int, DivisionError]` instead of `SIFR-INT-0005`, with local `Result` bindings and try-block unwrapping emitted through `Result<SifrInt, DivisionError>` and focused review/e2e coverage; direct `int` assignment remains a type mismatch outside handling, fixed-width and augassign remain fail-closed: PR #1876.
+  - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.
   - [x] Parsed integer literals beyond the historical `i64` slot lower to canonical decimal `LargeIntLiteral` HIR across decimal, hex, octal, and binary spellings, with review satisfied and quick validation passing: PR #1792.

--- a/reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md
@@ -1,0 +1,89 @@
+
+
+Based on my comprehensive review of the INT-1 slice implementation, here's my structured assessment:
+
+---
+
+# Review: INT-1 exact-int floor/mod Result[int, DivisionError]
+
+## Blocking Issues
+
+**None.** The implementation is sound and correctly implements the designed behavior.
+
+## Non-Blocking Observations
+
+### 1. Augassign Inconsistency (Design Question)
+
+The augmented assignment path (`value //= divisor` or `value %= divisor`) still produces `SIFR-INT-0005` errors even when the divisor is unproven:
+
+```
+value %= divisor  # Still SIFR-INT-0005
+```
+
+While binops now produce `Result[int, DivisionError]`:
+```
+value = 10 % divisor  # Now Result[int, DivisionError]
+```
+
+This asymmetry is likely intentional (augassign has no place to store the Result), but worth noting.
+
+### 2. E2E Pass Suite Failures
+
+The `test_e2e_pass` suite has pre-existing failures unrelated to this change:
+- `lazy_builtins`: Missing `map` function
+- `list_slice_copy`: Borrow after move issue  
+- `nested_function_nonlocal_accumulator`: Missing `mut` on closure
+
+These are not caused by the current changes.
+
+## Correctness Verification
+
+### HIR Typing (`expression_operators.rs`)
+| Scenario | Result |
+|----------|--------|
+| `10 // divisor` where `divisor: int` | `Result[int, DivisionError]` |
+| `10 // 3` (non-zero literal) | `int` |
+| `value %= divisor` (unproven) | SIFR-INT-0005 error |
+| `left // 2` where `left: uint8` | SIFR-INT-0005 (fixed-width fail-closed) |
+| `2 ** exponent` | SIFR-INT-0005 (exponentiation fail-closed) |
+| Stdlib lowering | Preserved exemption |
+
+### Codegen (`stmt_support_emitter.rs`)
+- Generates `SifrInt::checked_floor_div(&__sifr_floor_right).ok_or_else(...)` for Result divisions
+- Properly emits `?` operator in try-except contexts
+- Correctly converts `Result<int, DivisionError>` → `Result<SifrInt, DivisionError>`
+
+### Generated Rust (from fixture)
+```rust
+let __sifr_try_res: Result<(), DivisionError> = (|| {
+    let value: SifrInt = ({
+        let __sifr_floor_left: SifrInt = SifrInt::from_i64(10);
+        let __sifr_floor_right: SifrInt = SifrInt::from_i64(divisor);
+        __sifr_floor_left.checked_floor_div(&__sifr_floor_right)
+            .ok_or_else(|| DivisionError::new("division by zero".to_string()))
+    })?;
+    // ...
+})();
+```
+
+## Tests Status
+
+| Test Suite | Status |
+|------------|--------|
+| `cargo test -p sifr_hir exact_int` | ✅ 14 passed |
+| `exact_int_floor_mod_result.sifr` e2e | ✅ Passes |
+| `exact_int_division_requires_handling.sifr` e2e | ✅ Passes (error code updated) |
+
+## Summary
+
+**The review is satisfied.** This is a clean implementation that:
+
+1. Correctly produces `Result[int, DivisionError]` for unproven exact-int `//` and `%`
+2. Falls through to `int` when divisor is proven non-zero
+3. Maintains fail-closed behavior for fixed-width and exponentiation
+4. Supports try-except unwrapping via `?` operator and `RustExpr::Try`
+5. Generates appropriate `checked_floor_div/checked_floor_mod` with `ok_or_else` wrapping
+6. Preserves stdlib exemption
+7. Has adequate unit and e2e test coverage
+
+The slice is appropriately scoped and the partial nature is by design - fixed-width and exponentiation are intentionally excluded from this phase.


### PR DESCRIPTION
## Summary
- lower unproven exact-int `//` and `%` as `Result[int, DivisionError]` instead of `SIFR-INT-0005`
- emit local Result bindings and try-block unwraps through `Result<SifrInt, DivisionError>` using checked floor helpers
- preserve proven non-zero exact-int lowering, fixed-width fail-closed behavior, augassign fail-closed behavior, and stdlib exemption

## Validation
- scripts/run_all_tests.sh --profile quick
- reviewer satisfied: reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md