### PR TITLE
Add conservative task group surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_group_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/task_group_basic.sifr
@@ -1,0 +1,10 @@
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> None:
+    async with task.TaskGroup() as group:
+        handle = group.spawn(worker())
+        result = await handle.join()
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -878,11 +878,11 @@ fn body_contains_await(body: &[HirStmt]) -> bool {
 }
 
 fn module_uses_task_scope(module: &HirModule) -> bool {
-    fn stmt_is_task_scope(stmt: &HirStmt) -> bool {
+    fn stmt_uses_task_scope_runtime(stmt: &HirStmt) -> bool {
         matches!(
             stmt,
             HirStmt::AsyncWith {
-                kind: sifr_hir::HirAsyncWithKind::TaskScope,
+                kind: sifr_hir::HirAsyncWithKind::TaskScope | sifr_hir::HirAsyncWithKind::TaskGroup,
                 ..
             }
         )
@@ -890,7 +890,7 @@ fn module_uses_task_scope(module: &HirModule) -> bool {
 
     for func in &module.functions {
         let mut on_stmt = |stmt: &HirStmt| {
-            if stmt_is_task_scope(stmt) {
+            if stmt_uses_task_scope_runtime(stmt) {
                 TraversalControl::Stop
             } else {
                 TraversalControl::Continue
@@ -913,7 +913,7 @@ fn module_uses_task_scope(module: &HirModule) -> bool {
     for class in &module.classes {
         for method in &class.methods {
             let mut on_stmt = |stmt: &HirStmt| {
-                if stmt_is_task_scope(stmt) {
+                if stmt_uses_task_scope_runtime(stmt) {
                     TraversalControl::Stop
                 } else {
                     TraversalControl::Continue

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3703,6 +3703,31 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
 }
 
 #[test]
+fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.TaskGroup() as group:\n        handle = group.spawn(worker())\n        result = await handle.join()\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("struct __SifrTaskScope"));
+    assert!(result
+        .rust_source
+        .contains("let mut group = __SifrTaskScope::new();"));
+    assert!(result.rust_source.contains("group.spawn(worker());"));
+    assert!(result
+        .rust_source
+        .contains("group.__sifr_join_all().await;"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
 fn test_task_handle_join_lowers_to_task_result_observation() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -959,7 +959,7 @@ fn try_lower_simple_method_call_expr(
     args: &[HirExpr],
 ) -> Option<RustExpr> {
     if method == "spawn"
-        && matches!(resolve_alias_type(object.ty()), Type::Class { name, .. } if name == "TaskScope")
+        && matches!(resolve_alias_type(object.ty()), Type::Class { name, .. } if name == "TaskScope" || name == "TaskGroup")
     {
         let lowered_object = try_lower_leaf_or_name_expr(object)?;
         let lowered_args = args

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -1925,7 +1925,13 @@ fn try_lower_simple_async_with_stmt(
         bindings.borrowed_params,
         ctx,
     )?);
-    if let (sifr_hir::HirAsyncWithKind::TaskScope, Some(target)) = (kind, target) {
+    if let (true, Some(target)) = (
+        matches!(
+            kind,
+            sifr_hir::HirAsyncWithKind::TaskScope | sifr_hir::HirAsyncWithKind::TaskGroup
+        ),
+        target,
+    ) {
         block.push(RustStmt::Expr(RustExpr::Await(Box::new(
             RustExpr::MethodCall {
                 receiver: Box::new(RustExpr::Ident(target.to_string())),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7333,7 +7333,13 @@ impl RustEmitter {
                 },
             );
         }
-        if let (sifr_hir::HirAsyncWithKind::TaskScope, Some(target)) = (kind, target) {
+        if let (true, Some(target)) = (
+            matches!(
+                kind,
+                sifr_hir::HirAsyncWithKind::TaskScope | sifr_hir::HirAsyncWithKind::TaskGroup
+            ),
+            target,
+        ) {
             lowered_body.push(crate::RustStmt::Expr(crate::RustExpr::Await(Box::new(
                 crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Ident(target.to_string())),

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -105,6 +105,7 @@ pub struct HirFunction {
 #[derive(Debug, Clone)]
 pub enum HirAsyncWithKind {
     TaskScope,
+    TaskGroup,
     TaskTimeout { duration: HirExpr },
 }
 

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -17,6 +17,15 @@ fn task_scope_type() -> Type {
     }
 }
 
+fn task_group_type() -> Type {
+    Type::Class {
+        name: "TaskGroup".to_string(),
+        fields: vec![],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
 fn simple_with_target_name(optional_vars: Option<&Expr>, ctx: &mut LowerCtx) -> Option<String> {
     let vars = optional_vars?;
     if let Expr::Name(n) = vars {
@@ -283,7 +292,7 @@ pub(super) fn lower_async_with(
     let Some((task_fn, call)) = async_task_call_name(&item.context_expr) else {
         ctx.error_with_code_at(
             DiagnosticCode::TYPE_MISMATCH,
-            "async with only supports task.scope() and task.timeout(duration) in v1".to_string(),
+            "async with only supports task.scope(), task.TaskGroup(), and task.timeout(duration) in v1".to_string(),
             item.context_expr.range(),
         );
         return None;
@@ -314,6 +323,21 @@ pub(super) fn lower_async_with(
                     ctx.scope.define(name.clone(), task_scope_type());
                 }
                 (HirAsyncWithKind::TaskScope, target)
+            }
+            "TaskGroup" => {
+                if !call.arguments.args.is_empty() {
+                    ctx.error_with_code_at(
+                        DiagnosticCode::CALL_WRONG_POSITIONAL_COUNT,
+                        "task.TaskGroup() takes no arguments in v1".to_string(),
+                        item.context_expr.range(),
+                    );
+                    return None;
+                }
+                let target = simple_with_target_name(item.optional_vars.as_deref(), ctx);
+                if let Some(name) = &target {
+                    ctx.scope.define(name.clone(), task_group_type());
+                }
+                (HirAsyncWithKind::TaskGroup, target)
             }
             "timeout" => {
                 if call.arguments.args.len() != 1 {
@@ -351,7 +375,7 @@ pub(super) fn lower_async_with(
             _ => {
                 ctx.error_with_code_at(
                     DiagnosticCode::TYPE_MISMATCH,
-                    "async with only supports task.scope() and task.timeout(duration) in v1"
+                    "async with only supports task.scope(), task.TaskGroup(), and task.timeout(duration) in v1"
                         .to_string(),
                     item.context_expr.range(),
                 );

--- a/crates/sifr_hir/src/lower/task_scope_calls.rs
+++ b/crates/sifr_hir/src/lower/task_scope_calls.rs
@@ -7,7 +7,7 @@ use sifr_python_ast::{ExprAttribute, ExprCall};
 use sifr_type_system::Type;
 
 pub(super) fn is_task_scope_type(ty: &Type) -> bool {
-    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "TaskScope")
+    matches!(ty.resolve_alias(), Type::Class { name, .. } if name == "TaskScope" || name == "TaskGroup")
 }
 
 pub(super) fn lower_task_scope_spawn_call(

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -497,6 +497,7 @@ status: in_progress
 **Implementation progress:**
 
 - In progress task-scope ownership slice: added validation that an unobserved observer handle does not detach its child; normal `TaskScope` exit waits for the child before continuing.
+- In progress TaskGroup surface slice: `async with task.TaskGroup() as group` now lowers through the existing scope-owned child runtime for conservative infallible/no-capture children; group error policy and sibling cancellation remain follow-up milestone_async_3 slices.
 
 ---
 

--- a/reviews/phase-32-milestone-async-3-task-group-basic-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-3-task-group-basic-review-pass-1.md
@@ -1,0 +1,34 @@
+
+
+## Review Findings
+
+**SATISFIED** — no blocking issues.
+
+### HIR Recognition (`hir_nodes.rs`, `async_with.rs`)
+- `HirAsyncWithKind::TaskGroup` variant added alongside `TaskScope`
+- `lower_async_with` handles `"TaskGroup"` identifier, validates zero arguments, defines variable in scope with correct type
+- Error messages updated to mention all three supported async-with forms
+
+### Spawn on TaskGroup (`task_scope_calls.rs`, `lower_expr.rs`)
+- `is_task_scope_type` correctly includes both `TaskScope` and `TaskGroup`
+- This is **correctly conservative** — existing infallible/no-arg spawn validation (`"until task error plumbing lands"`, `"until task-boundary checking lands"`) applies uniformly, which is the intended design for this first slice
+
+### Codegen (`lib.rs`, `lower_stmt.rs`, `stmt_support_emitter.rs`)
+- `module_uses_task_scope` includes `TaskGroup` in its check, so `__SifrTaskScope` runtime is included when needed
+- Both async-with lowering sites emit `__sifr_join_all().await` on normal exit for both `TaskScope` and `TaskGroup`
+- Emitted Rust correctly shows `group.spawn()` returning `__SifrTask`, then `group.__sifr_join_all().await` before block exit
+
+### Test Coverage
+- **Unit test** (`test_task_group_basic_lowers_to_scope_runtime_substrate`): verifies `struct __SifrTaskScope`, `group.spawn(worker())`, `group.__sifr_join_all().await`, and `tokio` dependency
+- **E2E fixture** (`task_group_basic.sifr`): full end-to-end with spawn, join, and normal exit
+
+### PR Manifest (`pr_e2e_manifest.json`)
+- JSON valid, `"task_group_basic"` added correctly, trailing comma acceptable
+
+### Phase Doc (`32_async_ecosystem.md`)
+- Progress note accurately states: conservative infallible/no-capture children, group error policy and sibling cancellation deferred to follow-up slices
+
+### Alignment with Design Doc (`async_concurrency_model.md`)
+- Current slice correctly defers all TaskGroup-specific semantics (heterogeneous errors, sibling cancellation, group failure policy) per the model — this is a pure surface/recognition slice
+
+**No additional changes required.**

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -65,6 +65,7 @@
     "stdlib_subprocess",
     "cpython_json_subset",
     "cpython_math_semantic_corrections_subset",
-    "task_scope_unobserved_child_waits"
+    "task_scope_unobserved_child_waits",
+    "task_group_basic"
   ]
 }


### PR DESCRIPTION
## Summary
- recognize  as a milestone_async_3 built-in async-with form
- reuse the existing scope-owned task runtime for conservative infallible/no-capture TaskGroup children
- add codegen and e2e coverage, plus PR-manifest coverage and phase progress notes

## Validation
- cargo test -q -p sifr_codegen test_task_group_basic_lowers_to_scope_runtime_substrate
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_group_basic.sifr
- python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null
- cargo fmt --check
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase-32-milestone-async-3-task-group-basic-review-pass-1.md: SATISFIED