### PR TITLE
Deduplicate fixed-width promotion policy

### DIFF
--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -2,7 +2,7 @@
 
 use crate::{CodegenError, RustExpr, RustLiteral, RustParam, RustStmt, RustType};
 use sifr_hir::{HirExpr, HirFStringPart, HirIteratorOp, HirParam};
-use sifr_type_system::{FixedIntType, Type};
+use sifr_type_system::Type;
 use std::cell::RefCell;
 
 thread_local! {
@@ -1350,12 +1350,8 @@ fn is_int_like_simple(ty: &Type) -> bool {
 fn is_fixed_width_int_like_simple(ty: &Type) -> bool {
     matches!(
         resolve_alias_type(ty),
-        Type::FixedInt(fixed) if fixed_width_promotes_to_current_int(*fixed)
+        Type::FixedInt(fixed) if fixed.supports_current_scalar_promotion_to_int()
     )
-}
-
-fn fixed_width_promotes_to_current_int(fixed: FixedIntType) -> bool {
-    !matches!(fixed, FixedIntType::U64 | FixedIntType::USize)
 }
 
 fn is_float_like_simple(ty: &Type) -> bool {

--- a/crates/sifr_type_system/src/check.rs
+++ b/crates/sifr_type_system/src/check.rs
@@ -1,6 +1,6 @@
 //! Type checking rules for Sifr operators and expressions.
 
-use crate::types::{FixedIntType, Type};
+use crate::types::Type;
 use crate::union::{remove_none_from_union, union_contains_none};
 use sifr_diagnostics::DiagnosticCode;
 
@@ -24,7 +24,7 @@ fn is_integral_numeric_type(ty: &Type) -> bool {
 
 fn is_exact_or_fixed_integer_type(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::LiteralInt(_))
-        || matches!(ty, Type::FixedInt(fixed) if fixed_width_promotes_to_current_int(*fixed))
+        || matches!(ty, Type::FixedInt(fixed) if fixed.supports_current_scalar_promotion_to_int())
 }
 
 fn is_bool_type(ty: &Type) -> bool {
@@ -47,10 +47,6 @@ fn is_exact_to_float_integer_type(ty: &Type) -> bool {
 
 fn is_bool_integer_mixed_comparison(left: &Type, right: &Type) -> bool {
     (is_bool_type(left) && is_integer_type(right)) || (is_integer_type(left) && is_bool_type(right))
-}
-
-fn fixed_width_promotes_to_current_int(fixed: FixedIntType) -> bool {
-    !matches!(fixed, FixedIntType::U64 | FixedIntType::USize)
 }
 
 /// Type-check a binary operation (e.g., `a + b`, `a - b`).

--- a/crates/sifr_type_system/src/types.rs
+++ b/crates/sifr_type_system/src/types.rs
@@ -131,6 +131,13 @@ pub enum FixedIntType {
 }
 
 impl FixedIntType {
+    /// Temporary scalar arithmetic policy while ordinary fixed-width promotion
+    /// still depends on the current exact-int codegen surface.
+    #[must_use]
+    pub const fn supports_current_scalar_promotion_to_int(self) -> bool {
+        !matches!(self, Self::U64 | Self::USize)
+    }
+
     #[must_use]
     pub const fn supports_current_int_builtin_widening(self) -> bool {
         matches!(
@@ -1479,6 +1486,26 @@ mod tests {
             FixedIntType::USize,
         ] {
             assert!(!fixed.supports_current_int_builtin_widening());
+        }
+    }
+
+    #[test]
+    fn test_fixed_width_current_scalar_promotion_policy() {
+        for fixed in [
+            FixedIntType::I8,
+            FixedIntType::I16,
+            FixedIntType::I32,
+            FixedIntType::I64,
+            FixedIntType::U8,
+            FixedIntType::U16,
+            FixedIntType::U32,
+            FixedIntType::ISize,
+        ] {
+            assert!(fixed.supports_current_scalar_promotion_to_int());
+        }
+
+        for fixed in [FixedIntType::U64, FixedIntType::USize] {
+            assert!(!fixed.supports_current_scalar_promotion_to_int());
         }
     }
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -446,6 +446,7 @@ Validation:
 - [x] INT-2B milestone closure review pass 1 found the milestone ready to close with non-blocking follow-ups: `reviews/integer-model-int-2b-milestone-closure-review-pass-1.md`.
 - [x] INT-3 fitting fixed-width scalar `+`/`-`/`*` promotion review satisfied with no blockers and non-blocking broader-width coverage follow-up: `reviews/integer-model-int-3-fixed-width-scalar-promotion-review-pass-1.md`.
 - [x] INT-3 fitting fixed-width scalar promotion coverage review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-promotion-coverage-review-pass-1.md`.
+- [x] INT-3 fixed-width scalar promotion policy dedupe review satisfied after sharing the temporary scalar promotion helper between type checking and codegen: `reviews/integer-model-int-3-fixed-width-promotion-policy-dedupe-review-pass-1.md`.
 - [x] INT-3 fixed-width promotion narrowing-boundary hardening review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-narrowing-hardening-review-pass-1.md`.
 - [x] INT-3 fixed-width floor/modulo diagnostic scaffold review satisfied with no blockers: `reviews/integer-model-int-3-fixed-width-floor-mod-diagnostic-review-pass-1.md`.
 - [x] INT-3 integer exponentiation diagnostic scaffold review satisfied with no blockers: `reviews/integer-model-int-3-integer-power-diagnostic-review-pass-1.md`.
@@ -540,7 +541,7 @@ Validation:
 - [ ] INT-3 scalar arithmetic and numeric mixing
   - [x] Ordinary fixed-width scalar `+`, `-`, and `*` now promote fitting fixed-width operands to source-level `int` and cast operands before generated Rust arithmetic, preserving `int32(2_000_000_000) + int32(2_000_000_000) -> int`; review is satisfied and quick validation is passing: PR #1860.
   - [x] Fixed-width scalar promotion coverage now spans all fitting fixed-width families (`int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, and `isize`) while keeping `uint64` and `usize` blocked until the broader `SifrInt` promotion path; review is satisfied and quick validation is passing: PR #1861.
-  - [ ] Deduplicate the temporary `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands.
+  - [x] Deduplicate the temporary `fixed_width_promotes_to_current_int` policy between type checking and codegen once the broader `SifrInt` promotion path lands; review is satisfied and quick validation is passing: PR #1887.
   - [x] Promoted fixed-width arithmetic results are now hardened against implicit narrowing in fixed-width returns, list literals, dict literals, and generic class specialization; review is satisfied and quick validation is passing: PR #1862.
   - [x] Fixed-width scalar `//`, `%`, `//=`, and `%=` now fail closed with `SIFR-INT-0005` instead of lowering through ordinary Rust integer operators while the typed `Result[int, DivisionError]` path is pending; exact `int` non-zero proof behavior is preserved, review is satisfied, and quick validation is passing: PR #1863.
   - [x] Exact integer `**` now fails closed for negative or runtime-dependent exponents while preserving non-negative literal exponents, and fixed-width `**`/`**=` now emit `SIFR-INT-0005` instead of silently becoming float or lowering through unchecked casts; review is satisfied and quick validation is passing: PR #1864.

--- a/reviews/integer-model-int-3-fixed-width-promotion-policy-dedupe-review-pass-1.md
+++ b/reviews/integer-model-int-3-fixed-width-promotion-policy-dedupe-review-pass-1.md
@@ -1,0 +1,17 @@
+
+
+Review is satisfied.
+
+**Summary of the diff:**
+
+1. **Shared helper** — `FixedIntType::supports_current_scalar_promotion_to_int()` added in `types.rs:137-139` with a doc comment marking it as temporary. Policy: all fixed-width types except `U64` and `USize`.
+
+2. **check.rs** — `is_exact_or_fixed_integer_type()` at line 29 now calls the shared helper. The local `fixed_width_promotes_to_current_int()` function is gone.
+
+3. **lower_expr.rs** — `is_fixed_width_int_like_simple()` at line 1355 now calls the shared helper. The local duplicate function is gone.
+
+4. **Separation preserved** — `supports_current_int_builtin_widening()` (6 types) remains distinct and narrower than `supports_current_scalar_promotion_to_int()` (8 types).
+
+5. **Coverage** — New test `test_fixed_width_current_scalar_promotion_policy()` in `types.rs` iterates all 10 `FixedIntType` variants, asserting 8 promote and 2 (`U64`, `USize`) do not.
+
+No blockers. Deduplication is clean, scope is focused, and the validation results you ran confirm correctness.


### PR DESCRIPTION
## Summary
- move the temporary fixed-width scalar promotion policy onto FixedIntType
- use the shared policy from both type checking and codegen
- keep the narrower builtin widening policy separate and add focused coverage

## Review
- reviews/integer-model-int-3-fixed-width-promotion-policy-dedupe-review-pass-1.md

## Validation
- cargo fmt
- cargo test -p sifr_type_system fixed_width -- --nocapture
- cargo test -p sifr_codegen fixed_width -- --nocapture
- cargo test -p sifr_hir test_fixed_width_scalar_add_sub_mul_promote_to_int -- --nocapture
- git diff --check
- scripts/run_all_tests.sh --profile quick