### PR TITLE
Promote exact int local Result returns

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -16,6 +16,16 @@ def divide_or_one(a: int, b: int, use_division: bool) -> Result[int, DivisionErr
     return 1
 
 
+def divide_local(a: int, b: int) -> Result[int, DivisionError]:
+    value: Result[int, DivisionError] = a // b
+    return value
+
+
+def divide_local_again(a: int, b: int) -> Result[int, DivisionError]:
+    value: Result[int, DivisionError] = divide_local(a, b)
+    return value
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -38,5 +48,11 @@ def main():
     try:
         fallback: int = divide_or_one(10, 0, False)
         assert str(fallback) == '1'
+    except DivisionError as e:
+        _ = e
+
+    try:
+        local_result: int = divide_local_again(9, 3)
+        assert str(local_result) == '3'
     except DivisionError as e:
         _ = e

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -1010,11 +1010,16 @@ fn function_returns_result_sifr_int(
         return false;
     }
 
+    let local_result_bindings =
+        collect_sifr_int_result_local_bindings(&func.body, result_function_returns);
     let mut returns_sifr_int_result = false;
     let mut on_stmt = |stmt: &HirStmt| {
         if let HirStmt::Return { value: Some(value) } = stmt {
-            returns_sifr_int_result |=
-                hir_expr_returns_sifr_int_result(value, result_function_returns);
+            returns_sifr_int_result |= hir_expr_returns_sifr_int_result(
+                value,
+                result_function_returns,
+                &local_result_bindings,
+            );
         }
     };
     let mut on_expr = |_expr: &HirExpr| {};
@@ -1027,15 +1032,56 @@ fn function_returns_result_sifr_int(
     returns_sifr_int_result
 }
 
+fn collect_sifr_int_result_local_bindings(
+    body: &[HirStmt],
+    result_function_returns: &HashSet<String>,
+) -> HashSet<String> {
+    let mut result_bindings = HashSet::new();
+    let mut on_stmt = |stmt: &HirStmt| match stmt {
+        HirStmt::Let {
+            name, ty, value, ..
+        } if is_result_int_type(ty)
+            && hir_expr_returns_sifr_int_result(
+                value,
+                result_function_returns,
+                &result_bindings,
+            ) =>
+        {
+            result_bindings.insert(name.clone());
+        }
+        HirStmt::Assign { name, value }
+            if result_bindings.contains(name)
+                && !hir_expr_returns_sifr_int_result(
+                    value,
+                    result_function_returns,
+                    &result_bindings,
+                ) =>
+        {
+            result_bindings.remove(name);
+        }
+        _ => {}
+    };
+    let mut on_expr = |_expr: &HirExpr| {};
+    traversal::walk_stmts(
+        body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    result_bindings
+}
+
 fn hir_expr_returns_sifr_int_result(
     expr: &HirExpr,
     result_function_returns: &HashSet<String>,
+    local_result_bindings: &HashSet<String>,
 ) -> bool {
     match expr {
         HirExpr::BinOp { op, ty, .. } => {
             matches!(op.as_str(), "//" | "%") && is_result_int_type(ty)
         }
         HirExpr::Call { func, .. } => result_function_returns.contains(func),
+        HirExpr::Name { name, .. } => local_result_bindings.contains(name),
         _ => false,
     }
 }

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -465,6 +465,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` review satisfied after adding HIR typing, local/try `SifrInt` codegen, and focused e2e coverage: `reviews/integer-model-int-1-exact-int-floor-mod-result-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 1 completed with recursive nested return-type blocker: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 2 satisfied after making recursive nested return typing explicit: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-result return review satisfied after adding local binding promotion and chained helper coverage: `reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -499,6 +500,7 @@ Validation:
   - [x] Exact-int non-zero proof now covers early-exit `elif` zero guards and nested boolean guard composition such as `not (left == 0 or right == 0)`, with focused HIR/e2e coverage, review satisfied, and quick validation passing: PR #1875.
   - [x] Unproven exact-int `//` and `%` now lower as `Result[int, DivisionError]` instead of `SIFR-INT-0005`, with local `Result` bindings and try-block unwrapping emitted through `Result<SifrInt, DivisionError>` and focused review/e2e coverage; direct `int` assignment remains a type mismatch outside handling, fixed-width and augassign remain fail-closed: PR #1876.
   - [x] `Result[int, DivisionError]` function return boundaries that directly return unproven exact-int `//`/`%` or call another promoted result-returning helper now lower as `Result<SifrInt, DivisionError>`; promoted callers, try-unwrapped locals, chained helpers, and mixed plain-`Ok(int)` branches are covered, review is satisfied, and quick validation is passing: PR #1877.
+  - [x] `Result[int, DivisionError]` function return boundaries now also promote local `Result` bindings initialized from exact floor/mod results or promoted helper calls, preserving chained local-result helper returns through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1878.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md
@@ -1,0 +1,115 @@
+# Review: INT-1 Local Result Binding Return Slice
+
+## Verdict: SATISFIED
+
+The slice is correct and ready for commit. No blockers identified.
+
+---
+
+## Change Summary
+
+**`function_emitter.rs`:**
+- `function_returns_result_sifr_int` now collects `Result[int, DivisionError]`-shaped local bindings via `collect_sifr_int_result_local_bindings`
+- Returning one of those bindings marks the function as `Result<SifrInt, DivisionError>`
+- Assignment invalidation removes promotion when the RHS is not a SifrInt Result expression
+
+**`exact_int_floor_mod_result_return.sifr`:**
+- `divide_local()`: `value = a // b`, `return value`
+- `divide_local_again()`: `value = divide_local(a, b)`, `return value`
+- `main` try-unwraps the chained return and asserts `3`
+
+---
+
+## Soundness Analysis
+
+### Local Binding Collection (`collect_sifr_int_result_local_bindings`)
+
+| Aspect | Assessment |
+|--------|------------|
+| `LOCAL_SCOPE_ONLY` traversal | **Correct** — nested functions are scope boundaries; no cross-contamination |
+| Iterative collection | **Correct** — bindings accumulate during single left-to-right pass; order is sufficient |
+| Type check via `is_result_int_type` | **Correct** — matches `Result[Int, DivisionError]` or `Result[LiteralInt, DivisionError]` |
+| Assignment invalidation | **Correct** — `remove` only when `hir_expr_returns_sifr_int_result` returns false |
+| `hir_expr_returns_sifr_int_result` matches | `//`, `%` binops; calls to `result_function_returns`; `HirExpr::Name` refs |
+
+The collection order is sufficient: statements before a return statement are always visited before that return during `walk_stmts`, so by the time return analysis runs, all Let-bindings in scope have been collected.
+
+### Assignment Invalidation
+
+```
+value: Result[int, DivisionError] = a // b  # inserted
+value = other_result_var                   # kept (Name matches)
+value = some_int                           # removed
+value = a // b                             # re-inserted
+```
+
+The `if result_bindings.contains(name)` guard ensures only already-promoted bindings are invalidated. This correctly models the semantics: once a Result[int] binding holds a promoted value, reassigning from another promoted binding keeps it; reassigning from a non-promoted source removes it.
+
+### Return Path
+
+`function_returns_result_sifr_int` uses `LOCAL_SCOPE_ONLY` traversal with `hir_expr_returns_sifr_int_result(value, result_function_returns, &local_result_bindings)`. Since `local_result_bindings` is built by the same traversal order guarantee, the return expression sees the complete binding set.
+
+---
+
+## Missing Coverage (Acceptable for This Slice)
+
+The stated scope is: *"a function returning a local Result[int, DivisionError] binding that was initialized from an exact floor/mod result or from another promoted Result-returning helper."*
+
+The e2e test covers both sub-cases:
+1. `divide_local()` — direct `//` assignment (floor/mod result)
+2. `divide_local_again()` — chained promoted helper call
+
+**Not covered** (out of scope per the stated intent):
+- Reassignment patterns (e.g., `value = a // b; value = 42; return value`) — correctly handled by the invalidation logic, but not exercised
+- Conditional returns from promoted bindings (e.g., `if cond: return value; return Err(...)`)
+- Nested function returning a promoted local binding from its outer scope — requires `INCLUDE_NESTED_FUNCTIONS` and a separate tracking mechanism, out of scope for this slice
+
+---
+
+## Edge Case: Assignment Invalidation is Coarse
+
+The invalidation check is:
+```rust
+HirStmt::Assign { name, value }
+    if result_bindings.contains(name)
+        && !hir_expr_returns_sifr_int_result(value, result_function_returns, &result_bindings)
+```
+
+This means assigning from any non-SifrInt-Result expression removes promotion, including:
+- Function calls to helpers that *happen* to return a non-Result or `Result[non-int], _`
+- Complex expressions containing a promoted binding name
+
+Example:
+```python
+def helper() -> int: ...
+value: Result[int, DivisionError] = a // b
+value = helper()  # removed by invalidation, even though helper() is safe
+return value      # still returns Result[int, DivisionError], not Result[SifrInt, DivisionError>
+```
+
+This is **coarse but correct** for this slice: the function returns `Result[int, DivisionError]` which is the correct type when the value isn't SifrInt. The Rust codegen will produce `Result<i64, DivisionError>` for the `int` arm, matching the declared Sifr type. The only consequence is lost precision in the promoted return set, not a type mismatch.
+
+---
+
+## Validation Results
+
+```
+cargo check -p sifr_codegen                   ✓
+cargo test -p sifr_codegen function_emitter   ✓ (6 tests)
+cargo test -p sifr_hir -- --skip test_e2e_pass ✓ (481 tests)
+cargo test -p sifr -- --skip test_e2e_pass    ✓ (32 tests)
+scripts/run_all_tests.sh --profile quick      ✓ (e2e: 24/24 passed)
+SIFR_E2E_FIXTURE_MANIFEST=<manifest> cargo test -p sifr -- test_e2e_pass ✓ (exact_int_floor_mod_result_return)
+cargo fmt --check                             ✓
+```
+
+Generated Rust output (emitted) confirms:
+- `divide_local()` → `Result<SifrInt, DivisionError>`
+- `divide_local_again()` → `Result<SifrInt, DivisionError>`
+- `main` try-unwraps produce `SifrInt` in success branches
+
+---
+
+## Recommendation
+
+**Satisfied.** The slice is minimal, correct, and sufficiently tested. Commit as-is.


### PR DESCRIPTION
## Summary
- Detect local `Result[int, DivisionError]` bindings initialized from exact floor/mod results or promoted result-returning helpers.
- Promote functions returning those local result bindings to generated Rust `Result<SifrInt, DivisionError>`.
- Extend the exact floor/mod result return fixture with direct and chained local-result return coverage.
- Record the satisfied Opus review artifact.

## Validation
- `cargo fmt`
- `cargo check -p sifr_codegen`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr`
- `cargo test -p sifr_codegen function_emitter -- --nocapture`
- `cargo test -p sifr_hir exact_int -- --nocapture`
- `scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>`
- `scripts/run_all_tests.sh --profile quick`

Reviewer is satisfied: `reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md`.
