### PR TITLE
Promote exact int Result method parameters

### DIFF
--- a/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
+++ b/crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr
@@ -66,6 +66,11 @@ class Wrapper:
         return result
 
 
+class ResultBox:
+    def pass_result(self, own value: Result[int, DivisionError]) -> Result[int, DivisionError]:
+        return value
+
+
 def main():
     try:
         value: int = divide(10, 0)
@@ -107,6 +112,10 @@ def main():
     direct_arg: Result[int, DivisionError] = pass_result(divide(18, 6))
     _ = pass_result(result_arg)
     _ = alias_result(direct_arg)
+
+    result_box: ResultBox = ResultBox()
+    method_arg: Result[int, DivisionError] = result_box.pass_result(divide(36, 12))
+    _ = method_arg
 
     calc: Calculator = Calculator()
     try:

--- a/crates/sifr_codegen/src/class_method_emitter.rs
+++ b/crates/sifr_codegen/src/class_method_emitter.rs
@@ -236,6 +236,17 @@ impl RustEmitter {
             return self.rust_ir_type_with_generics(param_ty);
         }
 
+        let param_idx = method
+            .params
+            .iter()
+            .position(|param| param.name == param_name);
+        if param_idx.is_some_and(|idx| {
+            self.method_param_lowers_to_sifr_int_result(&class.name, &method.name, idx)
+        }) && is_result_int_type(param_ty)
+        {
+            return result_int_return_type_to_sifr_int(param_ty);
+        }
+
         let rust_ty = self.rust_type_with_generics(param_ty);
         if param_ty.ownership() != sifr_type_system::OwnershipKind::Copy && convention.is_borrowed()
         {
@@ -520,7 +531,7 @@ impl RustEmitter {
                 .contains(&result_method_key(&class.name, &method.name)),
         );
 
-        for param in &method.params {
+        for (param_idx, param) in method.params.iter().enumerate() {
             let effective_convention = if method.name == "new" {
                 ParamConvention::own()
             } else {
@@ -548,6 +559,11 @@ impl RustEmitter {
             }
             self.local_binding_types
                 .insert(param.name.clone(), param.ty.clone());
+            if self.method_param_lowers_to_sifr_int_result(&class.name, &method.name, param_idx) {
+                self.sifr_int_result_local_bindings
+                    .borrow_mut()
+                    .insert(param.name.clone());
+            }
         }
         self.register_local_body_binding_types(&method.body);
 

--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -243,19 +243,34 @@ impl RustEmitter {
                 receiver,
                 method,
                 args,
-            } => crate::RustExpr::MethodCall {
-                receiver: Box::new(match receiver.as_ref() {
+            } => {
+                let receiver = match receiver.as_ref() {
                     crate::RustExpr::Ident(name) if self.is_stdlib_constant(name) => {
                         crate::RustExpr::Ident(name.clone())
                     }
                     _ => self.rewrite_stdlib_constant_idents_in_expr(*receiver),
-                }),
-                method,
-                args: args
+                };
+                let receiver_class = self.rust_expr_class_name(&receiver);
+                let args = args
                     .into_iter()
-                    .map(|arg| self.rewrite_stdlib_constant_idents_in_expr(arg))
-                    .collect(),
-            },
+                    .enumerate()
+                    .map(|(idx, arg)| {
+                        let arg = self.rewrite_stdlib_constant_idents_in_expr(arg);
+                        if receiver_class.as_ref().is_some_and(|class_name| {
+                            self.method_param_lowers_to_sifr_int_result(class_name, &method, idx)
+                        }) {
+                            self.coerce_result_int_expr_to_sifr_int_value(arg)
+                        } else {
+                            arg
+                        }
+                    })
+                    .collect();
+                crate::RustExpr::MethodCall {
+                    receiver: Box::new(receiver),
+                    method,
+                    args,
+                }
+            }
             crate::RustExpr::FnCall { func, args } => {
                 let func = self.rewrite_stdlib_constant_idents_in_expr(*func);
                 let args = if let Some(func_name) = rust_expr_identifier_path(&func) {
@@ -1656,6 +1671,21 @@ impl RustEmitter {
         self.sifr_int_result_function_params
             .borrow()
             .get(name)
+            .is_some_and(|params| params.contains(&idx))
+    }
+
+    pub(super) fn method_param_lowers_to_sifr_int_result(
+        &self,
+        class_name: &str,
+        method_name: &str,
+        idx: usize,
+    ) -> bool {
+        self.sifr_int_result_method_params
+            .borrow()
+            .get(&crate::function_emitter::result_method_key(
+                class_name,
+                method_name,
+            ))
             .is_some_and(|params| params.contains(&idx))
     }
 

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -145,6 +145,7 @@ impl RustEmitter {
         let mut result_method_returns = HashSet::new();
         let mut function_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let mut result_function_params: HashMap<String, HashSet<usize>> = HashMap::new();
+        let mut result_method_params: HashMap<String, HashSet<usize>> = HashMap::new();
         let module_function_params = module
             .functions
             .iter()
@@ -158,12 +159,32 @@ impl RustEmitter {
                 )
             })
             .collect::<HashMap<_, _>>();
+        let module_method_params = module
+            .classes
+            .iter()
+            .flat_map(|class| {
+                class.methods.iter().map(|method| {
+                    (
+                        result_method_key(&class.name, &method.name),
+                        method
+                            .params
+                            .iter()
+                            .map(|param| param.ty.clone())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+            })
+            .collect::<HashMap<_, _>>();
         loop {
             let before = function_returns.len();
             let before_result_returns = result_function_returns.len();
             let before_result_methods = result_method_returns.len();
             let before_params = function_params.values().map(HashSet::len).sum::<usize>();
             let before_result_params = result_function_params
+                .values()
+                .map(HashSet::len)
+                .sum::<usize>();
+            let before_result_method_params = result_method_params
                 .values()
                 .map(HashSet::len)
                 .sum::<usize>();
@@ -195,6 +216,7 @@ impl RustEmitter {
                         &result_function_returns,
                         &result_method_returns,
                         &result_function_params,
+                        collect_sifr_int_result_function_param_names(func, &result_function_params),
                     ))
                     .then(|| func.name.clone())
                 })
@@ -205,11 +227,18 @@ impl RustEmitter {
                 .iter()
                 .flat_map(|class| {
                     class.methods.iter().filter_map(|method| {
+                        let method_key = result_method_key(&class.name, &method.name);
+                        let result_param_bindings = collect_sifr_int_result_method_param_names(
+                            method,
+                            &method_key,
+                            &result_method_params,
+                        );
                         function_returns_result_sifr_int(
                             method,
                             &result_function_returns,
                             &result_method_returns,
                             &result_function_params,
+                            result_param_bindings,
                         )
                         .then(|| result_method_key(&class.name, &method.name))
                     })
@@ -248,9 +277,61 @@ impl RustEmitter {
                         .or_default()
                         .extend(indexes);
                 }
+                for (name, indexes) in collect_sifr_int_result_call_arg_method_params(
+                    &func.body,
+                    &module_method_params,
+                    &result_function_returns,
+                    &result_method_returns,
+                    collect_sifr_int_result_function_param_names(func, &result_function_params),
+                ) {
+                    result_method_params
+                        .entry(name)
+                        .or_default()
+                        .extend(indexes);
+                }
+            }
+            for class in &module.classes {
+                for method in &class.methods {
+                    let method_key = result_method_key(&class.name, &method.name);
+                    let result_param_bindings = collect_sifr_int_result_method_param_names(
+                        method,
+                        &method_key,
+                        &result_method_params,
+                    );
+                    for (name, indexes) in
+                        collect_sifr_int_result_call_arg_function_params_with_initial(
+                            &method.body,
+                            &module_function_params,
+                            &result_function_returns,
+                            &result_method_returns,
+                            result_param_bindings.clone(),
+                        )
+                    {
+                        result_function_params
+                            .entry(name)
+                            .or_default()
+                            .extend(indexes);
+                    }
+                    for (name, indexes) in collect_sifr_int_result_call_arg_method_params(
+                        &method.body,
+                        &module_method_params,
+                        &result_function_returns,
+                        &result_method_returns,
+                        result_param_bindings,
+                    ) {
+                        result_method_params
+                            .entry(name)
+                            .or_default()
+                            .extend(indexes);
+                    }
+                }
             }
             let after_params = function_params.values().map(HashSet::len).sum::<usize>();
             let after_result_params = result_function_params
+                .values()
+                .map(HashSet::len)
+                .sum::<usize>();
+            let after_result_method_params = result_method_params
                 .values()
                 .map(HashSet::len)
                 .sum::<usize>();
@@ -259,6 +340,7 @@ impl RustEmitter {
                 && result_method_returns.len() == before_result_methods
                 && after_params == before_params
                 && after_result_params == before_result_params
+                && after_result_method_params == before_result_method_params
             {
                 break;
             }
@@ -268,6 +350,7 @@ impl RustEmitter {
         *self.sifr_int_result_method_returns.borrow_mut() = result_method_returns;
         *self.sifr_int_function_params.borrow_mut() = function_params;
         *self.sifr_int_result_function_params.borrow_mut() = result_function_params;
+        *self.sifr_int_result_method_params.borrow_mut() = result_method_params;
     }
 
     fn module_sifr_int_bindings(&self) -> HashSet<String> {
@@ -390,6 +473,10 @@ impl RustEmitter {
             &self.sifr_int_result_function_returns.borrow(),
             &self.sifr_int_result_method_returns.borrow(),
             &self.sifr_int_result_function_params.borrow(),
+            collect_sifr_int_result_function_param_names(
+                func,
+                &self.sifr_int_result_function_params.borrow(),
+            ),
         );
         let post_stmt_callable_conventions = {
             let mut conventions = self.callable_var_conventions.clone();
@@ -1077,6 +1164,7 @@ fn function_returns_result_sifr_int(
     result_function_returns: &HashSet<String>,
     result_method_returns: &HashSet<String>,
     result_function_params: &HashMap<String, HashSet<usize>>,
+    initial_result_bindings: HashSet<String>,
 ) -> bool {
     if !is_result_int_type(&func.return_type) {
         return false;
@@ -1089,13 +1177,11 @@ fn function_returns_result_sifr_int(
         result_method_returns,
         result_function_params,
     ));
-    let result_param_bindings =
-        collect_sifr_int_result_function_param_names(func, result_function_params);
     let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
         &func.body,
         &result_function_returns,
         result_method_returns,
-        result_param_bindings,
+        initial_result_bindings,
     );
     let mut returns_sifr_int_result = false;
     let mut on_stmt = |stmt: &HirStmt| {
@@ -1136,6 +1222,7 @@ fn collect_nested_sifr_int_result_function_returns(
                     &available_result_returns,
                     result_method_returns,
                     result_function_params,
+                    collect_sifr_int_result_function_param_names(func, result_function_params),
                 ) {
                     nested_returns.insert(func.name.clone());
                 }
@@ -1217,6 +1304,22 @@ fn collect_sifr_int_result_function_param_names(
         return HashSet::new();
     };
     func.params
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .collect()
+}
+
+fn collect_sifr_int_result_method_param_names(
+    method: &HirFunction,
+    method_key: &str,
+    result_method_params: &HashMap<String, HashSet<usize>>,
+) -> HashSet<String> {
+    let Some(indexes) = result_method_params.get(method_key) else {
+        return HashSet::new();
+    };
+    method
+        .params
         .iter()
         .enumerate()
         .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
@@ -1474,8 +1577,24 @@ fn collect_sifr_int_result_call_arg_function_params(
 ) -> HashMap<String, HashSet<usize>> {
     let result_param_bindings =
         collect_sifr_int_result_function_param_names(caller, result_function_params);
-    let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
+    collect_sifr_int_result_call_arg_function_params_with_initial(
         &caller.body,
+        module_function_params,
+        result_function_returns,
+        result_method_returns,
+        result_param_bindings,
+    )
+}
+
+fn collect_sifr_int_result_call_arg_function_params_with_initial(
+    body: &[HirStmt],
+    module_function_params: &HashMap<String, Vec<Type>>,
+    result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
+    result_param_bindings: HashSet<String>,
+) -> HashMap<String, HashSet<usize>> {
+    let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
+        body,
         result_function_returns,
         result_method_returns,
         result_param_bindings,
@@ -1506,7 +1625,67 @@ fn collect_sifr_int_result_call_arg_function_params(
         }
     };
     traversal::walk_stmts(
-        &caller.body,
+        body,
+        TraversalConfig::LOCAL_SCOPE_ONLY,
+        &mut on_stmt,
+        &mut on_expr,
+    );
+    discovered
+}
+
+fn collect_sifr_int_result_call_arg_method_params(
+    body: &[HirStmt],
+    module_method_params: &HashMap<String, Vec<Type>>,
+    result_function_returns: &HashSet<String>,
+    result_method_returns: &HashSet<String>,
+    result_param_bindings: HashSet<String>,
+) -> HashMap<String, HashSet<usize>> {
+    let local_result_bindings = collect_sifr_int_result_local_bindings_with_initial(
+        body,
+        result_function_returns,
+        result_method_returns,
+        result_param_bindings,
+    );
+    let mut discovered: HashMap<String, HashSet<usize>> = HashMap::new();
+    let mut on_stmt = |_stmt: &HirStmt| {};
+    let mut on_expr = |expr: &HirExpr| {
+        let HirExpr::MethodCall {
+            object,
+            method,
+            args,
+            ..
+        } = expr
+        else {
+            return;
+        };
+        let Some(class_name) = hir_expr_class_name(object) else {
+            return;
+        };
+        let method_key = result_method_key(&class_name, method);
+        let Some(params) = module_method_params.get(&method_key) else {
+            return;
+        };
+        for (idx, arg) in args.iter().enumerate() {
+            let Some(param_ty) = params.get(idx) else {
+                continue;
+            };
+            if is_result_int_type(param_ty)
+                && hir_expr_returns_sifr_int_result(
+                    arg,
+                    result_function_returns,
+                    result_method_returns,
+                    &local_result_bindings,
+                )
+            {
+                discovered
+                    .entry(method_key.clone())
+                    .or_default()
+                    .insert(idx);
+            }
+        }
+    };
+    traversal::walk_stmts(
+        body,
         TraversalConfig::LOCAL_SCOPE_ONLY,
         &mut on_stmt,
         &mut on_expr,

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1227,6 +1227,8 @@ struct RustEmitter {
     sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Module-level function `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
     sifr_int_result_function_params: RefCell<HashMap<String, HashSet<usize>>>,
+    /// Class method `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
+    sifr_int_result_method_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
     current_sifr_int_return: Cell<bool>,
     /// Whether the active function-like body returns `Result<SifrInt, E>` for source-level `Result[int, E]`.
@@ -1339,6 +1341,7 @@ impl RustEmitter {
             sifr_int_result_method_returns: RefCell::new(HashSet::new()),
             sifr_int_function_params: RefCell::new(HashMap::new()),
             sifr_int_result_function_params: RefCell::new(HashMap::new()),
+            sifr_int_result_method_params: RefCell::new(HashMap::new()),
             current_sifr_int_return: Cell::new(false),
             current_sifr_int_result_return: Cell::new(false),
             stmt_capture_stack: Vec::new(),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -2267,7 +2267,20 @@ impl RustEmitter {
             if let Some(method_params) =
                 self.resolve_registry_method_params(&effective_object_ty, method)
             {
+                let method_receiver_class =
+                    match crate::resolve_alias_type_for_plain_call(&effective_object_ty) {
+                        Type::Class { name, .. } => Some(name.clone()),
+                        _ => None,
+                    };
                 for (idx, lowered_arg) in lowered_args.iter_mut().enumerate() {
+                    if method_receiver_class.as_ref().is_some_and(|class_name| {
+                        self.method_param_lowers_to_sifr_int_result(class_name, method, idx)
+                    }) {
+                        *lowered_arg = self.coerce_result_int_expr_to_sifr_int_value(
+                            self.rewrite_stdlib_constant_idents_in_expr(lowered_arg.clone()),
+                        );
+                        continue;
+                    }
                     if let (Some((param_ty, convention)), Some(arg)) =
                         (method_params.get(idx), args.get(idx))
                     {

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -472,6 +472,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method return review satisfied after adding `Class::method` result-return propagation and method call-site coverage: `reviews/integer-model-int-1-exact-int-method-result-return-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` field-receiver method call review satisfied after resolving promoted calls through `self.field.clone().method(...)`: `reviews/integer-model-int-1-exact-int-method-field-result-call-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested-field receiver review satisfied after recursively lowering structured field access receivers: `reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md`.
+- [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method parameter review satisfied after promoting method parameters and direct promoted call arguments: `reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md`.
 
 ## Implementation Checklist
 
@@ -513,6 +514,7 @@ Validation:
   - [x] `Result[int, DivisionError]` class method returns now participate in exact result promotion, including method-to-method calls such as `self.divide(...)` and try-unwrapping of promoted method results; review is satisfied and quick validation is passing: PR #1882.
   - [x] Promoted `Result[int, DivisionError]` method calls through class fields now recover the receiver class from field metadata, so `self.calc.divide(...)` local aliases lower as `Result<SifrInt, DivisionError>` and unwrap through `SifrInt`; review is satisfied and quick validation is passing: PR #1883.
   - [x] Nested field receivers such as `self.holder.calc.divide(...)` now recursively lower through structured field access instead of falling into the production `compile_error!` stub, preserving promoted `Result<SifrInt, DivisionError>` local aliases; review is satisfied and quick validation is passing: PR #1884.
+  - [x] `Result[int, DivisionError]` class method parameters whose call sites receive promoted exact result expressions now lower as `Result<SifrInt, DivisionError>`, preserving method passthrough helpers and direct promoted call arguments; review is satisfied and quick validation is passing: PR #1885.
   - [ ] Continue the broader `Type::Int` migration beyond direct helper/local expression rewrites: direct function-return promotion and remaining `Result[int, DivisionError]` integration surfaces still need support.
 - [x] INT-2A parser boundary and literal capture
   - [x] Reserved `int128`/`uint128` names emit `SIFR-INT-0003`, with registry docs generated, review satisfied, and quick validation passing: PR #1791.

--- a/reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md
+++ b/reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md
@@ -1,0 +1,54 @@
+# Review: INT-1 Exact Int Method Result Parameters
+
+## Summary
+The implementation promotes class method `Result[int, E]` parameters to `Result<SifrInt, E>` when fixed-point analysis proves call sites pass exact integer result expressions. This follows prior merged work for exact int Result returns, locals, class method returns, field receiver calls, and nested field receiver calls.
+
+## Architecture
+
+### Fixed-Point State
+- **New state**: `sifr_int_result_method_params: HashMap<String, HashSet<usize>>` maps method keys to promoted parameter indices
+- **Termination**: Loop breaks when all three state maps (`function_params`, `result_function_params`, `result_method_params`) stabilize
+
+### Discovery Flow
+1. **Module-level**: `collect_sifr_int_result_call_arg_method_params` traverses module functions, finding method calls with exact-result arguments
+2. **Method-level**: Same traversal applied to class method bodies, seeding `result_function_params` from promoted method params
+3. **Seeding**: `function_returns_result_sifr_int` receives `initial_result_bindings` (promoted method params) to properly analyze method body returns
+
+### Lowering Integration
+- **Parameter lowering**: `class_method_emitter.rs` checks `method_param_lowers_to_sifr_int_result` before type lowering
+- **Local registration**: Promoted method params registered as exact-result locals before body lowering
+- **Call-site coercion**: `stmt_support_emitter.rs` and `expr_render_helpers.rs` apply coercion for receiver class and method param index
+
+## Verification
+
+### Generated Code (key excerpts)
+```rust
+// ResultBox.pass_result parameter lowered to Result<SifrInt, DivisionError>
+fn pass_result(&self, value: Result<SifrInt, DivisionError>) -> Result<SifrInt, DivisionError> {
+    return value;
+}
+
+// Call site coercion applied
+let method_arg: Result<SifrInt, DivisionError> = result_box.pass_result(divide(36 as i64, 12 as i64));
+```
+
+### Test Coverage
+- New fixture `ResultBox.pass_result` method with `Result[int, DivisionError]` parameter
+- Passthrough in `main()`: `result_box.pass_result(divide(36, 12))`
+- All prior exact-int fixtures pass (verified with `cargo run -q -p sifr -- emit`)
+
+### Pre-existing Failures (not introduced by this change)
+- `with_multiple` e2e fixture: Rust compilation error (`cannot find function map/list/filter`) - exists on `main`
+- 22 `sifr_codegen` unit test failures - exist on `main`
+
+## Assessment
+
+**Satisfactory to merge.** The implementation is sound:
+
+1. **Fixed-point correctness**: New state properly tracked, loop terminates when all maps stabilize
+2. **Call-site coercion**: Applied at correct lowering layers (stmt_support_emitter + expr_render_helpers)
+3. **Local registration**: Promoted method params registered before body lowering for proper alias analysis
+4. **Seeding correctness**: `function_returns_result_sifr_int` receives promoted method param bindings
+5. **Coverage**: Test fixture demonstrates full passthrough from `divide(...)` through method call
+
+No concrete blockers identified.


### PR DESCRIPTION
## Summary
- track class method Result[int, E] parameter positions that receive promoted exact integer Result expressions
- lower promoted method params and direct method call arguments through Result<SifrInt, E>
- add e2e coverage and record the satisfied Opus review artifact

## Review
- reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md

## Validation
- cargo fmt
- cargo check -p sifr_codegen
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/exact_int_floor_mod_result_return.sifr | rg -n 'pass_result|ResultBox|method_arg|Result<SifrInt'
- scripts/run_e2e_pass.sh --fixture-manifest <exact_int_floor_mod_result_return manifest>
- cargo test -p sifr_codegen function_emitter -- --nocapture
- cargo test -p sifr_codegen class_method -- --nocapture
- git diff --check
- scripts/run_all_tests.sh --profile quick