### PR TITLE
Promote exact int floor mod Result returns

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -1,0 +1,42 @@
+def divide(a: int, b: int) -> Result[int, DivisionError]:
+    return a // b
+
+
+def modulo(a: int, b: int) -> Result[int, DivisionError]:
+    return a % b
+
+
+def divide_again(a: int, b: int) -> Result[int, DivisionError]:
+    return divide(a, b)
+
+
+def divide_or_one(a: int, b: int, use_division: bool) -> Result[int, DivisionError]:
+    if use_division:
+        return a // b
+    return 1
+
+
+def main():
+    try:
+        value: int = divide(10, 0)
+        _ = value
+    except DivisionError as e:
+        assert str(e.message) == 'division by zero'
+
+    try:
+        quotient: int = divide_again(10, 3)
+        assert str(quotient) == '3'
+    except DivisionError as e:
+        _ = e
+
+    try:
+        rem: int = modulo(10, 3)
+        assert str(rem) == '1'
+    except DivisionError as e:
+        _ = e
+
+    try:
+        fallback: int = divide_or_one(10, 0, False)
+        assert str(fallback) == '1'
+    except DivisionError as e:
+        _ = e

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -625,6 +625,8 @@ impl RustEmitter {
                     let ret = self.rewrite_stdlib_constant_idents_in_expr(ret);
                     if self.current_sifr_int_return.get() {
                         self.coerce_expr_to_sifr_int_value(ret)
+                    } else if self.current_sifr_int_result_return.get() {
+                        self.coerce_result_int_expr_to_sifr_int_value(ret)
                     } else {
                         ret
                     }
@@ -1450,6 +1452,26 @@ impl RustEmitter {
         }
     }
 
+    pub(super) fn coerce_result_int_expr_to_sifr_int_value(
+        &self,
+        expr: crate::RustExpr,
+    ) -> crate::RustExpr {
+        match expr {
+            crate::RustExpr::FnCall { func, args } if is_ok_result_path(&func) => {
+                let args = args
+                    .into_iter()
+                    .map(|arg| self.coerce_expr_to_sifr_int_value(arg))
+                    .collect();
+                crate::RustExpr::FnCall { func, args }
+            }
+            crate::RustExpr::Paren(inner) => crate::RustExpr::Paren(Box::new(
+                self.coerce_result_int_expr_to_sifr_int_value(*inner),
+            )),
+            other if self.is_sifr_int_result_expr(&other) => other,
+            other => other,
+        }
+    }
+
     fn coerce_expr_to_sifr_int_comparison_operand(&self, expr: crate::RustExpr) -> crate::RustExpr {
         let coerced = self.coerce_expr_to_sifr_int(expr);
         if matches!(coerced, crate::RustExpr::Ref { .. }) {
@@ -1511,6 +1533,9 @@ impl RustEmitter {
             crate::RustExpr::MethodCall {
                 receiver, method, ..
             } if method == "ok_or_else" => self.is_sifr_int_checked_floor_option_expr(receiver),
+            crate::RustExpr::FnCall { func, .. } => {
+                self.is_sifr_int_result_returning_function_call(func)
+            }
             crate::RustExpr::Paren(inner) => self.is_sifr_int_result_expr(inner),
             _ => false,
         }
@@ -1540,6 +1565,14 @@ impl RustEmitter {
 
     fn is_sifr_int_returning_function_call(&self, func: &crate::RustExpr) -> bool {
         rust_expr_identifier_path(func).is_some_and(|name| self.function_returns_sifr_int(&name))
+    }
+
+    fn is_sifr_int_result_returning_function_call(&self, func: &crate::RustExpr) -> bool {
+        rust_expr_identifier_path(func).is_some_and(|name| {
+            self.sifr_int_result_function_returns
+                .borrow()
+                .contains(&name)
+        })
     }
 
     pub(super) fn function_returns_sifr_int(&self, name: &str) -> bool {
@@ -1683,6 +1716,14 @@ fn string_path_matches(path: &[String], expected: &[&str]) -> bool {
             .iter()
             .zip(expected)
             .all(|(segment, expected_segment)| segment == expected_segment)
+}
+
+fn is_ok_result_path(expr: &crate::RustExpr) -> bool {
+    match expr {
+        crate::RustExpr::Path(path) => string_path_matches(path, &["Ok"]),
+        crate::RustExpr::Ident(name) => name == "Ok",
+        _ => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -136,6 +136,7 @@ impl RustEmitter {
     pub(super) fn register_sifr_int_function_returns(&self, module: &HirModule) {
         let module_sifr_int_bindings = self.module_sifr_int_bindings();
         let mut function_returns = HashSet::new();
+        let mut result_function_returns = HashSet::new();
         let mut function_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let module_function_params = module
             .functions
@@ -152,6 +153,7 @@ impl RustEmitter {
             .collect::<HashMap<_, _>>();
         loop {
             let before = function_returns.len();
+            let before_result_returns = result_function_returns.len();
             let before_params = function_params.values().map(HashSet::len).sum::<usize>();
             let discovered = module
                 .functions
@@ -172,6 +174,15 @@ impl RustEmitter {
                 })
                 .collect::<Vec<_>>();
             function_returns.extend(discovered);
+            let discovered_result_returns = module
+                .functions
+                .iter()
+                .filter_map(|func| {
+                    (function_returns_result_sifr_int(func, &result_function_returns))
+                        .then(|| func.name.clone())
+                })
+                .collect::<Vec<_>>();
+            result_function_returns.extend(discovered_result_returns);
             for func in &module.functions {
                 let extra_forced_params =
                     collect_sifr_int_function_param_names(func, &function_params);
@@ -194,11 +205,15 @@ impl RustEmitter {
                 }
             }
             let after_params = function_params.values().map(HashSet::len).sum::<usize>();
-            if function_returns.len() == before && after_params == before_params {
+            if function_returns.len() == before
+                && result_function_returns.len() == before_result_returns
+                && after_params == before_params
+            {
                 break;
             }
         }
         *self.sifr_int_function_returns.borrow_mut() = function_returns;
+        *self.sifr_int_result_function_returns.borrow_mut() = result_function_returns;
         *self.sifr_int_function_params.borrow_mut() = function_params;
     }
 
@@ -317,6 +332,8 @@ impl RustEmitter {
                 &sifr_int_nested_capture_bindings,
                 &captured_shadowed_module_bindings,
             );
+        let nested_returns_sifr_int_result =
+            function_returns_result_sifr_int(func, &self.sifr_int_result_function_returns.borrow());
         let post_stmt_callable_conventions = {
             let mut conventions = self.callable_var_conventions.clone();
             let params = func
@@ -346,6 +363,7 @@ impl RustEmitter {
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
         let saved_current_sifr_int_return = self.current_sifr_int_return.get();
+        let saved_current_sifr_int_result_return = self.current_sifr_int_result_return.get();
         let nested_binding_mutable = saved_mutated_vars.contains(&func.name);
 
         self.current_return_type = Some(func.return_type.clone());
@@ -357,8 +375,15 @@ impl RustEmitter {
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
         self.current_sifr_int_return.set(nested_returns_sifr_int);
+        self.current_sifr_int_result_return
+            .set(nested_returns_sifr_int_result);
         if nested_returns_sifr_int {
             self.sifr_int_function_returns
+                .borrow_mut()
+                .insert(func.name.clone());
+        }
+        if nested_returns_sifr_int_result {
+            self.sifr_int_result_function_returns
                 .borrow_mut()
                 .insert(func.name.clone());
         }
@@ -412,6 +437,8 @@ impl RustEmitter {
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
         self.current_sifr_int_return
             .set(saved_current_sifr_int_return);
+        self.current_sifr_int_result_return
+            .set(saved_current_sifr_int_result_return);
 
         let lowered_stmt = if is_recursive {
             let params = func
@@ -436,6 +463,8 @@ impl RustEmitter {
                 params,
                 ret: if nested_returns_sifr_int {
                     Some(RustType::Named("SifrInt".to_string()))
+                } else if nested_returns_sifr_int_result {
+                    Some(result_int_return_type_to_sifr_int(&func.return_type))
                 } else {
                     self.lower_function_return_type(func, false)
                 },
@@ -599,6 +628,13 @@ impl RustEmitter {
         }
         if self.function_returns_sifr_int(&func.name) {
             return Some(RustType::Named("SifrInt".to_string()));
+        }
+        if self
+            .sifr_int_result_function_returns
+            .borrow()
+            .contains(&func.name)
+        {
+            return Some(result_int_return_type_to_sifr_int(&func.return_type));
         }
         Some(self.rust_ir_type_with_generics(&func.return_type))
     }
@@ -767,7 +803,10 @@ impl RustEmitter {
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
         let saved_sifr_int_function_returns = self.sifr_int_function_returns.borrow().clone();
+        let saved_sifr_int_result_function_returns =
+            self.sifr_int_result_function_returns.borrow().clone();
         let saved_current_sifr_int_return = self.current_sifr_int_return.get();
+        let saved_current_sifr_int_result_return = self.current_sifr_int_result_return.get();
 
         self.current_return_type = Some(func.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&func.body, &self.func_signatures);
@@ -780,6 +819,11 @@ impl RustEmitter {
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
         self.current_sifr_int_return
             .set(self.function_returns_sifr_int(&func.name));
+        self.current_sifr_int_result_return.set(
+            self.sifr_int_result_function_returns
+                .borrow()
+                .contains(&func.name),
+        );
         self.register_function_scope_params(&func.name, &func.params);
         let active_function_returns = self.function_sifr_int_returns_for_body(&func.body);
         *self.sifr_int_function_returns.borrow_mut() = active_function_returns;
@@ -886,8 +930,12 @@ impl RustEmitter {
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
         *self.sifr_int_function_returns.borrow_mut() = saved_sifr_int_function_returns;
+        *self.sifr_int_result_function_returns.borrow_mut() =
+            saved_sifr_int_result_function_returns;
         self.current_sifr_int_return
             .set(saved_current_sifr_int_return);
+        self.current_sifr_int_result_return
+            .set(saved_current_sifr_int_result_return);
     }
 }
 
@@ -952,6 +1000,64 @@ fn hir_function_returns_sifr_int(
         &mut on_expr,
     );
     returns_sifr_int
+}
+
+fn function_returns_result_sifr_int(
+    func: &HirFunction,
+    result_function_returns: &HashSet<String>,
+) -> bool {
+    if !is_result_int_type(&func.return_type) {
+        return false;
+    }
+
+    let mut returns_sifr_int_result = false;
+    let mut on_stmt = |stmt: &HirStmt| {
+        if let HirStmt::Return { value: Some(value) } = stmt {
+            returns_sifr_int_result |=
+                hir_expr_returns_sifr_int_result(value, result_function_returns);
+        }
+    };
+    let mut on_expr = |_expr: &HirExpr| {};
+    traversal::walk_stmts(
+        &func.body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    returns_sifr_int_result
+}
+
+fn hir_expr_returns_sifr_int_result(
+    expr: &HirExpr,
+    result_function_returns: &HashSet<String>,
+) -> bool {
+    match expr {
+        HirExpr::BinOp { op, ty, .. } => {
+            matches!(op.as_str(), "//" | "%") && is_result_int_type(ty)
+        }
+        HirExpr::Call { func, .. } => result_function_returns.contains(func),
+        _ => false,
+    }
+}
+
+fn is_result_int_type(ty: &Type) -> bool {
+    let Type::Result(ok_ty, _) = crate::resolve_alias_type_for_plain_call(ty) else {
+        return false;
+    };
+    matches!(
+        crate::resolve_alias_type_for_plain_call(ok_ty.as_ref()),
+        Type::Int | Type::LiteralInt(_)
+    )
+}
+
+fn result_int_return_type_to_sifr_int(ty: &Type) -> RustType {
+    let Type::Result(_, err_ty) = crate::resolve_alias_type_for_plain_call(ty) else {
+        return RustType::Named(ty.rust_type());
+    };
+    RustType::Result(
+        Box::new(RustType::Named("SifrInt".to_string())),
+        Box::new(crate::sifr_type_to_rust_type(err_ty)),
+    )
 }
 
 fn hir_function_returns_sifr_int_with_extra_forced(

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1215,10 +1215,14 @@ struct RustEmitter {
     sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
     /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_returns: RefCell<HashSet<String>>,
+    /// Function names whose `Result[int, E]` generated Rust return payload is `SifrInt`.
+    sifr_int_result_function_returns: RefCell<HashSet<String>>,
     /// Module-level function `int` parameters promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
     current_sifr_int_return: Cell<bool>,
+    /// Whether the active function-like body returns `Result<SifrInt, E>` for source-level `Result[int, E]`.
+    current_sifr_int_result_return: Cell<bool>,
     /// Stack used to capture structured statement emission as IR nodes.
     stmt_capture_stack: Vec<Vec<RustStmt>>,
     /// Recursion guard for non-structured emitter paths.
@@ -1321,8 +1325,10 @@ impl RustEmitter {
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_function_returns: RefCell::new(HashSet::new()),
+            sifr_int_result_function_returns: RefCell::new(HashSet::new()),
             sifr_int_function_params: RefCell::new(HashMap::new()),
             current_sifr_int_return: Cell::new(false),
+            current_sifr_int_result_return: Cell::new(false),
             stmt_capture_stack: Vec::new(),
             lowering_stats: LoweringStats::default(),
         }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -5497,7 +5497,14 @@ impl RustEmitter {
                              lowered: crate::RustExpr|
          -> Result<crate::RustExpr, crate::CodegenError> {
             if let Some(target_ty) = return_ty {
-                return this.coerce_local_value_for_target_type_for_ir(target_ty, value, lowered);
+                let coerced =
+                    this.coerce_local_value_for_target_type_for_ir(target_ty, value, lowered)?;
+                if this.current_sifr_int_result_return.get()
+                    && is_result_int_division_error_type(target_ty)
+                {
+                    return Ok(this.coerce_result_int_expr_to_sifr_int_value(coerced));
+                }
+                return Ok(coerced);
             }
             Ok(lowered)
         };

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -463,6 +463,8 @@ Validation:
 - [x] INT-4 fixed-width `sum`/`abs` builtin review pass 1 completed with guardrail and duplicate-policy blockers: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-1.md`.
 - [x] INT-4 fixed-width `sum`/`abs` builtin review pass 2 satisfied after extracting `abs` lowering and sharing the widening policy: `reviews/integer-model-int-4-fixed-width-sum-abs-builtins-review-pass-2.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` review satisfied after adding HIR typing, local/try `SifrInt` codegen, and focused e2e coverage: `reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 1 completed with recursive nested return-type blocker: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 2 satisfied after making recursive nested return typing explicit: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md`.
 
 ## Implementation Checklist
 
@@ -496,6 +498,7 @@ Validation:
   - [x] Conservative non-literal exact-int non-zero facts now suppress `SIFR-INT-0005` for guarded divisors in `x != 0` true branches, `if x == 0: return/raise` early-exit false paths, and `while x != 0` bodies; reassignment and augmented assignment clear those facts, and the guarded `DivisionError` pass fixture now uses the checked parameter divisor again; review is satisfied and quick validation is passing: PR #1859.
   - [x] Exact-int non-zero proof now covers early-exit `elif` zero guards and nested boolean guard composition such as `not (left == 0 or right == 0)`, with focused HIR/e2e coverage, review satisfied, and quick validation passing: PR #1875.
   - [x] Unproven exact-int `//` and `%` now lower as `Result[int, DivisionError]` instead of `SIFR-INT-0005`, with local `Result` bindings and try-block unwrapping emitted through `Result<SifrInt, DivisionError>` and focused review/e2e coverage; direct `int` assignment remains a type mismatch outside handling, fixed-width and augassign remain fail-closed: PR #1876.
+  - [x] `Result[int, DivisionError]` function return boundaries that directly return unproven exact-int `//`/`%` or call another promoted result-returning helper now lower as `Result<SifrInt, DivisionError>`; promoted callers, try-unwrapped locals, chained helpers, and mixed plain-`Ok(int)` branches are covered, review is satisfied, and quick validation is passing: PR #1877.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-1.md
@@ -1,0 +1,67 @@
+
+
+Based on my detailed review, I found one blocker and several non-blocking observations.
+
+---
+
+## Review: INT-1 Integer Model — Exact Int Floor Mod Result Return
+
+### Blocker: Nested-Function Recursive Return Type (`function_emitter.rs:464-467`)
+
+When emitting a recursive `RustStmt::LocalFn` (nested function with a self-reference), the `ret` field ignores `nested_returns_sifr_int_result`. Only `nested_returns_sifr_int` is checked:
+
+```rust
+ret: if nested_returns_sifr_int {
+    Some(RustType::Named("SifrInt".to_string()))
+} else {
+    self.lower_function_return_type(func, false)  // ← result_int path not considered
+},
+```
+
+`lower_function_return_type` does check `sifr_int_result_function_returns` (line 630-636), but at this point in `emit_nested_function`, the nested function's name **has already been inserted** into that set (lines 385-388). So this call will find it and return the correct type — but only by accident, through the side-effect of lines 385-388. This is fragile.
+
+**Fix**: Extend the conditional at line 464 to also check `nested_returns_sifr_int_result`:
+
+```rust
+ret: if nested_returns_sifr_int {
+    Some(RustType::Named("SifrInt".to_string()))
+} else if nested_returns_sifr_int_result {
+    Some(result_int_return_type_to_sifr_int(&func.return_type))
+} else {
+    self.lower_function_return_type(func, false)
+},
+```
+
+This makes the recursive nested-function return-type path explicit rather than relying on the lookup succeeding because of a prior side-effect.
+
+---
+
+### Non-blocking observations
+
+**1. `function_returns_result_sifr_int` is narrower than `hir_function_returns_sifr_int_with_extra_forced_and_shadowed`**
+
+`hir_function_returns_sifr_int` builds a forced-locals set that includes bindings from try-unwrapping promoted functions (`collect_sifr_int_forced_locals`). `function_returns_result_sifr_int` only checks direct `//`/`%` and calls. This is intentional: `Result[int, DivisionError]` functions shouldn't force locals through try-unwrapping *inside* the function (the return is the promotion point). However, if a future case emerges where a `Result[int, DivisionError]` function does `x = promoted_func(); return x`, detection will silently miss it until a fixed-point loop iteration picks it up. The fixed-point loop mitigates this, but it's worth documenting the asymmetry.
+
+**2. Module-level fixed-point loop (`register_sifr_int_function_returns`) correctly handles mutual recursion**
+
+Both `function_returns` and `result_function_returns` are part of the fixed-point convergence check (line 208-210), and the second pass over `result_function_returns` (lines 177-185) is ordered after the first pass over `function_returns`. This means cross-function mutual recursion between plain-SifrInt and Result-SifrInt functions is handled correctly.
+
+**3. `coerce_result_int_expr_to_sifr_int_value` is appropriately narrow**
+
+The coercion only rewrites `Ok(...)` (with recursive `coerce_expr_to_sifr_int_value` on the arg) and passes through SifrInt Result expressions unchanged. This avoids over-coercion. The `is_sifr_int_result_expr` predicate on line 1470 acts as an identity guard.
+
+**4. No test for try-unwrapping inside a promoted `Result[int, DivisionError]` function body**
+
+The e2e fixture covers direct `//`/`%` returns, chained calls, error handling, and mixed `Ok(1)`/`Ok(checked_floor_div(...))` branches — but no case where a promoted function does a try-unwrap on an earlier call and returns the unwrapped value. This is the gap described in observation #1 above.
+
+**5. `is_result_int_division_error_type` and `is_result_int_type` are nearly identical**
+
+Both check `Result(ok: Int|LiteralInt, err: DivisionError)` / `Result(ok: Int|LiteralInt, err: _)`. They should share a helper to avoid drift if the type system evolves.
+
+---
+
+### Verdict
+
+**Not ready to merge** due to the nested-function recursive return type fragility. The code currently works by accident (the side-effect lookup succeeds), but it's not semantically sound. The fix is a two-line change on `function_emitter.rs:464-467`.
+
+All other aspects — state save/restore, fixed-point convergence, Ok branch coercion, caller/try-unwrapping consistency, and e2e coverage — are correct. Once the nested-function fix is applied, this slice is acceptable for INT-1.

--- a/reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md
+++ b/reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md
@@ -1,0 +1,26 @@
+
+
+All validations pass. The blocker from pass 1 is resolved.
+
+**Verifier summary:**
+- `cargo fmt` — no output (already clean)
+- `cargo check -p sifr_codegen` — clean
+- E2E fixture `exact_int_floor_mod_result_return` — passes (compile + run)
+
+**Blocker resolution confirmed:**
+
+The fix at `function_emitter.rs:463–467` adds an explicit `else if nested_returns_sifr_int_result` branch alongside the existing `nested_returns_sifr_int` branch:
+
+```rust
+ret: if nested_returns_sifr_int {
+    Some(RustType::Named("SifrInt".to_string()))
+} else if nested_returns_sifr_int_result {
+    Some(result_int_return_type_to_sifr_int(&func.return_type))  // ← new
+} else {
+    self.lower_function_return_type(func, false)
+},
+```
+
+This eliminates the dependency on the side effect of inserting into `sifr_int_result_function_returns` before `lower_function_return_type` is called for the recursive case.
+
+**The reviewer is satisfied.**


### PR DESCRIPTION
## Summary
- Promote `Result[int, DivisionError]` functions that return unproven exact-int `//`/`%` or promoted helper calls to Rust `Result<SifrInt, DivisionError>`.
- Recognize promoted result-returning function calls at call sites so try-unwrapped `int` locals use `SifrInt`.
- Coerce plain `Ok(int)` return branches inside promoted result-returning functions to `Ok(SifrInt::from_i64(...))`.
- Add focused e2e coverage and record two Opus review passes.

## Validation
- `cargo fmt`
- `cargo check -p sifr_codegen`
- `cargo test -p sifr_codegen function_emitter -- --nocapture`
- `cargo test -p sifr_hir exact_int -- --nocapture`
- `scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>`
- `scripts/run_all_tests.sh --profile quick`

Reviewer pass 2 is satisfied: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md`.
