### PR TITLE
Reserve remaining integer diagnostic codes

### DIFF
--- a/crates/sifr_diagnostics/src/codes.rs
+++ b/crates/sifr_diagnostics/src/codes.rs
@@ -394,6 +394,26 @@ pub const DIAGNOSTIC_REGISTRY: &[DiagnosticRegistryEntry] = &[
     reserved_family_base("SIFR-TYPE-0000", "TYPE"),
     reserved_family_base("SIFR-DECIMAL-0000", "DECIMAL"),
     reserved_family_base("SIFR-INT-0000", "INT"),
+    reserved_code(
+        "SIFR-INT-0002",
+        "INT",
+        "Reserved for implicit narrowing from exact or fixed-width integer sources to narrower fixed-width targets.",
+    ),
+    reserved_code(
+        "SIFR-INT-0008",
+        "INT",
+        "Reserved for fixed-width array, tensor, or dataframe arithmetic without an explicit overflow policy.",
+    ),
+    reserved_code(
+        "SIFR-INT-0009",
+        "INT",
+        "Reserved for JSON or web-safe integer serialization policy failures.",
+    ),
+    reserved_code(
+        "SIFR-INT-0010",
+        "INT",
+        "Reserved for bytes or bytearray construction and mutation values that do not fit uint8.",
+    ),
     reserved_family_base("SIFR-CALL-0000", "CALL"),
     reserved_family_base("SIFR-OWN-0000", "OWN"),
     reserved_family_base("SIFR-FLOW-0000", "FLOW"),
@@ -1718,10 +1738,22 @@ pub fn active_registry_entries() -> impl Iterator<Item = &'static DiagnosticRegi
 }
 
 const fn reserved_family_base(id: &'static str, family: &'static str) -> DiagnosticRegistryEntry {
+    reserved_code(
+        id,
+        family,
+        "Reserved family base; not emitted as a diagnostic.",
+    )
+}
+
+const fn reserved_code(
+    id: &'static str,
+    family: &'static str,
+    summary: &'static str,
+) -> DiagnosticRegistryEntry {
     DiagnosticRegistryEntry {
         id,
         family,
-        summary: "Reserved family base; not emitted as a diagnostic.",
+        summary,
         state: DiagnosticState::Reserved,
         docs_path: "docs/errors/diagnostic-codes.md",
         representative_fixture_path: None,

--- a/docs/errors/diagnostic-codes.md
+++ b/docs/errors/diagnostic-codes.md
@@ -150,6 +150,10 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-TYPE-0000` | `TYPE` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-DECIMAL-0000` | `DECIMAL` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-INT-0000` | `INT` | Reserved family base; not emitted as a diagnostic. |
+| `SIFR-INT-0002` | `INT` | Reserved for implicit narrowing from exact or fixed-width integer sources to narrower fixed-width targets. |
+| `SIFR-INT-0008` | `INT` | Reserved for fixed-width array, tensor, or dataframe arithmetic without an explicit overflow policy. |
+| `SIFR-INT-0009` | `INT` | Reserved for JSON or web-safe integer serialization policy failures. |
+| `SIFR-INT-0010` | `INT` | Reserved for bytes or bytearray construction and mutation values that do not fit uint8. |
 | `SIFR-CALL-0000` | `CALL` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-OWN-0000` | `OWN` | Reserved family base; not emitted as a diagnostic. |
 | `SIFR-FLOW-0000` | `FLOW` | Reserved family base; not emitted as a diagnostic. |

--- a/internal_docs/diagnostic_codes.md
+++ b/internal_docs/diagnostic_codes.md
@@ -46,6 +46,10 @@ Tooling metadata defaults: `tool_actions` is empty, `fix_all_eligible` is `false
 | `SIFR-TYPE-0000` | `TYPE` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-DECIMAL-0000` | `DECIMAL` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-INT-0000` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-INT-0002` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-INT-0008` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-INT-0009` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
+| `SIFR-INT-0010` | `INT` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-CALL-0000` | `CALL` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-OWN-0000` | `OWN` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |
 | `SIFR-FLOW-0000` | `FLOW` | Reserved | n/a | `docs/errors/diagnostic-codes.md` | n/a | n/a | n/a | n/a | n/a | n/a | false |

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -484,6 +484,7 @@ Validation:
 - [x] INT-5 milestone closure review pass 1 satisfied: runtime JSON exact/web/string profile machinery, public `sifr.json` profile wrappers, JSON load digit limits, builtin error surfaces, and the schema/client/generated-serde/storage/`SIFR-INT-0009` boundary contract are complete for current surfaces; web/schema/model emitters remain explicitly deferred to later surface-owning phases: `reviews/integer-model-int-5-milestone-closure-review-pass-1.md`; PR #1894.
 - [x] INT-6A dtype contract lock review satisfied after adding the test-owned integer dtype contract artifact, quick/pr validation sentinels, fixed-width dtype construction/arithmetic/Arrow/Parquet rules, and the future `SIFR-INT-0008` emission contract: `reviews/integer-model-int-6a-dtype-contract-lock-review-pass-1.md`; PR #1895.
 - [x] INT-6B deferred dtype runtime integration closure review satisfied: array, tensor, dataframe, and Arrow/Parquet runtime surfaces are Phase 42 scope; the INT-6A dtype contract is wired into quick/pr/nightly/release validation lanes and fails closed against silent wrapping or implicit widening until those owning surfaces exist: `reviews/integer-model-int-6b-deferred-runtime-closure-review-pass-1.md`; PR #1896.
+- [x] INT-7 diagnostic family reservation wave 1 review satisfied after adding reserved non-emittable registry entries for `SIFR-INT-0002`, `SIFR-INT-0008`, `SIFR-INT-0009`, and `SIFR-INT-0010`, completing public/internal documentation coverage for `SIFR-INT-0001..0011`: `reviews/integer-model-int-7-diagnostic-family-reservation-review-pass-1.md`; PR #1897.
 
 ## Implementation Checklist
 
@@ -574,4 +575,5 @@ Validation:
 - [x] INT-6B deferred dtype runtime integration
   - [x] Runtime array/tensor/dataframe kernels and Arrow/Parquet loaders are deferred to Phase 42, where the owning data-science surfaces are planned. This phase now closes the milestone by linking the future owner and relying on the INT-6A validation contract to preserve dtype-preserving fallible arithmetic, explicit overflow policy APIs, explicit widening, fixed-width external schema mapping, and future `SIFR-INT-0008` emission until implementation surfaces exist: PR #1896.
 - [ ] INT-7 diagnostics, documentation, and migration cleanup
+  - [x] Reserved and documented the remaining non-emittable integer diagnostic slots `SIFR-INT-0002`, `SIFR-INT-0008`, `SIFR-INT-0009`, and `SIFR-INT-0010`, so the generated public and internal diagnostic tables now account for every `SIFR-INT-0001..0011` family code: PR #1897.
 - [ ] INT-8 closure hardening and performance gates

--- a/reviews/integer-model-int-7-diagnostic-family-reservation-review-pass-1.md
+++ b/reviews/integer-model-int-7-diagnostic-family-reservation-review-pass-1.md
@@ -1,0 +1,50 @@
+
+
+## Review Verdict: **SATISFIED**
+
+---
+
+### Question 1: Correct to use `DiagnosticState::Reserved` without `DiagnosticCode` constants?
+
+**Yes.** The change correctly uses `reserved_code(...)` for SIFR-INT-0002, 0008, 0009, 0010 — each with `state: DiagnosticState::Reserved`, `declared_severity: None`, `message_template: None`, `owner_module: None`, and `representative_fixture_path: None`. This matches the established reserved-code pattern used for family bases and prevents accidental emission while the owning implementation milestones are deferred.
+
+---
+
+### Question 2: Are reserved summaries aligned with `internal_docs/integer_model.md` and `issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md`?
+
+**Yes.** Cross-reference against the diagnostics table in `internal_docs/integer_model.md` (lines 465–478):
+
+| Code | Design doc summary | This change summary | Match |
+|------|-------------------|---------------------|-------|
+| 0002 | implicit narrowing from exact/fixed source to narrower fixed-width target | "Reserved for implicit narrowing from exact or fixed-width integer sources to narrower fixed-width targets." | ✓ |
+| 0008 | fixed-width array/tensor/dataframe arithmetic missing overflow policy | "Reserved for fixed-width array, tensor, or dataframe arithmetic without an explicit overflow policy." | ✓ |
+| 0009 | JSON/web-safe integer serialization policy failure | "Reserved for JSON or web-safe integer serialization policy failures." | ✓ |
+| 0010 | bytearray/bytes construction or mutation requires fitting `uint8` | "Reserved for bytes or bytearray construction and mutation values that do not fit uint8." | ✓ |
+
+All four summaries match the design doc language. The INT-7 checklist item "Reserve and document the `SIFR-INT-0001..0011` diagnostic families listed in `internal_docs/integer_model.md`" is now satisfied.
+
+---
+
+### Question 3: Does this satisfy an appropriate INT-7 wave, or is there a blocker before PR?
+
+**No blocker.** This change is a clean INT-7 reservation wave:
+
+- Scope: add `reserved_code` entries for SIFR-INT-0002, 0008, 0009, 0010 and regenerate both doc files.
+- The refactor from `reserved_family_base` to a generalized `reserved_code` helper with a custom summary parameter is a non-breaking simplification.
+- No `DiagnosticCode` constants were added, no active diagnostic behavior changes, no generated code surface is affected.
+- Full INT family now has all 11 codes accounted for (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 — two active slots are absent: INT-0002 is reserved, INT-0008 through 0010 are reserved for deferred surfaces).
+- The reserved codes appear in both generated documentation files with consistent state, family, and summary columns.
+
+---
+
+### Non-Blocking Follow-Ups
+
+1. **`bytearray` surface still deferred**: SIFR-INT-0010 is reserved for `bytearray` construction/mutation values that do not fit `uint8`. The INT-4 milestone deferred `bytearray` work to a future slice (see INT-4 closure: "deferred `bytearray`/`SIFR-INT-0010` work remains a future-slice follow-up"). Track this as a follow-up, not a gap in this change.
+
+2. **INT-7 remaining scope**: The INT-7 checklist (migration cleanup, public docs updates, transition fixture removal) is not addressed by this reservation wave. That scope remains for a subsequent wave.
+
+---
+
+### Issue-Review-History Statement
+
+**INT-7 diagnostic family reservation wave 1 review:** 4 reserved `SIFR-INT-*` entries (0002, 0008, 0009, 0010) correctly use `DiagnosticState::Reserved` without `DiagnosticCode` constants; summaries align with `internal_docs/integer_model.md` diagnostic table and INT-7 checklist requirements; refactor of `reserved_code` helper is non-breaking; all `SIFR-INT-0001..0011` codes are now accounted for; no blocker before PR. Remaining INT-7 migration cleanup and docs work is a future wave.


### PR DESCRIPTION
## Summary
- Reserve non-emittable SIFR-INT-0002, 0008, 0009, and 0010 registry entries
- Regenerate public/internal diagnostic code tables so SIFR-INT-0001..0011 are all accounted for
- Record the INT-7 reviewer artifact and tracker subitem

## Validation
- cargo run -q -p sifr_diagnostics --bin gen-error-docs
- cargo test -p sifr_diagnostics
- python3 scripts/check_diagnostic_docs_sync.py
- python3 scripts/check_diagnostic_code_coverage.py
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick