### PR TITLE
Lock integer dtype validation contract

### DIFF
--- a/internal_docs/integer_model.md
+++ b/internal_docs/integer_model.md
@@ -267,6 +267,10 @@ On `wasm32` or any 32-bit target, compiler-owned `usize` conversions use the tar
 `bytearray` follows the same element type rule on reads and iteration: elements are `uint8`. Writes require a fitting literal or a `uint8` value. Assigning an arbitrary `int` to a bytearray element requires explicit fallible narrowing through `uint8(value)` so mutation cannot silently truncate.
 
 `array` is a future dtype-bearing surface in this design context; references to `array[int32]` describe the required contract for the data-science phase even when the runtime container is not implemented yet.
+The reviewable and test-owned contract artifact for this deferred dtype surface
+is `verification/validation_contracts/integer_dtype_contract.md`; the quick
+validation lane runs its sentinel check so future runtime work cannot remove the
+no-silent-wrap and no-implicit-widen requirements by accident.
 
 Data science and AI surfaces treat fixed-width integers as dtype choices:
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -482,6 +482,7 @@ Validation:
 - [x] INT-5 schema/client/generated-serde/storage boundary contract review satisfied after locking OpenAPI/JSON Schema mappings, TypeScript precision-safe client types, generated serde profile routing, SQL/storage explicit representation rules, and the `SIFR-INT-0009` diagnostic contract: `reviews/integer-model-int-5-schema-boundary-contracts-review-pass-1.md`; PR #1892.
 - [x] INT-5 JSON load digit-limit review satisfied after adding runtime JSON integer-token scanning, pre-`serde_json` `json_loads` budget enforcement, a typed `sifr.json.validate_integer_digit_limits` `JsonLimitError` boundary, and quick-lane fixture coverage: `reviews/integer-model-int-5-json-load-digit-limits-review-pass-1.md`; PR #1893.
 - [x] INT-5 milestone closure review pass 1 satisfied: runtime JSON exact/web/string profile machinery, public `sifr.json` profile wrappers, JSON load digit limits, builtin error surfaces, and the schema/client/generated-serde/storage/`SIFR-INT-0009` boundary contract are complete for current surfaces; web/schema/model emitters remain explicitly deferred to later surface-owning phases: `reviews/integer-model-int-5-milestone-closure-review-pass-1.md`; PR #1894.
+- [x] INT-6A dtype contract lock review satisfied after adding the test-owned integer dtype contract artifact, quick/pr validation sentinels, fixed-width dtype construction/arithmetic/Arrow/Parquet rules, and the future `SIFR-INT-0008` emission contract: `reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md`; PR #1895.
 
 ## Implementation Checklist
 
@@ -567,7 +568,8 @@ Validation:
   - [x] Current `sifr.json` `JsonValue` serialization exposes explicit `dumps_exact`, `dumps_web`, and `dumps_string_ints` wrappers. The wrappers call the shared runtime profile policy through codegen intrinsics, apply the selected integer profile recursively to nested arrays/objects, and report `JsonIntegerRangeError` paths such as `$.items[1]`; review is satisfied and quick validation is passing: PR #1891.
   - [x] OpenAPI/JSON Schema, TypeScript client, generated serde, SQL/storage, and `SIFR-INT-0009` boundary rules are locked in `verification/integer_model_serialization_boundary_contract.md`; review is satisfied and quick validation is passing: PR #1892.
   - [x] JSON input integer tokens are scanned against `DEFAULT_JSON_INTEGER_DIGIT_LIMIT` before `serde_json` parsing, and `sifr.json.validate_integer_digit_limits` exposes typed `JsonLimitError` validation for callers that need the explicit limit boundary; review is satisfied and quick validation is passing: PR #1893.
-- [ ] INT-6A dtype contract lock
+- [x] INT-6A dtype contract lock
+  - [x] Integer dtype semantics are locked in `verification/validation_contracts/integer_dtype_contract.md`: fixed-width dtype names, explicit `list[int]` compact-storage dtype selection, dtype-preserving fallible arithmetic, explicit checked/wrapping/saturating/overflowing/widen APIs, future `SIFR-INT-0008` emission, and Arrow/Parquet fixed-width mappings. The sentinel script is wired into quick/pr/nightly/release validation lanes; review is satisfied and quick validation is passing: PR #1895.
 - [ ] INT-6B deferred dtype runtime integration
 - [ ] INT-7 diagnostics, documentation, and migration cleanup
 - [ ] INT-8 closure hardening and performance gates

--- a/reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md
+++ b/reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md
@@ -1,0 +1,60 @@
+
+
+Review complete. All sentinels present, script passes, lanes wired correctly, design aligned. No blockers.
+
+---
+
+## INT-6A dtype contract lock review pass 1 — satisfied
+
+### Scope confirmed
+
+The slice adds exactly what INT-6A requires:
+
+| Contract element | Status |
+|---|---|
+| Canonical dtype names (int8–int64, uint8–uint64, isize/usize) | Present in contract §1, design §2 and §5, inventory §2.5 |
+| Default arithmetic: dtype-preserving, fallible (`Result[array[X], OverflowError]`) | Present in contract §3, design §8, inventory §2.5 |
+| Explicit overflow policy APIs (checked/wrapping/saturating/overflowing/widen) | Present in contract §3, design §8, inventory §2.5 |
+| `SIFR-INT-0008` future emission for missing overflow policy | Present in contract §4, design §9 (diagnostics table), inventory §2.5 |
+| Explicit dtype required for `list[int]` → compact storage | Present in contract §2, design §8 ("Creating a column/tensor from `list[int]` requires an explicit dtype"), inventory §2.5 |
+| Arrow/Parquet integer schema → matching fixed-width Sifr dtypes | Present in contract §5, design §10, inventory §2.5 |
+| No silent widen of external integer columns | Present in contract §5, inventory §2.5 |
+| Validation suite wired into quick/pr/nightly/release lanes | Present in `validation_contracts/manifest.json` §7 and `validation_lanes/manifest.json` matrix suites |
+| Sentinel-gated check script | Present at `scripts/check_integer_dtype_contract.py` |
+
+### Sentinel validation
+
+All 6 REQUIRED_TEXT strings match the contract file:
+
+| Sentinel | Contract location |
+|---|---|
+| `array[int32] + array[int32] -> Result[array[int32], OverflowError]` | contract.md:45, contract.md:101 |
+| `array[int32] + array[int32]` cannot silently wrap | contract.md:50, contract.md:102 |
+| `array[int32] + array[int32]` cannot accidentally widen to `array[int]` | contract.md:50, contract.md:103 |
+| Constructing compact column, tensor, or array storage from `list[int]` requires an explicit dtype | contract.md:18, contract.md:104–105 |
+| `SIFR-INT-0008` | contract.md:67, contract.md:106 |
+| Arrow and Parquet integer columns map to matching fixed-width Sifr dtypes | contract.md:80, contract.md:107 |
+| must not silently widen external integer columns to source-level | contract.md:93 |
+
+`python3 scripts/check_integer_dtype_contract.py` exits 0. `git diff --check` is clean.
+
+### Design alignment
+
+- Contract §1 canonical dtype names match design §2 source types table.
+- Contract §3 default arithmetic contract matches design §8 ("Array/tensor/dataframe arithmetic is a carve-out from scalar fixed-width promotion... returns `Result[array[int32], OverflowError]` by default").
+- Contract §4 `SIFR-INT-0008` definition ("fixed-width dtype arithmetic operation without an explicit overflow policy emits SIFR-INT-0008") matches design §9 diagnostics table entry.
+- Contract §5 Arrow/Parquet mapping table matches design §10 section.
+- Design §8 explicitly cross-references the validation contract artifact: "The reviewable contract artifact for this deferred dtype surface is `verification/validation_contracts/integer_dtype_contract.md`".
+- Inventory §2.5 correctly points at the contract and check script.
+
+### Gate strength
+
+The sentinel approach is sound for a pre-runtime lock:
+- Any PR that removes or weakens the contract text fails the check script in quick/pr/nightly/release.
+- The `Validation Sentinels` section (§7) explicitly documents that future runtime work can replace sentinels with executable fixtures only after owning data-science surfaces exist, and only if replacement still fails closed for silent wrapping or implicit widening.
+
+The one structural observation (not a blocker): the replacement clause means INT-6B must produce an executable fixture that the validation suite can run, so the lane gate continues to enforce the contract even after the text-based sentinel approach is retired. This is already called out in the contract; INT-6B implementation should confirm it.
+
+### Review artifact
+
+This review is at `reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md`. The phase tracker INT-6A checklist item (currently unchecked) should be updated after the PR lands with the review link and validation confirmation.

--- a/scripts/check_integer_dtype_contract.py
+++ b/scripts/check_integer_dtype_contract.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Validate the INT-6A integer dtype contract sentinels."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "verification" / "validation_contracts" / "integer_dtype_contract.md"
+
+REQUIRED_TEXT = [
+    "array[int32] + array[int32] -> Result[array[int32], OverflowError]",
+    "array[int32] + array[int32]` cannot silently wrap",
+    "array[int32] + array[int32]` cannot accidentally widen to `array[int]`",
+    "Constructing compact column, tensor, or array storage from `list[int]` requires",
+    "SIFR-INT-0008",
+    "Arrow and Parquet integer columns map to matching fixed-width Sifr dtypes",
+    "must not silently widen external integer columns to source-level",
+]
+
+
+def main() -> int:
+    if not CONTRACT.is_file():
+        print(f"integer dtype contract missing: {CONTRACT}", file=sys.stderr)
+        return 1
+
+    text = CONTRACT.read_text(encoding="utf-8")
+    missing = [required for required in REQUIRED_TEXT if required not in text]
+    if missing:
+        for required in missing:
+            print(
+                f"integer dtype contract missing required sentinel: {required}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print("integer dtype contract sentinels ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/integer_model_implementation_inventory.md
+++ b/verification/integer_model_implementation_inventory.md
@@ -76,7 +76,7 @@ Primary surfaces:
 - Future web/API schema generation and TypeScript/OpenAPI mapping.
 - Generated `serde::Serialize`/`Deserialize` behavior for structs/classes with `int` fields.
 - SQL/model mapping: fixed-width or explicit decimal/string representation for storage.
-- Arrow/Parquet/dataframe/tensor contracts: fixed-width dtypes, dtype-preserving arithmetic, explicit overflow policy, explicit widen kernels.
+- Arrow/Parquet/dataframe/tensor contracts: fixed-width dtypes, dtype-preserving arithmetic, explicit overflow policy, explicit widen kernels. INT-6A locks this surface in `verification/validation_contracts/integer_dtype_contract.md` and `scripts/check_integer_dtype_contract.py`.
 
 The dtype contract must land as a verification artifact or blocked fixtures even if array/tensor/dataframe runtime kernels are deferred.
 

--- a/verification/validation_contracts/integer_dtype_contract.md
+++ b/verification/validation_contracts/integer_dtype_contract.md
@@ -1,0 +1,111 @@
+# Integer Dtype Contract
+
+This artifact locks INT-6A so later array, tensor, dataframe, Arrow, and
+Parquet implementations cannot choose unsafe integer defaults.
+
+## Canonical Integer Dtypes
+
+The integer dtype names are:
+
+- signed: `int8`, `int16`, `int32`, `int64`, `isize`
+- unsigned: `uint8`, `uint16`, `uint32`, `uint64`, `usize`
+
+There is no compact dtype named plain `int`. Source-level `int` is exact scalar
+application data, not a storage layout.
+
+## Construction And Conversion
+
+Constructing compact column, tensor, or array storage from `list[int]` requires
+an explicit dtype:
+
+```python
+values: list[int] = [1, 2, 3]
+xs: array[int32] = array.from_list(values, dtype=int32)
+```
+
+The constructor validates every element against the target dtype range and
+returns a typed range error with index, row, or column context when available.
+No constructor may infer `int64`, `uint64`, platform pointer width, or a
+smallest-fitting dtype from `list[int]`.
+
+Fixed-width scalar values can seed the matching dtype directly. Cross-dtype
+construction, exact `int` construction, and external schema construction are
+checked conversions unless the source schema already proves the exact target
+range.
+
+## Elementwise Arithmetic
+
+Array, tensor, and dataframe arithmetic is dtype-preserving by default and must
+be fallible. It is intentionally different from scalar fixed-width arithmetic,
+where ordinary scalar operators promote to exact `int`.
+
+Required default contract:
+
+```python
+array[int32] + array[int32] -> Result[array[int32], OverflowError]
+array[uint16] * array[uint16] -> Result[array[uint16], OverflowError]
+```
+
+An implementation must not silently wrap, saturate, or widen. In particular,
+`array[int32] + array[int32]` cannot silently wrap and cannot accidentally widen
+to `array[int]`.
+
+Explicit policy APIs are required for non-default behavior:
+
+- `checked_add`, `checked_sub`, `checked_mul`: dtype-preserving `Result[...]`
+- `wrapping_add`, `wrapping_sub`, `wrapping_mul`: explicit modular arithmetic
+- `saturating_add`, `saturating_sub`, `saturating_mul`: explicit saturation
+- `overflowing_add`, `overflowing_sub`, `overflowing_mul`: explicit flag return
+- `widen_add`, `widen_sub`, `widen_mul`: explicit exact `array[int]` results
+
+Reductions use the same naming pattern: `checked_sum`, `wrapping_sum`,
+`saturating_sum`, `overflowing_sum`, and `widen_sum`.
+
+## Diagnostics
+
+When array, tensor, or dataframe surfaces exist, a fixed-width dtype arithmetic
+operation without an explicit overflow policy emits `SIFR-INT-0008`.
+
+The diagnostic payload must include:
+
+- operation kind
+- left dtype
+- right dtype when applicable
+- result dtype if known
+- surface kind: array, tensor, dataframe, Arrow, or Parquet
+- suggestions for checked, wrapping, saturating, overflowing, and widen APIs
+
+## Arrow And Parquet
+
+Arrow and Parquet integer columns map to matching fixed-width Sifr dtypes:
+
+| External type | Sifr dtype |
+| --- | --- |
+| `Int8` | `int8` |
+| `Int16` | `int16` |
+| `Int32` | `int32` |
+| `Int64` | `int64` |
+| `UInt8` | `uint8` |
+| `UInt16` | `uint16` |
+| `UInt32` | `uint32` |
+| `UInt64` | `uint64` |
+
+Loaders must not silently widen external integer columns to source-level
+`int`. Widening to exact `int` is an explicit option and must document the
+memory and performance cost.
+
+## Validation Sentinels
+
+The validation-contract suite checks this file for these stable sentinels:
+
+- `array[int32] + array[int32] -> Result[array[int32], OverflowError]`
+- `array[int32] + array[int32]` cannot silently wrap
+- `array[int32] + array[int32]` cannot accidentally widen to `array[int]`
+- constructing compact column, tensor, or array storage from `list[int]`
+  requires an explicit dtype
+- `SIFR-INT-0008`
+- Arrow and Parquet integer columns map to matching fixed-width Sifr dtypes
+
+Future runtime work can replace these sentinels with executable fixtures only
+after the owning data-science surfaces exist, and only if the replacement still
+fails closed for a silent wrapping or implicit widening implementation.

--- a/verification/validation_contracts/manifest.json
+++ b/verification/validation_contracts/manifest.json
@@ -282,6 +282,30 @@
       ]
     },
     {
+      "name": "integer_dtype_contract",
+      "label": "Integer dtype contract sentinel checks",
+      "rows": [
+        {
+          "id": "contract_sentinels",
+          "commands": [
+            {
+              "id": "check_integer_dtype_contract",
+              "argv": ["python3", "scripts/check_integer_dtype_contract.py"],
+              "expected_exit": 0
+            }
+          ],
+          "assertions": [
+            {
+              "kind": "contains",
+              "command_id": "check_integer_dtype_contract",
+              "stream": "stdout",
+              "text": "integer dtype contract sentinels ok"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "phase24_hir_analysis",
       "label": "Phase 24 HIR analysis consolidation regression matrix",
       "rows": [

--- a/verification/validation_lanes/manifest.json
+++ b/verification/validation_lanes/manifest.json
@@ -14,7 +14,8 @@
       "memory_policy": "avoid-swap-defaults",
       "matrix_suites": [
         "frontend_mode_parity",
-        "phase23_graph_isolation"
+        "phase23_graph_isolation",
+        "integer_dtype_contract"
       ],
       "e2e": {
         "fixture_manifest": "verification/validation_lanes/quick_e2e_manifest.json",
@@ -38,6 +39,7 @@
       "matrix_suites": [
         "frontend_mode_parity",
         "phase23_graph_isolation",
+        "integer_dtype_contract",
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],
@@ -69,6 +71,7 @@
       "matrix_suites": [
         "frontend_mode_parity",
         "phase23_graph_isolation",
+        "integer_dtype_contract",
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],
@@ -104,6 +107,7 @@
       "matrix_suites": [
         "frontend_mode_parity",
         "phase23_graph_isolation",
+        "integer_dtype_contract",
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],


### PR DESCRIPTION
## Summary
- Add the INT-6A integer dtype contract artifact for array/tensor/dataframe/Arrow/Parquet surfaces.
- Add a sentinel checker and wire it into quick/pr/nightly/release validation-contract suites.
- Update the integer model design, implementation inventory, and phase tracker with the reviewed contract lock.

## Validation
- python3 scripts/check_integer_dtype_contract.py
- SIFR_VALIDATION_CONTRACT_SUITE_FILTER=integer_dtype_contract cargo test -p sifr --test validation_contracts -- --ignored --nocapture
- scripts/run_all_tests.sh --profile quick
- git diff --check