### PR TITLE
Expose JSON integer profile wrappers

### DIFF
--- a/crates/sifr/tests/e2e/pass/json_integer_profiles.sifr
+++ b/crates/sifr/tests/e2e/pass/json_integer_profiles.sifr
@@ -1,0 +1,36 @@
+from sifr.json import (
+    JsonValue,
+    dumps_exact,
+    dumps_string_ints,
+    dumps_web,
+    from_array,
+    from_int,
+    from_object,
+)
+
+
+def main() -> None:
+    safe_value: JsonValue = from_object(
+        [("items", from_array([from_int(1), from_int(9007199254740991)]))]
+    )
+    try:
+        safe_payload: str = dumps_web(safe_value)
+        assert safe_payload == "{\"items\":[1,9007199254740991]}"
+    except JsonIntegerRangeError as e:
+        assert False
+
+    unsafe_value: JsonValue = from_object(
+        [("items", from_array([from_int(1), from_int(9007199254740992)]))]
+    )
+    try:
+        bad_payload: str = dumps_web(unsafe_value)
+        _ = bad_payload
+        assert False
+    except JsonIntegerRangeError as e:
+        assert e.profile == "json.web"
+        assert e.path == "$.items[1]"
+
+    assert dumps_string_ints(unsafe_value) == "{\"items\":[\"1\",\"9007199254740992\"]}"
+    assert dumps_exact(safe_value) == "{\"items\":[1,9007199254740991]}"
+
+    print("json integer profiles ok")

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -48,6 +48,8 @@ pub(crate) fn collect_referenced_builtin_error_classes(
             "ParseError",
             "ValueError",
             "JSONDecodeError",
+            "JsonIntegerRangeError",
+            "JsonLimitError",
             "TOMLDecodeError",
             "RegexError",
         ] {

--- a/crates/sifr_codegen/src/intrinsics/json.rs
+++ b/crates/sifr_codegen/src/intrinsics/json.rs
@@ -205,6 +205,192 @@ fn json_null_value_expr() -> RustExpr {
     ])
 }
 
+#[derive(Clone, Copy)]
+enum JsonIntegerProfileLowering {
+    Exact,
+    Web,
+    StringInts,
+}
+
+impl JsonIntegerProfileLowering {
+    const fn runtime_variant(self) -> &'static str {
+        match self {
+            Self::Exact => "Exact",
+            Self::Web => "Web",
+            Self::StringInts => "StringInts",
+        }
+    }
+
+    const fn is_fallible(self) -> bool {
+        matches!(self, Self::Web)
+    }
+}
+
+fn runtime_json_profile(profile: JsonIntegerProfileLowering) -> RustExpr {
+    RustExpr::Path(vec![
+        "sifr_runtime".to_string(),
+        "json".to_string(),
+        "JsonIntegerProfile".to_string(),
+        profile.runtime_variant().to_string(),
+    ])
+}
+
+fn runtime_json_encoding_path(variant: &str) -> String {
+    format!("sifr_runtime::json::JsonIntegerEncoding::{variant}")
+}
+
+fn sifr_int_from_i64(value: RustExpr) -> RustExpr {
+    RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            "sifr_runtime".to_string(),
+            "SifrInt".to_string(),
+            "from_i64".to_string(),
+        ])),
+        args: vec![value],
+    }
+}
+
+fn path_as_str() -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::Ident("path".to_string())),
+        method: "as_str".to_string(),
+        args: vec![],
+    }
+}
+
+fn json_profile_error_struct_from_runtime(err_name: &str) -> RustExpr {
+    RustExpr::StructInit {
+        name: "JsonIntegerRangeError".to_string(),
+        fields: vec![
+            (
+                "message".to_string(),
+                RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                        method: "message".to_string(),
+                        args: vec![],
+                    }),
+                    method: "to_string".to_string(),
+                    args: vec![],
+                },
+            ),
+            (
+                "path".to_string(),
+                RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                        method: "path".to_string(),
+                        args: vec![],
+                    }),
+                    method: "to_string".to_string(),
+                    args: vec![],
+                },
+            ),
+            (
+                "profile".to_string(),
+                RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                        method: "profile".to_string(),
+                        args: vec![],
+                    }),
+                    method: "to_string".to_string(),
+                    args: vec![],
+                },
+            ),
+        ],
+    }
+}
+
+fn json_integer_profile_encode_expr(profile: JsonIntegerProfileLowering) -> RustExpr {
+    RustExpr::Try(Box::new(RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                "sifr_runtime".to_string(),
+                "json".to_string(),
+                "encode_integer_for_profile".to_string(),
+            ])),
+            args: vec![
+                RustExpr::Ref {
+                    mutable: false,
+                    expr: Box::new(sifr_int_from_i64(RustExpr::Ident("v".to_string()))),
+                },
+                runtime_json_profile(profile),
+                path_as_str(),
+            ],
+        }),
+        method: "map_err".to_string(),
+        args: vec![RustExpr::Ident(
+            "__sifr_json_integer_range_error_from_runtime".to_string(),
+        )],
+    }))
+}
+
+fn json_profile_int_match_arms(profile: JsonIntegerProfileLowering) -> Vec<RustStmt> {
+    vec![
+        RustStmt::IfLet {
+            pattern: "Some(v)".to_string(),
+            expr: RustExpr::Field {
+                expr: Box::new(RustExpr::Ident("value".to_string())),
+                field: "int_value".to_string(),
+            },
+            then_body: vec![
+                RustStmt::Let {
+                    mutable: false,
+                    name: "__encoded_int".to_string(),
+                    ty: None,
+                    value: json_integer_profile_encode_expr(profile),
+                },
+                RustStmt::Match {
+                    expr: RustExpr::Ident("__encoded_int".to_string()),
+                    arms: vec![
+                        RustMatchArm {
+                            pattern: runtime_json_encoding_path("Number(_)"),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![RustStmt::Return(Some(ok_expr(json_value_from_scalar(
+                                RustExpr::Ident("v".to_string()),
+                            ))))],
+                        },
+                        RustMatchArm {
+                            pattern: runtime_json_encoding_path("DecimalString(decimal)"),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![RustStmt::Return(Some(ok_expr(json_value_from_string(
+                                RustExpr::Ident("decimal".to_string()),
+                            ))))],
+                        },
+                    ],
+                },
+            ],
+            else_body: None,
+        },
+        RustStmt::Return(Some(ok_expr(json_null_value_expr()))),
+    ]
+}
+
+fn child_array_path_expr() -> RustExpr {
+    RustExpr::FormatMacro {
+        name: "format".to_string(),
+        format_str: "{}[{}]".to_string(),
+        args: vec![
+            RustExpr::Ident("path".to_string()),
+            RustExpr::Ident("idx".to_string()),
+        ],
+    }
+}
+
+fn child_object_path_expr() -> RustExpr {
+    RustExpr::FormatMacro {
+        name: "format".to_string(),
+        format_str: "{}.{}".to_string(),
+        args: vec![
+            RustExpr::Ident("path".to_string()),
+            RustExpr::Ident("entry_key".to_string()),
+        ],
+    }
+}
+
 pub(super) fn lower_json_loads(args: &[RustExpr]) -> Option<RustExpr> {
     if args.len() != 1 {
         return None;
@@ -753,5 +939,349 @@ pub(super) fn lower_json_dumps_value(args: &[RustExpr]) -> Option<RustExpr> {
                 is_move: false,
             }],
         })),
+    })
+}
+
+pub(super) fn lower_json_dumps_value_exact(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_json_dumps_value_profile(args, JsonIntegerProfileLowering::Exact)
+}
+
+pub(super) fn lower_json_dumps_value_web(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_json_dumps_value_profile(args, JsonIntegerProfileLowering::Web)
+}
+
+pub(super) fn lower_json_dumps_value_string_ints(args: &[RustExpr]) -> Option<RustExpr> {
+    lower_json_dumps_value_profile(args, JsonIntegerProfileLowering::StringInts)
+}
+
+fn lower_json_dumps_value_profile(
+    args: &[RustExpr],
+    profile: JsonIntegerProfileLowering,
+) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let serde_result = RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                "serde_json".to_string(),
+                "to_string".to_string(),
+            ])),
+            args: vec![RustExpr::Ref {
+                mutable: false,
+                expr: Box::new(RustExpr::Try(Box::new(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Ident(
+                        "__sifr_json_value_to_serde_profile".to_string(),
+                    )),
+                    args: vec![
+                        RustExpr::Ref {
+                            mutable: false,
+                            expr: Box::new(RustExpr::Ident("__json_value".to_string())),
+                        },
+                        string_expr("$"),
+                    ],
+                }))),
+            }],
+        }),
+        method: "unwrap_or_else".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![RustParam::Named {
+                name: "_err".to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(string_expr("null")),
+            is_move: false,
+        }],
+    };
+    let final_expr = if profile.is_fallible() {
+        ok_expr(serde_result)
+    } else {
+        RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::FnCall {
+                func: Box::new(RustExpr::Closure {
+                    params: vec![],
+                    body: Box::new(RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "Ok::<String, JsonIntegerRangeError>".to_string()
+                        ])),
+                        args: vec![serde_result],
+                    }),
+                    is_move: false,
+                }),
+                args: vec![],
+            }),
+            method: "unwrap_or_else".to_string(),
+            args: vec![RustExpr::Closure {
+                params: vec![RustParam::Named {
+                    name: "_err".to_string(),
+                    ty: RustType::Named("_".to_string()),
+                }],
+                body: Box::new(string_expr("null")),
+                is_move: false,
+            }],
+        }
+    };
+
+    Some(RustExpr::Block {
+        stmts: vec![
+            RustStmt::Let {
+                mutable: false,
+                name: "__json_value".to_string(),
+                ty: None,
+                value: args[0].clone(),
+            },
+            RustStmt::LocalFn {
+                name: "__sifr_json_integer_range_error_from_runtime".to_string(),
+                params: vec![RustParam::Named {
+                    name: "err".to_string(),
+                    ty: RustType::Named("sifr_runtime::json::JsonIntegerRangeError".to_string()),
+                }],
+                ret: Some(RustType::Named("JsonIntegerRangeError".to_string())),
+                body: vec![RustStmt::Return(Some(
+                    json_profile_error_struct_from_runtime("err"),
+                ))],
+            },
+            RustStmt::LocalFn {
+                name: "__sifr_json_value_to_serde_profile".to_string(),
+                params: vec![
+                    RustParam::Named {
+                        name: "value".to_string(),
+                        ty: RustType::Ref {
+                            mutable: false,
+                            inner: Box::new(RustType::Named("JsonValue".to_string())),
+                        },
+                    },
+                    RustParam::Named {
+                        name: "path".to_string(),
+                        ty: RustType::String_,
+                    },
+                ],
+                ret: Some(RustType::Named(
+                    "Result<serde_json::Value, JsonIntegerRangeError>".to_string(),
+                )),
+                body: vec![RustStmt::Match {
+                    expr: RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Field {
+                            expr: Box::new(RustExpr::Ident("value".to_string())),
+                            field: "kind".to_string(),
+                        }),
+                        method: "as_str".to_string(),
+                        args: vec![],
+                    },
+                    arms: vec![
+                        RustMatchArm {
+                            pattern: "\"null\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![RustStmt::Return(Some(ok_expr(json_null_value_expr())))],
+                        },
+                        RustMatchArm {
+                            pattern: "\"bool\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![
+                                RustStmt::IfLet {
+                                    pattern: "Some(v)".to_string(),
+                                    expr: RustExpr::Field {
+                                        expr: Box::new(RustExpr::Ident("value".to_string())),
+                                        field: "bool_value".to_string(),
+                                    },
+                                    then_body: vec![RustStmt::Return(Some(ok_expr(
+                                        json_value_from_scalar(RustExpr::Ident("v".to_string())),
+                                    )))],
+                                    else_body: None,
+                                },
+                                RustStmt::Return(Some(ok_expr(json_null_value_expr()))),
+                            ],
+                        },
+                        RustMatchArm {
+                            pattern: "\"int\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: json_profile_int_match_arms(profile),
+                        },
+                        RustMatchArm {
+                            pattern: "\"float\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![
+                                RustStmt::IfLet {
+                                    pattern: "Some(v)".to_string(),
+                                    expr: RustExpr::Field {
+                                        expr: Box::new(RustExpr::Ident("value".to_string())),
+                                        field: "float_value".to_string(),
+                                    },
+                                    then_body: vec![RustStmt::Return(Some(ok_expr(
+                                        json_value_from_scalar(RustExpr::Ident("v".to_string())),
+                                    )))],
+                                    else_body: None,
+                                },
+                                RustStmt::Return(Some(ok_expr(json_null_value_expr()))),
+                            ],
+                        },
+                        RustMatchArm {
+                            pattern: "\"str\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![
+                                RustStmt::IfLet {
+                                    pattern: "Some(v)".to_string(),
+                                    expr: RustExpr::Clone(Box::new(RustExpr::Field {
+                                        expr: Box::new(RustExpr::Ident("value".to_string())),
+                                        field: "str_value".to_string(),
+                                    })),
+                                    then_body: vec![RustStmt::Return(Some(ok_expr(
+                                        json_value_from_string(RustExpr::Ident("v".to_string())),
+                                    )))],
+                                    else_body: None,
+                                },
+                                RustStmt::Return(Some(ok_expr(json_null_value_expr()))),
+                            ],
+                        },
+                        RustMatchArm {
+                            pattern: "\"array\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![
+                                RustStmt::Let {
+                                    mutable: true,
+                                    name: "converted".to_string(),
+                                    ty: None,
+                                    value: RustExpr::Vec(vec![]),
+                                },
+                                RustStmt::For {
+                                    var: "(idx, item)".to_string(),
+                                    iter: RustExpr::MethodCall {
+                                        receiver: Box::new(boxed_field_clone_iter(
+                                            "value",
+                                            "array_items",
+                                        )),
+                                        method: "enumerate".to_string(),
+                                        args: vec![],
+                                    },
+                                    body: vec![RustStmt::Expr(RustExpr::MethodCall {
+                                        receiver: Box::new(RustExpr::Ident(
+                                            "converted".to_string(),
+                                        )),
+                                        method: "push".to_string(),
+                                        args: vec![RustExpr::Try(Box::new(RustExpr::FnCall {
+                                            func: Box::new(RustExpr::Ident(
+                                                "__sifr_json_value_to_serde_profile".to_string(),
+                                            )),
+                                            args: vec![
+                                                RustExpr::Ref {
+                                                    mutable: false,
+                                                    expr: Box::new(RustExpr::Ident(
+                                                        "item".to_string(),
+                                                    )),
+                                                },
+                                                child_array_path_expr(),
+                                            ],
+                                        }))],
+                                    })],
+                                },
+                                RustStmt::Return(Some(ok_expr(RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "serde_json".to_string(),
+                                        "Value".to_string(),
+                                        "Array".to_string(),
+                                    ])),
+                                    args: vec![RustExpr::Ident("converted".to_string())],
+                                }))),
+                            ],
+                        },
+                        RustMatchArm {
+                            pattern: "\"object\"".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![
+                                RustStmt::Let {
+                                    mutable: true,
+                                    name: "converted".to_string(),
+                                    ty: None,
+                                    value: RustExpr::FnCall {
+                                        func: Box::new(RustExpr::Path(vec![
+                                            "serde_json".to_string(),
+                                            "Map".to_string(),
+                                            "new".to_string(),
+                                        ])),
+                                        args: vec![],
+                                    },
+                                },
+                                RustStmt::For {
+                                    var: "entry".to_string(),
+                                    iter: boxed_field_clone_iter("value", "object_items"),
+                                    body: vec![
+                                        RustStmt::Let {
+                                            mutable: false,
+                                            name: "entry_key".to_string(),
+                                            ty: None,
+                                            value: RustExpr::Field {
+                                                expr: Box::new(RustExpr::Ident(
+                                                    "entry".to_string(),
+                                                )),
+                                                field: "0".to_string(),
+                                            },
+                                        },
+                                        RustStmt::Let {
+                                            mutable: false,
+                                            name: "entry_value".to_string(),
+                                            ty: None,
+                                            value: RustExpr::Field {
+                                                expr: Box::new(RustExpr::Ident(
+                                                    "entry".to_string(),
+                                                )),
+                                                field: "1".to_string(),
+                                            },
+                                        },
+                                        RustStmt::Expr(RustExpr::MethodCall {
+                                            receiver: Box::new(RustExpr::Ident(
+                                                "converted".to_string(),
+                                            )),
+                                            method: "insert".to_string(),
+                                            args: vec![
+                                                RustExpr::Clone(Box::new(RustExpr::Ident(
+                                                    "entry_key".to_string(),
+                                                ))),
+                                                RustExpr::Try(Box::new(RustExpr::FnCall {
+                                                    func: Box::new(RustExpr::Ident(
+                                                        "__sifr_json_value_to_serde_profile"
+                                                            .to_string(),
+                                                    )),
+                                                    args: vec![
+                                                        RustExpr::Ref {
+                                                            mutable: false,
+                                                            expr: Box::new(RustExpr::Ident(
+                                                                "entry_value".to_string(),
+                                                            )),
+                                                        },
+                                                        child_object_path_expr(),
+                                                    ],
+                                                })),
+                                            ],
+                                        }),
+                                    ],
+                                },
+                                RustStmt::Return(Some(ok_expr(RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "serde_json".to_string(),
+                                        "Value".to_string(),
+                                        "Object".to_string(),
+                                    ])),
+                                    args: vec![RustExpr::Ident("converted".to_string())],
+                                }))),
+                            ],
+                        },
+                        RustMatchArm {
+                            pattern: "_".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![RustStmt::Return(Some(ok_expr(json_null_value_expr())))],
+                        },
+                    ],
+                }],
+            },
+        ],
+        expr: Some(Box::new(final_expr)),
     })
 }

--- a/crates/sifr_codegen/src/intrinsics/mod.rs
+++ b/crates/sifr_codegen/src/intrinsics/mod.rs
@@ -42,6 +42,9 @@ fn additional_required_crates(name: &str) -> &'static [&'static str] {
     match name {
         // random_gauss uses rand_distr::Normal in addition to rand::rng.
         "random_gauss" => &["rand_distr"],
+        "json_dumps_value_exact" | "json_dumps_value_web" | "json_dumps_value_string_ints" => {
+            &["sifr_runtime"]
+        }
         _ => &[],
     }
 }
@@ -163,6 +166,12 @@ fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<LoweredIntr
         "json_loads" => (json::lower_json_loads(args), Some("serde_json")),
         "json_dumps" => (json::lower_json_dumps(args), Some("serde_json")),
         "json_dumps_value" => (json::lower_json_dumps_value(args), Some("serde_json")),
+        "json_dumps_value_exact" => (json::lower_json_dumps_value_exact(args), Some("serde_json")),
+        "json_dumps_value_web" => (json::lower_json_dumps_value_web(args), Some("serde_json")),
+        "json_dumps_value_string_ints" => (
+            json::lower_json_dumps_value_string_ints(args),
+            Some("serde_json"),
+        ),
         "assert_eq" => (test::lower_assert_eq(args), None),
         "assert_ne" => (test::lower_assert_ne(args), None),
         "assert_true" => (test::lower_assert_true(args), None),

--- a/crates/sifr_codegen/src/stdlib_filter.rs
+++ b/crates/sifr_codegen/src/stdlib_filter.rs
@@ -354,6 +354,11 @@ fn is_shared_use_path(path: &[String]) -> bool {
             if std == "std"
                 && sync == "sync"
                 && symbol == "Mutex"
+    ) || matches!(
+        path,
+        [runtime, symbol]
+            if runtime == "sifr_runtime"
+                && symbol == "SifrInt"
     )
 }
 

--- a/crates/sifr_hir/src/stdlib/io_json.rs
+++ b/crates/sifr_hir/src/stdlib/io_json.rs
@@ -24,6 +24,19 @@ fn json_decode_error_ty() -> Type {
     }
 }
 
+fn json_integer_range_error_ty() -> Type {
+    Type::Class {
+        name: "JsonIntegerRangeError".to_string(),
+        fields: vec![
+            ("message".to_string(), Type::Str),
+            ("path".to_string(), Type::Str),
+            ("profile".to_string(), Type::Str),
+        ],
+        methods: vec![],
+        parent_class: Some("Error".to_string()),
+    }
+}
+
 /// _sifr.io — File I/O intrinsics
 pub(super) fn intrinsic_io() -> IntrinsicModule {
     let mut functions = HashMap::new();
@@ -95,6 +108,27 @@ pub(super) fn intrinsic_json() -> IntrinsicModule {
     // json_dumps_value(obj: JsonValue) -> str
     functions.insert(
         "json_dumps_value".to_string(),
+        FunctionType::all_borrow(vec![("obj".to_string(), json_value_stub())], Type::Str),
+    );
+
+    // json_dumps_value_exact(obj: JsonValue) -> str
+    functions.insert(
+        "json_dumps_value_exact".to_string(),
+        FunctionType::all_borrow(vec![("obj".to_string(), json_value_stub())], Type::Str),
+    );
+
+    // json_dumps_value_web(obj: JsonValue) -> Result[str, JsonIntegerRangeError]
+    functions.insert(
+        "json_dumps_value_web".to_string(),
+        FunctionType::all_borrow(
+            vec![("obj".to_string(), json_value_stub())],
+            Type::Result(Box::new(Type::Str), Box::new(json_integer_range_error_ty())),
+        ),
+    );
+
+    // json_dumps_value_string_ints(obj: JsonValue) -> str
+    functions.insert(
+        "json_dumps_value_string_ints".to_string(),
         FunctionType::all_borrow(vec![("obj".to_string(), json_value_stub())], Type::Str),
     );
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -478,6 +478,7 @@ Validation:
 - [x] INT-1 exact-int floor/mod `Result[int, DivisionError]` class-method parameter review satisfied after promoting method parameters and direct promoted call arguments: `reviews/integer-model-int-1-exact-int-method-result-params-review-pass-1.md`.
 - [x] INT-1 milestone closure review pass 1 satisfied: INT-1 is ready to close; all 38 checklist items (including the broad `Type::Int` migration follow-up) are addressed by the landed PR sequence; remaining `bigint` transition fixtures are owned by INT-7; validation passes: `reviews/integer-model-int-1-milestone-closure-review-pass-1.md`.
 - [x] INT-5 runtime JSON integer profile machinery review satisfied after adding `sifr_runtime::json` exact/web/string profile helpers, JS-safe integer enforcement, digit-limit validation, canonical builtin error registration, and focused runtime/e2e coverage: `reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md`; PR #1890.
+- [x] INT-5 stdlib JSON profile wrapper review satisfied after exposing `dumps_exact`, `dumps_web`, and `dumps_string_ints` through the current `sifr.json` `JsonValue` boundary with recursive runtime-profile enforcement and focused e2e coverage: `reviews/integer-model-int-5-json-profile-stdlib-wrappers-review-pass-1.md`; PR #1891.
 
 ## Implementation Checklist
 
@@ -560,6 +561,7 @@ Validation:
   - [x] `sum(list[int32])` and `abs(int8.MIN)` now widen to `int` for the currently safe fixed-width builtin families, with shared policy coverage, focused e2e coverage, review satisfied, and quick validation passing: PR #1874.
 - [ ] INT-5 serialization, web, and schema boundaries
   - [x] Shared runtime JSON integer profile primitives now live in `sifr_runtime::json`: `json.exact` emits exact integer numbers, `json.web` rejects JavaScript-unsafe JSON numbers with `JsonIntegerRangeError`, and `json.string_ints` emits decimal strings. `JsonIntegerRangeError` and `JsonLimitError` are registered as builtin errors and covered by runtime/e2e tests; review is satisfied and quick validation is passing: PR #1890.
+  - [x] Current `sifr.json` `JsonValue` serialization exposes explicit `dumps_exact`, `dumps_web`, and `dumps_string_ints` wrappers. The wrappers call the shared runtime profile policy through codegen intrinsics, apply the selected integer profile recursively to nested arrays/objects, and report `JsonIntegerRangeError` paths such as `$.items[1]`; review is satisfied and quick validation is passing: PR #1891.
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration
 - [ ] INT-7 diagnostics, documentation, and migration cleanup

--- a/lib/sifr/json.sifr
+++ b/lib/sifr/json.sifr
@@ -1,5 +1,12 @@
 from _sifr.fs import read_text, write_text
-from _sifr.json import json_dumps, json_dumps_value, json_loads
+from _sifr.json import (
+    json_dumps,
+    json_dumps_value,
+    json_dumps_value_exact,
+    json_dumps_value_string_ints,
+    json_dumps_value_web,
+    json_loads,
+)
 from sifr.io import FileHandle
 
 
@@ -247,6 +254,18 @@ def load(path: str) -> Result[JsonValue, Error]:
 
 def dumps(value: JsonValue) -> str:
     return json_dumps_value(value)
+
+
+def dumps_exact(value: JsonValue) -> str:
+    return json_dumps_value_exact(value)
+
+
+def dumps_web(value: JsonValue) -> Result[str, JsonIntegerRangeError]:
+    return json_dumps_value_web(value)
+
+
+def dumps_string_ints(value: JsonValue) -> str:
+    return json_dumps_value_string_ints(value)
 
 
 def dump_handle(value: JsonValue, fh: FileHandle) -> Result[None, IOError]:

--- a/reviews/integer-model-int-5-json-profile-stdlib-wrappers-review-pass-1.md
+++ b/reviews/integer-model-int-5-json-profile-stdlib-wrappers-review-pass-1.md
@@ -1,0 +1,42 @@
+
+
+I've completed a thorough review of the INT-5 stdlib JSON integer profile wrapper slice. Here are my findings:
+
+## Review Summary
+
+**No blockers found.** The reviewer is satisfied for this INT-5 stdlib JSON profile wrapper slice.
+
+### Review Details
+
+**1. Policy delegation to sifr_runtime::json (no duplication)**
+- `dumps_exact`, `dumps_web`, `dumps_string_ints` in `lib/sifr/json.sifr` are thin wrappers that delegate to the runtime intrinsics (`json_dumps_value_exact`, `json_dumps_value_web`, `json_dumps_value_string_ints`).
+- The actual policy lives in `sifr_runtime/src/json.rs` via `encode_integer_for_profile()` and `JsonIntegerProfile` variants. No duplication outside the runtime.
+
+**2. dumps_web recursive rejection with useful error context**
+- The test in `json_integer_profiles.sifr` confirms `dumps_web` rejects 9007199254740992 (outside JS safe range) and surfaces `JsonIntegerRangeError` with `profile == "json.web"` and `path == "$.items[1]"`.
+- The path construction via `child_array_path_expr()` and `child_object_path_expr()` in `intrinsics/json.rs` correctly builds JSON pointer notation.
+
+**3. dumps_string_ints encodes integers as decimal strings, dumps_exact preserves numeric JSON**
+- `dumps_string_ints` emits `"9007199254740992"` as a string (verified in test).
+- `dumps_exact` emits `9007199254740991` as a JSON number, preserving current JsonValue int storage behavior.
+
+**4. HIR intrinsic types, codegen, and error refs completeness**
+- `intrinsics/mod.rs` registers all three new intrinsics with correct signatures including `JsonIntegerRangeError` type definition.
+- `additional_required_crates()` in `intrinsics/mod.rs` correctly declares `sifr_runtime` for the profile intrinsics.
+- `error_refs.rs` already includes `JsonIntegerRangeError` in the builtin error list that gets emitted when intrinsics are used.
+- `stdlib_filter.rs` has `JsonIntegerRangeError` in `GLOBAL_INFRA_TYPES`.
+
+**5. Test sufficiency**
+- The e2e test in `json_integer_profiles.sifr` covers:
+  - Happy path (JS-safe integers with `dumps_web`)
+  - Sad path (JS-unsafe integer rejection with correct error fields)
+  - `dumps_string_ints` encoding behavior
+  - `dumps_exact` numeric preservation
+- Existing tests (`stdlib_json_consolidated.sifr`, `cpython_json.sifr`) still pass, confirming no regression.
+
+**Validation already run confirms:**
+- `cargo fmt --check` passes
+- `cargo check -p sifr_codegen` passes  
+- E2E tests for json_integer_profiles, stdlib_json_consolidated, and cpython_json all pass
+
+The slice is ready for PR.


### PR DESCRIPTION
## Summary
- expose explicit sifr.json dumps_exact, dumps_web, and dumps_string_ints wrappers for JsonValue serialization
- lower profile wrappers through shared sifr_runtime::json integer profile policy with recursive array/object path tracking
- add e2e coverage for web-safe rejection, decimal string encoding, exact numeric output, and existing JSON fixture compatibility

## Validation
- cargo fmt --check
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/json_integer_profiles.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_json_consolidated.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cpython_json.sifr
- cargo check -p sifr_codegen
- scripts/run_all_tests.sh --profile quick