### PR TITLE
Close INT-6B deferred dtype runtime milestone

### DIFF
--- a/internal_docs/phases/42_data_science_ml.md
+++ b/internal_docs/phases/42_data_science_ml.md
@@ -26,6 +26,7 @@ Add data science and ML capabilities after the web framework phase, while preser
 
 ## Quality Contract
 - Entry criteria: Phase 41 is completed and prior reliability/diagnostics guarantees remain green.
+- DataFrame, Arrow/Parquet, tensor, and array integer dtype work must satisfy the integer dtype contract in `verification/validation_contracts/integer_dtype_contract.md`: fixed-width external integer columns map to matching Sifr dtypes, compact storage from `list[int]` requires an explicit dtype, fixed-width dtype arithmetic is fallible and dtype-preserving by default, and explicit checked/wrapping/saturating/overflowing/widen APIs are required.
 - Phase 27 non-regression baseline is required at phase start and must remain green through completion.
 - Phase 27 non-regression invariants that must hold in this phase include: no user-triggerable panic paths; no data-dependent emitted `.unwrap()` / `.expect()` / `panic!` in user runtime paths; stable diagnostic contract (codes, severity, spans, URLs, suggestions, schema); canonical/lossless `json` diagnostics with `human` and `compact` as renderer views only; enforced recovery limits with deterministic ordering; and enforced exit-code and CLI stability contracts (`0/1/2/3`, and unknown `--diagnostic-format` exits `2` before semantic work).
 - Any milestone that regresses these invariants is incomplete, even if its local scope passes.

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -483,6 +483,7 @@ Validation:
 - [x] INT-5 JSON load digit-limit review satisfied after adding runtime JSON integer-token scanning, pre-`serde_json` `json_loads` budget enforcement, a typed `sifr.json.validate_integer_digit_limits` `JsonLimitError` boundary, and quick-lane fixture coverage: `reviews/integer-model-int-5-json-load-digit-limits-review-pass-1.md`; PR #1893.
 - [x] INT-5 milestone closure review pass 1 satisfied: runtime JSON exact/web/string profile machinery, public `sifr.json` profile wrappers, JSON load digit limits, builtin error surfaces, and the schema/client/generated-serde/storage/`SIFR-INT-0009` boundary contract are complete for current surfaces; web/schema/model emitters remain explicitly deferred to later surface-owning phases: `reviews/integer-model-int-5-milestone-closure-review-pass-1.md`; PR #1894.
 - [x] INT-6A dtype contract lock review satisfied after adding the test-owned integer dtype contract artifact, quick/pr validation sentinels, fixed-width dtype construction/arithmetic/Arrow/Parquet rules, and the future `SIFR-INT-0008` emission contract: `reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md`; PR #1895.
+- [x] INT-6B deferred dtype runtime integration closure review satisfied: array, tensor, dataframe, and Arrow/Parquet runtime surfaces are Phase 42 scope; the INT-6A dtype contract is wired into quick/pr/nightly/release validation lanes and fails closed against silent wrapping or implicit widening until those owning surfaces exist: `reviews/integer-model-int-6b-deferred-runtime-closure-review-pass-1.md`; PR #1896.
 
 ## Implementation Checklist
 
@@ -570,6 +571,7 @@ Validation:
   - [x] JSON input integer tokens are scanned against `DEFAULT_JSON_INTEGER_DIGIT_LIMIT` before `serde_json` parsing, and `sifr.json.validate_integer_digit_limits` exposes typed `JsonLimitError` validation for callers that need the explicit limit boundary; review is satisfied and quick validation is passing: PR #1893.
 - [x] INT-6A dtype contract lock
   - [x] Integer dtype semantics are locked in `verification/validation_contracts/integer_dtype_contract.md`: fixed-width dtype names, explicit `list[int]` compact-storage dtype selection, dtype-preserving fallible arithmetic, explicit checked/wrapping/saturating/overflowing/widen APIs, future `SIFR-INT-0008` emission, and Arrow/Parquet fixed-width mappings. The sentinel script is wired into quick/pr/nightly/release validation lanes; review is satisfied and quick validation is passing: PR #1895.
-- [ ] INT-6B deferred dtype runtime integration
+- [x] INT-6B deferred dtype runtime integration
+  - [x] Runtime array/tensor/dataframe kernels and Arrow/Parquet loaders are deferred to Phase 42, where the owning data-science surfaces are planned. This phase now closes the milestone by linking the future owner and relying on the INT-6A validation contract to preserve dtype-preserving fallible arithmetic, explicit overflow policy APIs, explicit widening, fixed-width external schema mapping, and future `SIFR-INT-0008` emission until implementation surfaces exist: PR #1896.
 - [ ] INT-7 diagnostics, documentation, and migration cleanup
 - [ ] INT-8 closure hardening and performance gates

--- a/reviews/integer-model-int-6b-deferred-runtime-closure-review-pass-1.md
+++ b/reviews/integer-model-int-6b-deferred-runtime-closure-review-pass-1.md
@@ -1,0 +1,54 @@
+
+
+## INT-6B Phase/Milestone Closure Review
+
+### Verdict: SATISFIED
+
+INT-6B can be closed. There are no concrete blockers. The runtime kernels and loaders are legitimately deferred because the owning data-science surfaces (Phase 42: DataFrame, Parquet, tensor, array) do not yet exist, and Phase 42 depends on Phase 41 which is not yet complete. The INT-6A validation contract already fails closed against silent wrapping or implicit widening, and the quick/pr/nightly/release validation lanes all run the sentinel check.
+
+---
+
+### Non-Blocking Findings
+
+**N-1: INT-6A checklist item text is inaccurate.**  
+The INT-6A checklist entry at `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md:572` reads "review is satisfied and quick validation is passing: PR #1895." This conflates INT-6A's own review artifact with INT-6B's closure work. Before closing INT-6B, update the checklist entry to cross-reference INT-6A's completed review and state the deferred scope.
+
+**N-2: No `SIFR-INT-0008` implementation exists yet.**  
+`SIFR-INT-0008` (fixed-width array/tensor/dataframe arithmetic missing overflow policy) is reserved in the diagnostic inventory and referenced in the contract, but has no active implementation. The contract correctly notes the diagnostic fires "once those surfaces exist." The INT-6B checklist item should record this as explicitly deferred, not implied.
+
+**N-3: Phase 42 dependency is untracked.**  
+`internal_docs/phases/42_data_science_ml.md` states it depends on Phase 41. There is no cross-reference in the integer model tracking from INT-6B to the Phase 42 milestone that will eventually own array/tensor/dataframe runtime surfaces. Consider adding a tracking note in the issue checklist or the phase doc linking the dtype arithmetic work to its Phase 42 consumer.
+
+---
+
+### Blocking Findings
+
+None.
+
+---
+
+### Closable Scope Confirmation
+
+| INT-6B Acceptance Criterion | Status |
+|---|---|
+| Runtime kernels satisfy INT-6A contract | **Deferred** — array/tensor/dataframe surfaces do not exist yet (Phase 42 pending Phase 41). No blocking implementation exists to close. |
+| Wrapping/saturating/overflowing/widen kernels are explicit | **Deferred** — same as above. INT-6A contract locks the requirement; no surface exists yet. |
+| Loading external integer columns does not silently widen | **Deferred** — same as above. INT-6A contract locks the Arrow/Parquet mapping table. |
+
+The sentinel script `scripts/check_integer_dtype_contract.py` confirms all six INT-6A required sentinels are present. Quick validation passes.
+
+---
+
+### Recommended Closure PR Edits
+
+1. **Issue checklist**: Mark INT-6B `[x] complete` with a note: *"Deferred: owning array/tensor/dataframe surfaces are Phase 42 scope. INT-6A validation contract is wired into all validation lanes and fails closed for silent wrap/implicit widen."*
+
+2. **Review history**: Add a cross-reference to this closure review pass and the INT-6A review artifact.
+
+3. **Phase 42 doc**: Optionally add a cross-reference to `verification/validation_contracts/integer_dtype_contract.md` as a Phase 42 entry dependency.
+
+---
+
+### Statement for Issue Review History
+
+> INT-6B deferred dtype runtime integration milestone closure review: array, tensor, dataframe, and Arrow/Parquet runtime surfaces are owned by Phase 42 (Data Science and ML), which depends on Phase 41. The INT-6A dtype contract validation artifact (`verification/validation_contracts/integer_dtype_contract.md`) is wired into quick/pr/nightly/release validation lanes, the sentinel script passes, and the contract fails closed against silent wrapping or implicit widening. No blocking implementation exists because the owning runtime surfaces do not exist. INT-6B is satisfiably closed; actual kernel and loader implementation is deferred to Phase 42. Non-blocking notes: INT-6A checklist text should be updated for cross-reference accuracy; `SIFR-INT-0008` remains deferred until surfaces exist; Phase 42 dependency is untracked from the integer model.


### PR DESCRIPTION
## Summary
- Record the INT-6B Claude closure review verdict as satisfied
- Mark INT-6B complete as deferred to Phase 42 owning data-science surfaces
- Link Phase 42 data/tensor/Arrow/Parquet work to the integer dtype contract

## Validation
- git diff --check
- scripts/run_all_tests.sh --profile quick