### PR TITLE
Promote exact int Result method returns

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -42,6 +42,14 @@ def alias_result(own value: Result[int, DivisionError]) -> Result[int, DivisionE
     return other
 
 
+class Calculator:
+    def divide(self, a: int, b: int) -> Result[int, DivisionError]:
+        return a // b
+
+    def divide_again(self, a: int, b: int) -> Result[int, DivisionError]:
+        return self.divide(a, b)
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -83,3 +91,10 @@ def main():
     direct_arg: Result[int, DivisionError] = pass_result(divide(18, 6))
     _ = pass_result(result_arg)
     _ = alias_result(direct_arg)
+
+    calc: Calculator = Calculator()
+    try:
+        method_result: int = calc.divide_again(21, 7)
+        assert str(method_result) == '3'
+    except DivisionError as e:
+        _ = e

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -1,4 +1,5 @@
 use crate::{
+    function_emitter::{is_result_int_type, result_int_return_type_to_sifr_int, result_method_key},
     helpers::{body_contains_field_assign_codegen, collect_mutated_vars_with_sigs},
     hir_analysis::traversal::{self, TraversalConfig},
     RustEmitter, RustExpr, RustItem, RustParam, RustStmt, RustType, RustTypeParam, Visibility,
@@ -258,6 +259,14 @@ impl RustEmitter {
         if method.return_type == Type::None {
             return None;
         }
+        if is_result_int_type(&method.return_type)
+            && self
+                .sifr_int_result_method_returns
+                .borrow()
+                .contains(&result_method_key(&class.name, &method.name))
+        {
+            return Some(result_int_return_type_to_sifr_int(&method.return_type));
+        }
         if let Type::Class { name: ret_name, .. } = &method.return_type {
             if !class.type_params.is_empty() && ret_name == &class.name {
                 return Some(RustType::Named(format!(
@@ -492,6 +501,9 @@ impl RustEmitter {
         let saved_sifr_int_local_bindings = self.sifr_int_local_bindings.borrow().clone();
         let saved_sifr_int_forced_local_bindings =
             self.sifr_int_forced_local_bindings.borrow().clone();
+        let saved_sifr_int_result_local_bindings =
+            self.sifr_int_result_local_bindings.borrow().clone();
+        let saved_current_sifr_int_result_return = self.current_sifr_int_result_return.get();
 
         self.current_return_type = Some(method.return_type.clone());
         self.mutated_vars = collect_mutated_vars_with_sigs(&method.body, &self.func_signatures);
@@ -501,6 +513,12 @@ impl RustEmitter {
         self.local_binding_types.clear();
         self.sifr_int_local_bindings.borrow_mut().clear();
         self.sifr_int_forced_local_bindings.borrow_mut().clear();
+        self.sifr_int_result_local_bindings.borrow_mut().clear();
+        self.current_sifr_int_result_return.set(
+            self.sifr_int_result_method_returns
+                .borrow()
+                .contains(&result_method_key(&class.name, &method.name)),
+        );
 
         for param in &method.params {
             let effective_convention = if method.name == "new" {
@@ -601,6 +619,9 @@ impl RustEmitter {
         self.local_binding_types = saved_local_binding_types;
         *self.sifr_int_local_bindings.borrow_mut() = saved_sifr_int_local_bindings;
         *self.sifr_int_forced_local_bindings.borrow_mut() = saved_sifr_int_forced_local_bindings;
+        *self.sifr_int_result_local_bindings.borrow_mut() = saved_sifr_int_result_local_bindings;
+        self.current_sifr_int_result_return
+            .set(saved_current_sifr_int_result_return);
 
         RustItem::Fn {
             name: method.name.clone(),

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1547,6 +1547,9 @@ impl RustEmitter {
             crate::RustExpr::MethodCall {
                 receiver, method, ..
             } if method == "ok_or_else" => self.is_sifr_int_checked_floor_option_expr(receiver),
+            crate::RustExpr::MethodCall {
+                receiver, method, ..
+            } => self.is_sifr_int_result_returning_method_call(receiver, method),
             crate::RustExpr::FnCall { func, .. } => {
                 self.is_sifr_int_result_returning_function_call(func)
             }
@@ -1588,6 +1591,33 @@ impl RustEmitter {
                 .borrow()
                 .contains(&name)
         })
+    }
+
+    fn is_sifr_int_result_returning_method_call(
+        &self,
+        receiver: &crate::RustExpr,
+        method: &str,
+    ) -> bool {
+        self.rust_expr_class_name(receiver)
+            .is_some_and(|class_name| {
+                self.sifr_int_result_method_returns.borrow().contains(
+                    &crate::function_emitter::result_method_key(&class_name, method),
+                )
+            })
+    }
+
+    fn rust_expr_class_name(&self, expr: &crate::RustExpr) -> Option<String> {
+        match expr {
+            crate::RustExpr::Ident(name) if name == "self" => self.current_class_name.clone(),
+            crate::RustExpr::Ident(name) => self.local_binding_types.get(name).and_then(|ty| {
+                match crate::resolve_alias_type_for_plain_call(ty) {
+                    Type::Class { name, .. } => Some(name.clone()),
+                    _ => None,
+                }
+            }),
+            crate::RustExpr::Paren(inner) => self.rust_expr_class_name(inner),
+            _ => None,
+        }
     }
 
     pub(super) fn function_returns_sifr_int(&self, name: &str) -> bool {

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -142,6 +142,7 @@ impl RustEmitter {
         let module_sifr_int_bindings = self.module_sifr_int_bindings();
         let mut function_returns = HashSet::new();
         let mut result_function_returns = HashSet::new();
+        let mut result_method_returns = HashSet::new();
         let mut function_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let mut result_function_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let module_function_params = module
@@ -160,6 +161,7 @@ impl RustEmitter {
         loop {
             let before = function_returns.len();
             let before_result_returns = result_function_returns.len();
+            let before_result_methods = result_method_returns.len();
             let before_params = function_params.values().map(HashSet::len).sum::<usize>();
             let before_result_params = result_function_params
                 .values()
@@ -191,12 +193,29 @@ impl RustEmitter {
                     (function_returns_result_sifr_int(
                         func,
                         &result_function_returns,
+                        &result_method_returns,
                         &result_function_params,
                     ))
                     .then(|| func.name.clone())
                 })
                 .collect::<Vec<_>>();
             result_function_returns.extend(discovered_result_returns);
+            let discovered_result_method_returns = module
+                .classes
+                .iter()
+                .flat_map(|class| {
+                    class.methods.iter().filter_map(|method| {
+                        function_returns_result_sifr_int(
+                            method,
+                            &result_function_returns,
+                            &result_method_returns,
+                            &result_function_params,
+                        )
+                        .then(|| result_method_key(&class.name, &method.name))
+                    })
+                })
+                .collect::<Vec<_>>();
+            result_method_returns.extend(discovered_result_method_returns);
             for func in &module.functions {
                 let extra_forced_params =
                     collect_sifr_int_function_param_names(func, &function_params);
@@ -221,6 +240,7 @@ impl RustEmitter {
                     func,
                     &module_function_params,
                     &result_function_returns,
+                    &result_method_returns,
                     &result_function_params,
                 ) {
                     result_function_params
@@ -236,6 +256,7 @@ impl RustEmitter {
                 .sum::<usize>();
             if function_returns.len() == before
                 && result_function_returns.len() == before_result_returns
+                && result_method_returns.len() == before_result_methods
                 && after_params == before_params
                 && after_result_params == before_result_params
             {
@@ -244,6 +265,7 @@ impl RustEmitter {
         }
         *self.sifr_int_function_returns.borrow_mut() = function_returns;
         *self.sifr_int_result_function_returns.borrow_mut() = result_function_returns;
+        *self.sifr_int_result_method_returns.borrow_mut() = result_method_returns;
         *self.sifr_int_function_params.borrow_mut() = function_params;
         *self.sifr_int_result_function_params.borrow_mut() = result_function_params;
     }
@@ -366,6 +388,7 @@ impl RustEmitter {
         let nested_returns_sifr_int_result = function_returns_result_sifr_int(
             func,
             &self.sifr_int_result_function_returns.borrow(),
+            &self.sifr_int_result_method_returns.borrow(),
             &self.sifr_int_result_function_params.borrow(),
         );
         let post_stmt_callable_conventions = {
@@ -1052,6 +1075,7 @@ fn hir_function_returns_sifr_int(
 fn function_returns_result_sifr_int(
     func: &HirFunction,
     result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
     result_function_params: &HashMap<String, HashSet<usize>>,
 ) -> bool {
     if !is_result_int_type(&func.return_type) {
@@ -1062,6 +1086,7 @@ fn function_returns_result_sifr_int(
     result_function_returns.extend(collect_nested_sifr_int_result_function_returns(
         &func.body,
         &result_function_returns,
+        result_method_returns,
         result_function_params,
     ));
     let result_param_bindings =
@@ -1069,6 +1094,7 @@ fn function_returns_result_sifr_int(
     let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
         &func.body,
         &result_function_returns,
+        result_method_returns,
         result_param_bindings,
     );
     let mut returns_sifr_int_result = false;
@@ -1077,6 +1103,7 @@ fn function_returns_result_sifr_int(
             returns_sifr_int_result |= hir_expr_returns_sifr_int_result(
                 value,
                 &result_function_returns,
+                result_method_returns,
                 &local_result_bindings,
             );
         }
@@ -1094,6 +1121,7 @@ fn function_returns_result_sifr_int(
 fn collect_nested_sifr_int_result_function_returns(
     body: &[HirStmt],
     inherited_result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
     result_function_params: &HashMap<String, HashSet<usize>>,
 ) -> HashSet<String> {
     let mut nested_returns = HashSet::new();
@@ -1106,6 +1134,7 @@ fn collect_nested_sifr_int_result_function_returns(
                 if function_returns_result_sifr_int(
                     func,
                     &available_result_returns,
+                    result_method_returns,
                     result_function_params,
                 ) {
                     nested_returns.insert(func.name.clone());
@@ -1133,6 +1162,7 @@ fn collect_sifr_int_result_local_bindings(
     collect_sifr_int_result_local_bindings_with_initial(
         body,
         result_function_returns,
+        &HashSet::new(),
         HashSet::new(),
     )
 }
@@ -1140,6 +1170,7 @@ fn collect_sifr_int_result_local_bindings(
 fn collect_sifr_int_result_local_bindings_with_initial(
     body: &[HirStmt],
     result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
     mut result_bindings: HashSet<String>,
 ) -> HashSet<String> {
     let mut on_stmt = |stmt: &HirStmt| match stmt {
@@ -1149,6 +1180,7 @@ fn collect_sifr_int_result_local_bindings_with_initial(
             && hir_expr_returns_sifr_int_result(
                 value,
                 result_function_returns,
+                result_method_returns,
                 &result_bindings,
             ) =>
         {
@@ -1159,6 +1191,7 @@ fn collect_sifr_int_result_local_bindings_with_initial(
                 && !hir_expr_returns_sifr_int_result(
                     value,
                     result_function_returns,
+                    result_method_returns,
                     &result_bindings,
                 ) =>
         {
@@ -1193,6 +1226,7 @@ fn collect_sifr_int_result_function_param_names(
 fn hir_expr_returns_sifr_int_result(
     expr: &HirExpr,
     result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
     local_result_bindings: &HashSet<String>,
 ) -> bool {
     match expr {
@@ -1200,12 +1234,17 @@ fn hir_expr_returns_sifr_int_result(
             matches!(op.as_str(), "//" | "%") && is_result_int_type(ty)
         }
         HirExpr::Call { func, .. } => result_function_returns.contains(func),
+        HirExpr::MethodCall { object, method, .. } => {
+            hir_expr_class_name(object).is_some_and(|class_name| {
+                result_method_returns.contains(&result_method_key(&class_name, method))
+            })
+        }
         HirExpr::Name { name, .. } => local_result_bindings.contains(name),
         _ => false,
     }
 }
 
-fn is_result_int_type(ty: &Type) -> bool {
+pub(crate) fn is_result_int_type(ty: &Type) -> bool {
     let Type::Result(ok_ty, _) = crate::resolve_alias_type_for_plain_call(ty) else {
         return false;
     };
@@ -1215,7 +1254,7 @@ fn is_result_int_type(ty: &Type) -> bool {
     )
 }
 
-fn result_int_return_type_to_sifr_int(ty: &Type) -> RustType {
+pub(crate) fn result_int_return_type_to_sifr_int(ty: &Type) -> RustType {
     let Type::Result(_, err_ty) = crate::resolve_alias_type_for_plain_call(ty) else {
         return RustType::Named(ty.rust_type());
     };
@@ -1223,6 +1262,17 @@ fn result_int_return_type_to_sifr_int(ty: &Type) -> RustType {
         Box::new(RustType::Named("SifrInt".to_string())),
         Box::new(crate::sifr_type_to_rust_type(err_ty)),
     )
+}
+
+pub(crate) fn result_method_key(class_name: &str, method_name: &str) -> String {
+    format!("{class_name}::{method_name}")
+}
+
+fn hir_expr_class_name(expr: &HirExpr) -> Option<String> {
+    match crate::resolve_alias_type_for_plain_call(expr.ty()) {
+        Type::Class { name, .. } => Some(name.clone()),
+        _ => None,
+    }
 }
 
 fn hir_function_returns_sifr_int_with_extra_forced(
@@ -1419,6 +1469,7 @@ fn collect_sifr_int_result_call_arg_function_params(
     caller: &HirFunction,
     module_function_params: &HashMap<String, Vec<Type>>,
     result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
     result_function_params: &HashMap<String, HashSet<usize>>,
 ) -> HashMap<String, HashSet<usize>> {
     let result_param_bindings =
@@ -1426,6 +1477,7 @@ fn collect_sifr_int_result_call_arg_function_params(
     let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
         &caller.body,
         result_function_returns,
+        result_method_returns,
         result_param_bindings,
     );
     let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
@@ -1445,6 +1497,7 @@ fn collect_sifr_int_result_call_arg_function_params(
                 && hir_expr_returns_sifr_int_result(
                     arg,
                     result_function_returns,
+                    result_method_returns,
                     &local_result_bindings,
                 )
             {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1219,6 +1219,8 @@ struct RustEmitter {
     sifr_int_function_returns: RefCell<HashSet<String>>,
     /// Function names whose `Result[int, E]` generated Rust return payload is `SifrInt`.
     sifr_int_result_function_returns: RefCell<HashSet<String>>,
+    /// Class method keys whose `Result[int, E]` generated Rust return payload is `SifrInt`.
+    sifr_int_result_method_returns: RefCell<HashSet<String>>,
     /// Module-level function `int` parameters promoted from legacy `i64` to `SifrInt`.
     sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Module-level function `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
@@ -1331,6 +1333,7 @@ impl RustEmitter {
             sifr_int_result_local_bindings: RefCell::new(HashSet::new()),
             sifr_int_function_returns: RefCell::new(HashSet::new()),
             sifr_int_result_function_returns: RefCell::new(HashSet::new()),
+            sifr_int_result_method_returns: RefCell::new(HashSet::new()),
             sifr_int_function_params: RefCell::new(HashMap::new()),
             sifr_int_result_function_params: RefCell::new(HashMap::new()),
             current_sifr_int_return: Cell::new(false),

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -469,6 +469,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested result-helper return review satisfied after adding nested fixed-point propagation and e2e coverage: `reviews/integer-model-int-1-exact-int-nested-result-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` parameter-boundary review satisfied after promoting result params and passthrough returns: `reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-alias review satisfied after registering `Result<SifrInt, E>` locals and alias coverage: `reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method return review satisfied after adding `Class::method` result-return propagation and method call-site coverage: `reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -507,6 +508,7 @@ Validation:
   - [x] Nested `Result[int, DivisionError]` helpers discovered inside a returning function now participate in result-return promotion, so outers returning nested helper calls lower through `Result<SifrInt, DivisionError>`; review is satisfied and quick validation is passing: PR #1879.
   - [x] `Result[int, DivisionError]` parameter boundaries whose call sites receive promoted exact result expressions now lower those params as `Result<SifrInt, DivisionError>`, preserving owned passthrough helpers and direct promoted call arguments; review is satisfied and quick validation is passing: PR #1880.
   - [x] `Result[int, DivisionError]` local aliases that receive promoted result params or locals now register as `Result<SifrInt, DivisionError>`, preserving alias-return and downstream call shapes; review is satisfied and quick validation is passing: PR #1881.
+  - [x] `Result[int, DivisionError]` class method returns now participate in exact result promotion, including method-to-method calls such as `self.divide(...)` and try-unwrapping of promoted method results; review is satisfied and quick validation is passing: PR #1882.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md
@@ -1,0 +1,45 @@
+The clippy warning on `is_sifr_int_checked_floor_option_expr` is pre-existing code, not from this slice. All clippy warnings are pre-existing in `sifr_hir` or unrelated code.
+
+---
+
+## Review Verdict: SATISFIED
+
+The INT-1 class method result-return slice is **correct and acceptable for merge**. Here's my analysis by concern:
+
+### 1. Fixed-point discovery — sound and terminates ✅
+
+The loop in `register_sifr_int_function_returns` (function_emitter.rs:161-265) now tracks `result_method_returns` alongside the four existing counters (`function_returns`, `result_function_returns`, `function_params`, `result_function_params`). The termination check at lines 257-264 correctly includes `result_method_returns.len() == before_result_methods`. Each iteration can only add entries (never remove), sets are bounded by module contents, so termination is guaranteed. Method discovery is monotonic: it can trigger function param discovery, which can trigger more method discovery, but the dependency graph is acyclic by construction.
+
+### 2. Resolving method calls by receiver class — sound enough ✅
+
+- **`hir_expr_class_name`** (function_emitter.rs:1271): Resolves via `expr.ty()` — the HIR type annotation set by the type checker. For `self.divide()` the receiver `self` has type `Calculator`, so `hir_expr_class_name` returns `Some("Calculator")`. This is the authoritative source.
+- **`rust_expr_class_name`** (expr_render_helpers.rs:1609): Limited to `Ident` (including `self` via `current_class_name`) and `Paren`. Falls through `None` for field access / subscript receivers. This is intentional and appropriate for the codegen layer — it handles the cases that actually appear in HIR-lowered Rust (simple identifiers and parenthesized variants), while complex receivers go through different lowering paths.
+
+### 3. Class method emission saves/restores all needed state ✅
+
+In `lower_class_method_item` (class_method_emitter.rs:501-624):
+- Saves and restores `sifr_int_result_local_bindings` (lines 504-505, 621-622)
+- Saves and restores `current_sifr_int_result_return` (lines 506, 623-624)
+- Sets `current_sifr_int_result_return` at entry based on `sifr_int_result_method_returns` (lines 517-521)
+- `lower_class_method_return_type` checks the promoted set and returns `Result<SifrInt, E>` (lines 262-269)
+
+This mirrors the pattern used for `current_sifr_int_return` in nested functions (function_emitter.rs lines 424-425, 499-502).
+
+### 4. Interactions with module functions, locals, method-to-method calls ✅
+
+- `hir_expr_returns_sifr_int_result` (function_emitter.rs:1226) now handles `HirExpr::MethodCall` by looking up `result_method_returns`. This flows through `collect_nested_sifr_int_result_function_returns`, `collect_sifr_int_result_local_bindings_with_initial`, `collect_sifr_int_result_call_arg_function_params`, and `function_returns_result_sifr_int`.
+- `calc.divide_again(...)` → `self.divide(...)` chain: `Calculator::divide` is promoted (direct floor division), `Calculator::divide_again` is promoted (calls promoted `self.divide`), the call site `calc.divide_again(21, 7)` correctly returns `Result<SifrInt, DivisionError>` which unwraps to `SifrInt`.
+- Module functions and local aliases interact correctly — they're tracked in separate sets.
+
+### 5. Test coverage ✅
+
+The e2e test covers:
+- `Calculator.divide()` — direct `a // b` → `Result<SifrInt, E>`
+- `Calculator.divide_again()` — method-to-method propagation via `self.divide(a, b)`
+- Try unwrapping `calc.divide_again(21, 7)` asserting result value
+
+The emitted Rust confirms correct signatures for both methods and all module functions/local bindings.
+
+### Minor note (non-blocking)
+
+`rust_expr_class_name` returns `None` for method calls on field access (`obj.method()`) or subscript receivers. This is a limitation but not a blocker: the primary case (`self.method()` and `variable.method()` where `variable: ClassName`) is handled. Complex receivers go through the non-promoted path, which is safe (produces `Result<i64, E>` but that's already the legacy behavior). A future extension could add field/subscript support if needed.


### PR DESCRIPTION
## Summary
- add Class::method result-return promotion for Result[int, DivisionError] methods that lower through SifrInt
- propagate promoted method calls through HIR result-return analysis and Rust call-site result detection
- set class method result-return state during method emission and lower promoted method signatures to Result<SifrInt, E>
- extend exact floor/mod Result e2e coverage with method-to-method propagation and try unwrapping
- update INT-1 phase tracker and store satisfied reviewer output

## Review
- Satisfied: reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md

## Validation
- cargo fmt
- cargo check -p sifr_codegen
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
- scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>
- cargo test -p sifr_codegen function_emitter -- --nocapture
- cargo test -p sifr_codegen class_method -- --nocapture
- scripts/run_all_tests.sh --profile quick (67.36s; 24/24 pass fixtures; cache_hits=6/6)
- git diff --check