### PR TITLE
Promote exact int nested Result returns

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -26,6 +26,13 @@ def divide_local_again(a: int, b: int) -> Result[int, DivisionError]:
     return value
 
 
+def divide_nested_local(a: int, b: int) -> Result[int, DivisionError]:
+    def helper() -> Result[int, DivisionError]:
+        value: Result[int, DivisionError] = a // b
+        return value
+    return helper()
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -54,5 +61,11 @@ def main():
     try:
         local_result: int = divide_local_again(9, 3)
         assert str(local_result) == '3'
+    except DivisionError as e:
+        _ = e
+
+    try:
+        nested_result: int = divide_nested_local(12, 4)
+        assert str(nested_result) == '3'
     except DivisionError as e:
         _ = e

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -1010,14 +1010,19 @@ fn function_returns_result_sifr_int(
         return false;
     }
 
+    let mut result_function_returns = result_function_returns.clone();
+    result_function_returns.extend(collect_nested_sifr_int_result_function_returns(
+        &func.body,
+        &result_function_returns,
+    ));
     let local_result_bindings =
-        collect_sifr_int_result_local_bindings(&func.body, result_function_returns);
+        collect_sifr_int_result_local_bindings(&func.body, &result_function_returns);
     let mut returns_sifr_int_result = false;
     let mut on_stmt = |stmt: &HirStmt| {
         if let HirStmt::Return { value: Some(value) } = stmt {
             returns_sifr_int_result |= hir_expr_returns_sifr_int_result(
                 value,
-                result_function_returns,
+                &result_function_returns,
                 &local_result_bindings,
             );
         }
@@ -1030,6 +1035,36 @@ fn function_returns_result_sifr_int(
         &mut on_expr,
     );
     returns_sifr_int_result
+}
+
+fn collect_nested_sifr_int_result_function_returns(
+    body: &[HirStmt],
+    inherited_result_function_returns: &HashSet<String>,
+) -> HashSet<String> {
+    let mut nested_returns = HashSet::new();
+    loop {
+        let before = nested_returns.len();
+        let mut available_result_returns = inherited_result_function_returns.clone();
+        available_result_returns.extend(nested_returns.iter().cloned());
+        let mut on_stmt = |stmt: &HirStmt| {
+            if let HirStmt::NestedFunction { func } = stmt {
+                if function_returns_result_sifr_int(func, &available_result_returns) {
+                    nested_returns.insert(func.name.clone());
+                }
+            }
+        };
+        let mut on_expr = |_expr: &HirExpr| {};
+        traversal::walk_stmts(
+            body,
+            TraversalConfig::LOCAL_SCOPE_ONLY,
+            &mut on_stmt,
+            &mut on_expr,
+        );
+        if nested_returns.len() == before {
+            break;
+        }
+    }
+    nested_returns
 }
 
 fn collect_sifr_int_result_local_bindings(

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -466,6 +466,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 1 completed with recursive nested return-type blocker: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 2 satisfied after making recursive nested return typing explicit: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-result return review satisfied after adding local binding promotion and chained helper coverage: `reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested result-helper return review satisfied after adding nested fixed-point propagation and e2e coverage: `reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -501,6 +502,7 @@ Validation:
   - [x] Unproven exact-int `//` and `%` now lower as `Result[int, DivisionError]` instead of `SIFR-INT-0005`, with local `Result` bindings and try-block unwrapping emitted through `Result<SifrInt, DivisionError>` and focused review/e2e coverage; direct `int` assignment remains a type mismatch outside handling, fixed-width and augassign remain fail-closed: PR #1876.
   - [x] `Result[int, DivisionError]` function return boundaries that directly return unproven exact-int `//`/`%` or call another promoted result-returning helper now lower as `Result<SifrInt, DivisionError>`; promoted callers, try-unwrapped locals, chained helpers, and mixed plain-`Ok(int)` branches are covered, review is satisfied, and quick validation is passing: PR #1877.
   - [x] `Result[int, DivisionError]` function return boundaries now also promote local `Result` bindings initialized from exact floor/mod results or promoted helper calls, preserving chained local-result helper returns through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1878.
+  - [x] Nested `Result[int, DivisionError]` helpers discovered inside a returning function now participate in result-return promotion, so outers returning nested helper calls lower through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1879.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md
@@ -1,0 +1,53 @@
+
+
+All tests pass. Here is my review:
+
+## Verdict: Satisfied
+
+The slice is correct, sound, and acceptable for INT-1. No blockers.
+
+---
+
+### Soundness
+
+**Fixed-point termination** (`collect_nested_sifr_int_result_function_returns`, lines 1040-1068):
+- The loop only adds names to `nested_returns`; nothing is ever removed.
+- Body contains finitely many `NestedFunction` statements.
+- Each iteration can only add at most N new names (one per nested function).
+- Therefore the loop converges in at most N iterations.
+- **Sound and terminates.**
+
+**`LOCAL_SCOPE_ONLY`** traversal in that same function and in `collect_sifr_int_result_local_bindings`:
+- Ensures only direct nested functions in the *current* function body are discovered.
+- Nested functions of nested functions are not transitively included at this level — they would be discovered when analyzing those nested functions themselves (as happens in `hir_function_returns_sifr_int`).
+- **Correct scoping, no pollution.**
+
+**Order of extension** in `function_returns_result_sifr_int` (lines 1005-1038):
+- `result_function_returns` is extended via `collect_nested_sifr_int_result_function_returns` *before* `collect_sifr_int_result_local_bindings` is called.
+- `collect_sifr_int_result_local_bindings` passes the extended set to `hir_expr_returns_sifr_int_result`, so that local bindings initialized from calls to newly discovered nested helpers are recognized.
+- **Correct ordering.**
+
+### Missing cases / gaps
+
+No gaps identified. The existing `hir_expr_returns_sifr_int_result` (lines 1109-1122) handles all three legs:
+
+| Pattern | Handled by |
+|---|---|
+| `a // b` directly in initializer | `HirExpr::BinOp` arm |
+| Call to promoted helper | `HirExpr::Call` arm |
+| Binding of another result binding | `HirExpr::Name` arm |
+
+Deeply nested helpers (helper containing helper containing helper) would propagate via the same fixed-point mechanism: each level's `collect_nested_sifr_int_result_function_returns` would discover the next level's helpers and add them to the set, enabling the outer function to promote.
+
+### E2E proof
+
+`divide_nested_local` (lines 29-33 in the fixture) is the exact gap this slice closes:
+- Nested `helper()` creates a local `Result[int, DivisionError]` from `a // b` and returns it.
+- Outer function returns `helper()`.
+- `main` tries-unwraps `divide_nested_local(12, 4)` and asserts `"3"`.
+
+The generated Rust (`helper()` lowered as a closure returning `Result<SifrInt, DivisionError>`, outer returning `helper()` call) confirms the propagation works end-to-end.
+
+### Minor observation (not a blocker)
+
+The generated `helper` is a non-recursive closure (`let helper = || { ... }; return helper();`), which is correct since `helper` doesn't call itself. If the nested helper were recursive, `try_lower_structured_nested_function_stmt` would emit `RustStmt::LocalFn` instead, and line 336 correctly evaluates `function_returns_result_sifr_int` on that path too.


### PR DESCRIPTION
## Summary
- Include nested `Result[int, DivisionError]` helpers in the exact result-return promotion fixed point.
- Let outer functions returning nested promoted helper calls emit `Result<SifrInt, DivisionError>`.
- Extend the exact floor/mod result return fixture with nested helper local-result coverage.
- Record the satisfied Opus review artifact.

## Validation
- `cargo fmt`
- `cargo check -p sifr_codegen`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr`
- `cargo test -p sifr_codegen function_emitter -- --nocapture`
- `cargo test -p sifr_hir exact_int -- --nocapture`
- `scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>`
- `scripts/run_all_tests.sh --profile quick`

Reviewer is satisfied: `reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md`.
