### PR TITLE
Lower exact int Result nested field calls

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -58,6 +58,14 @@ class Holder:
         return result
 
 
+class Wrapper:
+    holder: Holder
+
+    def divide_nested_field(self, a: int, b: int) -> Result[int, DivisionError]:
+        result: Result[int, DivisionError] = self.holder.calc.divide(a, b)
+        return result
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -111,5 +119,12 @@ def main():
     try:
         field_result: int = holder.divide_field(24, 8)
         assert str(field_result) == '3'
+    except DivisionError as e:
+        _ = e
+
+    wrapper: Wrapper = Wrapper(holder)
+    try:
+        nested_field_result: int = wrapper.divide_nested_field(30, 10)
+        assert str(nested_field_result) == '3'
     except DivisionError as e:
         _ = e

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -765,9 +765,15 @@ impl RustEmitter {
         field: &str,
         ty: &Type,
     ) -> Result<Option<crate::RustExpr>, crate::CodegenError> {
-        let Some(lowered_object) = crate::try_lower_leaf_or_name_expr_result(object)? else {
-            return Ok(None);
-        };
+        let lowered_object =
+            if let Some(lowered_leaf) = crate::try_lower_leaf_or_name_expr_result(object)? {
+                lowered_leaf
+            } else {
+                let Some(lowered_object) = self.lower_stmt_expr_for_ir(object)? else {
+                    return Ok(None);
+                };
+                lowered_object
+            };
 
         Ok(Some(self.lower_field_access_expr_with_lowered_object(
             object,

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -471,6 +471,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` local-alias review satisfied after registering `Result<SifrInt, E>` locals and alias coverage: `reviews/integer-model-int-1-exact-int-result-local-alias-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method return review satisfied after adding `Class::method` result-return propagation and method call-site coverage: `reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` field-receiver method call review satisfied after resolving promoted calls through `self.field.clone().method(...)`: `reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested-field receiver review satisfied after recursively lowering structured field access receivers: `reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -511,6 +512,7 @@ Validation:
   - [x] `Result[int, DivisionError]` local aliases that receive promoted result params or locals now register as `Result<SifrInt, DivisionError>`, preserving alias-return and downstream call shapes; review is satisfied and quick validation is passing: PR #1881.
   - [x] `Result[int, DivisionError]` class method returns now participate in exact result promotion, including method-to-method calls such as `self.divide(...)` and try-unwrapping of promoted method results; review is satisfied and quick validation is passing: PR #1882.
   - [x] Promoted `Result[int, DivisionError]` method calls through class fields now recover the receiver class from field metadata, so `self.calc.divide(...)` local aliases lower as `Result<SifrInt, DivisionError>` and unwrap through `SifrInt`; review is satisfied and quick validation is passing: PR #1883.
+  - [x] Nested field receivers such as `self.holder.calc.divide(...)` now recursively lower through structured field access instead of falling into the production `compile_error!` stub, preserving promoted `Result<SifrInt, DivisionError>` local aliases; review is satisfied and quick validation is passing: PR #1884.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md
@@ -1,0 +1,43 @@
+
+
+---
+
+## Review Verdict: Satisfied
+
+### Summary
+
+The changes correctly implement recursive lowering of structured field access receivers to enable `self.holder.calc.divide(...)` lowering without compile_error. The fix is minimal, focused, and composes correctly with existing field access and method call handling.
+
+### Code Review
+
+**`crates/sifr_codegen/src/expr_render_helpers.rs` lines 762-784**
+
+The change adds a fallback to `self.lower_stmt_expr_for_ir(object)` when `try_lower_leaf_or_name_expr_result` returns `None`. For a nested field receiver like `self.holder.calc` (FieldAccess of FieldAccess of Name), the first call to `try_lower_structured_field_access_expr`:
+1. `try_lower_leaf_or_name_expr_result(object)` → `None` (it's a FieldAccess, not a leaf/name)
+2. Calls `self.lower_stmt_expr_for_ir(object)` → recursively lowers `self.holder.calc` to `self.holder.clone().calc`
+3. Then applies `lower_field_access_expr_with_lowered_object` with the already-lowered receiver
+
+This correctly produces `self.holder.clone().calc` for the nested field access.
+
+**Composition with Result promotion**: The recursive lowering produces the correct `RustExpr` structure (`RustExpr::Field { expr: RustExpr::MethodCall { ... }, field: "calc" }`). When this is used as the receiver in `lower_stmt_expr_for_ir` for the MethodCall, it flows correctly into the Result promotion system from the previous PR.
+
+**Safety**: The recursion terminates because each recursive call to `try_lower_structured_field_access_expr` works on the inner `object` field, which is structurally smaller in the AST. Eventually it reaches a `HirExpr::Name` which is handled by the first branch.
+
+**`crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr`**
+
+The test adds `Wrapper` class with `divide_nested_field` covering `self.holder.calc.divide(a, b)` returning `Result[int, DivisionError]`. The test:
+- Constructs `Wrapper` from a `Holder`
+- Calls `wrapper.divide_nested_field(30, 10)` expecting `3`
+- Covers the missing production path (nested FieldAccess receiver → MethodCall → Result binding)
+
+### Validated
+
+- `cargo fmt --check` passes
+- `cargo check -p sifr_codegen` passes  
+- `cargo run -q -p sifr -- emit` confirms nested field generates `self.holder.clone().calc.divide(a, b)` with no compile_error
+- E2E suite: 32 passed, 1 failed (pre-existing `callable_apply_twice` issue, not introduced by this change)
+- Isolated nested field test confirms general case works (`self.inner.get()` → `self.inner.clone().get()`)
+
+### No Blockers
+
+The slice is acceptable for INT-1. The approach is sound, minimal, and the test coverage is appropriate.


### PR DESCRIPTION
## Summary
- recursively lower structured field-access receivers instead of falling into the production compile_error path
- preserve promoted Result<SifrInt, DivisionError> locals for nested receivers like self.holder.calc.divide(...)
- add Wrapper.divide_nested_field e2e coverage to the exact floor/mod Result fixture
- update INT-1 phase tracker and store satisfied reviewer output

## Review
- Satisfied: reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md

## Validation
- cargo fmt
- cargo check -p sifr_codegen
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
- scripts/run_e2e_pass.sh --fixture-manifest <manifest selecting exact_int_floor_mod_result_return>
- cargo test -p sifr_codegen function_emitter -- --nocapture
- cargo test -p sifr_codegen class_method -- --nocapture
- scripts/run_all_tests.sh --profile quick (71.31s; 24/24 pass fixtures; cache_hits=6/6)
- git diff --check