### PR TITLE
Promote exact int Result field method calls

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -50,6 +50,14 @@ class Calculator:
         return self.divide(a, b)
 
 
+class Holder:
+    calc: Calculator
+
+    def divide_field(self, a: int, b: int) -> Result[int, DivisionError]:
+        result: Result[int, DivisionError] = self.calc.divide(a, b)
+        return result
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -96,5 +104,12 @@ def main():
     try:
         method_result: int = calc.divide_again(21, 7)
         assert str(method_result) == '3'
+    except DivisionError as e:
+        _ = e
+
+    holder: Holder = Holder(calc)
+    try:
+        field_result: int = holder.divide_field(24, 8)
+        assert str(field_result) == '3'
     except DivisionError as e:
         _ = e

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -1615,6 +1615,21 @@ impl RustEmitter {
                     _ => None,
                 }
             }),
+            crate::RustExpr::Field { expr, field } => {
+                self.rust_expr_class_name(expr).and_then(|owner_class| {
+                    self.class_field_types
+                        .get(&(owner_class, field.clone()))
+                        .and_then(|ty| match crate::resolve_alias_type_for_plain_call(ty) {
+                            Type::Class { name, .. } => Some(name.clone()),
+                            _ => None,
+                        })
+                })
+            }
+            crate::RustExpr::MethodCall {
+                receiver,
+                method,
+                args,
+            } if method == "clone" && args.is_empty() => self.rust_expr_class_name(receiver),
             crate::RustExpr::Paren(inner) => self.rust_expr_class_name(inner),
             _ => None,
         }

--- a/crates/sifr_codegen/src/field_analysis_helpers.rs
+++ b/crates/sifr_codegen/src/field_analysis_helpers.rs
@@ -83,6 +83,8 @@ impl RustEmitter {
                 .insert(class.name.clone(), field_names);
             let mut deps = HashSet::new();
             for (field_name, field_ty) in &class.fields {
+                self.class_field_types
+                    .insert((class.name.clone(), field_name.clone()), field_ty.clone());
                 for target in &class_names {
                     if type_references_class(field_ty, target) {
                         deps.insert(target.clone());
@@ -167,6 +169,10 @@ impl RustEmitter {
         let same_class_names =
             HashSet::from([local_class_name.to_string(), source_class_name.to_string()]);
         for (field_name, field_ty) in fields {
+            self.class_field_types.insert(
+                (local_class_name.to_string(), field_name.clone()),
+                field_ty.clone(),
+            );
             if type_references_any_class(field_ty, &same_class_names) {
                 let key = (local_class_name.to_string(), field_name.clone());
                 self.recursive_fields.insert(key.clone());

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1157,6 +1157,8 @@ struct RustEmitter {
     recursive_field_rust_types: HashMap<(String, String), String>,
     /// Map from class name -> ordered list of field names (for constructor arg mapping)
     class_field_order: HashMap<String, Vec<String>>,
+    /// Map of (`class_name`, `field_name`) -> field type for method receiver recovery.
+    class_field_types: HashMap<(String, String), Type>,
     /// Map from nested function name -> list of captured variable (name, type) pairs
     /// Used to pass extra args at call sites for recursive+capturing nested functions
     nested_fn_captures: HashMap<String, Vec<NestedFnCapture>>,
@@ -1309,6 +1311,7 @@ impl RustEmitter {
             recursive_fields: HashSet::new(),
             recursive_field_rust_types: HashMap::new(),
             class_field_order: HashMap::new(),
+            class_field_types: HashMap::new(),
             nested_fn_captures: HashMap::new(),
             module_constants: HashMap::new(),
             generic_classes: HashSet::new(),

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -470,6 +470,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` parameter-boundary review satisfied after promoting result params and passthrough returns: `reviews/integer-model-int-1-exact-int-result-param-boundary-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-alias review satisfied after registering `Result<SifrInt, E>` locals and alias coverage: `reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method return review satisfied after adding `Class::method` result-return propagation and method call-site coverage: `reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` field-receiver method call review satisfied after resolving promoted calls through `self.field.clone().method(...)`: `reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -509,6 +510,7 @@ Validation:
   - [x] `Result[int, DivisionError]` parameter boundaries whose call sites receive promoted exact result expressions now lower those params as `Result<SifrInt, DivisionError>`, preserving owned passthrough helpers and direct promoted call arguments; review is satisfied and quick validation is passing: PR #1880.
   - [x] `Result[int, DivisionError]` local aliases that receive promoted result params or locals now register as `Result<SifrInt, DivisionError>`, preserving alias-return and downstream call shapes; review is satisfied and quick validation is passing: PR #1881.
   - [x] `Result[int, DivisionError]` class method returns now participate in exact result promotion, including method-to-method calls such as `self.divide(...)` and try-unwrapping of promoted method results; review is satisfied and quick validation is passing: PR #1882.
+  - [x] Promoted `Result[int, DivisionError]` method calls through class fields now recover the receiver class from field metadata, so `self.calc.divide(...)` local aliases lower as `Result<SifrInt, DivisionError>` and unwrap through `SifrInt`; review is satisfied and quick validation is passing: PR #1883.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md
@@ -1,0 +1,58 @@
+
+
+## INT-1 Field Receiver Result Promotion Review
+
+### Verdict: SATISFIED
+
+The slice is correct and ready for INT-1. No blockers found.
+
+---
+
+### Correctness
+
+**Generated output is correct.** `Holder.divide_field` correctly emits:
+```rust
+let result: Result<SifrInt, DivisionError> = self.calc.clone().divide(a, b);
+```
+
+The chain `self.calc.clone().divide(...)` is recognized as a `Calculator` method returning `Result<SifrInt, DivisionError>` via:
+1. `rust_expr_class_name(self.calc.clone())` → resolves `self.calc` → `Calculator` via `class_field_types`
+2. `is_sifr_int_result_returning_method_call(receiver, "divide")` → checks `(Calculator, divide)` in `sifr_int_result_method_returns`
+
+**Field receiver resolution is sound.** `RustExpr::Field { expr, field }` correctly recurses: `rust_expr_class_name(self.calc)` → `rust_expr_class_name(self)` → `"Holder"` → `class_field_types[(Holder, "calc")] = Type::Class(Calculator)`.
+
+### Clone() Unwrapping Scope
+
+Tight and correct. Matches only the auto-inserted clone: `MethodCall { method: "clone", args: empty }`. Any other `.clone()` usage (e.g., programmer-written on a non-Sifr type) would produce `None` from `rust_expr_class_name` and fall through to regular codegen.
+
+### class_field_types Population
+
+- **Module classes**: Populated in `detect_recursive_fields` (line 86-87) — runs once per module emit.
+- **Imported/external classes**: Populated in `register_external_class_fields` (line 172-175) — called for each stdlib import.
+- **Staleness risk**: LOW. Both sources are deterministic from source declarations. The emitter does not modify class_field_types after population — no invalidation needed.
+
+No other code path writes to `class_field_types`, so no stale cross-module contamination risk.
+
+### Missing Cases (Non-Blocking)
+
+1. **Chained fields** (e.g., `self.outer.inner.method()`): Would require an additional recursive step in `rust_expr_class_name`. Not covered by this slice, not part of the original gap, can be added if needed.
+2. **Nested method calls on fields** (e.g., `self.calc.get_calculator().divide(...)`): Would require `MethodCall` in `rust_expr_class_name` to resolve the intermediate method's return type — not covered, not in scope.
+
+These are out-of-scope gaps, not regressions.
+
+### Test Coverage
+
+- `Holder.calc: Calculator` + `Holder.divide_field` covers the exact gap scenario.
+- 584 unit tests pass.
+- 24 e2e pass tests in quick lane pass.
+- 22 pre-existing unit test failures are baseline (unchanged from main branch).
+
+### CI Signal
+
+- `cargo fmt --check`: Clean
+- `cargo check -p sifr_codegen`: Clean  
+- Clippy warnings in `sifr_hir` are pre-existing (unrelated to this change)
+
+### Summary
+
+The slice is focused, correct, and sound. It closes the field-receiver gap that was identified during INT-1 review. No blockers. **Reviewer is satisfied.**


### PR DESCRIPTION
## Summary
- track class field types for method receiver recovery
- recognize promoted Result[int, DivisionError] method calls through field receivers and clone() wrappers
- add Holder.calc e2e coverage proving self.calc.divide(...) locals lower as Result<SifrInt, DivisionError>
- update INT-1 phase tracker and store satisfied reviewer output

## Review
- Satisfied: reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md

## Validation
- cargo fmt
- cargo check -p sifr_codegen
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
- scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>
- cargo test -p sifr_codegen function_emitter -- --nocapture
- cargo test -p sifr_codegen class_method -- --nocapture
- scripts/run_all_tests.sh --profile quick (73.23s; 24/24 pass fixtures; cache_hits=6/6)
- git diff --check