### PR TITLE
Lock integer serialization boundary contracts

### DIFF
--- a/internal_docs/integer_model.md
+++ b/internal_docs/integer_model.md
@@ -339,6 +339,12 @@ Under `json.web`, schema-driven public models default to JSON numbers only when 
 
 Core rule: Sifr never silently loses integer precision when crossing a boundary. A serializer either preserves the exact integer, proves the target can represent it, or returns a typed error.
 
+The reviewable contract artifact for schema, client, generated serde, and
+storage boundary mappings is
+`verification/integer_model_serialization_boundary_contract.md`. Future web,
+ORM, and schema phases must update that artifact when they implement the
+corresponding runtime surfaces.
+
 ### JSON
 
 Sifr's JSON parser parses integer number tokens into exact `int` values. A JSON number token with no `.`, `e`, or `E` is an integer token. Fractional or exponent-bearing number tokens follow the selected numeric profile, initially `float` unless a Phase 28 decimal profile is requested.

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -479,6 +479,7 @@ Validation:
 - [x] INT-1 milestone closure review pass 1 satisfied: INT-1 is ready to close; all 38 checklist items (including the broad `Type::Int` migration follow-up) are addressed by the landed PR sequence; remaining `bigint` transition fixtures are owned by INT-7; validation passes: `reviews/integer-model-int-1-milestone-closure-review-pass-1.md`.
 - [x] INT-5 runtime JSON integer profile machinery review satisfied after adding `sifr_runtime::json` exact/web/string profile helpers, JS-safe integer enforcement, digit-limit validation, canonical builtin error registration, and focused runtime/e2e coverage: `reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md`; PR #1890.
 - [x] INT-5 stdlib JSON profile wrapper review satisfied after exposing `dumps_exact`, `dumps_web`, and `dumps_string_ints` through the current `sifr.json` `JsonValue` boundary with recursive runtime-profile enforcement and focused e2e coverage: `reviews/integer-model-int-5-json-profile-stdlib-wrappers-review-pass-1.md`; PR #1891.
+- [x] INT-5 schema/client/generated-serde/storage boundary contract review satisfied after locking OpenAPI/JSON Schema mappings, TypeScript precision-safe client types, generated serde profile routing, SQL/storage explicit representation rules, and the `SIFR-INT-0009` diagnostic contract: `reviews/integer-model-int-5-schema-boundary-contracts-review-pass-1.md`; PR #1892.
 
 ## Implementation Checklist
 
@@ -562,6 +563,7 @@ Validation:
 - [ ] INT-5 serialization, web, and schema boundaries
   - [x] Shared runtime JSON integer profile primitives now live in `sifr_runtime::json`: `json.exact` emits exact integer numbers, `json.web` rejects JavaScript-unsafe JSON numbers with `JsonIntegerRangeError`, and `json.string_ints` emits decimal strings. `JsonIntegerRangeError` and `JsonLimitError` are registered as builtin errors and covered by runtime/e2e tests; review is satisfied and quick validation is passing: PR #1890.
   - [x] Current `sifr.json` `JsonValue` serialization exposes explicit `dumps_exact`, `dumps_web`, and `dumps_string_ints` wrappers. The wrappers call the shared runtime profile policy through codegen intrinsics, apply the selected integer profile recursively to nested arrays/objects, and report `JsonIntegerRangeError` paths such as `$.items[1]`; review is satisfied and quick validation is passing: PR #1891.
+- [x] OpenAPI/JSON Schema, TypeScript client, generated serde, SQL/storage, and `SIFR-INT-0009` boundary rules are locked in `verification/integer_model_serialization_boundary_contract.md`; review is satisfied and quick validation is passing: PR #1892.
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration
 - [ ] INT-7 diagnostics, documentation, and migration cleanup

--- a/reviews/integer-model-int-5-schema-boundary-contracts-review-pass-1.md
+++ b/reviews/integer-model-int-5-schema-boundary-contracts-review-pass-1.md
@@ -1,0 +1,82 @@
+
+
+Based on my thorough review of the three working-tree artifacts, here is my assessment:
+
+---
+
+## INT-5 Schema Boundary Contract Review
+
+**Verdict: No blockers. Reviewer is satisfied for this INT-5 schema boundary contract slice.**
+
+---
+
+### Review Details
+
+**1. OpenAPI/JSON Schema integer mappings — adequate coverage**
+
+The contract correctly maps:
+- Fixed-width types (`int8`-`uint32`) → `json.web` with explicit `minimum`/`maximum` bounds
+- `int64`/`uint64` → `json.web` decimal string default with `x-sifr-format: integer-decimal-string`
+- Exact `int` → `json.web` decimal string default or range-error policy
+- `json.string_ints` → decimal string with `x-sifr-format` marker
+- `json.exact` → `type: integer` with `x-sifr-integer-profile: exact` and client warning
+
+The fail-closed rule with `SIFR-INT-0009` (line 40) and field-path-plus-suggested-policies payload is appropriately actionable for future schema emitters. One intentional asymmetry exists (`int` defaults to decimal string *or* typed error policy, while `int64`/`uint64` default to decimal string) — this is deliberate given exact `int` may have provably-bounded static ranges, while `int64`/`uint64` are inherently 64-bit. Not a blocker.
+
+**2. TypeScript client mappings — precision loss prevention is explicit**
+
+The most critical clause is on lines 54-57: "*int64, uint64, and exact int response fields under json.web default to decimal strings. A generated TypeScript number for those fields is valid only when the schema also carries a static safe range.*"
+
+This directly addresses the silent precision loss risk. The branded `SifrDecimalIntString` type (lines 50-51) prevents accidental misuse. `bigint` mapping is gated behind *explicit* runtime + JSON parser strategy configuration, not a silent fallback. No blockers.
+
+**3. Generated serde — profile selection bypass prevention is locked**
+
+Lines 60-74 correctly prohibit:
+- Direct Rust primitive or `SifrInt` serde behavior that bypasses profile selection
+- Internal derives without explicit profile declaration
+- Recursive/nested field inheritance without explicit override
+
+The distinction between *public/browser-facing* (default `json.web`) and *internal* (must declare explicitly) is the right split. Serialization failures return `JsonIntegerRangeError` with model path; digit-limit violations return `JsonLimitError`. This is consistent with the runtime profile machinery reviewed in PRs #1890 and #1891.
+
+**4. SQL/storage — explicit representation requirements are unambiguous**
+
+The table on lines 78-87 makes ORM/storage behavior explicit:
+- Fixed-width SQL columns require `uint*`/`int*` field or fallible narrowing
+- Unsigned dialect columns require explicit `uint*`
+- `NUMERIC`/`DECIMAL` with integer scale: requires checked exact `int` mapping
+- Text/binary formats require explicit policy
+
+The critical anti-inference rule ("ORM and storage layers must not infer `int64` or `BIGINT` from a plain Sifr `int` annotation") prevents the exact silent-widening failure this contract is designed to stop.
+
+**5. SIFR-INT-0009 diagnostic contract — runtime vs. compile-time distinction is clear**
+
+The contract cleanly separates:
+- **Compile-time/generation-time**: `SIFR-INT-0009` is emitted when schema or generation steps would create unsafe/ambiguous integer boundaries (lines 94-96)
+- **Runtime**: `JsonIntegerRangeError` for selected-profile violations (lines 97-99)
+- **Decoder layer**: `JsonLimitError` for untrusted integer token budget violations
+
+Diagnostic payload requirements (lines 101-107) cover boundary kind, field/path, selected/missing profile, static range, and suggested alternatives — sufficient for future compiler/schema tooling to produce actionable diagnostics.
+
+**6. Blockers before opening contract-lock PR**
+
+None identified.
+
+---
+
+### Minor Observations (non-blocking)
+
+1. **Exact-client "exact-client support" terminology** (line 52): The contract says `bigint` is valid "only when the target runtime and JSON parser strategy are explicitly configured." Future TypeScript/ORM phases will need to define *how* "explicitly configured" is declared in schema metadata. This is appropriately deferred to the owning phases — the contract correctly notes it must be explicit.
+
+2. **`int` vs. `int64` asymmetry** (lines 34-35): `int64`/`uint64` map to decimal string by default; plain `int` maps to decimal string *or* typed error policy. This asymmetry is intentional (exact `int` may have provably-bounded ranges; `int64` is inherently 64-bit), but implementors should document why the asymmetry exists when they ship the owning phases.
+
+3. **"fallible narrowing" in SQL table** (line 83): The contract says "fallible narrowing from `int` with range checks." Future ORM phases will need to define the fallible API shape. This is appropriately deferred.
+
+---
+
+### Contract Quality Assessment
+
+The artifact is well-structured as an *intent and constraint document* rather than an implementation spec — it correctly establishes hard rules that future owning phases (web, ORM, schema generators, TypeScript clients) cannot violate while appropriately deferring implementation mechanics (safe-range constraint syntax, exact-client configuration declaration, ORM narrowing API shape) to those owning phases.
+
+The cross-references from `internal_docs/integer_model.md` (lines 344-346) and `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md` (line 565) correctly tie the contract into the canonical design and phase tracker.
+
+**The reviewer is satisfied. This INT-5 schema boundary contract slice is ready to open as a contract-lock PR.**

--- a/verification/integer_model_serialization_boundary_contract.md
+++ b/verification/integer_model_serialization_boundary_contract.md
@@ -1,0 +1,107 @@
+# Integer Model Serialization Boundary Contract
+
+Status: INT-5 contract lock.
+
+This artifact locks the integer boundary rules that later web, schema, ORM,
+and generated serde implementations must satisfy. Runtime JSON profile helpers
+live in `sifr_runtime::json`; framework layers may wrap that API, but must not
+reimplement or weaken the policy.
+
+## JSON Profiles
+
+All JSON serializers that can see Sifr `int` values must choose exactly one
+integer profile at the boundary:
+
+| Profile | JSON representation | Failure behavior |
+| --- | --- | --- |
+| `json.exact` | canonical base-10 JSON number | no precision loss; consumers must support exact integer numbers |
+| `json.web` | JSON number only for JavaScript-safe integers | values outside `[-9007199254740991, 9007199254740991]` return `JsonIntegerRangeError` unless the field explicitly opts into string encoding |
+| `json.string_ints` | decimal JSON string for every integer | no range error for integer magnitude; parser digit limits still apply |
+
+Profile rules apply recursively to nested lists, dictionaries, object fields,
+and generated model fields. Error paths use `$` as the root, `[index]` for
+array elements, and `.field` or `.key` for object members when available.
+
+## OpenAPI And JSON Schema
+
+Schema generation must reflect the selected integer profile and the static
+integer range. It must not emit a browser-facing unbounded integer schema for a
+Sifr `int`.
+
+| Sifr field | Selected profile | Schema contract |
+| --- | --- | --- |
+| `int8`, `int16`, `int32`, `uint8`, `uint16`, `uint32` | `json.web` | `type: integer` with exact `minimum` and `maximum`; may be TypeScript `number` |
+| `int64`, `uint64` | `json.web` | decimal string by default: `type: string`, `pattern: "^-?[0-9]+$"`, `x-sifr-format: integer-decimal-string`; numeric schema requires an explicit safe-range constraint |
+| `int` | `json.web` | decimal string by default or a typed `JsonIntegerRangeError` policy; numeric schema requires a static safe range |
+| any integer | `json.string_ints` | decimal string schema with `x-sifr-format: integer-decimal-string` |
+| any integer | `json.exact` | `type: integer`, `x-sifr-integer-profile: exact`, and a generated-client warning unless the client target supports exact integer parsing |
+
+If a route or model lacks enough policy to select one of these mappings, schema
+generation must fail closed with `SIFR-INT-0009` and include the field path plus
+suggested policies (`json.web` string encoding, explicit safe range,
+`json.string_ints`, or exact-client support).
+
+## TypeScript Client Mapping
+
+Generated TypeScript clients must make precision visible in the type:
+
+| Schema shape | TypeScript type |
+| --- | --- |
+| JavaScript-safe integer number | `number` |
+| decimal integer string | branded `SifrDecimalIntString` unless the user opts into plain `string` |
+| exact-client integer profile | `bigint` only when the target runtime and JSON parser strategy are explicitly configured |
+
+`int64`, `uint64`, and exact `int` response fields under `json.web` default to
+decimal strings. A generated TypeScript `number` for those fields is valid only
+when the schema also carries a static safe range.
+
+## Generated Serde
+
+Generated `serde::Serialize` and `serde::Deserialize` implementations for Sifr
+classes/structs must route integer fields through the selected JSON integer
+profile. They must not derive directly to Rust primitive or `SifrInt` serde
+behavior in a way that bypasses profile selection.
+
+Required behavior:
+
+- Public/browser-facing derives default to `json.web`.
+- Internal derives must declare `json.exact`, `json.web`, or
+  `json.string_ints` explicitly.
+- Nested collections and nested model fields inherit the containing profile
+  unless a more specific field annotation overrides it.
+- Serialization failures return `JsonIntegerRangeError` with the model path.
+- Decoder digit limits return `JsonLimitError` before allocating unbounded
+  integer values.
+
+## SQL And Storage
+
+Storage schemas must choose representation explicitly. Source-level `int` is an
+exact scalar type, not a default database width.
+
+| Storage target | Required Sifr contract |
+| --- | --- |
+| `SMALLINT`, `INTEGER`, `BIGINT` | fixed-width Sifr field or fallible narrowing from `int` with range checks |
+| unsigned dialect column | explicit `uint*` field or fallible narrowing from `int` |
+| `NUMERIC`/`DECIMAL` integer scale | exact `int` mapping only when precision and scale constraints are checked |
+| text or JSON string column | explicit decimal-string policy |
+| binary fixed-width format | fixed-width field plus explicit endian/range policy |
+
+ORM and storage layers must not infer `int64` or `BIGINT` from a plain Sifr
+`int` annotation.
+
+## Diagnostic Contract
+
+`SIFR-INT-0009` is the compiler/schema diagnostic for JSON or web-safe integer
+serialization policy failures. It is emitted when a compile-time, schema, or
+generation step would otherwise create an unsafe or ambiguous integer boundary.
+Runtime values that violate a selected JSON profile return
+`JsonIntegerRangeError`; untrusted integer token budget violations return
+`JsonLimitError`.
+
+Diagnostic payloads must include:
+
+- boundary kind: JSON, OpenAPI, TypeScript, serde, SQL, or binary format
+- field/path
+- selected or missing profile
+- static range when known
+- suggested policy alternatives


### PR DESCRIPTION
## Summary
- Add the INT-5 serialization boundary contract artifact for JSON Schema/OpenAPI, TypeScript clients, generated serde, SQL/storage, and SIFR-INT-0009.
- Link the contract from the integer model design and phase tracker.
- Store the satisfied Claude Opus review artifact for this milestone slice.

## Validation
- scripts/run_all_tests.sh --profile quick
- git diff --check