### PR TITLE
Track exact int Result local aliases

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -37,6 +37,11 @@ def pass_result(own value: Result[int, DivisionError]) -> Result[int, DivisionEr
     return value
 
 
+def alias_result(own value: Result[int, DivisionError]) -> Result[int, DivisionError]:
+    other: Result[int, DivisionError] = value
+    return other
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -77,4 +82,4 @@ def main():
     result_arg: Result[int, DivisionError] = divide(15, 5)
     direct_arg: Result[int, DivisionError] = pass_result(divide(18, 6))
     _ = pass_result(result_arg)
-    _ = direct_arg
+    _ = alias_result(direct_arg)

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -524,11 +524,17 @@ impl RustEmitter {
                             .insert(name.clone());
                         (Some(crate::RustType::Named("SifrInt".to_string())), value)
                     } else if is_result_legacy_i64_type(&ty) && value_is_sifr_int_result {
+                        self.sifr_int_result_local_bindings
+                            .borrow_mut()
+                            .insert(name.clone());
                         (ty.map(result_i64_type_to_sifr_int), value)
                     } else {
                         if !force_sifr_int {
                             self.sifr_int_local_bindings.borrow_mut().remove(&name);
                         }
+                        self.sifr_int_result_local_bindings
+                            .borrow_mut()
+                            .remove(&name);
                         (ty, value)
                     };
                 crate::RustStmt::Let {
@@ -566,6 +572,11 @@ impl RustEmitter {
                             .borrow_mut()
                             .insert(name.clone());
                         self.coerce_expr_to_sifr_int_value(value)
+                    }
+                    crate::RustExpr::Ident(name)
+                        if self.is_registered_sifr_int_result_local(name) =>
+                    {
+                        self.coerce_result_int_expr_to_sifr_int_value(value)
                     }
                     _ => value,
                 };
@@ -1539,6 +1550,7 @@ impl RustEmitter {
             crate::RustExpr::FnCall { func, .. } => {
                 self.is_sifr_int_result_returning_function_call(func)
             }
+            crate::RustExpr::Ident(name) => self.is_registered_sifr_int_result_local(name),
             crate::RustExpr::Paren(inner) => self.is_sifr_int_result_expr(inner),
             _ => false,
         }
@@ -1594,6 +1606,10 @@ impl RustEmitter {
             .borrow()
             .get(name)
             .is_some_and(|params| params.contains(&idx))
+    }
+
+    fn is_registered_sifr_int_result_local(&self, name: &str) -> bool {
+        self.sifr_int_result_local_bindings.borrow().contains(name)
     }
 }
 

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -69,6 +69,11 @@ impl RustEmitter {
                     .borrow_mut()
                     .insert(param.name.clone());
             }
+            if self.function_param_lowers_to_sifr_int_result(func_name, param_idx) {
+                self.sifr_int_result_local_bindings
+                    .borrow_mut()
+                    .insert(param.name.clone());
+            }
         }
     }
 
@@ -391,6 +396,8 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
+        let saved_sifr_int_result_local_bindings =
+            self.sifr_int_result_local_bindings.borrow().clone();
         let saved_current_sifr_int_return = self.current_sifr_int_return.get();
         let saved_current_sifr_int_result_return = self.current_sifr_int_result_return.get();
         let nested_binding_mutable = saved_mutated_vars.contains(&func.name);
@@ -403,6 +410,7 @@ impl RustEmitter {
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
+        self.sifr_int_result_local_bindings.borrow_mut().clear();
         self.current_sifr_int_return.set(nested_returns_sifr_int);
         self.current_sifr_int_result_return
             .set(nested_returns_sifr_int_result);
@@ -464,6 +472,7 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+        *self.sifr_int_result_local_bindings.borrow_mut() = saved_sifr_int_result_local_bindings;
         self.current_sifr_int_return
             .set(saved_current_sifr_int_return);
         self.current_sifr_int_result_return
@@ -836,6 +845,8 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
+        let saved_sifr_int_result_local_bindings =
+            self.sifr_int_result_local_bindings.borrow().clone();
         let saved_sifr_int_function_returns = self.sifr_int_function_returns.borrow().clone();
         let saved_sifr_int_result_function_returns =
             self.sifr_int_result_function_returns.borrow().clone();
@@ -851,6 +862,7 @@ impl RustEmitter {
         self.none_widened_local_bindings.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
+        self.sifr_int_result_local_bindings.borrow_mut().clear();
         self.current_sifr_int_return
             .set(self.function_returns_sifr_int(&func.name));
         self.current_sifr_int_result_return.set(
@@ -963,6 +975,7 @@ impl RustEmitter {
         self.none_widened_local_bindings = saved_none_widened_local_bindings;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+        *self.sifr_int_result_local_bindings.borrow_mut() = saved_sifr_int_result_local_bindings;
         *self.sifr_int_function_returns.borrow_mut() = saved_sifr_int_function_returns;
         *self.sifr_int_result_function_returns.borrow_mut() =
             saved_sifr_int_result_function_returns;

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1213,6 +1213,8 @@ struct RustEmitter {
     sifr_int_local_bindings: RefCell<HashSet<String>>,
     /// Local names pre-promoted to `SifrInt` because a later assignment needs exact-int storage.
     sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
+    /// Local names whose generated Rust `Result[int, E]` binding payload is `SifrInt`.
+    sifr_int_result_local_bindings: RefCell<HashSet<String>>,
     /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_returns: RefCell<HashSet<String>>,
     /// Function names whose `Result[int, E]` generated Rust return payload is `SifrInt`.
@@ -1326,6 +1328,7 @@ impl RustEmitter {
             none_widened_local_bindings: HashSet::new(),
             sifr_int_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_forced_local_bindings: RefCell::new(HashSet::new()),
+            sifr_int_result_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_function_returns: RefCell::new(HashSet::new()),
             sifr_int_result_function_returns: RefCell::new(HashSet::new()),
             sifr_int_function_params: RefCell::new(HashMap::new()),

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -468,6 +468,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-result return review satisfied after adding local binding promotion and chained helper coverage: `reviews/integer-model-int-1-exact-int-result-local-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested result-helper return review satisfied after adding nested fixed-point propagation and e2e coverage: `reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` parameter-boundary review satisfied after promoting result params and passthrough returns: `reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-alias review satisfied after registering `Result<SifrInt, E>` locals and alias coverage: `reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -505,6 +506,7 @@ Validation:
   - [x] `Result[int, DivisionError]` function return boundaries now also promote local `Result` bindings initialized from exact floor/mod results or promoted helper calls, preserving chained local-result helper returns through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1878.
   - [x] Nested `Result[int, DivisionError]` helpers discovered inside a returning function now participate in result-return promotion, so outers returning nested helper calls lower through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1879.
   - [x] `Result[int, DivisionError]` parameter boundaries whose call sites receive promoted exact result expressions now lower those params as `Result<SifrInt, DivisionError>`, preserving owned passthrough helpers and direct promoted call arguments; review is satisfied and quick validation is passing: PR #1880.
+  - [x] `Result[int, DivisionError]` local aliases that receive promoted result params or locals now register as `Result<SifrInt, DivisionError>`, preserving alias-return and downstream call shapes; review is satisfied and quick validation is passing: PR #1881.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md
@@ -1,0 +1,49 @@
+Based on my comprehensive review, here is my assessment:
+
+## Review Summary
+
+### Overall Assessment: SATISFIED
+
+The INT-1 slice correctly implements Result<SifrInt, E> local binding support for promoted Result parameters. All generated Rust is type-correct.
+
+### Detailed Findings
+
+#### 1. Result-local binding state save/restore in additional emitter scopes
+**No additional scopes needed.** Save/restore is correctly implemented in:
+- `emit_function` (lib.rs:848-849, 865, 978)
+- `try_lower_structured_nested_function_stmt` (function_emitter.rs:399-400, 413, 475)
+
+`capture_structured_stmts` doesn't touch the binding state, which is correct since it captures IR, not scopes.
+
+#### 2. Recognizing Ident(name) as SifrInt result expression is sound
+**Sound.** `sifr_int_result_local_bindings` is populated only through controlled entry points:
+1. `register_function_scope_params` (function_emitter.rs:72-76): registers promoted params
+2. `rewrite_stdlib_constant_idents_in_stmt` Let branch (expr_render_helpers.rs:526-538): registers locals
+
+The `Ident` check in `is_sifr_int_result_expr` (expr_render_helpers.rs:1553) delegates to `is_registered_sifr_int_result_local`, which only returns true for names in the controlled set.
+
+#### 3. Let/Assign rewriting correctly registers and invalidates result locals
+**Correct.** The Let branch (expr_render_helpers.rs:526-538):
+- Registers when type is `Result[i64, E]` AND value is `is_sifr_int_result_expr`
+- Invalidates (removes) in the else branch (lines 535-537) when the condition no longer holds
+
+The Assign branch (lines 576-579) correctly coerces to registered result locals via `coerce_result_int_expr_to_sifr_int_value`.
+
+#### 4. Interaction with promoted Result params and returns
+**Correct.** The emit output confirms:
+
+```rust
+fn alias_result(value: Result<SifrInt, DivisionError>) -> Result<SifrInt, DivisionError> {
+    let other: Result<SifrInt, DivisionError> = value;
+    return other;
+}
+```
+
+Both `value` (parameter) and `other` (local) correctly lower to `Result<SifrInt, DivisionError>`.
+
+### Test Results
+- All 6 function_emitter tests pass
+- All 18 expr_render_helpers tests pass
+- The 3 e2e failures (`lazy_builtins`, `list_slice_copy`, `nested_function_nonlocal_accumulator`) are pre-existing and unrelated to this slice
+
+### No Blockers


### PR DESCRIPTION
## Summary
- register promoted Result[int, DivisionError] params as Result<SifrInt, E> locals in codegen scope
- propagate Result<SifrInt, E> local aliases through let/assign rewriting and result-expression detection
- add e2e coverage for aliasing a promoted result parameter/local and returning it
- update INT-1 phase tracker and store satisfied reviewer output

## Review
- Satisfied: reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md

## Validation
- scripts/run_all_tests.sh --profile quick (75.54s; 24/24 pass fixtures; cache_hits=6/6)
- git diff --check