### PR TITLE
Phase 32: lower await on task handles

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_handle_await.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_await.sifr
@@ -1,0 +1,10 @@
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        result = await handle
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3725,6 +3725,26 @@ fn test_task_handle_join_lowers_to_task_result_observation() {
 }
 
 #[test]
+fn test_await_task_handle_desugars_to_join_observation() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("handle.join().await"));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<i64, std::convert::Infallible>"));
+}
+
+#[test]
 fn test_sync_main_does_not_require_tokio() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -404,6 +404,12 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
             } = value.as_ref()
             {
                 try_lower_simple_method_call_expr(object, method, args)?
+            } else if matches!(resolve_alias_type(value.ty()), Type::Task(_, _)) {
+                RustExpr::MethodCall {
+                    receiver: Box::new(try_lower_leaf_or_name_expr(value)?),
+                    method: "join".to_string(),
+                    args: vec![],
+                }
             } else {
                 try_lower_leaf_or_name_expr(value)?
             };

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -389,6 +389,8 @@ status: in_progress
 - Added validation coverage for `scope_spawn_core.sifr`, `scope_spawn_capture_rejected.sifr`, `scope_spawn_non_coroutine_rejected.sifr`, and `detached_spawn_not_available.sifr`.
 - In progress task-handle observation slice: `handle.join()` is recognized as an async task observation operation and lowers to a private generated `TaskResult` substrate for conservative infallible task handles.
 - Added positive validation fixture: `task_handle_join.sifr`.
+- In progress task-handle await slice: direct `await handle` now desugars to the same private join observation path as `await handle.join()`.
+- Added positive validation fixture: `task_handle_await.sifr`.
 
 ---
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, conservative `scope.spawn`, and task-handle join support are underway |
+| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, conservative `scope.spawn`, task-handle join, and direct task-handle await support are underway |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |

--- a/reviews/phase-32-milestone-async-2-await-task-handle-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-2-await-task-handle-review-pass-1.md
@@ -1,0 +1,46 @@
+
+
+## Review Verdict: **SATISFIED**
+
+The staged diff is correct, minimal, and ready for PR.
+
+---
+
+### 1. Blocking Findings
+
+**None.** No blocking issues found.
+
+---
+
+### 2. Non-Blocking Observations
+
+| # | Category | Finding |
+|---|----------|---------|
+| 1 | **Test coverage** | The unit test `test_await_task_handle_desugars_to_join_observation` and e2e fixture `task_handle_await.sifr` are sufficient. The e2e `task_handle_join.sifr` fixture remains as canonical `await handle.join()` baseline coverage. |
+| 2 | **Generated output verification** | Confirmed that `await handle` produces `handle.join().await` in generated Rust and types correctly as `__SifrTaskResult<i64, std::convert::Infallible>`. |
+| 3 | **Pre-existing e2e failures** | The `with_enter_exit`, `with_multiple`, and other sync-context-manager fixtures fail on both `main` and this branch due to a pre-existing mutability bug (`E0596`). These are unrelated to this patch. |
+| 4 | **HIR maintainability** | The new `else if` branch in `lower_expr.rs:407-412` is a simple type match + emit pattern. No decomposition warranted at this scale. Guardrails pass. |
+| 5 | **Docs sync** | `32_async_ecosystem.md` line 392-393 correctly records the task-handle await slice status. `roadmap.md` correctly reflects ongoing Phase 32 work. |
+
+---
+
+### 3. Extra Validation Recommended
+
+All recommended validations were already run and passed per your context. A few optional follow-ups for thoroughness:
+
+```bash
+# Verify the join() method call case still works (existing behavior preserved)
+cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/task_handle_join.sifr
+
+# Verify non-Task await paths unchanged
+cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/await_chain.sifr
+
+# Quick regression: ensure task_handle_await.sifr generates without errors
+cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/task_handle_await.sifr
+```
+
+---
+
+### Summary
+
+The patch is a clean, 6-line codegen addition plus tests and docs updates. It correctly implements the Phase 32 semantic contract (decision 5): direct `await handle` desugars to `handle.join().await`, producing `TaskResult[T, E]`. The implementation is minimal, type-safe, and has no user-triggerable panic paths. Ready to ship.


### PR DESCRIPTION
## Summary
- lower direct `await handle` on task handles through the existing private `join()` observation path
- add codegen coverage and an e2e pass fixture for `task_handle_await.sifr`
- update Phase 32 and roadmap tracking notes

## Validation
- `cargo fmt --check`
- `cargo check -q -p sifr_codegen -p sifr`
- `cargo test -q -p sifr_codegen await_task_handle`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/task_handle_await.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_await.sifr`
- selected e2e manifest for `task_handle_await`
- `scripts/check_hir_maintainability_guardrails.py`
- `cargo clippy -q -p sifr_codegen -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Opus review: `reviews/phase-32-milestone-async-2-await-task-handle-review-pass-1.md`
- Verdict: SATISFIED; no blockers