### PR TITLE
Validate gather handle collection consumption

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
@@ -1,0 +1,15 @@
+async def first() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def second() -> int:
+    await task.sleep(0.0)
+    return 2
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handles = [scope.spawn(first()), scope.spawn(second())]
+        result = await task.gather(handles)
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -499,6 +499,7 @@ status: in_progress
 - In progress task-scope ownership slice: added validation that an unobserved observer handle does not detach its child; normal `TaskScope` exit waits for the child before continuing.
 - In progress TaskGroup surface slice: `async with task.TaskGroup() as group` now lowers through the existing scope-owned child runtime for conservative infallible/no-capture children; group error policy and sibling cancellation remain follow-up milestone_async_3 slices.
 - In progress gather slice: `task.gather([...])` accepts homogeneous task-handle lists, consumes the handles, awaits them in deterministic input order, and returns a `TaskResult[list[T], E]` through a private runtime helper; fail-fast fallible child policy remains a follow-up slice once fallible spawn lands.
+- In progress gather collection-consumption slice: added validation for gathering a named task-handle list so the milestone's explicit handle-collection consumption path is covered.
 
 ---
 

--- a/reviews/phase-32-milestone-async-3-gather-collection-consumed-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-3-gather-collection-consumed-review-pass-1.md
@@ -1,0 +1,63 @@
+
+
+## Review Findings
+
+### Files Reviewed
+- `crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr` (new untracked file)
+- `internal_docs/phases/32_async_ecosystem.md` (+1 line)
+- `verification/validation_lanes/pr_e2e_manifest.json` (+2 lines, -1 line)
+
+---
+
+### 1. Fixture exercises the named list path (not just inline literal)
+**SATISFIED.** The fixture uses `handles = [scope.spawn(first()), scope.spawn(second())]` followed by `await task.gather(handles)`, which is the named list variable path. The companion `task_gather_ordered.sifr` exercises the inline literal path `[scope.spawn(...)]` so both paths are covered.
+
+---
+
+### 2. Fixture within conservative spawn/gather limits
+**SATISFIED.** 2 spawns in scope, 0 captures, no fallible returns. Well within the conservative fallback constraints documented in the phase doc.
+
+---
+
+### 3. Fixture in phase positive validation set and PR manifest
+**SATISFIED.** 
+- Phase doc line 472: `task_handle_collection_consumed.sifr` is listed under the milestone_async_3 positive validation set.
+- PR manifest: `task_handle_collection_consumed` added with correct JSON syntax (trailing comma after `task_gather_ordered`).
+
+---
+
+### 4. Phase progress note accurate and not overstated
+**SATISFIED.** The added sentence:
+```
+- In progress gather collection-consumption slice: added validation for gathering a named task-handle list so the milestone's explicit handle-collection consumption path is covered.
+```
+This is accurate — it's a validation slice, not implementation, and correctly describes the coverage goal. It does not overstate completion.
+
+---
+
+### 5. No compiler code changes
+**SATISFIED.** `git diff --stat` shows only the two non-compiler files changed. No `crates/` changes.
+
+---
+
+### 6. No additional blocking changes required
+**SATISFIED.** 
+- JSON syntax valid.
+- Local validation passed: `scripts/run_all_tests.sh --profile quick` reports 23/23 pass, including the new fixture.
+- Fixture is lexically placed in the correct e2e pass directory.
+- Companion review log file exists (empty, as expected for pass-1).
+
+---
+
+### Note on review artifacts
+Two untracked files exist in the working directory as expected:
+- `reviews/phase-32-milestone-async-3-gather-collection-consumed-review-pass-1.md`
+- `reviews/phase-32-milestone-async-3-gather-collection-consumed-review-pass-1.claude.log`
+
+These are properly untracked and do not affect the PR slice.
+
+---
+
+## Result
+
+**SATISFIED** — No blocking findings. The PR slice correctly adds validation for the named task-handle collection consumption path without introducing compiler changes or documentation inaccuracies.

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -67,6 +67,7 @@
     "cpython_math_semantic_corrections_subset",
     "task_scope_unobserved_child_waits",
     "task_group_basic",
-    "task_gather_ordered"
+    "task_gather_ordered",
+    "task_handle_collection_consumed"
   ]
 }


### PR DESCRIPTION
## Summary
- add e2e validation for gathering a named task-handle list
- add the fixture to the PR e2e manifest
- record the milestone_async_3 gather collection-consumption progress note

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
- python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase-32-milestone-async-3-gather-collection-consumed-review-pass-1.md: SATISFIED
