### PR TITLE
Add JSON integer profile runtime helpers

### DIFF
--- a/crates/sifr/tests/e2e/pass/json_integer_error_builtins.sifr
+++ b/crates/sifr/tests/e2e/pass/json_integer_error_builtins.sifr
@@ -1,0 +1,11 @@
+def main() -> None:
+    range_error: JsonIntegerRangeError = JsonIntegerRangeError("unsafe integer")
+    assert range_error.message == "unsafe integer"
+    assert range_error.path == ""
+    assert range_error.profile == ""
+
+    limit_error: JsonLimitError = JsonLimitError("too many digits")
+    assert limit_error.message == "too many digits"
+    assert limit_error.limit == 0
+
+    print("json integer error builtins ok")

--- a/crates/sifr_codegen/src/intrinsic_method_emitters.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters.rs
@@ -603,6 +603,8 @@ fn registry_can_construct_error_from_message(ty_name: &str) -> bool {
             | "ImportError"
             | "IOError"
             | "RegexError"
+            | "JsonIntegerRangeError"
+            | "JsonLimitError"
             | "HashlibError"
             | "DecimalConversionError"
     )

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -140,6 +140,8 @@ const BUILTIN_ERROR_CLASSES: &[&str] = &[
     "DivisionError",
     "KeyError",
     "JSONDecodeError",
+    "JsonIntegerRangeError",
+    "JsonLimitError",
     "TOMLDecodeError",
     "RegexError",
     "FileNotFoundError",
@@ -507,6 +509,40 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
                             ("line".to_string(), RustExpr::Literal(RustLiteral::Int(0))),
                             ("column".to_string(), RustExpr::Literal(RustLiteral::Int(0))),
                         ],
+                    )
+                } else if error_name == "JsonIntegerRangeError" {
+                    (
+                        vec![
+                            ("path".to_string(), sifr_type_to_rust_type(&Type::Str)),
+                            ("profile".to_string(), sifr_type_to_rust_type(&Type::Str)),
+                        ],
+                        vec![
+                            (
+                                "path".to_string(),
+                                RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "String".to_string(),
+                                        "new".to_string(),
+                                    ])),
+                                    args: vec![],
+                                },
+                            ),
+                            (
+                                "profile".to_string(),
+                                RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "String".to_string(),
+                                        "new".to_string(),
+                                    ])),
+                                    args: vec![],
+                                },
+                            ),
+                        ],
+                    )
+                } else if error_name == "JsonLimitError" {
+                    (
+                        vec![("limit".to_string(), sifr_type_to_rust_type(&Type::Int))],
+                        vec![("limit".to_string(), RustExpr::Literal(RustLiteral::Int(0)))],
                     )
                 } else if error_name == "RegexError" {
                     (

--- a/crates/sifr_codegen/src/stdlib_filter.rs
+++ b/crates/sifr_codegen/src/stdlib_filter.rs
@@ -60,6 +60,8 @@ const GLOBAL_INFRA_TYPES: &[&str] = &[
     "NotImplementedError",
     "Error",
     "JSONDecodeError",
+    "JsonIntegerRangeError",
+    "JsonLimitError",
     "TOMLDecodeError",
     "FileNotFoundError",
     "PermissionError",

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -50,6 +50,8 @@ fn can_construct_error_from_message_for_ir(ty_name: &str) -> bool {
             | "ImportError"
             | "IOError"
             | "RegexError"
+            | "JsonIntegerRangeError"
+            | "JsonLimitError"
             | "HashlibError"
             | "DecimalConversionError"
     )

--- a/crates/sifr_hir/src/lower/integer_nonzero_guards.rs
+++ b/crates/sifr_hir/src/lower/integer_nonzero_guards.rs
@@ -23,7 +23,7 @@ impl LowerCtx {
     }
 
     pub(super) fn restore_proven_nonzero_integer_bindings(&mut self, snapshot: &HashSet<String>) {
-        self.proven_nonzero_integer_bindings = snapshot.clone();
+        self.proven_nonzero_integer_bindings.clone_from(snapshot);
     }
 }
 
@@ -32,7 +32,7 @@ pub(super) fn detect_true_nonzero_integer_guards(expr: &Expr, ctx: &LowerCtx) ->
         Expr::Compare(cmp) if cmp.ops.len() == 1 && cmp.comparators.len() == 1 => {
             detect_compare_nonzero_guard(
                 cmp.left.as_ref(),
-                &cmp.ops[0],
+                cmp.ops[0],
                 &cmp.comparators[0],
                 true,
                 ctx,
@@ -57,7 +57,7 @@ pub(super) fn detect_false_nonzero_integer_guards(expr: &Expr, ctx: &LowerCtx) -
         Expr::Compare(cmp) if cmp.ops.len() == 1 && cmp.comparators.len() == 1 => {
             detect_compare_nonzero_guard(
                 cmp.left.as_ref(),
-                &cmp.ops[0],
+                cmp.ops[0],
                 &cmp.comparators[0],
                 false,
                 ctx,
@@ -79,7 +79,7 @@ pub(super) fn detect_false_nonzero_integer_guards(expr: &Expr, ctx: &LowerCtx) -
 
 fn detect_compare_nonzero_guard(
     left: &Expr,
-    op: &CmpOp,
+    op: CmpOp,
     right: &Expr,
     is_true_branch: bool,
     ctx: &LowerCtx,

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -95,6 +95,47 @@ pub(super) fn register_builtins(ctx: &mut LowerCtx) {
         );
     }
 
+    // --- JSON integer boundary errors (parent: Error, profile-specific fields) ---
+    {
+        let fields = vec![
+            ("message".to_string(), Type::Str),
+            ("path".to_string(), Type::Str),
+            ("profile".to_string(), Type::Str),
+        ];
+        let class_ty = Type::Class {
+            name: "JsonIntegerRangeError".to_string(),
+            fields: fields.clone(),
+            methods: vec![],
+            parent_class: Some("Error".to_string()),
+        };
+        ctx.class_types
+            .insert("JsonIntegerRangeError".to_string(), class_ty.clone());
+        ctx.error_types.insert("JsonIntegerRangeError".to_string());
+        ctx.functions.insert(
+            "JsonIntegerRangeError".to_string(),
+            FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
+        );
+    }
+    {
+        let fields = vec![
+            ("message".to_string(), Type::Str),
+            ("limit".to_string(), Type::Int),
+        ];
+        let class_ty = Type::Class {
+            name: "JsonLimitError".to_string(),
+            fields: fields.clone(),
+            methods: vec![],
+            parent_class: Some("Error".to_string()),
+        };
+        ctx.class_types
+            .insert("JsonLimitError".to_string(), class_ty.clone());
+        ctx.error_types.insert("JsonLimitError".to_string());
+        ctx.functions.insert(
+            "JsonLimitError".to_string(),
+            FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
+        );
+    }
+
     // --- IOError subclasses (parent: IOError) ---
     let io_subclasses = [
         "FileNotFoundError",

--- a/crates/sifr_runtime/src/json.rs
+++ b/crates/sifr_runtime/src/json.rs
@@ -1,0 +1,287 @@
+use crate::{SifrInt, DEFAULT_MAX_INTEGER_DIGITS};
+use num_traits::ToPrimitive;
+use std::fmt;
+
+pub const DEFAULT_JSON_INTEGER_DIGIT_LIMIT: usize = DEFAULT_MAX_INTEGER_DIGITS;
+pub const JS_SAFE_INTEGER_MIN: i64 = -9_007_199_254_740_991;
+pub const JS_SAFE_INTEGER_MAX: i64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonIntegerProfile {
+    Exact,
+    Web,
+    StringInts,
+}
+
+impl JsonIntegerProfile {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "json.exact",
+            Self::Web => "json.web",
+            Self::StringInts => "json.string_ints",
+        }
+    }
+
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "json.exact" | "exact" => Some(Self::Exact),
+            "json.web" | "web" => Some(Self::Web),
+            "json.string_ints" | "string_ints" => Some(Self::StringInts),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonIntegerEncoding {
+    Number(String),
+    DecimalString(String),
+}
+
+impl JsonIntegerEncoding {
+    #[must_use]
+    pub fn decimal_text(&self) -> &str {
+        match self {
+            Self::Number(value) | Self::DecimalString(value) => value,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_number(&self) -> bool {
+        matches!(self, Self::Number(_))
+    }
+
+    #[must_use]
+    pub const fn is_decimal_string(&self) -> bool {
+        matches!(self, Self::DecimalString(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonIntegerRangeError {
+    message: String,
+    path: String,
+    profile: &'static str,
+}
+
+impl JsonIntegerRangeError {
+    #[must_use]
+    pub fn new(message: String, path: String, profile: &'static str) -> Self {
+        Self {
+            message,
+            path,
+            profile,
+        }
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    #[must_use]
+    pub const fn profile(&self) -> &'static str {
+        self.profile
+    }
+}
+
+impl fmt::Display for JsonIntegerRangeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for JsonIntegerRangeError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonLimitError {
+    message: String,
+    limit: usize,
+}
+
+impl JsonLimitError {
+    #[must_use]
+    pub fn new(message: String, limit: usize) -> Self {
+        Self { message, limit }
+    }
+
+    #[must_use]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[must_use]
+    pub const fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+impl fmt::Display for JsonLimitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for JsonLimitError {}
+
+pub fn encode_integer_for_profile(
+    value: &SifrInt,
+    profile: JsonIntegerProfile,
+    path: &str,
+) -> Result<JsonIntegerEncoding, JsonIntegerRangeError> {
+    let decimal = value.to_string();
+    match profile {
+        JsonIntegerProfile::Exact => Ok(JsonIntegerEncoding::Number(decimal)),
+        JsonIntegerProfile::StringInts => Ok(JsonIntegerEncoding::DecimalString(decimal)),
+        JsonIntegerProfile::Web => encode_web_integer(value, decimal, path),
+    }
+}
+
+pub fn validate_integer_token_digit_limit(token: &str, limit: usize) -> Result<(), JsonLimitError> {
+    let digit_count = json_integer_token_digit_count(token).ok_or_else(|| {
+        JsonLimitError::new(
+            format!("json integer token is not a decimal integer: {token}"),
+            limit,
+        )
+    })?;
+    if digit_count > limit {
+        return Err(JsonLimitError::new(
+            format!("json integer token has {digit_count} digits, exceeding limit {limit}"),
+            limit,
+        ));
+    }
+    Ok(())
+}
+
+fn encode_web_integer(
+    value: &SifrInt,
+    decimal: String,
+    path: &str,
+) -> Result<JsonIntegerEncoding, JsonIntegerRangeError> {
+    let Some(value) = value.as_bigint().to_i64() else {
+        return Err(web_range_error(&decimal, path));
+    };
+    if (JS_SAFE_INTEGER_MIN..=JS_SAFE_INTEGER_MAX).contains(&value) {
+        Ok(JsonIntegerEncoding::Number(decimal))
+    } else {
+        Err(web_range_error(&decimal, path))
+    }
+}
+
+fn web_range_error(value: &str, path: &str) -> JsonIntegerRangeError {
+    JsonIntegerRangeError::new(
+        format!(
+            "integer value {value} at {path} cannot be emitted as a JSON number under json.web"
+        ),
+        path.to_string(),
+        JsonIntegerProfile::Web.as_str(),
+    )
+}
+
+fn json_integer_token_digit_count(token: &str) -> Option<usize> {
+    let unsigned = token
+        .strip_prefix('-')
+        .or_else(|| token.strip_prefix('+'))
+        .unwrap_or(token);
+    if unsigned.is_empty() || !unsigned.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    Some(unsigned.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(value: &str) -> SifrInt {
+        SifrInt::parse_decimal(value, DEFAULT_JSON_INTEGER_DIGIT_LIMIT)
+            .unwrap_or_else(|err| panic!("{err}"))
+    }
+
+    #[test]
+    fn exact_profile_emits_large_integers_as_numbers() {
+        let value = parse("100000000000000000000000000000000000000");
+        let encoded = encode_integer_for_profile(&value, JsonIntegerProfile::Exact, "$.id")
+            .unwrap_or_else(|err| panic!("{err}"));
+
+        assert_eq!(
+            encoded,
+            JsonIntegerEncoding::Number("100000000000000000000000000000000000000".to_string())
+        );
+    }
+
+    #[test]
+    fn string_ints_profile_emits_decimal_strings() {
+        let value = SifrInt::from_i64(42);
+        let encoded = encode_integer_for_profile(&value, JsonIntegerProfile::StringInts, "$.id")
+            .unwrap_or_else(|err| panic!("{err}"));
+
+        assert_eq!(
+            encoded,
+            JsonIntegerEncoding::DecimalString("42".to_string())
+        );
+    }
+
+    #[test]
+    fn web_profile_accepts_javascript_safe_boundaries() {
+        for value in [JS_SAFE_INTEGER_MIN, JS_SAFE_INTEGER_MAX] {
+            let encoded = encode_integer_for_profile(
+                &SifrInt::from_i64(value),
+                JsonIntegerProfile::Web,
+                "$.value",
+            )
+            .unwrap_or_else(|err| panic!("{err}"));
+
+            assert_eq!(encoded, JsonIntegerEncoding::Number(value.to_string()));
+        }
+    }
+
+    #[test]
+    fn web_profile_rejects_javascript_unsafe_numbers() {
+        for value in [JS_SAFE_INTEGER_MIN - 1, JS_SAFE_INTEGER_MAX + 1] {
+            let err = encode_integer_for_profile(
+                &SifrInt::from_i64(value),
+                JsonIntegerProfile::Web,
+                "$.value",
+            )
+            .expect_err("unsafe JSON web integer should fail");
+
+            assert_eq!(err.path(), "$.value");
+            assert_eq!(err.profile(), "json.web");
+        }
+    }
+
+    #[test]
+    fn web_profile_rejects_arbitrary_precision_numbers() {
+        let value = parse("100000000000000000000000000000000000000");
+        let err = encode_integer_for_profile(&value, JsonIntegerProfile::Web, "$.value")
+            .expect_err("large exact int should not be emitted as json.web number");
+
+        assert_eq!(err.path(), "$.value");
+        assert_eq!(err.profile(), "json.web");
+    }
+
+    #[test]
+    fn integer_token_limit_ignores_sign_and_enforces_digits() {
+        validate_integer_token_digit_limit("-1234", 4).expect("sign should not count");
+        let err = validate_integer_token_digit_limit("+12345", 4)
+            .expect_err("five digits should exceed the configured limit");
+
+        assert_eq!(err.limit(), 4);
+    }
+
+    #[test]
+    fn integer_token_limit_rejects_non_integer_tokens() {
+        let err = validate_integer_token_digit_limit("12.0", 4)
+            .expect_err("non-integer token should be rejected");
+
+        assert_eq!(err.limit(), 4);
+    }
+}

--- a/crates/sifr_runtime/src/lib.rs
+++ b/crates/sifr_runtime/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, allow(clippy::expect_used))]
 
 mod int;
+pub mod json;
 
 pub use int::{
     IntegerParseError, IntegerRangeError, NormalizedIntegerHash, SifrInt,

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -477,6 +477,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` nested-field receiver review satisfied after recursively lowering structured field access receivers: `reviews/integer-model-int-1-exact-int-nested-field-result-call-review-pass-1.md`.
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method parameter review satisfied after promoting method parameters and direct promoted call arguments: `reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md`.
 - [x] INT-1 milestone closure review pass 1 satisfied: INT-1 is ready to close; all 38 checklist items (including the broad `Type::Int` migration follow-up) are addressed by the landed PR sequence; remaining `bigint` transition fixtures are owned by INT-7; validation passes: `reviews/integer-model-int-1-milestone-closure-review-pass-1.md`.
+- [x] INT-5 runtime JSON integer profile machinery review satisfied after adding `sifr_runtime::json` exact/web/string profile helpers, JS-safe integer enforcement, digit-limit validation, canonical builtin error registration, and focused runtime/e2e coverage: `reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md`; PR #1890.
 
 ## Implementation Checklist
 
@@ -558,6 +559,7 @@ Validation:
   - [x] Fixed-width match literal patterns now reuse the fixed-width fitting diagnostic path, so in-range `uint8` cases such as `case 255` lower and out-of-range cases such as `case 256` fail with `SIFR-INT-0001`; review is satisfied and quick validation is passing: PR #1873.
   - [x] `sum(list[int32])` and `abs(int8.MIN)` now widen to `int` for the currently safe fixed-width builtin families, with shared policy coverage, focused e2e coverage, review satisfied, and quick validation passing: PR #1874.
 - [ ] INT-5 serialization, web, and schema boundaries
+  - [x] Shared runtime JSON integer profile primitives now live in `sifr_runtime::json`: `json.exact` emits exact integer numbers, `json.web` rejects JavaScript-unsafe JSON numbers with `JsonIntegerRangeError`, and `json.string_ints` emits decimal strings. `JsonIntegerRangeError` and `JsonLimitError` are registered as builtin errors and covered by runtime/e2e tests; review is satisfied and quick validation is passing: PR #1890.
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration
 - [ ] INT-7 diagnostics, documentation, and migration cleanup

--- a/reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md
+++ b/reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md
@@ -1,0 +1,49 @@
+
+
+## INT-5 Runtime JSON Profile Slice Review
+
+**Verdict: No blockers. Reviewer is satisfied for this slice.**
+
+### Review Findings
+
+**1. `sifr_runtime::json` — Centralization of JSON Integer Profile Policy**
+
+The `json.rs` module correctly implements the three canonical profiles (`Exact`, `Web`, `StringInts`) with consistent naming via `as_str()` ("json.exact", "json.web", "json.string_ints") and `from_name()` parsing that accepts both short and full forms. The `encode_integer_for_profile` dispatch and `validate_integer_token_digit_limit` helper are appropriately scoped as first runtime primitives.
+
+**2. `json.web` — JavaScript Safe Integer Rejection**
+
+`encode_web_integer` at line 163-176 correctly rejects values outside `JS_SAFE_INTEGER_MIN` (`-9007199254740991`) through `JS_SAFE_INTEGER_MAX` (`9007199254740991`) rather than silently emitting unsafe JSON numbers. The check uses an inclusive range bound: `(JS_SAFE_INTEGER_MIN..=JS_SAFE_INTEGER_MAX).contains(&value)`. Additionally, arbitrary-precision integers that cannot convert to i64 are also rejected via the `value.as_bigint().to_i64()` fallibility path. Tests cover:
+- Safe boundary values (min and max) — accepted
+- Just-beyond-boundary values — rejected with `JsonIntegerRangeError`
+- Large arbitrary-precision values — rejected
+
+**3. `JsonIntegerRangeError` and `JsonLimitError` — Shape and Registration**
+
+Both error types are consistently shaped:
+- `JsonIntegerRangeError` has `message`, `path`, `profile` fields, matching the architecture doc requirement for "field path, value range issue, and policy alternatives"
+- `JsonLimitError` has `message`, `limit` fields for digit-limit enforcement
+
+Registration is complete across all canonical builtin paths:
+- **HIR lowering** (`typing_and_functions.rs`): Both registered as error types with parent `Error`, proper field definitions, and constructor signatures
+- **Codegen preamble** (`lib.rs`): Both in `BUILTIN_ERROR_CLASSES`, with field/default emission for generated struct definitions
+- **Stdlib filter** (`stdlib_filter.rs`): Both in `GLOBAL_INFRA_TYPES` for DCE suppression
+
+Users and generated code can reference them directly — the e2e test confirms direct instantiation and field access work end-to-end.
+
+**4. Digit-Limit Helper — Appropriateness**
+
+`validate_integer_token_digit_limit` is appropriate as a first runtime primitive for untrusted integer token limits:
+- Correctly strips sign prefix before counting
+- Rejects non-integer tokens (e.g., "12.0")
+- Enforces the configured limit with a typed `JsonLimitError` containing the actual digit count
+- Re-exports `DEFAULT_MAX_INTEGER_DIGITS` as `DEFAULT_JSON_INTEGER_DIGIT_LIMIT` (4096 digits per architecture doc)
+
+**5. Test Sufficiency**
+
+- **Runtime unit tests** (7 passing): Profile encoding, safe boundary acceptance, unsafe boundary rejection, arbitrary-precision rejection, digit-limit sign handling, non-integer token rejection
+- **E2E test** (`json_integer_error_builtins.sifr`): Verifies end-to-end instantiation and field access of both error types from Sifr source
+- **`scripts/run_all_tests.sh --profile quick`**: All 24 e2e pass tests pass
+
+**Pre-existing codegen clippy warnings** in `expr_render_helpers.rs` and `function_emitter.rs` are unrelated to this slice and outside the scope of INT-5.
+
+**No blockers. This slice is ready for PR.**


### PR DESCRIPTION
## Summary
- add sifr_runtime::json integer profile helpers for json.exact, json.web, and json.string_ints
- register JsonIntegerRangeError and JsonLimitError in HIR/codegen builtin error surfaces
- add runtime unit coverage, e2e builtin-error coverage, and the satisfied reviewer artifact

## Validation
- cargo fmt --check
- cargo test -p sifr_runtime json -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/json_integer_error_builtins.sifr
- cargo check -p sifr_codegen
- scripts/run_all_tests.sh --profile quick