### PR TITLE
Phase 32: add task.sleep runtime primitive

### DIFF
--- a/crates/sifr/tests/e2e/fail/task_sleep_invalid_duration.sifr
+++ b/crates/sifr/tests/e2e/fail/task_sleep_invalid_duration.sifr
@@ -1,0 +1,5 @@
+# expect-error: SIFR-TYPE-0002
+
+async def main() -> None:
+    await task.sleep("soon")
+    return None

--- a/crates/sifr/tests/e2e/fail/task_sleep_outside_async.sifr
+++ b/crates/sifr/tests/e2e/fail/task_sleep_outside_async.sifr
@@ -1,0 +1,5 @@
+# expect-error: SIFR-TYPE-0002
+
+def main() -> None:
+    task.sleep(0.0)
+    return None

--- a/crates/sifr/tests/e2e/pass/task_sleep.sifr
+++ b/crates/sifr/tests/e2e/pass/task_sleep.sifr
@@ -1,0 +1,4 @@
+async def main() -> None:
+    await task.sleep(0.0)
+    await task.sleep(-0.01)
+    return None

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -121,6 +121,7 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     );
     let rust_file = RustFile { items: file_items };
     let rust_source = Renderer::new().render_file(&rust_file);
+    let uses_task_sleep = super::module_uses_task_sleep(module);
 
     CodegenResult {
         rust_source,
@@ -140,6 +141,9 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
             }
             if import_needs.runtime.needs_sifr_int {
                 crates.insert("sifr_runtime".to_string());
+            }
+            if uses_task_sleep {
+                crates.insert("tokio".to_string());
             }
             crates
         },

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -55,6 +55,7 @@ use helpers::{
     collect_referenced_vars_with_types, default_param_convention, is_hashable_type_codegen,
     module_uses_bigint,
 };
+use hir_analysis::traversal::{self, TraversalConfig, TraversalControl};
 use ir_imports::{collect_import_needs_from_items, collect_import_needs_from_source};
 use ir_optimize::remove_trivial_clones_in_items;
 use ir_validate::validate_items;
@@ -596,6 +597,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
         assembled_body_items.extend(emitter.body_items.clone());
     }
     let has_async_main_entrypoint = annotate_async_main_entrypoint(&mut assembled_body_items);
+    let uses_task_sleep = module_uses_task_sleep(module);
     let body_import_needs = collect_import_needs_from_items(&assembled_body_items);
     let stdlib_import_needs = collect_import_needs_from_source(&stdlib_preamble);
     let needs_hashmap = body_import_needs.collections.needs_hashmap
@@ -743,7 +745,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             if needs_sifr_int {
                 crates.insert("sifr_runtime".to_string());
             }
-            if has_async_main_entrypoint {
+            if has_async_main_entrypoint || uses_task_sleep {
                 crates.insert("tokio".to_string());
             }
             crates
@@ -777,6 +779,76 @@ fn annotate_async_main_entrypoint(items: &mut Vec<RustItem>) -> bool {
             }
         }
     }
+    false
+}
+
+fn module_uses_task_sleep(module: &HirModule) -> bool {
+    fn expr_is_task_sleep(expr: &HirExpr) -> bool {
+        matches!(expr, HirExpr::Call { func, .. } if func == "__sifr_task_sleep")
+    }
+
+    for (_, _, value) in &module.constants {
+        let mut on_expr = |expr: &HirExpr| {
+            if expr_is_task_sleep(expr) {
+                TraversalControl::Stop
+            } else {
+                TraversalControl::Continue
+            }
+        };
+        if matches!(
+            traversal::walk_expr_until(value, &mut on_expr),
+            TraversalControl::Stop
+        ) {
+            return true;
+        }
+    }
+
+    for func in &module.functions {
+        let mut on_stmt = |_stmt: &HirStmt| TraversalControl::Continue;
+        let mut on_expr = |expr: &HirExpr| {
+            if expr_is_task_sleep(expr) {
+                TraversalControl::Stop
+            } else {
+                TraversalControl::Continue
+            }
+        };
+        if matches!(
+            traversal::walk_stmts_until(
+                &func.body,
+                TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+                &mut on_stmt,
+                &mut on_expr
+            ),
+            TraversalControl::Stop
+        ) {
+            return true;
+        }
+    }
+
+    for class in &module.classes {
+        for method in &class.methods {
+            let mut on_stmt = |_stmt: &HirStmt| TraversalControl::Continue;
+            let mut on_expr = |expr: &HirExpr| {
+                if expr_is_task_sleep(expr) {
+                    TraversalControl::Stop
+                } else {
+                    TraversalControl::Continue
+                }
+            };
+            if matches!(
+                traversal::walk_stmts_until(
+                    &method.body,
+                    TraversalConfig::INCLUDE_NESTED_FUNCTIONS,
+                    &mut on_stmt,
+                    &mut on_expr
+                ),
+                TraversalControl::Stop
+            ) {
+                return true;
+            }
+        }
+    }
+
     false
 }
 

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3593,6 +3593,45 @@ fn test_async_main_entrypoint_gets_tokio_bootstrap_dependency() {
 }
 
 #[test]
+fn test_task_sleep_lowers_to_tokio_sleep_and_requires_tokio() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module("async def main() -> None:\n    await task.sleep(0.0)\n    return None\n")
+                .expect("parse failed")
+                .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("tokio::time::sleep"));
+    assert!(result
+        .rust_source
+        .contains("std::time::Duration::from_secs_f64"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_task_sleep_requires_tokio_without_async_main() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def wait_once() -> None:\n    await task.sleep(0.0)\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(!result
+        .rust_source
+        .contains("#[tokio::main(flavor = \"current_thread\")]"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
 fn test_sync_main_does_not_require_tokio() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -384,13 +384,17 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
         }
         HirExpr::Await { value, .. } => {
             let lowered_value = if let HirExpr::Call { func, args, .. } = value.as_ref() {
-                let lowered_args = args
-                    .iter()
-                    .map(try_lower_leaf_or_name_expr)
-                    .collect::<Option<Vec<_>>>()?;
-                RustExpr::FnCall {
-                    func: Box::new(RustExpr::Ident(func.clone())),
-                    args: lowered_args,
+                if func == "__sifr_task_sleep" {
+                    try_lower_task_sleep_call_expr(args)?
+                } else {
+                    let lowered_args = args
+                        .iter()
+                        .map(try_lower_leaf_or_name_expr)
+                        .collect::<Option<Vec<_>>>()?;
+                    RustExpr::FnCall {
+                        func: Box::new(RustExpr::Ident(func.clone())),
+                        args: lowered_args,
+                    }
                 }
             } else {
                 try_lower_leaf_or_name_expr(value)?
@@ -505,6 +509,9 @@ fn try_lower_leaf_or_name_expr(expr: &HirExpr) -> Option<RustExpr> {
 }
 
 fn try_lower_simple_call_expr(func: &str, args: &[HirExpr]) -> Option<RustExpr> {
+    if func == "__sifr_task_sleep" {
+        return try_lower_task_sleep_call_expr(args);
+    }
     if func == "hash" {
         return try_lower_simple_hash_call_expr(args);
     }
@@ -546,6 +553,59 @@ fn try_lower_simple_call_expr(func: &str, args: &[HirExpr]) -> Option<RustExpr> 
     Some(RustExpr::FnCall {
         func: Box::new(RustExpr::Ident(func.to_string())),
         args: lowered_args,
+    })
+}
+
+fn try_lower_task_sleep_call_expr(args: &[HirExpr]) -> Option<RustExpr> {
+    let [duration] = args else {
+        return None;
+    };
+    let seconds = RustExpr::Cast {
+        expr: Box::new(try_lower_leaf_or_name_expr(duration)?),
+        ty: RustType::F64,
+    };
+    let seconds_name = "__sifr_task_sleep_seconds".to_string();
+    let finite_positive = RustExpr::BinOp {
+        left: Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(seconds_name.clone())),
+            method: "is_finite".to_string(),
+            args: vec![],
+        }),
+        op: "&&".to_string(),
+        right: Box::new(RustExpr::BinOp {
+            left: Box::new(RustExpr::Ident(seconds_name.clone())),
+            op: ">".to_string(),
+            right: Box::new(RustExpr::Literal(RustLiteral::Float(0.0))),
+        }),
+    };
+    let duration_expr = RustExpr::Block {
+        stmts: vec![RustStmt::Let {
+            mutable: false,
+            name: seconds_name.clone(),
+            ty: Some(RustType::F64),
+            value: seconds,
+        }],
+        expr: Some(Box::new(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                "std".to_string(),
+                "time".to_string(),
+                "Duration".to_string(),
+                "from_secs_f64".to_string(),
+            ])),
+            args: vec![RustExpr::If {
+                cond: Box::new(finite_positive),
+                then_expr: Box::new(RustExpr::Ident(seconds_name)),
+                else_expr: Some(Box::new(RustExpr::Literal(RustLiteral::Float(0.0)))),
+            }],
+        })),
+    };
+    Some(RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            "tokio".to_string(),
+            "time".to_string(),
+            "sleep".to_string(),
+        ])),
+        args: vec![duration_expr],
     })
 }
 

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -56,6 +56,7 @@ use super::sequence_guard_detection::{
     detect_false_exit_sequence_guards, detect_true_sequence_guards,
 };
 use super::subscript_type::resolve_subscript_result_type;
+use super::task_calls::{lower_task_module_call, TaskModuleCall};
 pub(super) use super::tuple_unpack::{lower_star_unpack_assign, lower_tuple_unpack_assign};
 use super::type_bounds::{type_satisfies_bound, type_satisfies_constraint};
 use super::typing_and_functions::resolve_annotation_expr;
@@ -388,6 +389,11 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
     if let (None, Expr::Attribute(attr)) = (&compat_alias, call.func.as_ref()) {
         if let Some(factory_call) = lower_bytes_type_factory_call(attr, call, ctx) {
             return Some(factory_call);
+        }
+        match lower_task_module_call(attr, call, ctx) {
+            TaskModuleCall::Lowered(expr) => return Some(expr),
+            TaskModuleCall::Rejected => return None,
+            TaskModuleCall::NotTaskModuleCall => {}
         }
         return lower_method_call(attr, call, ctx);
     }

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -97,6 +97,7 @@ mod statement_diagnostics;
 mod statement_diagnostics_tests;
 mod statements;
 mod subscript_type;
+mod task_calls;
 mod tuple_unpack;
 #[cfg(test)]
 mod type_alias_tests;

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -1,0 +1,87 @@
+use super::expression_diagnostics;
+use super::expressions::lower_expr;
+use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Expr, ExprAttribute, ExprCall};
+use sifr_type_system::Type;
+
+pub(super) enum TaskModuleCall {
+    Lowered(HirExpr),
+    Rejected,
+    NotTaskModuleCall,
+}
+
+pub(super) fn lower_task_module_call(
+    attr: &ExprAttribute,
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> TaskModuleCall {
+    let Expr::Name(module_name) = attr.value.as_ref() else {
+        return TaskModuleCall::NotTaskModuleCall;
+    };
+    if module_name.id.as_str() != "task" {
+        return TaskModuleCall::NotTaskModuleCall;
+    }
+    if attr.attr.as_str() != "sleep" {
+        return TaskModuleCall::NotTaskModuleCall;
+    }
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "task.sleep() is only valid inside async functions".to_string(),
+            call.range(),
+        );
+        return TaskModuleCall::Rejected;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "task.sleep() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return TaskModuleCall::Rejected;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "task.sleep() takes exactly one duration argument".to_string(),
+            call_arity_range(call),
+        );
+        return TaskModuleCall::Rejected;
+    }
+    let Some(duration) = lower_expr(&call.arguments.args[0], ctx) else {
+        return TaskModuleCall::Rejected;
+    };
+    if !matches!(duration.ty().resolve_alias(), Type::Int | Type::Float) {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "task.sleep() duration must be int or float, got '{}'",
+                duration.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskModuleCall::Rejected;
+    }
+    TaskModuleCall::Lowered(HirExpr::Call {
+        func: "__sifr_task_sleep".to_string(),
+        args: vec![duration],
+        ty: Type::Awaitable(Box::new(Type::None)),
+    })
+}
+
+fn first_call_keyword_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .keywords
+        .first()
+        .map_or_else(|| call.func.range(), |keyword| keyword.range)
+}
+
+fn call_arity_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .args
+        .first()
+        .map_or_else(|| call.func.range(), Ranged::range)
+}

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -379,6 +379,8 @@ status: in_progress
 
 - Completed first runtime bootstrap slice: auto-detect `async def main()`, emit a private Tokio-backed runtime bootstrap with `#[tokio::main(flavor = "current_thread")]`, and add the Tokio dependency only for async entrypoints.
 - Added positive validation fixture: `async_runtime_bootstrap.sifr`.
+- In progress task sleep slice: lower `task.sleep(duration)` inside async functions to the private runtime substrate, reject invalid duration/call sites during HIR lowering, and require Tokio only when generated code references the private sleep primitive.
+- Added validation coverage for `task_sleep.sifr`, `task_sleep_outside_async.sifr`, and `task_sleep_invalid_duration.sifr`.
 
 ---
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap is underway |
+| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap plus `task.sleep` are underway |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |

--- a/reviews/phase-32-milestone-async-2-task-sleep-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-2-task-sleep-review-pass-1.md
@@ -1,0 +1,162 @@
+# Review: Phase 32 milestone_async_2 task.sleep slice
+
+Date: 2026-05-09
+Reviewer: Claude
+
+## Verdict: SATISFIED
+
+This slice is acceptable to open as a PR. All concrete review criteria pass; no blockers remain.
+
+---
+
+## 1. HIR Lowering Correctness
+
+**`crates/sifr_hir/src/lower/task_calls.rs`**
+- `lower_task_module_call` checks all four call-site validity requirements before lowering:
+  - Must be called on `task` module attribute (not a free function or other module)
+  - Must be `task.sleep` specifically (future `task.X` calls fall through to `NotTaskModuleCall`)
+  - Must be inside an async function (error: `task.sleep() is only valid inside async functions`)
+  - Must have exactly 1 positional arg (error: `task.sleep() takes exactly one duration argument`)
+  - Duration arg must lower to `Int | Float` type (error: `task.sleep() duration must be int or float, got '{type}'`)
+- Keyword arguments are rejected with diagnostic: `task.sleep() does not accept keyword arguments`
+- All errors use `DiagnosticCode::TYPE_MISMATCH` — correct for call-site type mismatches
+- On success, emits `HirExpr::Call { func: "__sifr_task_sleep", args: [duration], ty: Awaitable(None) }` — correct affine call encoding
+
+**`crates/sifr_hir/src/lower/expressions.rs:393-398`**
+- `lower_task_module_call` is checked before `lower_method_call` — correct precedence so `task.sleep` does not fall through to method-call lowering
+- `NotTaskModuleCall` falls through cleanly; `Rejected` propagates `None` (no double-reporting)
+
+**Async context tracking**
+- `ctx.current_function_is_async` is set by `lower_function_signature` before processing body (verified at `typing_and_functions.rs:949-952`)
+- `task.sleep` diagnostics inside async functions are sound; diagnostics outside async functions are correct
+
+---
+
+## 2. Codegen Correctness and Safety
+
+**`crates/sifr_codegen/src/lower_expr.rs:559-610` (`try_lower_task_sleep_call_expr`)**
+- Duration cast to `f64` covers both `Int` and `Float` HIR input types
+- Guard pattern:
+  ```rust
+  if __sifr_task_sleep_seconds.is_finite() && (__sifr_task_sleep_seconds > 0.0) {
+      __sifr_task_sleep_seconds
+  } else {
+      0.0
+  }
+  ```
+  - `is_finite()` handles `NaN`, `inf`, `-inf`
+  - `> 0.0` handles negative values
+  - Combined: any invalid input defaults to `Duration::from_secs_f64(0.0)` — no panic, no unwrap
+- `std::time::Duration::from_secs_f64` is called with the guard expression as argument — Tokio receives a safe `Duration`
+- `tokio::time::sleep(duration).await` — correct async sleep primitive
+
+**No user-triggerable runtime panics**: All data-dependent decisions use conditional branching, not `.unwrap()`/`.expect()`. Invalid durations produce zero-duration sleep, which is well-defined Tokio behavior.
+
+**Both lowering paths covered:**
+- `try_lower_leaf_expr` (for `await task.sleep(x)`) at line 386-405
+- `try_lower_simple_call_expr` (for bare `task.sleep(x)`) at line 512-514
+
+Both route through `try_lower_task_sleep_call_expr`.
+
+---
+
+## 3. Tokio Dependency Detection
+
+**Normal codegen** (`crates/sifr_codegen/src/lib.rs:745`):
+```rust
+if has_async_main_entrypoint || uses_task_sleep {
+    crates.insert("tokio".to_string());
+}
+```
+Tokio is added if either: (a) async `main()` detected, or (b) `task.sleep` is used anywhere in the module.
+
+**Test codegen** (`crates/sifr_codegen/src/entrypoints.rs:145-147`):
+```rust
+if uses_task_sleep {
+    crates.insert("tokio".to_string());
+}
+```
+Tokio is added for test executables that use `task.sleep` even without async `main()`.
+
+**`module_uses_task_sleep`** (`lib.rs:782-849`):
+- Walks constants, functions, and class methods
+- Uses `traversal::walk_expr_until` and `traversal::walk_stmts_until` with `INCLUDE_NESTED_FUNCTIONS` config
+- Short-circuits on first `HirExpr::Call { func: "__sifr_task_sleep", ... }` match
+- No false negatives for nested functions, class methods, or constant expressions
+
+---
+
+## 4. Fixture and Test Coverage
+
+**E2E pass fixture**: `crates/sifr/tests/e2e/pass/task_sleep.sifr`
+- `async def main()` with two calls: `await task.sleep(0.0)` and `await task.sleep(-0.01)`
+- Passes `check`, `emit`, and `run`
+- Negative-duration case covered (defaults to 0.0)
+
+**E2E fail fixtures**:
+- `task_sleep_outside_async.sifr`: `def main()` calls `task.sleep(0.0)` → `SIFR-TYPE-0002`
+- `task_sleep_invalid_duration.sifr`: `async def main()` calls `await task.sleep("soon")` → `SIFR-TYPE-0002`
+
+**Unit tests** (`crates/sifr_codegen/src/lib_codegen_tests.rs`):
+- `test_task_sleep_lowers_to_tokio_sleep_and_requires_tokio`: Verifies `tokio::time::sleep` in output, `Duration::from_secs_f64` in output, and `tokio` in required crates
+- `test_task_sleep_requires_tokio_without_async_main`: Verifies `tokio` is added without `#[tokio::main(...)]` for non-`main` async functions
+
+**Validation run results** (all passed locally):
+- `cargo fmt --check`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `cargo check -q -p sifr_hir -p sifr_codegen -p sifr`
+- `cargo test -q -p sifr_codegen task_sleep` (2 tests)
+- E2E pass suite with fixture manifest
+- `sifr check` on both fail fixtures (correct diagnostics)
+- `scripts/run_all_tests.sh --profile quick`
+
+---
+
+## 5. Documentation Updates
+
+**`internal_docs/phases/32_async_ecosystem.md`** (lines 382-383):
+```
+- In progress task sleep slice: lower `task.sleep(duration)` inside async functions to the private runtime substrate, reject invalid duration/call sites during HIR lowering, and require Tokio only when generated code references the private sleep primitive.
+- Added validation coverage for `task_sleep.sifr`, `task_sleep_outside_async.sifr`, and `task_sleep_invalid_duration.sifr`.
+```
+Status accurately reflects slice as in-progress. Coverage list matches fixtures added.
+
+**`internal_docs/roadmap.md`** (line 63):
+```
+| 32 | Async and Ecosystem Foundation | in_progress | ... | milestone_async_1 is complete and milestone_async_2 runtime bootstrap plus `task.sleep` are underway
+```
+Correct: `task.sleep` is part of `milestone_async_2`.
+
+---
+
+## Minor Observations (not blockers)
+
+1. **`task_calls.rs` module name**: "task_calls" is slightly generic given it currently only handles `task.sleep`. Future additions (e.g., `task.timeout`, `task.spawn`) will justify the plural. Acceptable as-is.
+
+2. **Negative duration in fixture**: `await task.sleep(-0.01)` is handled gracefully (defaults to 0.0) but not explicitly tested. The unit test `test_task_sleep_lowers_to_tokio_sleep_and_requires_tokio` only checks `0.0`. This is a post-launch improvement opportunity, not a blocker.
+
+3. **No demo file**: No `demos/m32_task_sleep.sifr` exists. The design doc shows `task.sleep` usage in examples, and `demos/m32_task_core_demo.sifr` exists per the phase file. Not a blocker — demo coverage can follow as a separate slice.
+
+4. **No negative-duration HIR diagnostic**: If a user passes a negative float literal, the HIR lowering succeeds and the guard handles it at runtime. This is intentional per the design: invalid durations produce zero-duration sleep (well-defined Tokio behavior). No change needed.
+
+5. **`RustExpr::Block` with stmts in function-call arg position**: The generated code uses block-with-let as a tokio sleep argument. Verified that `render_block_expr` handles `stmts` + `expr` correctly, and other code paths already use `RustExpr::Block` in call-arg positions (confirmed via grep — many existing uses). No concern.
+
+---
+
+## Summary
+
+| Criterion | Status |
+|---|---|
+| HIR lowering correctness | PASS |
+| Diagnostics on invalid call sites | PASS |
+| Tokio `Duration` safety (no panics) | PASS |
+| Tokio dep detection (normal codegen) | PASS |
+| Tokio dep detection (test codegen) | PASS |
+| `module_uses_task_sleep` traversal | PASS |
+| E2E pass fixture | PASS |
+| E2E fail fixtures with diagnostics | PASS |
+| Unit test coverage | PASS |
+| HIR maintainability guardrails | PASS |
+| Docs updated (phase file + roadmap) | PASS |
+
+No concrete blockers. Ready to open PR.


### PR DESCRIPTION
## Summary
- lower async-only task.sleep(duration) to a private __sifr_task_sleep awaitable
- emit Tokio time sleep with guarded Duration construction and Tokio dependency detection
- add task.sleep pass/fail fixtures, codegen coverage, docs, and reviewer artifact

## Validation
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- cargo check -q -p sifr_hir -p sifr_codegen -p sifr
- cargo test -q -p sifr_codegen task_sleep
- SIFR_E2E_FIXTURE_MANIFEST=/Users/yaseralnajjar/work/sifr/codebase/tmp/phase32_task_sleep_manifest.json cargo test -q -p sifr --test e2e test_e2e_pass -- --nocapture
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_sleep_outside_async.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_sleep_invalid_duration.sifr
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus reviewer verdict: SATISFIED (reviews/phase-32-milestone-async-2-task-sleep-review-pass-1.md)