### PR TITLE
Fix INT-8 clippy closure warnings

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -532,13 +532,13 @@ impl RustEmitter {
                 let value_is_sifr_int = self.is_sifr_int_expr(&value);
                 let value_is_sifr_int_result = self.is_sifr_int_result_expr(&value);
                 let (ty, value) =
-                    if is_legacy_i64_type(&ty) && (value_is_sifr_int || force_sifr_int) {
+                    if is_legacy_i64_type(ty.as_ref()) && (value_is_sifr_int || force_sifr_int) {
                         let value = self.coerce_expr_to_sifr_int_value(value);
                         self.sifr_int_local_bindings
                             .borrow_mut()
                             .insert(name.clone());
                         (Some(crate::RustType::Named("SifrInt".to_string())), value)
-                    } else if is_result_legacy_i64_type(&ty) && value_is_sifr_int_result {
+                    } else if is_result_legacy_i64_type(ty.as_ref()) && value_is_sifr_int_result {
                         self.sifr_int_result_local_bindings
                             .borrow_mut()
                             .insert(name.clone());
@@ -1567,7 +1567,7 @@ impl RustEmitter {
             } => self.is_sifr_int_result_expr(inner),
             crate::RustExpr::MethodCall {
                 receiver, method, ..
-            } if method == "ok_or_else" => self.is_sifr_int_checked_floor_option_expr(receiver),
+            } if method == "ok_or_else" => Self::is_sifr_int_checked_floor_option_expr(receiver),
             crate::RustExpr::MethodCall {
                 receiver, method, ..
             } => self.is_sifr_int_result_returning_method_call(receiver, method),
@@ -1580,7 +1580,7 @@ impl RustEmitter {
         }
     }
 
-    fn is_sifr_int_checked_floor_option_expr(&self, expr: &crate::RustExpr) -> bool {
+    fn is_sifr_int_checked_floor_option_expr(expr: &crate::RustExpr) -> bool {
         matches!(
             expr,
             crate::RustExpr::MethodCall {
@@ -1756,12 +1756,12 @@ fn is_sifr_int_operand_coercion_op(op: &str) -> bool {
     is_sifr_int_arithmetic_op(op) || is_sifr_int_comparison_op(op)
 }
 
-fn is_legacy_i64_type(ty: &Option<crate::RustType>) -> bool {
+fn is_legacy_i64_type(ty: Option<&crate::RustType>) -> bool {
     matches!(ty, Some(crate::RustType::I64))
         || matches!(ty, Some(crate::RustType::Named(name)) if name == "i64")
 }
 
-fn is_result_legacy_i64_type(ty: &Option<crate::RustType>) -> bool {
+fn is_result_legacy_i64_type(ty: Option<&crate::RustType>) -> bool {
     matches!(ty, Some(crate::RustType::Result(ok, _)) if is_legacy_i64_rust_type(ok))
         || matches!(ty, Some(crate::RustType::Named(name)) if name.starts_with("Result<i64, "))
 }

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -114,10 +114,8 @@ impl RustEmitter {
         let local_int_bindings = self
             .local_binding_types
             .iter()
-            .filter_map(|(name, ty)| {
-                matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
-                    .then(|| name.clone())
-            })
+            .filter(|(_, ty)| matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int))
+            .map(|(name, _)| name.clone())
             .collect::<HashSet<_>>();
         if local_int_bindings.is_empty() {
             return;
@@ -191,10 +189,10 @@ impl RustEmitter {
             let discovered = module
                 .functions
                 .iter()
-                .filter_map(|func| {
+                .filter(|func| {
                     let extra_forced_params =
                         collect_sifr_int_function_param_names(func, &function_params);
-                    (matches!(
+                    matches!(
                         crate::resolve_alias_type_for_plain_call(&func.return_type),
                         Type::Int
                     ) && hir_function_returns_sifr_int_with_extra_forced(
@@ -202,46 +200,49 @@ impl RustEmitter {
                         &module_sifr_int_bindings,
                         &function_returns,
                         &extra_forced_params,
-                    ))
-                    .then(|| func.name.clone())
+                    )
                 })
+                .map(|func| func.name.clone())
                 .collect::<Vec<_>>();
             function_returns.extend(discovered);
             let discovered_result_returns = module
                 .functions
                 .iter()
-                .filter_map(|func| {
-                    (function_returns_result_sifr_int(
+                .filter(|func| {
+                    function_returns_result_sifr_int(
                         func,
                         &result_function_returns,
                         &result_method_returns,
                         &result_function_params,
                         collect_sifr_int_result_function_param_names(func, &result_function_params),
-                    ))
-                    .then(|| func.name.clone())
+                    )
                 })
+                .map(|func| func.name.clone())
                 .collect::<Vec<_>>();
             result_function_returns.extend(discovered_result_returns);
             let discovered_result_method_returns = module
                 .classes
                 .iter()
                 .flat_map(|class| {
-                    class.methods.iter().filter_map(|method| {
-                        let method_key = result_method_key(&class.name, &method.name);
-                        let result_param_bindings = collect_sifr_int_result_method_param_names(
-                            method,
-                            &method_key,
-                            &result_method_params,
-                        );
-                        function_returns_result_sifr_int(
-                            method,
-                            &result_function_returns,
-                            &result_method_returns,
-                            &result_function_params,
-                            result_param_bindings,
-                        )
-                        .then(|| result_method_key(&class.name, &method.name))
-                    })
+                    class
+                        .methods
+                        .iter()
+                        .filter(|method| {
+                            let method_key = result_method_key(&class.name, &method.name);
+                            let result_param_bindings = collect_sifr_int_result_method_param_names(
+                                method,
+                                &method_key,
+                                &result_method_params,
+                            );
+                            function_returns_result_sifr_int(
+                                method,
+                                &result_function_returns,
+                                &result_method_returns,
+                                &result_function_params,
+                                result_param_bindings,
+                            )
+                        })
+                        .map(|method| result_method_key(&class.name, &method.name))
                 })
                 .collect::<Vec<_>>();
             result_method_returns.extend(discovered_result_method_returns);
@@ -356,11 +357,11 @@ impl RustEmitter {
     fn module_sifr_int_bindings(&self) -> HashSet<String> {
         self.module_constants
             .iter()
-            .filter_map(|(name, (ty, rust_name))| {
-                (matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
-                    && rust_name.ends_with("()"))
-                .then(|| name.clone())
+            .filter(|(_, (ty, rust_name))| {
+                matches!(crate::resolve_alias_type_for_plain_call(ty), Type::Int)
+                    && rust_name.ends_with("()")
             })
+            .map(|(name, _)| name.clone())
             .collect::<HashSet<_>>()
     }
 
@@ -450,10 +451,8 @@ impl RustEmitter {
         );
         let sifr_int_recursive_captures = recursive_captures
             .iter()
-            .filter_map(|capture| {
-                self.recursive_capture_lowers_to_sifr_int(capture)
-                    .then(|| capture.name.clone())
-            })
+            .filter(|capture| self.recursive_capture_lowers_to_sifr_int(capture))
+            .map(|capture| capture.name.clone())
             .collect::<HashSet<_>>();
         let mut sifr_int_nested_capture_bindings = sifr_int_recursive_captures.clone();
         sifr_int_nested_capture_bindings.extend(sifr_int_captured_forced_locals.iter().cloned());
@@ -1306,7 +1305,8 @@ fn collect_sifr_int_result_function_param_names(
     func.params
         .iter()
         .enumerate()
-        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .filter(|(idx, _)| indexes.contains(idx))
+        .map(|(_, param)| param.name.clone())
         .collect()
 }
 
@@ -1322,7 +1322,8 @@ fn collect_sifr_int_result_method_param_names(
         .params
         .iter()
         .enumerate()
-        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .filter(|(idx, _)| indexes.contains(idx))
+        .map(|(_, param)| param.name.clone())
         .collect()
 }
 
@@ -1514,7 +1515,8 @@ fn collect_sifr_int_function_param_names(
     func.params
         .iter()
         .enumerate()
-        .filter_map(|(idx, param)| indexes.contains(&idx).then(|| param.name.clone()))
+        .filter(|(idx, _)| indexes.contains(idx))
+        .map(|(_, param)| param.name.clone())
         .collect()
 }
 
@@ -1712,14 +1714,14 @@ fn collect_nested_sifr_int_function_returns(
         let before = function_returns.len();
         let discovered = nested_functions
             .iter()
-            .filter_map(|func| {
+            .filter(|func| {
                 let captured_forced =
                     collect_sifr_int_captured_forced_locals(func, outer_forced_locals);
                 let captured_shadowed = collect_sifr_int_captured_shadowed_module_bindings(
                     func,
                     outer_shadowed_module_bindings,
                 );
-                (matches!(
+                matches!(
                     crate::resolve_alias_type_for_plain_call(&func.return_type),
                     Type::Int
                 ) && hir_function_returns_sifr_int_with_extra_forced_and_shadowed(
@@ -1728,9 +1730,9 @@ fn collect_nested_sifr_int_function_returns(
                     &function_returns,
                     &captured_forced,
                     &captured_shadowed,
-                ))
-                .then(|| func.name.clone())
+                )
             })
+            .map(|func| func.name.clone())
             .collect::<Vec<_>>();
         function_returns.extend(discovered);
         if function_returns.len() == before {
@@ -1772,12 +1774,12 @@ fn collect_captured_outer_names(
     let locally_defined = collect_locally_defined_vars(&func.body);
     collect_referenced_vars_with_types(&func.body)
         .into_iter()
-        .filter_map(|(name, _)| {
-            (!param_names.contains(&name)
-                && !locally_defined.contains(&name)
-                && outer_names.contains(&name))
-            .then_some(name)
+        .filter(|(name, _)| {
+            !param_names.contains(name)
+                && !locally_defined.contains(name)
+                && outer_names.contains(name)
         })
+        .map(|(name, _)| name)
         .collect()
 }
 

--- a/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
+++ b/issues/ad-hoc-integer-model-and-fixed-width-numeric-contract.md
@@ -490,6 +490,7 @@ Validation:
 - [x] INT-7 transition fixture quarantine review satisfied after removing `bigint_arithmetic` from quick/pr manifests, adding transition-quarantine comments and the quarantine tracking artifact for remaining alias fixtures, updating decimal demos/fixtures away from public `bigint(...)` forms, and syncing the implementation inventory: `reviews/integer-model-int-7-transition-fixture-quarantine-review-pass-1.md`; PR #1899.
 - [x] INT-7 milestone closure review pass 1 satisfied: all acceptance criteria are met, the five prior closure blockers are resolved by PRs #1897/#1898/#1899, quick validation passes, transition quarantine artifacts are in place, and `SIFR-TYPE-0006` is documented as transition-only until alias removal: `reviews/integer-model-int-7-milestone-closure-review-pass-1.md`; PR #1900.
 - [x] INT-8 closure hardening gates review pass 1 satisfied: the Sifr small-int loop fixture, integer closure performance runner, ratified 10x pre-Phase-35 throughput threshold, zero-allocation probes, integer JSON/fixed-width property seeds, and closure hardening artifact satisfy the implementation wave with no blockers: `reviews/integer-model-int-8-closure-hardening-gates-review-pass-1.md`; PR #1901.
+- [x] INT-8 clippy closure cleanup review pass 1 satisfied: mechanical codegen iterator/helper refactors preserve behavior while restoring `cargo clippy --workspace -- -D warnings` for the closure gate: `reviews/integer-model-int-8-clippy-closure-cleanup-review-pass-1.md`; PR #1902.
 
 ## Implementation Checklist
 
@@ -586,3 +587,4 @@ Validation:
   - [x] INT-7 milestone closure review is satisfied with no blockers: `reviews/integer-model-int-7-milestone-closure-review-pass-1.md`; PR #1900.
 - [ ] INT-8 closure hardening and performance gates
   - [x] Added `verification/perf/sifr_int_loop.sifr`, `scripts/run_integer_model_closure_perf.py`, integer external-boundary and fixed-width helper fuzz/property seeds, and `verification/integer_model_closure_hardening.md`; the runner reports zero heap allocations for small `SifrInt` accumulation/counter/hash loops and a local observed slowdown near 3.1x under the ratified 10x pre-Phase-35 threshold: PR #1901.
+  - [x] Cleaned up codegen clippy findings exposed by the INT-8 closure gate without semantic changes, restoring `cargo clippy --workspace -- -D warnings`: PR #1902.

--- a/reviews/integer-model-int-8-clippy-closure-cleanup-review-pass-1.md
+++ b/reviews/integer-model-int-8-clippy-closure-cleanup-review-pass-1.md
@@ -1,0 +1,21 @@
+
+
+All validations pass. Review complete.
+
+---
+
+**Verdict: SATISFIED**
+
+**Blockers: None**
+
+**Non-blocking notes:**
+
+1. **Mechanically correct refactors** — all three categories (associated fn → standalone, `&Option<T>` → `Option<&T>`, `filter_map(... .then(...))` → `filter(...).map(...)`) are semantics-preserving. The iterator chains are pure `Some`-producing mappers with no side effects or conditional branching beyond the filter predicate.
+
+2. **No closure variable borrowing risk** — none of the rewritten closures capture anything from their environment. All referenced values (`name`, `rust_name`, `capture`, `func`, `idx`, `param`, `outer_forced_locals`, `outer_shadowed_module_bindings`, `function_params`, `result_function_params`, `result_method_params`, `indexes`) are either:
+   - Passed as explicit parameters (the filter/map closures don't capture them — they come from the iterator pipeline)
+   - Referenced inside a closure only for the `collect_captured_outer_names` case, but captured by value from the function parameters before the iterator, not from a captured closure
+
+3. **Minor style note** — `is_legacy_i64_type(ty.as_ref())` and `is_result_legacy_i64_type(ty.as_ref())` on lines 535/541 are passing `Option<&RustType>` while the callers could pass `ty.as_ref()` more uniformly if desired, but this is pre-existing and not a regression.
+
+4. **Clippy warnings resolved** — the three original warnings (unused `self`, `&Option<T>` params, `filter_map(... bool.then(...))`) are all resolved with no new warnings introduced.


### PR DESCRIPTION
## Summary
- Resolve codegen clippy warnings blocking the INT-8 closure gate
- Keep SifrInt discovery/helper logic behavior-preserving while replacing filter_map(bool.then) patterns
- Record the satisfied cleanup review in the phase tracker

## Validation
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick