### PR TITLE
Phase 32: add task handle join observation

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_handle_join.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_join.sifr
@@ -1,0 +1,10 @@
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        result = await handle.join()
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3703,6 +3703,28 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
 }
 
 #[test]
+fn test_task_handle_join_lowers_to_task_result_observation() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle.join()\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("enum __SifrTaskResult<T, E>"));
+    assert!(result.rust_source.contains("async fn join(self)"));
+    assert!(result.rust_source.contains("handle.join().await"));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<i64, std::convert::Infallible>"));
+}
+
+#[test]
 fn test_sync_main_does_not_require_tokio() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -396,6 +396,14 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
                         args: lowered_args,
                     }
                 }
+            } else if let HirExpr::MethodCall {
+                object,
+                method,
+                args,
+                ..
+            } = value.as_ref()
+            {
+                try_lower_simple_method_call_expr(object, method, args)?
             } else {
                 try_lower_leaf_or_name_expr(value)?
             };
@@ -964,6 +972,14 @@ fn try_lower_simple_method_call_expr(
             receiver: Box::new(lowered_object),
             method: method.to_string(),
             args: lowered_args,
+        });
+    }
+    if method == "join" && matches!(resolve_alias_type(object.ty()), Type::Task(_, _)) {
+        let lowered_object = try_lower_leaf_or_name_expr(object)?;
+        return Some(RustExpr::MethodCall {
+            receiver: Box::new(lowered_object),
+            method: method.to_string(),
+            args: vec![],
         });
     }
     // Method-call lowering is ownership- and type-convention-sensitive.

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -28,6 +28,13 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
                 task_error_type_to_rust_type(err),
             ],
         },
+        Type::TaskResult(ok, err) => RustType::Generic {
+            base: "__SifrTaskResult".to_string(),
+            params: vec![
+                sifr_type_to_rust_type(ok),
+                task_error_type_to_rust_type(err),
+            ],
+        },
         Type::Union(members) => {
             let non_none: Vec<&Type> = members
                 .iter()
@@ -160,6 +167,91 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     RustType::Named("std::marker::PhantomData<E>".to_string()),
                 ),
             ],
+        },
+        RustItem::Enum {
+            name: "__SifrTaskResult<T, E>".to_string(),
+            visibility: Visibility::Private,
+            derives: vec!["Debug".to_string()],
+            repr: None,
+            variants: vec![
+                crate::RustEnumVariant {
+                    name: "Ok".to_string(),
+                    tuple_fields: vec![RustType::Named("T".to_string())],
+                    fields: vec![],
+                    value: None,
+                },
+                crate::RustEnumVariant {
+                    name: "Err".to_string(),
+                    tuple_fields: vec![RustType::Named("E".to_string())],
+                    fields: vec![],
+                    value: None,
+                },
+                crate::RustEnumVariant {
+                    name: "Cancelled".to_string(),
+                    tuple_fields: vec![],
+                    fields: vec![],
+                    value: None,
+                },
+            ],
+        },
+        RustItem::Impl {
+            target: "__SifrTask<T, E>".to_string(),
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec![],
+                },
+                crate::RustTypeParam {
+                    name: "E".to_string(),
+                    bounds: vec![],
+                },
+            ],
+            trait_: None,
+            items: vec![RustItem::Fn {
+                name: "join".to_string(),
+                visibility: Visibility::Private,
+                type_params: vec![],
+                params: vec![RustParam::SelfValue],
+                ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
+                body: vec![RustStmt::IfLet {
+                    pattern: "Some(receiver)".to_string(),
+                    expr: RustExpr::Field {
+                        expr: Box::new(RustExpr::Ident("self".to_string())),
+                        field: "receiver".to_string(),
+                    },
+                    then_body: vec![RustStmt::Match {
+                        expr: RustExpr::Await(Box::new(RustExpr::Ident("receiver".to_string()))),
+                        arms: vec![
+                            RustMatchArm {
+                                pattern: "Ok(value)".to_string(),
+                                bindings: vec![],
+                                guard: None,
+                                body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "__SifrTaskResult".to_string(),
+                                        "Ok".to_string(),
+                                    ])),
+                                    args: vec![RustExpr::Ident("value".to_string())],
+                                }))],
+                            },
+                            RustMatchArm {
+                                pattern: "Err(_)".to_string(),
+                                bindings: vec![],
+                                guard: None,
+                                body: vec![RustStmt::Return(Some(RustExpr::Path(vec![
+                                    "__SifrTaskResult".to_string(),
+                                    "Cancelled".to_string(),
+                                ])))],
+                            },
+                        ],
+                    }],
+                    else_body: Some(vec![RustStmt::Return(Some(RustExpr::Path(vec![
+                        "__SifrTaskResult".to_string(),
+                        "Cancelled".to_string(),
+                    ])))]),
+                }],
+                is_async: true,
+            }],
         },
         RustItem::Struct {
             name: "__SifrTaskScope".to_string(),

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -57,6 +57,7 @@ use super::sequence_guard_detection::{
 };
 use super::subscript_type::resolve_subscript_result_type;
 use super::task_calls::{lower_task_module_call, TaskCallLowering};
+use super::task_handle_calls::{is_task_handle_type, lower_task_handle_method_call};
 use super::task_scope_calls::{is_task_scope_type, lower_task_scope_spawn_call};
 pub(super) use super::tuple_unpack::{lower_star_unpack_assign, lower_tuple_unpack_assign};
 use super::type_bounds::{type_satisfies_bound, type_satisfies_constraint};
@@ -2133,6 +2134,11 @@ pub(super) fn lower_method_call(
     let method_name = attr.attr.to_string();
     if is_task_scope_type(object.ty()) && method_name == "spawn" {
         return lower_task_scope_spawn_call(object, attr, call, ctx);
+    }
+    if is_task_handle_type(object.ty()) {
+        if let Some(expr) = lower_task_handle_method_call(object.clone(), &method_name, call, ctx) {
+            return Some(expr);
+        }
     }
     let object_ty_for_args = canonicalize_class_surface_type(object.ty().resolve_alias());
     let args = match &object_ty_for_args {

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -98,6 +98,7 @@ mod statement_diagnostics_tests;
 mod statements;
 mod subscript_type;
 mod task_calls;
+mod task_handle_calls;
 mod task_scope_calls;
 mod tuple_unpack;
 #[cfg(test)]

--- a/crates/sifr_hir/src/lower/task_handle_calls.rs
+++ b/crates/sifr_hir/src/lower/task_handle_calls.rs
@@ -1,0 +1,62 @@
+use super::expression_diagnostics;
+use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_python_ast::ExprCall;
+use sifr_type_system::Type;
+
+pub(super) fn is_task_handle_type(ty: &Type) -> bool {
+    matches!(ty.resolve_alias(), Type::Task(_, _))
+}
+
+pub(super) fn lower_task_handle_method_call(
+    object: HirExpr,
+    method_name: &str,
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<HirExpr> {
+    if method_name != "join" {
+        return None;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "Task.join() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return None;
+    }
+    if !call.arguments.args.is_empty() {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "Task.join() takes no arguments".to_string(),
+            call_arity_range(call),
+        );
+        return None;
+    }
+    let Type::Task(ok_ty, err_ty) = object.ty().resolve_alias() else {
+        return None;
+    };
+    let result_ok_ty = ok_ty.clone();
+    let result_err_ty = err_ty.clone();
+    Some(HirExpr::MethodCall {
+        object: Box::new(object),
+        method: method_name.to_string(),
+        args: vec![],
+        ty: Type::Awaitable(Box::new(Type::TaskResult(result_ok_ty, result_err_ty))),
+    })
+}
+
+fn first_call_keyword_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .keywords
+        .first()
+        .map_or_else(|| call.func.range(), |keyword| keyword.range)
+}
+
+fn call_arity_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .args
+        .last()
+        .map_or_else(|| call.func.range(), Ranged::range)
+}

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -387,6 +387,8 @@ status: in_progress
 - Added positive validation fixture: `task_scope_container.sifr`.
 - In progress conservative spawn slice: `scope.spawn(coro)` accepts no-argument infallible coroutine calls, returns a typed task observer handle, and records an owned child driver in the task scope so normal scope exit awaits dropped/unobserved handles instead of detaching them.
 - Added validation coverage for `scope_spawn_core.sifr`, `scope_spawn_capture_rejected.sifr`, `scope_spawn_non_coroutine_rejected.sifr`, and `detached_spawn_not_available.sifr`.
+- In progress task-handle observation slice: `handle.join()` is recognized as an async task observation operation and lowers to a private generated `TaskResult` substrate for conservative infallible task handles.
+- Added positive validation fixture: `task_handle_join.sifr`.
 
 ---
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, and conservative `scope.spawn` support are underway |
+| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, conservative `scope.spawn`, and task-handle join support are underway |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |

--- a/reviews/phase-32-milestone-async-2-task-handle-join-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-2-task-handle-join-review-pass-1.md
@@ -1,0 +1,76 @@
+
+
+Review complete. Let me compile the findings.
+
+---
+
+## Phase 32 milestone_async_2 task-handle-join review, pass 1
+
+### Verdict: SATISFIED
+
+### Blocking Findings: None
+
+### Scope Reviewed
+
+All 9 changed files across HIR lowering, codegen, preamble substrate, tests, and docs:
+
+| File | Change |
+|---|---|
+| `crates/sifr_hir/src/lower/task_handle_calls.rs` | NEW — HIR recognition and type for `Task[T, E].join()` |
+| `crates/sifr_hir/src/lower/expressions.rs` | 6-line dispatch to task_handle_calls |
+| `crates/sifr_hir/src/lower/mod.rs` | module registration |
+| `crates/sifr_codegen/src/lower_expr.rs` | simple method-call lowering for `join` on Task |
+| `crates/sifr_codegen/src/preamble.rs` | `__SifrTaskResult` enum + `impl __SifrTask::join()` |
+| `crates/sifr_codegen/src/lib_codegen_tests.rs` | codegen unit test |
+| `crates/sifr/tests/e2e/pass/task_handle_join.sifr` | positive e2e fixture |
+| `internal_docs/phases/32_async_ecosystem.md` | progress notes |
+| `internal_docs/roadmap.md` | status line update |
+
+### Correctness Checks
+
+1. **HIR type for `handle.join()`**: `Awaitable(TaskResult(ok, err))` — matches the model contract (`join` → `TaskResult[T, E]`). `task_handle_calls.rs:46`
+
+2. **Arity validation**: zero positional args, zero keyword args, with targeted diagnostics for each violation — `task_handle_calls.rs:21-35`
+
+3. **Codegen path**: `join` on `Type::Task` goes through `try_lower_simple_method_call_expr` at `lower_expr.rs:977-983`, emitting `handle.join()` — no args, no unwrap. Verified by emit output and codegen test assertions at `lib_codegen_tests.rs:3714-3723`.
+
+4. **`__SifrTaskResult` enum**: `Ok(T)`, `Err(E)`, `Cancelled` — three-variant private substrate. `preamble.rs:170-196`
+
+5. **`impl __SifrTask::join`**: awaits the oneshot receiver; `Ok(value)` → `Ok`, `Err(_)` (sender dropped/sender cancelled) → `Cancelled`, `None` receiver → `Cancelled`. Correct handling of the closed-observer case without panics. `preamble.rs:210-254`
+
+6. **Generated Rust** (`handle.join().await` on `__SifrTaskResult<i64, Infallible>`) — verified via `cargo run -q -p sifr -- emit`.
+
+### Contract Alignment
+
+- `Task[T, E].join()` → `Awaitable[TaskResult[T, E]]` ✓
+- `handle.join()` desugars to `handle.join().await` ✓ (model: `await Task[T, E]` = syntactic sugar for `await handle.join()`)
+- `__SifrTaskResult::Ok(T)`, `Err(E)`, `Cancelled` — matches model `TaskResult` branches ✓
+- Closed-observer maps to `Cancelled` (not `Err`), no panics on receiver-closed ✓
+- Infallible `Err` branch maps to `Cancelled` as designed for conservative infallible spawn ✓
+- No user-triggerable panic paths in generated code ✓
+
+### Validations Run
+
+All pass:
+- `cargo fmt --check`
+- `cargo check -q -p sifr_hir -p sifr_codegen -p sifr`
+- `cargo clippy -q -p sifr_hir -p sifr_codegen -- -D warnings`
+- `cargo test -q -p sifr_codegen task_handle_join`
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/task_handle_join.sifr`
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/task_handle_join.sifr`
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_join.sifr`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+
+### Non-Blocking Observations
+
+1. **E2E suite not run to completion** — the e2e pass suite is slow (1000+ fixtures); I ran targeted fixture operations instead. The fixture file `task_handle_join.sifr` exists in the pass directory and will be discovered by the suite when run via `scripts/run_all_tests.sh` or `scripts/run_e2e_pass.sh`.
+
+2. **Known limitations correctly documented** — affine consumption for double-observation, user-facing `TaskResult` matching ergonomics, and fallible task error plumbing are listed as deferred per design. The implementation is honest about its conservative infallible substrate boundary.
+
+3. **`Task` does not yet implement `Awaitable` directly** — `await task_handle` is not yet lowering to `handle.join().await` automatically. The model marks this as a task-handle observation operation, but the desugaring path (`await Task[T, E]` → `await handle.join()`) is not wired yet. This is correctly classified as an upcoming item and does not block this slice.
+
+4. **HIR new-file convention** — `task_handle_calls.rs` follows the existing pattern established by `task_calls.rs` and `task_scope_calls.rs`. No monolithic-file violations. Guardrails check passes.
+
+### Summary
+
+Clean implementation with correct type semantics, no panic paths, targeted validation, and honest deferral documentation. All checks pass. Ready for PR.


### PR DESCRIPTION
## Summary
- add HIR recognition for `Task.join()` as `Awaitable[TaskResult[T, E]]`
- generate private `__SifrTaskResult<T, E>` and async `__SifrTask::join(self)`
- lower `await handle.join()` to generated Rust and add a focused pass fixture
- update Phase 32 tracking docs

## Validation
- `cargo fmt --check`
- `cargo check -q -p sifr_hir -p sifr_codegen -p sifr`
- `cargo test -q -p sifr_codegen task_handle_join`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/task_handle_join.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_join.sifr`
- selected e2e pass manifest for `task_handle_join`
- `scripts/check_hir_maintainability_guardrails.py`
- `cargo clippy -q -p sifr_hir -p sifr_codegen -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`

## Review
- `reviews/phase-32-milestone-async-2-task-handle-join-review-pass-1.md` (SATISFIED)
