### PR TITLE
Enforce JSON integer token digit limits

### DIFF
--- a/crates/sifr/tests/e2e/pass/stdlib_json_consolidated.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_json_consolidated.sifr
@@ -1,5 +1,5 @@
 # Consolidated stdlib json coverage for structured-value parity
-from sifr.json import JsonValue, loads, json_dumps
+from sifr.json import JsonValue, loads, json_dumps, validate_integer_digit_limits
 
 
 def main() -> None:
@@ -23,6 +23,24 @@ def main() -> None:
     try:
         _bad: JsonValue = loads("{")
         _ = _bad
+        assert False
+    except JSONDecodeError as e:
+        assert len(e.message) > 0
+
+    oversized_integer: str = "1"
+    for _index in range(0, 4097):
+        oversized_integer = oversized_integer + "0"
+
+    try:
+        _: None = validate_integer_digit_limits(oversized_integer)
+        assert False
+    except JsonLimitError as e:
+        assert e.limit == 4096
+        assert len(e.message) > 0
+
+    try:
+        _too_large: JsonValue = loads("{\"id\":" + oversized_integer + "}")
+        _ = _too_large
         assert False
     except JSONDecodeError as e:
         assert len(e.message) > 0

--- a/crates/sifr_codegen/src/intrinsics/json.rs
+++ b/crates/sifr_codegen/src/intrinsics/json.rs
@@ -302,6 +302,75 @@ fn json_profile_error_struct_from_runtime(err_name: &str) -> RustExpr {
     }
 }
 
+fn json_limit_error_struct_from_runtime(err_name: &str) -> RustExpr {
+    RustExpr::StructInit {
+        name: "JsonLimitError".to_string(),
+        fields: vec![
+            (
+                "message".to_string(),
+                RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                        method: "message".to_string(),
+                        args: vec![],
+                    }),
+                    method: "to_string".to_string(),
+                    args: vec![],
+                },
+            ),
+            (
+                "limit".to_string(),
+                RustExpr::Cast {
+                    expr: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                        method: "limit".to_string(),
+                        args: vec![],
+                    }),
+                    ty: RustType::I64,
+                },
+            ),
+        ],
+    }
+}
+
+fn json_limit_error_as_decode_error(err_name: &str) -> RustExpr {
+    json_decode_error(
+        RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(err_name.to_string())),
+                method: "message".to_string(),
+                args: vec![],
+            }),
+            method: "to_string".to_string(),
+            args: vec![],
+        },
+        RustExpr::Literal(RustLiteral::Int(0)),
+        RustExpr::Literal(RustLiteral::Int(0)),
+    )
+}
+
+fn json_validate_integer_digit_limits_expr(input: RustExpr) -> RustExpr {
+    RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            "sifr_runtime".to_string(),
+            "json".to_string(),
+            "validate_json_integer_digit_limits".to_string(),
+        ])),
+        args: vec![
+            RustExpr::MethodCall {
+                receiver: Box::new(input),
+                method: "as_ref".to_string(),
+                args: vec![],
+            },
+            RustExpr::Path(vec![
+                "sifr_runtime".to_string(),
+                "json".to_string(),
+                "DEFAULT_JSON_INTEGER_DIGIT_LIMIT".to_string(),
+            ]),
+        ],
+    }
+}
+
 fn json_integer_profile_encode_expr(profile: JsonIntegerProfileLowering) -> RustExpr {
     RustExpr::Try(Box::new(RustExpr::MethodCall {
         receiver: Box::new(RustExpr::FnCall {
@@ -402,6 +471,17 @@ pub(super) fn lower_json_loads(args: &[RustExpr]) -> Option<RustExpr> {
                 name: "__json_input".to_string(),
                 ty: None,
                 value: args[0].clone(),
+            },
+            RustStmt::LocalFn {
+                name: "__sifr_json_limit_error_as_decode_error".to_string(),
+                params: vec![RustParam::Named {
+                    name: "err".to_string(),
+                    ty: RustType::Named("sifr_runtime::json::JsonLimitError".to_string()),
+                }],
+                ret: Some(RustType::Named("JSONDecodeError".to_string())),
+                body: vec![RustStmt::Return(Some(json_limit_error_as_decode_error(
+                    "err",
+                )))],
             },
             RustStmt::LocalFn {
                 name: "__sifr_json_value_from_serde".to_string(),
@@ -593,61 +673,118 @@ pub(super) fn lower_json_loads(args: &[RustExpr]) -> Option<RustExpr> {
         ],
         expr: Some(Box::new(RustExpr::MethodCall {
             receiver: Box::new(RustExpr::MethodCall {
-                receiver: Box::new(RustExpr::FnCall {
-                    func: Box::new(RustExpr::Path(vec![
-                        "serde_json".to_string(),
-                        "from_str::<serde_json::Value>".to_string(),
-                    ])),
-                    args: vec![RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::Ident("__json_input".to_string())),
-                        method: "as_ref".to_string(),
-                        args: vec![],
-                    }],
-                }),
+                receiver: Box::new(json_validate_integer_digit_limits_expr(RustExpr::Ident(
+                    "__json_input".to_string(),
+                ))),
                 method: "map_err".to_string(),
-                args: vec![RustExpr::Closure {
-                    params: vec![RustParam::Named {
-                        name: "e".to_string(),
-                        ty: RustType::Named("_".to_string()),
-                    }],
-                    body: Box::new(json_decode_error(
-                        RustExpr::MethodCall {
-                            receiver: Box::new(RustExpr::Ident("e".to_string())),
-                            method: "to_string".to_string(),
-                            args: vec![],
-                        },
-                        RustExpr::Cast {
-                            expr: Box::new(RustExpr::MethodCall {
-                                receiver: Box::new(RustExpr::Ident("e".to_string())),
-                                method: "line".to_string(),
-                                args: vec![],
-                            }),
-                            ty: RustType::I64,
-                        },
-                        RustExpr::Cast {
-                            expr: Box::new(RustExpr::MethodCall {
-                                receiver: Box::new(RustExpr::Ident("e".to_string())),
-                                method: "column".to_string(),
-                                args: vec![],
-                            }),
-                            ty: RustType::I64,
-                        },
-                    )),
-                    is_move: false,
-                }],
+                args: vec![RustExpr::Ident(
+                    "__sifr_json_limit_error_as_decode_error".to_string(),
+                )],
             }),
             method: "and_then".to_string(),
             args: vec![RustExpr::Closure {
                 params: vec![RustParam::Named {
-                    name: "parsed".to_string(),
-                    ty: RustType::Named("serde_json::Value".to_string()),
+                    name: "_".to_string(),
+                    ty: RustType::Unit,
                 }],
-                body: Box::new(RustExpr::FnCall {
-                    func: Box::new(RustExpr::Ident("__sifr_json_value_from_serde".to_string())),
-                    args: vec![RustExpr::Ident("parsed".to_string())],
+                body: Box::new(RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "serde_json".to_string(),
+                                "from_str::<serde_json::Value>".to_string(),
+                            ])),
+                            args: vec![RustExpr::MethodCall {
+                                receiver: Box::new(RustExpr::Ident("__json_input".to_string())),
+                                method: "as_ref".to_string(),
+                                args: vec![],
+                            }],
+                        }),
+                        method: "map_err".to_string(),
+                        args: vec![RustExpr::Closure {
+                            params: vec![RustParam::Named {
+                                name: "e".to_string(),
+                                ty: RustType::Named("_".to_string()),
+                            }],
+                            body: Box::new(json_decode_error(
+                                RustExpr::MethodCall {
+                                    receiver: Box::new(RustExpr::Ident("e".to_string())),
+                                    method: "to_string".to_string(),
+                                    args: vec![],
+                                },
+                                RustExpr::Cast {
+                                    expr: Box::new(RustExpr::MethodCall {
+                                        receiver: Box::new(RustExpr::Ident("e".to_string())),
+                                        method: "line".to_string(),
+                                        args: vec![],
+                                    }),
+                                    ty: RustType::I64,
+                                },
+                                RustExpr::Cast {
+                                    expr: Box::new(RustExpr::MethodCall {
+                                        receiver: Box::new(RustExpr::Ident("e".to_string())),
+                                        method: "column".to_string(),
+                                        args: vec![],
+                                    }),
+                                    ty: RustType::I64,
+                                },
+                            )),
+                            is_move: false,
+                        }],
+                    }),
+                    method: "and_then".to_string(),
+                    args: vec![RustExpr::Closure {
+                        params: vec![RustParam::Named {
+                            name: "parsed".to_string(),
+                            ty: RustType::Named("serde_json::Value".to_string()),
+                        }],
+                        body: Box::new(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Ident(
+                                "__sifr_json_value_from_serde".to_string(),
+                            )),
+                            args: vec![RustExpr::Ident("parsed".to_string())],
+                        }),
+                        is_move: false,
+                    }],
                 }),
                 is_move: false,
             }],
+        })),
+    })
+}
+
+pub(super) fn lower_json_validate_integer_digit_limits(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(RustExpr::Block {
+        stmts: vec![
+            RustStmt::Let {
+                mutable: false,
+                name: "__json_input".to_string(),
+                ty: None,
+                value: args[0].clone(),
+            },
+            RustStmt::LocalFn {
+                name: "__sifr_json_limit_error_from_runtime".to_string(),
+                params: vec![RustParam::Named {
+                    name: "err".to_string(),
+                    ty: RustType::Named("sifr_runtime::json::JsonLimitError".to_string()),
+                }],
+                ret: Some(RustType::Named("JsonLimitError".to_string())),
+                body: vec![RustStmt::Return(Some(
+                    json_limit_error_struct_from_runtime("err"),
+                ))],
+            },
+        ],
+        expr: Some(Box::new(RustExpr::MethodCall {
+            receiver: Box::new(json_validate_integer_digit_limits_expr(RustExpr::Ident(
+                "__json_input".to_string(),
+            ))),
+            method: "map_err".to_string(),
+            args: vec![RustExpr::Ident(
+                "__sifr_json_limit_error_from_runtime".to_string(),
+            )],
         })),
     })
 }

--- a/crates/sifr_codegen/src/intrinsics/mod.rs
+++ b/crates/sifr_codegen/src/intrinsics/mod.rs
@@ -42,9 +42,11 @@ fn additional_required_crates(name: &str) -> &'static [&'static str] {
     match name {
         // random_gauss uses rand_distr::Normal in addition to rand::rng.
         "random_gauss" => &["rand_distr"],
-        "json_dumps_value_exact" | "json_dumps_value_web" | "json_dumps_value_string_ints" => {
-            &["sifr_runtime"]
-        }
+        "json_loads"
+        | "json_validate_integer_digit_limits"
+        | "json_dumps_value_exact"
+        | "json_dumps_value_web"
+        | "json_dumps_value_string_ints" => &["sifr_runtime"],
         _ => &[],
     }
 }
@@ -164,6 +166,9 @@ fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<LoweredIntr
         "file_read_bytes" => (file_handles::lower_file_read_bytes(args), None),
         "file_write_bytes" => (file_handles::lower_file_write_bytes(args), None),
         "json_loads" => (json::lower_json_loads(args), Some("serde_json")),
+        "json_validate_integer_digit_limits" => {
+            (json::lower_json_validate_integer_digit_limits(args), None)
+        }
         "json_dumps" => (json::lower_json_dumps(args), Some("serde_json")),
         "json_dumps_value" => (json::lower_json_dumps_value(args), Some("serde_json")),
         "json_dumps_value_exact" => (json::lower_json_dumps_value_exact(args), Some("serde_json")),
@@ -409,7 +414,21 @@ mod tests {
         let loads = lower_intrinsic("json_loads", &["payload".to_string()])
             .expect("json_loads should lower");
         assert_eq!(loads.required_crate, Some("serde_json"));
-        assert!(render_expr(&loads.expr).contains("serde_json::from_str"));
+        assert!(loads.additional_required_crates.contains(&"sifr_runtime"));
+        let loads_rendered = render_expr(&loads.expr);
+        assert!(loads_rendered.contains("serde_json::from_str"));
+        assert!(loads_rendered.contains("validate_json_integer_digit_limits"));
+
+        let validate = lower_intrinsic(
+            "json_validate_integer_digit_limits",
+            &["payload".to_string()],
+        )
+        .expect("json_validate_integer_digit_limits should lower");
+        assert_eq!(validate.required_crate, None);
+        assert!(validate
+            .additional_required_crates
+            .contains(&"sifr_runtime"));
+        assert!(render_expr(&validate.expr).contains("JsonLimitError"));
 
         let dumps =
             lower_intrinsic("json_dumps", &["value".to_string()]).expect("json_dumps should lower");

--- a/crates/sifr_hir/src/stdlib/io_json.rs
+++ b/crates/sifr_hir/src/stdlib/io_json.rs
@@ -37,6 +37,18 @@ fn json_integer_range_error_ty() -> Type {
     }
 }
 
+fn json_limit_error_ty() -> Type {
+    Type::Class {
+        name: "JsonLimitError".to_string(),
+        fields: vec![
+            ("message".to_string(), Type::Str),
+            ("limit".to_string(), Type::Int),
+        ],
+        methods: vec![],
+        parent_class: Some("Error".to_string()),
+    }
+}
+
 /// _sifr.io — File I/O intrinsics
 pub(super) fn intrinsic_io() -> IntrinsicModule {
     let mut functions = HashMap::new();
@@ -96,6 +108,15 @@ pub(super) fn intrinsic_json() -> IntrinsicModule {
                 Box::new(json_value_stub()),
                 Box::new(json_decode_error_ty()),
             ),
+        ),
+    );
+
+    // json_validate_integer_digit_limits(s: str) -> Result[None, JsonLimitError]
+    functions.insert(
+        "json_validate_integer_digit_limits".to_string(),
+        FunctionType::all_borrow(
+            vec![("s".to_string(), Type::Str)],
+            Type::Result(Box::new(Type::None), Box::new(json_limit_error_ty())),
         ),
     );
 

--- a/crates/sifr_runtime/src/json.rs
+++ b/crates/sifr_runtime/src/json.rs
@@ -160,6 +160,52 @@ pub fn validate_integer_token_digit_limit(token: &str, limit: usize) -> Result<(
     Ok(())
 }
 
+pub fn validate_json_integer_digit_limits(input: &str, limit: usize) -> Result<(), JsonLimitError> {
+    let bytes = input.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'"' => {
+                index = skip_json_string(bytes, index + 1);
+            }
+            b'-' | b'0'..=b'9' if is_json_number_start_context(bytes, index) => {
+                let token_start = index;
+                if bytes[index] == b'-' {
+                    index += 1;
+                }
+                let digit_start = index;
+                while index < bytes.len() && bytes[index].is_ascii_digit() {
+                    index += 1;
+                }
+                let digit_count = index.saturating_sub(digit_start);
+                if digit_count == 0 {
+                    index = token_start + 1;
+                    continue;
+                }
+                let is_integer_token = index >= bytes.len()
+                    || matches!(bytes[index], b',' | b']' | b'}')
+                    || bytes[index].is_ascii_whitespace();
+                if is_integer_token {
+                    if digit_count > limit {
+                        return Err(JsonLimitError::new(
+                            format!(
+                                "json integer token at byte {token_start} has {digit_count} digits, exceeding limit {limit}"
+                            ),
+                            limit,
+                        ));
+                    }
+                } else {
+                    index = skip_json_number_suffix(bytes, index);
+                }
+            }
+            _ => {
+                index += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn encode_web_integer(
     value: &SifrInt,
     decimal: String,
@@ -194,6 +240,45 @@ fn json_integer_token_digit_count(token: &str) -> Option<usize> {
         return None;
     }
     Some(unsigned.len())
+}
+
+fn skip_json_string(bytes: &[u8], mut index: usize) -> usize {
+    let mut escaped = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'"' {
+            return index + 1;
+        }
+        index += 1;
+    }
+    index
+}
+
+fn skip_json_number_suffix(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len()
+        && (bytes[index].is_ascii_digit()
+            || matches!(bytes[index], b'.' | b'e' | b'E' | b'+' | b'-'))
+    {
+        index += 1;
+    }
+    index
+}
+
+fn is_json_number_start_context(bytes: &[u8], index: usize) -> bool {
+    let mut cursor = index;
+    while cursor > 0 {
+        cursor -= 1;
+        let byte = bytes[cursor];
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        return matches!(byte, b'[' | b',' | b':');
+    }
+    true
 }
 
 #[cfg(test)]
@@ -283,5 +368,32 @@ mod tests {
             .expect_err("non-integer token should be rejected");
 
         assert_eq!(err.limit(), 4);
+    }
+
+    #[test]
+    fn json_digit_limit_rejects_integer_tokens_outside_strings() {
+        let payload = format!(r#"{{"id":{},"quoted":"{}"}}"#, "9".repeat(5), "8".repeat(8));
+        let err = validate_json_integer_digit_limits(&payload, 4)
+            .expect_err("oversized JSON integer token should fail");
+
+        assert_eq!(err.limit(), 4);
+        assert!(err.message().contains("5 digits"));
+    }
+
+    #[test]
+    fn json_digit_limit_ignores_string_digits_and_fractional_numbers() {
+        let payload = r#"{"quoted":"123456","fraction":12345.25,"exp":12345e2}"#;
+
+        validate_json_integer_digit_limits(payload, 4)
+            .expect("only integer number tokens are limited in this phase");
+    }
+
+    #[test]
+    fn json_digit_limit_checks_nested_array_numbers() {
+        let payload = r#"{"items":[1,-2345]}"#;
+        let err = validate_json_integer_digit_limits(payload, 3)
+            .expect_err("nested oversized JSON integer token should fail");
+
+        assert!(err.message().contains("4 digits"));
     }
 }

--- a/internal_docs/integer_model.md
+++ b/internal_docs/integer_model.md
@@ -350,6 +350,10 @@ corresponding runtime surfaces.
 Sifr's JSON parser parses integer number tokens into exact `int` values. A JSON number token with no `.`, `e`, or `E` is an integer token. Fractional or exponent-bearing number tokens follow the selected numeric profile, initially `float` unless a Phase 28 decimal profile is requested.
 
 JSON readers apply deterministic resource limits such as maximum integer digits and maximum document bytes. Exceeding those limits returns `JsonLimitError` rather than allocating unbounded memory from untrusted input.
+The current `sifr.json.loads` path validates JSON integer token digit budgets
+before handing input to `serde_json`; compatibility keeps `loads` on
+`JSONDecodeError`, while `sifr.json.validate_integer_digit_limits` exposes the
+typed `JsonLimitError` boundary directly.
 
 Recommended writing profiles:
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -480,6 +480,7 @@ Validation:
 - [x] INT-5 runtime JSON integer profile machinery review satisfied after adding `sifr_runtime::json` exact/web/string profile helpers, JS-safe integer enforcement, digit-limit validation, canonical builtin error registration, and focused runtime/e2e coverage: `reviews/integer-model-int-5-json-profile-runtime-review-pass-1.md`; PR #1890.
 - [x] INT-5 stdlib JSON profile wrapper review satisfied after exposing `dumps_exact`, `dumps_web`, and `dumps_string_ints` through the current `sifr.json` `JsonValue` boundary with recursive runtime-profile enforcement and focused e2e coverage: `reviews/integer-model-int-5-json-profile-stdlib-wrappers-review-pass-1.md`; PR #1891.
 - [x] INT-5 schema/client/generated-serde/storage boundary contract review satisfied after locking OpenAPI/JSON Schema mappings, TypeScript precision-safe client types, generated serde profile routing, SQL/storage explicit representation rules, and the `SIFR-INT-0009` diagnostic contract: `reviews/integer-model-int-5-schema-boundary-contracts-review-pass-1.md`; PR #1892.
+- [x] INT-5 JSON load digit-limit review satisfied after adding runtime JSON integer-token scanning, pre-`serde_json` `json_loads` budget enforcement, a typed `sifr.json.validate_integer_digit_limits` `JsonLimitError` boundary, and quick-lane fixture coverage: `reviews/integer-model-int-5-json-load-digit-limits-review-pass-1.md`; PR #1893.
 
 ## Implementation Checklist
 
@@ -563,7 +564,8 @@ Validation:
 - [ ] INT-5 serialization, web, and schema boundaries
   - [x] Shared runtime JSON integer profile primitives now live in `sifr_runtime::json`: `json.exact` emits exact integer numbers, `json.web` rejects JavaScript-unsafe JSON numbers with `JsonIntegerRangeError`, and `json.string_ints` emits decimal strings. `JsonIntegerRangeError` and `JsonLimitError` are registered as builtin errors and covered by runtime/e2e tests; review is satisfied and quick validation is passing: PR #1890.
   - [x] Current `sifr.json` `JsonValue` serialization exposes explicit `dumps_exact`, `dumps_web`, and `dumps_string_ints` wrappers. The wrappers call the shared runtime profile policy through codegen intrinsics, apply the selected integer profile recursively to nested arrays/objects, and report `JsonIntegerRangeError` paths such as `$.items[1]`; review is satisfied and quick validation is passing: PR #1891.
-- [x] OpenAPI/JSON Schema, TypeScript client, generated serde, SQL/storage, and `SIFR-INT-0009` boundary rules are locked in `verification/integer_model_serialization_boundary_contract.md`; review is satisfied and quick validation is passing: PR #1892.
+  - [x] OpenAPI/JSON Schema, TypeScript client, generated serde, SQL/storage, and `SIFR-INT-0009` boundary rules are locked in `verification/integer_model_serialization_boundary_contract.md`; review is satisfied and quick validation is passing: PR #1892.
+  - [x] JSON input integer tokens are scanned against `DEFAULT_JSON_INTEGER_DIGIT_LIMIT` before `serde_json` parsing, and `sifr.json.validate_integer_digit_limits` exposes typed `JsonLimitError` validation for callers that need the explicit limit boundary; review is satisfied and quick validation is passing: PR #1893.
 - [ ] INT-6A dtype contract lock
 - [ ] INT-6B deferred dtype runtime integration
 - [ ] INT-7 diagnostics, documentation, and migration cleanup

--- a/lib/sifr/json.sifr
+++ b/lib/sifr/json.sifr
@@ -6,6 +6,7 @@ from _sifr.json import (
     json_dumps_value_string_ints,
     json_dumps_value_web,
     json_loads,
+    json_validate_integer_digit_limits,
 )
 from sifr.io import FileHandle
 
@@ -224,6 +225,10 @@ def from_object(items: list[tuple[str, JsonValue]]) -> JsonValue:
 
 def loads(s: str) -> Result[JsonValue, JSONDecodeError]:
     return json_loads(s)
+
+
+def validate_integer_digit_limits(s: str) -> Result[None, JsonLimitError]:
+    return json_validate_integer_digit_limits(s)
 
 
 def _decode_loaded_json(content: str) -> Result[JsonValue, Error]:

--- a/reviews/integer-model-int-5-json-load-digit-limits-review-pass-1.md
+++ b/reviews/integer-model-int-5-json-load-digit-limits-review-pass-1.md
@@ -1,0 +1,82 @@
+
+
+Review complete. The implementation is sound. No blockers found.
+
+---
+
+## INT-5 JSON Load Digit-Limit Slice Review
+
+### Verdict: Satisfied
+
+The slice correctly implements the INT-5 scope: parser digit limits and typed errors for untrusted JSON integer tokens.
+
+---
+
+### What was reviewed
+
+| File | Changes |
+|------|---------|
+| `sifr_runtime/src/json.rs` | `validate_json_integer_digit_limits` scanner, `JsonLimitError` type |
+| `sifr_codegen/src/intrinsics/json.rs` | `lower_json_loads`, `lower_json_validate_integer_digit_limits` |
+| `sifr_codegen/src/intrinsics/mod.rs` | Registry entries with `sifr_runtime` in `additional_required_crates` |
+| `sifr_hir/src/stdlib/io_json.rs` | `validate_integer_digit_limits` wrapper, `JsonLimitError` type definition |
+| `lib/sifr/json.sifr` | `validate_integer_digit_limits` public API |
+| `crates/sifr/tests/e2e/pass/stdlib_json_consolidated.sifr` | Quick-lane fixture coverage |
+
+---
+
+### Implementation correctness
+
+**Scanner** (`validate_json_integer_digit_limits`, json.rs:163-207)
+- Correctly skips strings before scanning number tokens
+- `is_json_number_start_context` correctly identifies `[{` or `,` prefixes
+- Integer-token termination is correct: `,`, `]`, `}`, or whitespace
+- Fraction/exponent tokens delegate to `skip_json_number_suffix`
+- `digit_count` computed from unsigned portion (sign not counted)
+
+**Codegen wiring** (json.rs:463-754)
+- `json_loads` calls `validate_json_integer_digit_limits` *before* `serde_json::from_str`
+- `JsonLimitError` is converted to `JSONDecodeError` via `__sifr_json_limit_error_as_decode_error`
+- `json_validate_integer_digit_limits` returns `JsonLimitError` directly
+- Both intrinsics declare `sifr_runtime` in `additional_required_crates`
+
+**Type system** (mod.rs:40-50, 114-121)
+- `JsonLimitError` has `message: str`, `limit: int`, parent `Error`
+- `json_validate_integer_digit_limits` has `str -> Result[None, JsonLimitError]`
+
+**Boundary contract alignment**
+- `DEFAULT_JSON_INTEGER_DIGIT_LIMIT = DEFAULT_MAX_INTEGER_DIGITS = 4096` ✓
+- `JsonLimitError` for digit budget violations ✓
+- `JsonIntegerRangeError` for profile-enforced range violations ✓
+- Doc contract: "untrusted integer token budget violations return `JsonLimitError`" ✓
+
+---
+
+### Edge cases noted (acceptable)
+
+**`+`-prefixed numbers** (json.rs:177): The scanner counts `+` as a digit character and would not terminate the integer token at `+`. However, `+` is not valid JSON, so `serde_json` will reject it. The error still surfaces (as `JSONDecodeError` from the parse phase), just not with the digit-limit message. This is acceptable for the INT-5 scope.
+
+**Leading zeros**: `01` has `digit_count = 2`. This is correct behavior — the scanner enforces digit budget, not JSON spec compliance. `serde_json` handles the parse error.
+
+---
+
+### Test coverage
+
+| Test | Purpose |
+|------|---------|
+| `json_digit_limit_rejects_integer_tokens_outside_strings` | Over-budget int outside string ✓ |
+| `json_digit_limit_ignores_string_digits_and_fractional_numbers` | Strings/exponents not counted ✓ |
+| `json_digit_limit_checks_nested_array_numbers` | Nested structures ✓ |
+| `integer_token_limit_ignores_sign_and_enforces_digits` | Sign not counted ✓ |
+| `integer_token_limit_rejects_non_integer_tokens` | `12.0` rejected ✓ |
+| `e2e: stdlib_json_consolidated.sifr` | Quick-lane fixture ✓ |
+
+---
+
+### Pre-existing issues (unrelated to this slice)
+
+Clippy errors in `function_emitter.rs:1309,1325,1517` — `filter_map_bool_then` — exist in `sifr_codegen` but are not introduced by this slice.
+
+---
+
+### No blockers. Slice is acceptable as one INT-5 milestone PR.


### PR DESCRIPTION
## Summary
- Add runtime scanning for JSON integer number tokens before serde_json parsing.
- Wire json_loads to enforce DEFAULT_JSON_INTEGER_DIGIT_LIMIT and expose sifr.json.validate_integer_digit_limits for typed JsonLimitError validation.
- Add quick-lane JSON fixture coverage and record the satisfied reviewer artifact.

## Validation
- cargo test -p sifr_runtime json -- --nocapture
- cargo test -p sifr_codegen lowers_json_intrinsics_with_dependency_metadata -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_json_consolidated.sifr
- scripts/run_all_tests.sh --profile quick
- git diff --check