### PR TITLE
Phase 32: add conservative scope spawn core

### DIFF
--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -1259,7 +1259,8 @@ fn sifr_runtime_dependency_spec() -> String {
 }
 
 fn tokio_dependency_spec() -> String {
-    "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"time\"] }".to_string()
+    "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }"
+        .to_string()
 }
 
 fn discover_sifr_runtime_path() -> Option<PathBuf> {
@@ -3675,8 +3676,9 @@ fn test_generate_cargo_toml_required_tokio_uses_runtime_features() {
     let required_crates = normalize_dependency_set(vec!["tokio".to_string()]);
 
     let cargo_toml = generate_cargo_toml(&stdlib_modules, &required_crates, "sifr_output");
-    assert!(cargo_toml
-        .contains("tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"time\"] }"));
+    assert!(cargo_toml.contains(
+        "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }"
+    ));
 }
 
 fn sample_cache_entry(

--- a/crates/sifr/tests/e2e/fail/detached_spawn_not_available.sifr
+++ b/crates/sifr/tests/e2e/fail/detached_spawn_not_available.sifr
@@ -1,0 +1,7 @@
+async def worker() -> int:
+    return 1
+
+
+async def main() -> None:
+    handle = task.spawn(worker())
+    return None

--- a/crates/sifr/tests/e2e/fail/scope_spawn_capture_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/scope_spawn_capture_rejected.sifr
@@ -1,0 +1,8 @@
+async def worker(value: int) -> int:
+    return value
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker(1))
+    return None

--- a/crates/sifr/tests/e2e/fail/scope_spawn_non_coroutine_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/scope_spawn_non_coroutine_rejected.sifr
@@ -1,0 +1,4 @@
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(1)
+    return None

--- a/crates/sifr/tests/e2e/pass/scope_spawn_core.sifr
+++ b/crates/sifr/tests/e2e/pass/scope_spawn_core.sifr
@@ -1,0 +1,9 @@
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -92,7 +92,8 @@ pub fn sifr_runtime_dependency_spec() -> String {
 }
 
 fn tokio_dependency_spec() -> String {
-    "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"time\"] }".to_string()
+    "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }"
+        .to_string()
 }
 
 fn discover_sifr_runtime_path() -> Option<PathBuf> {
@@ -748,7 +749,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             if needs_sifr_int {
                 crates.insert("sifr_runtime".to_string());
             }
-            if has_async_main_entrypoint || uses_task_sleep {
+            if has_async_main_entrypoint || uses_task_sleep || module_uses_task_scope(module) {
                 crates.insert("tokio".to_string());
             }
             crates

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3671,7 +3671,35 @@ fn test_task_scope_context_materializes_runtime_container() {
     assert!(result.rust_source.contains("impl __SifrTaskScope"));
     assert!(result
         .rust_source
-        .contains("let scope = __SifrTaskScope::new();"));
+        .contains("let mut scope = __SifrTaskScope::new();"));
+    assert!(result
+        .rust_source
+        .contains("scope.__sifr_join_all().await;"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("struct __SifrTask<T, E>"));
+    assert!(result.rust_source.contains("fn spawn<"));
+    assert!(result.rust_source.contains("tokio::sync::oneshot::channel"));
+    assert!(result.rust_source.contains("scope.spawn(worker());"));
+    assert!(result
+        .rust_source
+        .contains("scope.__sifr_join_all().await;"));
+    assert!(result.required_crates.contains("tokio"));
 }
 
 #[test]
@@ -3703,8 +3731,9 @@ fn test_generate_project_emits_tokio_dependency_when_required() {
         &required_crates,
     );
 
-    assert!(cargo_toml
-        .contains("tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"time\"] }"));
+    assert!(cargo_toml.contains(
+        "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }"
+    ));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -937,9 +937,35 @@ fn try_lower_simple_method_call_expr(
     method: &str,
     args: &[HirExpr],
 ) -> Option<RustExpr> {
-    let _ = object;
-    let _ = method;
-    let _ = args;
+    if method == "spawn"
+        && matches!(resolve_alias_type(object.ty()), Type::Class { name, .. } if name == "TaskScope")
+    {
+        let lowered_object = try_lower_leaf_or_name_expr(object)?;
+        let lowered_args = args
+            .iter()
+            .map(|arg| {
+                if let HirExpr::Call {
+                    func,
+                    args: call_args,
+                    ..
+                } = arg
+                {
+                    if call_args.is_empty() {
+                        return Some(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Ident(func.clone())),
+                            args: vec![],
+                        });
+                    }
+                }
+                try_lower_leaf_expr(arg)
+            })
+            .collect::<Option<Vec<_>>>()?;
+        return Some(RustExpr::MethodCall {
+            receiver: Box::new(lowered_object),
+            method: method.to_string(),
+            args: lowered_args,
+        });
+    }
     // Method-call lowering is ownership- and type-convention-sensitive.
     // Keep it on the structured emitter path where binding context is available.
     None

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -1901,7 +1901,7 @@ fn try_lower_simple_async_with_stmt(
     let mut block = Vec::new();
     if let Some(target) = target {
         block.push(RustStmt::Let {
-            mutable: false,
+            mutable: true,
             name: target.to_string(),
             ty: None,
             value: RustExpr::FnCall {
@@ -1921,6 +1921,15 @@ fn try_lower_simple_async_with_stmt(
         bindings.borrowed_params,
         ctx,
     )?);
+    if let (sifr_hir::HirAsyncWithKind::TaskScope, Some(target)) = (kind, target) {
+        block.push(RustStmt::Expr(RustExpr::Await(Box::new(
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(target.to_string())),
+                method: "__sifr_join_all".to_string(),
+                args: vec![],
+            },
+        ))));
+    }
 
     Some(vec![RustStmt::Block(block)])
 }
@@ -4335,6 +4344,12 @@ fn try_lower_simple_let_value(ty: &Type, value: &HirExpr) -> Option<RustExpr> {
     }
     if is_none_type(ty) && matches!(value, HirExpr::NoneLiteral) {
         return Some(RustExpr::Literal(RustLiteral::Unit));
+    }
+    if matches!(
+        crate::resolve_alias_type_for_plain_call(ty),
+        Type::Task(_, _)
+    ) {
+        return try_lower_leaf_expr(value);
     }
     if !is_alias_equivalent_type(ty, value.ty()) {
         return None;

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -21,6 +21,13 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
             Box::new(sifr_type_to_rust_type(ok)),
             Box::new(sifr_type_to_rust_type(err)),
         ),
+        Type::Task(ok, err) => RustType::Generic {
+            base: "__SifrTask".to_string(),
+            params: vec![
+                sifr_type_to_rust_type(ok),
+                task_error_type_to_rust_type(err),
+            ],
+        },
         Type::Union(members) => {
             let non_none: Vec<&Type> = members
                 .iter()
@@ -34,6 +41,14 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
             }
         }
         _ => RustType::Named(ty.rust_type()),
+    }
+}
+
+fn task_error_type_to_rust_type(ty: &Type) -> RustType {
+    if matches!(ty.resolve_alias(), Type::Never) {
+        RustType::Named("std::convert::Infallible".to_string())
+    } else {
+        sifr_type_to_rust_type(ty)
     }
 }
 
@@ -130,27 +145,163 @@ pub fn build_error_type_items(
 pub fn build_task_scope_items() -> Vec<RustItem> {
     vec![
         RustItem::Struct {
+            name: "__SifrTask<T, E>".to_string(),
+            visibility: Visibility::Private,
+            derives: vec![],
+            fields: vec![
+                (
+                    "receiver".to_string(),
+                    RustType::Option(Box::new(RustType::Named(
+                        "tokio::sync::oneshot::Receiver<T>".to_string(),
+                    ))),
+                ),
+                (
+                    "_error".to_string(),
+                    RustType::Named("std::marker::PhantomData<E>".to_string()),
+                ),
+            ],
+        },
+        RustItem::Struct {
             name: "__SifrTaskScope".to_string(),
             visibility: Visibility::Private,
-            derives: vec!["Debug".to_string()],
-            fields: vec![],
+            derives: vec![],
+            fields: vec![(
+                "children".to_string(),
+                RustType::Vec(Box::new(RustType::Named(
+                    "tokio::task::JoinHandle<()>".to_string(),
+                ))),
+            )],
         },
         RustItem::Impl {
             target: "__SifrTaskScope".to_string(),
             type_params: vec![],
             trait_: None,
-            items: vec![RustItem::Fn {
-                name: "new".to_string(),
-                visibility: Visibility::Private,
-                type_params: vec![],
-                params: vec![],
-                ret: Some(RustType::Named("Self".to_string())),
-                body: vec![RustStmt::Return(Some(RustExpr::StructInit {
-                    name: "Self".to_string(),
-                    fields: vec![],
-                }))],
-                is_async: false,
-            }],
+            items: vec![
+                RustItem::Fn {
+                    name: "new".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![],
+                    ret: Some(RustType::Named("Self".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "Self".to_string(),
+                        fields: vec![(
+                            "children".to_string(),
+                            RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec!["Vec".to_string(), "new".to_string()])),
+                                args: vec![],
+                            },
+                        )],
+                    }))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "spawn".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![
+                        crate::RustTypeParam {
+                            name: "T".to_string(),
+                            bounds: vec!["Send".to_string(), "'static".to_string()],
+                        },
+                        crate::RustTypeParam {
+                            name: "F".to_string(),
+                            bounds: vec![
+                                "std::future::Future<Output = T>".to_string(),
+                                "Send".to_string(),
+                                "'static".to_string(),
+                            ],
+                        },
+                    ],
+                    params: vec![
+                        RustParam::SelfParam { mutable: true },
+                        RustParam::Named {
+                            name: "future".to_string(),
+                            ty: RustType::Named("F".to_string()),
+                        },
+                    ],
+                    ret: Some(RustType::Named(
+                        "__SifrTask<T, std::convert::Infallible>".to_string(),
+                    )),
+                    body: vec![
+                        RustStmt::LetPattern {
+                            pattern: "(sender, receiver)".to_string(),
+                            value: RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec![
+                                    "tokio".to_string(),
+                                    "sync".to_string(),
+                                    "oneshot".to_string(),
+                                    "channel".to_string(),
+                                ])),
+                                args: vec![],
+                            },
+                        },
+                        RustStmt::Let {
+                            mutable: false,
+                            name: "child".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "tokio::spawn(async move { let result = future.await; let _ = sender.send(result); })"
+                                    .to_string(),
+                            ),
+                        },
+                        RustStmt::Expr(RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Field {
+                                expr: Box::new(RustExpr::Ident("self".to_string())),
+                                field: "children".to_string(),
+                            }),
+                            method: "push".to_string(),
+                            args: vec![RustExpr::Ident("child".to_string())],
+                        }),
+                        RustStmt::Return(Some(RustExpr::StructInit {
+                            name: "__SifrTask".to_string(),
+                            fields: vec![
+                                (
+                                    "receiver".to_string(),
+                                    RustExpr::FnCall {
+                                        func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                                        args: vec![RustExpr::Ident("receiver".to_string())],
+                                    },
+                                ),
+                                (
+                                    "_error".to_string(),
+                                    RustExpr::Path(vec![
+                                        "std".to_string(),
+                                        "marker".to_string(),
+                                        "PhantomData".to_string(),
+                                    ]),
+                                ),
+                            ],
+                        })),
+                    ],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "__sifr_join_all".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfParam { mutable: true }],
+                    ret: Some(RustType::Unit),
+                    body: vec![RustStmt::Loop {
+                        body: vec![RustStmt::IfLet {
+                            pattern: "Some(child)".to_string(),
+                            expr: RustExpr::MethodCall {
+                                receiver: Box::new(RustExpr::Field {
+                                    expr: Box::new(RustExpr::Ident("self".to_string())),
+                                    field: "children".to_string(),
+                                }),
+                                method: "pop".to_string(),
+                                args: vec![],
+                            },
+                            then_body: vec![RustStmt::LetPattern {
+                                pattern: "_".to_string(),
+                                value: RustExpr::Await(Box::new(RustExpr::Ident("child".to_string()))),
+                            }],
+                            else_body: Some(vec![RustStmt::Break]),
+                        }],
+                    }],
+                    is_async: true,
+                },
+            ],
         },
     ]
 }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7243,7 +7243,7 @@ impl RustEmitter {
             lowered_body.insert(
                 0,
                 crate::RustStmt::Let {
-                    mutable: false,
+                    mutable: true,
                     name: target.to_string(),
                     ty: None,
                     value: crate::RustExpr::FnCall {
@@ -7255,6 +7255,15 @@ impl RustEmitter {
                     },
                 },
             );
+        }
+        if let (sifr_hir::HirAsyncWithKind::TaskScope, Some(target)) = (kind, target) {
+            lowered_body.push(crate::RustStmt::Expr(crate::RustExpr::Await(Box::new(
+                crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Ident(target.to_string())),
+                    method: "__sifr_join_all".to_string(),
+                    args: vec![],
+                },
+            ))));
         }
         Ok(Some(RustStmt::Block(lowered_body)))
     }

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -57,6 +57,7 @@ use super::sequence_guard_detection::{
 };
 use super::subscript_type::resolve_subscript_result_type;
 use super::task_calls::{lower_task_module_call, TaskCallLowering};
+use super::task_scope_calls::{is_task_scope_type, lower_task_scope_spawn_call};
 pub(super) use super::tuple_unpack::{lower_star_unpack_assign, lower_tuple_unpack_assign};
 use super::type_bounds::{type_satisfies_bound, type_satisfies_constraint};
 use super::typing_and_functions::resolve_annotation_expr;
@@ -2130,6 +2131,9 @@ pub(super) fn lower_method_call(
 
     let mut object = lower_expr(&attr.value, ctx)?;
     let method_name = attr.attr.to_string();
+    if is_task_scope_type(object.ty()) && method_name == "spawn" {
+        return lower_task_scope_spawn_call(object, attr, call, ctx);
+    }
     let object_ty_for_args = canonicalize_class_surface_type(object.ty().resolve_alias());
     let args = match &object_ty_for_args {
         Type::Class { name, methods, .. } => {

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -98,6 +98,7 @@ mod statement_diagnostics_tests;
 mod statements;
 mod subscript_type;
 mod task_calls;
+mod task_scope_calls;
 mod tuple_unpack;
 #[cfg(test)]
 mod type_alias_tests;

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -25,6 +25,14 @@ pub(super) fn lower_task_module_call(
         return TaskCallLowering::NoMatch;
     }
     if attr.attr.as_str() != "sleep" {
+        if attr.attr.as_str() == "spawn" {
+            expression_diagnostics::type_mismatch(
+                ctx,
+                "task.spawn() is not available in v1; use scope.spawn(...) inside async with task.scope()".to_string(),
+                call.range(),
+            );
+            return TaskCallLowering::Rejected;
+        }
         return TaskCallLowering::NoMatch;
     }
     if !ctx.current_function_is_async {

--- a/crates/sifr_hir/src/lower/task_scope_calls.rs
+++ b/crates/sifr_hir/src/lower/task_scope_calls.rs
@@ -1,0 +1,95 @@
+use super::expression_diagnostics;
+use super::expressions::lower_expr;
+use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_python_ast::{ExprAttribute, ExprCall};
+use sifr_type_system::Type;
+
+pub(super) fn is_task_scope_type(ty: &Type) -> bool {
+    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "TaskScope")
+}
+
+pub(super) fn lower_task_scope_spawn_call(
+    object: HirExpr,
+    attr: &ExprAttribute,
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<HirExpr> {
+    if !ctx.current_function_is_async {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "scope.spawn() is only valid inside async functions".to_string(),
+            call.range(),
+        );
+        return None;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "scope.spawn() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return None;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "scope.spawn() takes exactly one coroutine argument".to_string(),
+            call_arity_range(call),
+        );
+        return None;
+    }
+
+    let coroutine = lower_expr(&call.arguments.args[0], ctx)?;
+    let Type::Coroutine(ok_ty, err_ty) = coroutine.ty().resolve_alias() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "scope.spawn() requires a coroutine argument, got '{}'",
+                coroutine.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return None;
+    };
+    let task_ok_ty = ok_ty.clone();
+    let task_err_ty = err_ty.clone();
+    if !matches!(task_err_ty.resolve_alias(), Type::Never) {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "scope.spawn() currently accepts only infallible coroutine arguments until task error plumbing lands".to_string(),
+            call.arguments.args[0].range(),
+        );
+        return None;
+    }
+    if !matches!(&coroutine, HirExpr::Call { args, .. } if args.is_empty()) {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "scope.spawn() currently accepts only no-argument coroutine calls until task-boundary checking lands".to_string(),
+            call.arguments.args[0].range(),
+        );
+        return None;
+    }
+
+    Some(HirExpr::MethodCall {
+        object: Box::new(object),
+        method: attr.attr.to_string(),
+        args: vec![coroutine],
+        ty: Type::Task(task_ok_ty, task_err_ty),
+    })
+}
+
+fn first_call_keyword_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .keywords
+        .first()
+        .map_or_else(|| call.func.range(), |keyword| keyword.range)
+}
+
+fn call_arity_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .args
+        .last()
+        .map_or_else(|| call.func.range(), Ranged::range)
+}

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -385,6 +385,8 @@ status: in_progress
 - Added positive validation fixture: `async_main_result_bootstrap.sifr`.
 - In progress task scope container slice: `async with task.scope() as scope` now materializes a private generated `TaskScope` runtime container instead of binding the placeholder unit value.
 - Added positive validation fixture: `task_scope_container.sifr`.
+- In progress conservative spawn slice: `scope.spawn(coro)` accepts no-argument infallible coroutine calls, returns a typed task observer handle, and records an owned child driver in the task scope so normal scope exit awaits dropped/unobserved handles instead of detaching them.
+- Added validation coverage for `scope_spawn_core.sifr`, `scope_spawn_capture_rejected.sifr`, `scope_spawn_non_coroutine_rejected.sifr`, and `detached_spawn_not_available.sifr`.
 
 ---
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, and the task-scope container are underway |
+| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, and conservative `scope.spawn` support are underway |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |

--- a/reviews/phase-32-milestone-async-2-scope-spawn-core-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-2-scope-spawn-core-review-pass-1.md
@@ -1,0 +1,100 @@
+# Phase 32 milestone_async_2 scope.spawn core review — pass 1
+
+## Verdict: SATISFIED
+
+## Changes reviewed
+
+The staged diff on `phase32-scope-spawn-core` adds conservative `scope.spawn(coro)` lowering for `TaskScope` values:
+
+| File | Role |
+|---|---|
+| `sifr_hir/src/lower/task_scope_calls.rs` | New HIR module: `lower_task_scope_spawn_call` with all phase-gate rejections |
+| `sifr_hir/src/lower/mod.rs` | Registers the new module |
+| `sifr_hir/src/lower/task_calls.rs` | Rejects `task.spawn(...)` with phase-specific diagnostic |
+| `sifr_hir/src/lower/expressions.rs` | Wires `spawn` method on `TaskScope` to the new HIR lowering path |
+| `sifr_codegen/src/lower_expr.rs` | Lowers `scope.spawn(coro)` method call to Rust |
+| `sifr_codegen/src/lower_stmt.rs` | Injects `scope.__sifr_join_all().await` on `async with task.scope()` normal exit |
+| `sifr_codegen/src/stmt_support_emitter.rs` | Same injection in the general emitter path |
+| `sifr_codegen/src/preamble.rs` | Emits `__SifrTask<T, E>` and `__SifrTaskScope` with `spawn` and `__sifr_join_all` |
+| `sifr_codegen/src/lib.rs` | Wires Tokio `sync` feature when task scope is used |
+| `sifr/tests/e2e/pass/scope_spawn_core.sifr` | Positive fixture |
+| `sifr/tests/e2e/fail/{scope_spawn_capture_rejected,scope_spawn_non_coroutine_rejected,detached_spawn_not_available}.sifr` | Negative fixtures |
+| `sifr_codegen/src/lib_codegen_tests.rs` | Codegen unit tests for the spawn substrate |
+| `internal_docs/phases/32_async_ecosystem.md` | Tracks the slice |
+| `internal_docs/roadmap.md` | Updated milestone description |
+
+---
+
+## Validation performed
+
+| Check | Result |
+|---|---|
+| `cargo check -p sifr_hir -p sifr_codegen -p sifr` | PASS |
+| `cargo clippy -p sifr_hir -p sifr_codegen -- -D warnings` | PASS (no warnings) |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | PASS |
+| `cargo fmt --check` | PASS |
+| `sifr check` on `scope_spawn_core.sifr` | PASS (no errors) |
+| `sifr check` on `scope_spawn_capture_rejected.sifr` | Diagnostic: "scope.spawn() currently accepts only no-argument coroutine calls" |
+| `sifr check` on `scope_spawn_non_coroutine_rejected.sifr` | Diagnostic: "scope.spawn() requires a coroutine argument, got 'int'" |
+| `sifr check` on `detached_spawn_not_available.sifr` | Diagnostic: "task.spawn() is not available in v1; use scope.spawn(...)" |
+| `cargo run -q -p sifr -- run scope_spawn_core.sifr` | PASS |
+| `cargo emit` on `scope_spawn_core.sifr` | Generated code verified |
+| `cargo test -p sifr_codegen scope_spawn` | PASS |
+| `cargo test -p sifr_codegen task_scope_context` | PASS |
+| `scripts/run_all_tests.sh --profile quick` | PASS |
+
+---
+
+## Blocking findings: none
+
+## Non-blocking observations
+
+### 1. `__SifrTask` receiver is allocated but never polled in this slice
+
+The generated `__SifrTask<T, E>` struct holds a `tokio::sync::oneshot::Receiver<T>` alongside a `PhantomData<E>`. The `spawn` implementation sends the task result through the channel:
+
+```rust
+let child = tokio::spawn(async move {
+    let result = future.await;
+    let _ = sender.send(result);
+});
+```
+
+The receiver is placed in the returned `__SifrTask` observer handle, but neither the handle nor its receiver is ever awaited in this milestone — the handle is dropped and `__sifr_join_all` only polls the `JoinHandle<()>`, not the oneshot receiver. The spawned task continues (and the sender is dropped) when the channel is closed by the task completing normally.
+
+This is intentional per the design ("Joining/awaiting task handles and `TaskResult` materialization are upcoming slices"). Future slices that materialize `TaskResult` will poll the receiver. The current structure is sound for that path.
+
+### 2. Both emitter paths modified for `__sifr_join_all` injection
+
+`lower_stmt.rs:try_lower_simple_async_with_stmt` and `stmt_support_emitter.rs:emit_async_with` both now inject `scope.__sifr_join_all().await` at the end of a `TaskScope` body. This duplication is deliberate — `stmt_support_emitter.rs` handles the general emitter path used for more complex constructs, and `lower_stmt.rs` handles the simplified fast-path. Both are correct.
+
+### 3. Tokio feature string updated in two places
+
+`lib.rs` and `tests/e2e.rs` both update the `tokio` dependency spec to include `"sync"`. The test file mirrors the runtime string to keep the dependency spec test accurate. This is fine.
+
+### 4. HIR `task_scope_calls.rs` helper naming
+
+The new module follows the existing pattern of `task_calls.rs` for module-level task primitives. The `is_task_scope_type` helper is public to `super` (the `expressions` module) and used only at the call site. The helper and lowering function are well-scoped.
+
+---
+
+## Design compliance
+
+| Design contract point | Status |
+|---|---|
+| `scope.spawn(coro)` returns typed `Task[T, E]` in HIR | Correct |
+| Fallible coroutines rejected until task error plumbing lands | Correct |
+| Non-empty-call captures rejected until task-boundary checking lands | Correct |
+| `task.spawn(...)` rejected with phase-specific diagnostic | Correct |
+| Normal scope exit joins spawned tasks via `__sifr_join_all` | Correct |
+| `__SifrTaskScope` owns `JoinHandle<()>` children | Correct |
+| `__SifrTask` observer handle backed by oneshot + PhantomData | Correct |
+| Tokio `sync` feature added only when task scope is used | Correct |
+| `mutable: true` on `let mut scope` so `__sifr_join_all` can borrow mutably | Correct |
+| `#[tokio::main]` bootstrap not affected for non-async entrypoints | Correct |
+
+---
+
+## Conclusion
+
+The implementation is correct, well-scoped, and consistent with the documented design and phase plan. All validations pass. Ready to land.


### PR DESCRIPTION
## Summary
- add conservative `scope.spawn(coro)` lowering for task-scope values
- generate private `__SifrTask` observer handles and `__SifrTaskScope` child-driver ownership for normal scope-exit joining
- reject unsupported captures, non-coroutines, fallible coroutines, and detached `task.spawn(...)`
- add focused pass/fail fixtures and update Phase 32 tracking docs

## Validation
- `cargo fmt --check`
- `scripts/check_hir_maintainability_guardrails.py`
- `cargo check -q -p sifr_hir -p sifr_codegen -p sifr`
- `cargo test -q -p sifr_codegen scope_spawn`
- `cargo test -q -p sifr_codegen task_scope_context`
- `cargo clippy -q -p sifr_hir -p sifr_codegen -- -D warnings`
- selected e2e pass manifest for `scope_spawn_core`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/scope_spawn_core.sifr`
- direct `sifr check` on the three new negative fixtures
- `scripts/run_all_tests.sh --profile quick`

## Review
- `reviews/phase-32-milestone-async-2-scope-spawn-core-review-pass-1.md` (SATISFIED)
