### PR TITLE
Promote exact int Result parameter boundaries

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -33,6 +33,10 @@ def divide_nested_local(a: int, b: int) -> Result[int, DivisionError]:
     return helper()
 
 
+def pass_result(own value: Result[int, DivisionError]) -> Result[int, DivisionError]:
+    return value
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -69,3 +73,8 @@ def main():
         assert str(nested_result) == '3'
     except DivisionError as e:
         _ = e
+
+    result_arg: Result[int, DivisionError] = divide(15, 5)
+    direct_arg: Result[int, DivisionError] = pass_result(divide(18, 6))
+    _ = pass_result(result_arg)
+    _ = direct_arg

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -265,6 +265,9 @@ impl RustEmitter {
                             let arg = self.rewrite_stdlib_constant_idents_in_expr(arg);
                             if self.function_param_lowers_to_sifr_int(&func_name, idx) {
                                 self.coerce_expr_to_sifr_int_value(arg)
+                            } else if self.function_param_lowers_to_sifr_int_result(&func_name, idx)
+                            {
+                                self.coerce_result_int_expr_to_sifr_int_value(arg)
                             } else {
                                 arg
                             }
@@ -1581,6 +1584,13 @@ impl RustEmitter {
 
     pub(super) fn function_param_lowers_to_sifr_int(&self, name: &str, idx: usize) -> bool {
         self.sifr_int_function_params
+            .borrow()
+            .get(name)
+            .is_some_and(|params| params.contains(&idx))
+    }
+
+    pub(super) fn function_param_lowers_to_sifr_int_result(&self, name: &str, idx: usize) -> bool {
+        self.sifr_int_result_function_params
             .borrow()
             .get(name)
             .is_some_and(|params| params.contains(&idx))

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -138,6 +138,7 @@ impl RustEmitter {
         let mut function_returns = HashSet::new();
         let mut result_function_returns = HashSet::new();
         let mut function_params: HashMap<String, HashSet<usize>> = HashMap::new();
+        let mut result_function_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let module_function_params = module
             .functions
             .iter()
@@ -155,6 +156,10 @@ impl RustEmitter {
             let before = function_returns.len();
             let before_result_returns = result_function_returns.len();
             let before_params = function_params.values().map(HashSet::len).sum::<usize>();
+            let before_result_params = result_function_params
+                .values()
+                .map(HashSet::len)
+                .sum::<usize>();
             let discovered = module
                 .functions
                 .iter()
@@ -178,8 +183,12 @@ impl RustEmitter {
                 .functions
                 .iter()
                 .filter_map(|func| {
-                    (function_returns_result_sifr_int(func, &result_function_returns))
-                        .then(|| func.name.clone())
+                    (function_returns_result_sifr_int(
+                        func,
+                        &result_function_returns,
+                        &result_function_params,
+                    ))
+                    .then(|| func.name.clone())
                 })
                 .collect::<Vec<_>>();
             result_function_returns.extend(discovered_result_returns);
@@ -203,11 +212,27 @@ impl RustEmitter {
                 ) {
                     function_params.entry(name).or_default().extend(indexes);
                 }
+                for (name, indexes) in collect_sifr_int_result_call_arg_function_params(
+                    func,
+                    &module_function_params,
+                    &result_function_returns,
+                    &result_function_params,
+                ) {
+                    result_function_params
+                        .entry(name)
+                        .or_default()
+                        .extend(indexes);
+                }
             }
             let after_params = function_params.values().map(HashSet::len).sum::<usize>();
+            let after_result_params = result_function_params
+                .values()
+                .map(HashSet::len)
+                .sum::<usize>();
             if function_returns.len() == before
                 && result_function_returns.len() == before_result_returns
                 && after_params == before_params
+                && after_result_params == before_result_params
             {
                 break;
             }
@@ -215,6 +240,7 @@ impl RustEmitter {
         *self.sifr_int_function_returns.borrow_mut() = function_returns;
         *self.sifr_int_result_function_returns.borrow_mut() = result_function_returns;
         *self.sifr_int_function_params.borrow_mut() = function_params;
+        *self.sifr_int_result_function_params.borrow_mut() = result_function_params;
     }
 
     fn module_sifr_int_bindings(&self) -> HashSet<String> {
@@ -332,8 +358,11 @@ impl RustEmitter {
                 &sifr_int_nested_capture_bindings,
                 &captured_shadowed_module_bindings,
             );
-        let nested_returns_sifr_int_result =
-            function_returns_result_sifr_int(func, &self.sifr_int_result_function_returns.borrow());
+        let nested_returns_sifr_int_result = function_returns_result_sifr_int(
+            func,
+            &self.sifr_int_result_function_returns.borrow(),
+            &self.sifr_int_result_function_params.borrow(),
+        );
         let post_stmt_callable_conventions = {
             let mut conventions = self.callable_var_conventions.clone();
             let params = func
@@ -610,6 +639,11 @@ impl RustEmitter {
             )
         {
             return RustType::Named("SifrInt".to_string());
+        }
+        if self.function_param_lowers_to_sifr_int_result(func_name, param_idx)
+            && is_result_int_type(&param.ty)
+        {
+            return result_int_return_type_to_sifr_int(&param.ty);
         }
         self.lower_function_param_type(&param.ty, param.convention)
     }
@@ -1005,6 +1039,7 @@ fn hir_function_returns_sifr_int(
 fn function_returns_result_sifr_int(
     func: &HirFunction,
     result_function_returns: &HashSet<String>,
+    result_function_params: &HashMap<String, HashSet<usize>>,
 ) -> bool {
     if !is_result_int_type(&func.return_type) {
         return false;
@@ -1014,9 +1049,15 @@ fn function_returns_result_sifr_int(
     result_function_returns.extend(collect_nested_sifr_int_result_function_returns(
         &func.body,
         &result_function_returns,
+        result_function_params,
     ));
-    let local_result_bindings =
-        collect_sifr_int_result_local_bindings(&func.body, &result_function_returns);
+    let result_param_bindings =
+        collect_sifr_int_result_function_param_names(func, result_function_params);
+    let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
+        &func.body,
+        &result_function_returns,
+        result_param_bindings,
+    );
     let mut returns_sifr_int_result = false;
     let mut on_stmt = |stmt: &HirStmt| {
         if let HirStmt::Return { value: Some(value) } = stmt {
@@ -1040,6 +1081,7 @@ fn function_returns_result_sifr_int(
 fn collect_nested_sifr_int_result_function_returns(
     body: &[HirStmt],
     inherited_result_function_returns: &HashSet<String>,
+    result_function_params: &HashMap<String, HashSet<usize>>,
 ) -> HashSet<String> {
     let mut nested_returns = HashSet::new();
     loop {
@@ -1048,7 +1090,11 @@ fn collect_nested_sifr_int_result_function_returns(
         available_result_returns.extend(nested_returns.iter().cloned());
         let mut on_stmt = |stmt: &HirStmt| {
             if let HirStmt::NestedFunction { func } = stmt {
-                if function_returns_result_sifr_int(func, &available_result_returns) {
+                if function_returns_result_sifr_int(
+                    func,
+                    &available_result_returns,
+                    result_function_params,
+                ) {
                     nested_returns.insert(func.name.clone());
                 }
             }
@@ -1071,7 +1117,18 @@ fn collect_sifr_int_result_local_bindings(
     body: &[HirStmt],
     result_function_returns: &HashSet<String>,
 ) -> HashSet<String> {
-    let mut result_bindings = HashSet::new();
+    collect_sifr_int_result_local_bindings_with_initial(
+        body,
+        result_function_returns,
+        HashSet::new(),
+    )
+}
+
+fn collect_sifr_int_result_local_bindings_with_initial(
+    body: &[HirStmt],
+    result_function_returns: &HashSet<String>,
+    mut result_bindings: HashSet<String>,
+) -> HashSet<String> {
     let mut on_stmt = |stmt: &HirStmt| match stmt {
         HirStmt::Let {
             name, ty, value, ..
@@ -1104,6 +1161,20 @@ fn collect_sifr_int_result_local_bindings(
         &mut on_expr,
     );
     result_bindings
+}
+
+fn collect_sifr_int_result_function_param_names(
+    func: &HirFunction,
+    result_function_params: &HashMap<String, HashSet<usize>>,
+) -> HashSet<String> {
+    let Some(indexes) = result_function_params.get(&func.name) else {
+        return HashSet::new();
+    };
+    func.params
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .collect()
 }
 
 fn hir_expr_returns_sifr_int_result(
@@ -1324,6 +1395,52 @@ fn collect_sifr_int_call_arg_function_params(
     };
     traversal::walk_stmts(
         body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    discovered
+}
+
+fn collect_sifr_int_result_call_arg_function_params(
+    caller: &HirFunction,
+    module_function_params: &HashMap<String, Vec<Type>>,
+    result_function_returns: &HashSet<String>,
+    result_function_params: &HashMap<String, HashSet<usize>>,
+) -> HashMap<String, HashSet<usize>> {
+    let result_param_bindings =
+        collect_sifr_int_result_function_param_names(caller, result_function_params);
+    let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
+        &caller.body,
+        result_function_returns,
+        result_param_bindings,
+    );
+    let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
+    let mut on_stmt = |_stmt: &HirStmt| {};
+    let mut on_expr = |expr: &HirExpr| {
+        let HirExpr::Call { func, args, .. } = expr else {
+            return;
+        };
+        let Some(params) = module_function_params.get(func) else {
+            return;
+        };
+        for (idx, arg) in args.iter().enumerate() {
+            let Some(param_ty) = params.get(idx) else {
+                continue;
+            };
+            if is_result_int_type(param_ty)
+                && hir_expr_returns_sifr_int_result(
+                    arg,
+                    result_function_returns,
+                    &local_result_bindings,
+                )
+            {
+                discovered.entry(func.clone()).or_default().insert(idx);
+            }
+        }
+    };
+    traversal::walk_stmts(
+        &caller.body,
         TraversalConfig::LOCAL_SCOPE_ONLY,
         &mut on_stmt,
         &mut on_expr,

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1219,6 +1219,8 @@ struct RustEmitter {
     sifr_int_result_function_returns: RefCell<HashSet<String>>,
     /// Module-level function `int` parameters promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
+    /// Module-level function `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
+    sifr_int_result_function_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
     current_sifr_int_return: Cell<bool>,
     /// Whether the active function-like body returns `Result<SifrInt, E>` for source-level `Result[int, E]`.
@@ -1327,6 +1329,7 @@ impl RustEmitter {
             sifr_int_function_returns: RefCell::new(HashSet::new()),
             sifr_int_result_function_returns: RefCell::new(HashSet::new()),
             sifr_int_function_params: RefCell::new(HashMap::new()),
+            sifr_int_result_function_params: RefCell::new(HashMap::new()),
             current_sifr_int_return: Cell::new(false),
             current_sifr_int_result_return: Cell::new(false),
             stmt_capture_stack: Vec::new(),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -5274,6 +5274,11 @@ impl RustEmitter {
                 adapted.push(self.coerce_expr_to_sifr_int_value(lowered_arg));
                 continue;
             }
+            if self.function_param_lowers_to_sifr_int_result(func, idx) {
+                let lowered_arg = self.rewrite_stdlib_constant_idents_in_expr(lowered_arg);
+                adapted.push(self.coerce_result_int_expr_to_sifr_int_value(lowered_arg));
+                continue;
+            }
 
             let param_rust_type = param_ty.rust_type();
             if param_rust_type.starts_with("Box<")

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -467,6 +467,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` return-boundary review pass 2 satisfied after making recursive nested return typing explicit: `reviews/integer-model-int-1-exact-int-floor-mod-result-returns-review-pass-2.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-result return review satisfied after adding local binding promotion and chained helper coverage: `reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested result-helper return review satisfied after adding nested fixed-point propagation and e2e coverage: `reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` parameter-boundary review satisfied after promoting result params and passthrough returns: `reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -503,6 +504,7 @@ Validation:
   - [x] `Result[int, DivisionError]` function return boundaries that directly return unproven exact-int `//`/`%` or call another promoted result-returning helper now lower as `Result<SifrInt, DivisionError>`; promoted callers, try-unwrapped locals, chained helpers, and mixed plain-`Ok(int)` branches are covered, review is satisfied, and quick validation is passing: PR #1877.
   - [x] `Result[int, DivisionError]` function return boundaries now also promote local `Result` bindings initialized from exact floor/mod results or promoted helper calls, preserving chained local-result helper returns through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1878.
   - [x] Nested `Result[int, DivisionError]` helpers discovered inside a returning function now participate in result-return promotion, so outers returning nested helper calls lower through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1879.
+  - [x] `Result[int, DivisionError]` parameter boundaries whose call sites receive promoted exact result expressions now lower those params as `Result<SifrInt, DivisionError>`, preserving owned passthrough helpers and direct promoted call arguments; review is satisfied and quick validation is passing: PR #1880.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md
@@ -1,0 +1,59 @@
+
+
+## Review: INT-1 Result Param Boundary Slice
+
+**Verdict: SATISFIED**
+
+### Summary
+
+The slice correctly implements promotion of `Result[int, E]` parameters to `Result<SifrInt, E]` when call sites pass promoted result expressions. The generated Rust for the test fixture is valid and runs correctly.
+
+### Detailed Findings
+
+**1. Fixed point interaction with result function return promotion**
+
+The loop at `function_emitter.rs:155–239` correctly converges when all three propagate:
+- `function_returns` (plain int)
+- `result_function_returns` (Result[int, E])
+- `function_params` (plain int params)  
+- `result_function_params` (Result[int, E] params)
+
+The iteration order is sound: result params are discovered from result function returns, then result function returns are re-computed (including seeding from result params), then params are re-discovered. This mirrors the pattern used for plain int params/returns.
+
+**2. Seeding `function_returns_result_sifr_int` with promoted result param names**
+
+`sifr_int_result_function_params` is correctly threaded through to `function_returns_result_sifr_int` at line 1042. The seed at lines 1054–1059 correctly combines:
+- Nested helper returns (via `collect_nested_sifr_int_result_function_returns`)
+- Promoted result param passthrough bindings (via `collect_sifr_int_result_function_param_names` → `collect_sifr_int_result_local_bindings_with_initial`)
+
+A function parameter that receives `Result<SifrInt, E>` and returns it directly (like `pass_result`) is correctly identified as needing promotion.
+
+**3. Call argument coercion is correctly scoped**
+
+The coercion at `expr_render_helpers.rs:268–270` fires only when:
+- The called function has a promoted result param at that index
+- The argument is a known `Result<SifrInt, E]` expression (local binding, promoted call, or `//`/`%`)
+
+`coerce_result_int_expr_to_sifr_int_value` is conservative: it creates new `Ok(SifrInt::from_i64(...))` wrappers only for bare `Ok(...)` calls, and passes through already-promoted result expressions unchanged. This is correct.
+
+**4. No state save/restore or nested-scope issues**
+
+- `sifr_int_result_function_params` is a simple `HashMap<String, HashSet<usize>>`, populated monotonically in the fixed-point loop. No stack/unwind needed.
+- `collect_sifr_int_result_call_arg_function_params` uses `TraversalConfig::LOCAL_SCOPE_ONLY`, correctly avoiding nested function bodies when discovering param→call-site bindings.
+- The `collect_sifr_int_result_function_param_names` helper safely returns `HashSet::new()` when the function has no promoted result params.
+
+**5. Test fixture correctness**
+
+The generated `pass_result`:
+```rust
+fn pass_result(value: Result<SifrInt, DivisionError>) -> Result<SifrInt, DivisionError> {
+    return value;
+}
+```
+correctly receives `Result<SifrInt, DivisionError>` and returns `Result<SifrInt, DivisionError>`. Both test cases (`pass_result(result_arg)` and `pass_result(divide(18, 6))`) compile and run.
+
+### Pre-existing e2e failures
+
+The group-level compilation failures (`with_break`, `with_early_return`, etc.) are pre-existing — they fail identically without this slice due to missing Rust stdlib imports (`map`, `list`, `filter`). These are unrelated to INT-1.
+
+### No blockers identified. The slice is acceptable for INT-1.


### PR DESCRIPTION
## Summary
- Discover `Result[int, DivisionError]` function parameters whose call sites receive promoted exact result expressions.
- Lower promoted result parameters as `Result<SifrInt, DivisionError>` and seed result-return analysis from those params.
- Coerce call arguments for promoted result params through the existing result-int coercion path.
- Extend exact floor/mod result fixture coverage for owned passthrough helpers with local and direct promoted result arguments.
- Record the satisfied Opus review artifact.

## Validation
- `cargo fmt`
- `cargo check -p sifr_codegen`
- `cargo run -q -p sifr -- emit <temporary passthrough fixtures>`
- `cargo test -p sifr_codegen function_emitter -- --nocapture`
- `cargo test -p sifr_hir exact_int -- --nocapture`
- `scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>`
- `scripts/run_all_tests.sh --profile quick`

Reviewer is satisfied: `reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md`.
