### PR TITLE
Add conservative task race

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
+++ b/crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
@@ -1,0 +1,35 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_task_race_cancels_losers_" + str(getpid()) + ".txt"
+
+
+async def fast() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def slow_writes_marker() -> int:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "lost")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 2
+
+
+async def main() -> None:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    async with task.scope() as scope:
+        result = await task.race([scope.spawn(fast()), scope.spawn(slow_writes_marker())])
+
+    assert not exists(path)
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -888,7 +888,7 @@ fn module_uses_task_scope(module: &HirModule) -> bool {
         )
     }
     fn expr_uses_task_scope_runtime(expr: &HirExpr) -> bool {
-        matches!(expr, HirExpr::Call { func, .. } if func == "__sifr_task_gather")
+        matches!(expr, HirExpr::Call { func, .. } if func == "__sifr_task_gather" || func == "__sifr_task_race")
     }
 
     for func in &module.functions {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3750,6 +3750,28 @@ fn test_task_gather_lowers_to_private_gather_helper() {
 }
 
 #[test]
+fn test_task_race_lowers_to_private_race_helper() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def first() -> int:\n    return 1\n\nasync def second() -> int:\n    await task.sleep(1.0)\n    return 2\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        result = await task.race([scope.spawn(first()), scope.spawn(second())])\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("async fn __sifr_task_race"));
+    assert!(result.rust_source.contains("__sifr_task_race(vec!["));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<i64, std::convert::Infallible>"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
 fn test_task_handle_join_lowers_to_task_result_observation() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -535,6 +535,15 @@ fn try_lower_simple_call_expr(func: &str, args: &[HirExpr]) -> Option<RustExpr> 
             args: vec![try_lower_leaf_or_name_expr(handles)?],
         });
     }
+    if func == "__sifr_task_race" {
+        let [handles] = args else {
+            return None;
+        };
+        return Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Ident(func.to_string())),
+            args: vec![try_lower_leaf_or_name_expr(handles)?],
+        });
+    }
     if func == "hash" {
         return try_lower_simple_hash_call_expr(args);
     }

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -501,6 +501,29 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             ))],
             is_async: true,
         },
+        RustItem::Fn {
+            name: "__sifr_task_race".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
+                },
+                crate::RustTypeParam {
+                    name: "E".to_string(),
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
+                },
+            ],
+            params: vec![RustParam::Named {
+                name: "handles".to_string(),
+                ty: RustType::Named("Vec<__SifrTask<T, E>>".to_string()),
+            }],
+            ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
+            body: vec![RustStmt::Expr(RustExpr::Ident(
+                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, _error } = handle;\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(value) => __SifrTaskResult::Ok(value),\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
+            ))],
+            is_async: true,
+        },
     ]
 }
 

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1581,6 +1581,24 @@ fn test_task_timeout_consumes_handle_binding() {
 }
 
 #[test]
+fn test_task_race_consumes_handle_collection_binding() {
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handles = [scope.spawn(worker()), scope.spawn(worker())]\n        result = await task.race(handles)\n        second = await task.race(handles)\n    return None\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|e| {
+        e.message.contains("moved value")
+            && e.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && e.primary_range
+                == Some(range_for_after(
+                    source,
+                    "second = await task.race(",
+                    "handles",
+                ))
+    }));
+}
+
+#[test]
 fn test_task_timeout_context_manager_requires_timeout_error_result_for_awaits() {
     let source = "async def main() -> None:\n    async with task.timeout(1.0):\n        await task.sleep(0.0)\n    return None\n";
     let result = lower_source(source);

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -28,6 +28,7 @@ pub(super) fn lower_task_module_call(
         "sleep" => lower_task_sleep_call(call, ctx),
         "timeout" => lower_task_timeout_call(call, ctx),
         "gather" => lower_task_gather_call(call, ctx),
+        "race" => lower_task_race_call(call, ctx),
         "spawn" => {
             expression_diagnostics::type_mismatch(
                 ctx,
@@ -102,6 +103,68 @@ fn lower_task_gather_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLoweri
             Box::new(Type::List(result_ok_ty)),
             result_err_ty,
         ))),
+    })
+}
+
+fn lower_task_race_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "task.race() is only valid inside async functions".to_string(),
+            call.range(),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "task.race() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "task.race() takes exactly one list of task handles".to_string(),
+            call_arity_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+
+    let Some(handles) = lower_expr(&call.arguments.args[0], ctx) else {
+        return TaskCallLowering::Rejected;
+    };
+    let handles_ty = handles.ty().clone();
+    let Type::List(element_ty) = handles_ty.resolve_alias() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "task.race() argument must be list[Task[T, E]], got '{}'",
+                handles.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    };
+    let Type::Task(ok_ty, err_ty) = element_ty.resolve_alias() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "task.race() argument must be list[Task[T, E]], got '{}'",
+                handles.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    };
+    let result_ok_ty = ok_ty.clone();
+    let result_err_ty = err_ty.clone();
+    mark_task_handle_names_moved(&handles, ctx);
+    TaskCallLowering::Lowered(HirExpr::Call {
+        func: "__sifr_task_race".to_string(),
+        args: vec![handles],
+        ty: Type::Awaitable(Box::new(Type::TaskResult(result_ok_ty, result_err_ty))),
     })
 }
 

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -500,6 +500,7 @@ status: in_progress
 - In progress TaskGroup surface slice: `async with task.TaskGroup() as group` now lowers through the existing scope-owned child runtime for conservative infallible/no-capture children; group error policy and sibling cancellation remain follow-up milestone_async_3 slices.
 - In progress gather slice: `task.gather([...])` accepts homogeneous task-handle lists, consumes the handles, awaits them in deterministic input order, and returns a `TaskResult[list[T], E]` through a private runtime helper; fail-fast fallible child policy remains a follow-up slice once fallible spawn lands.
 - In progress gather collection-consumption slice: added validation for gathering a named task-handle list so the milestone's explicit handle-collection consumption path is covered.
+- In progress race slice: `task.race([...])` accepts homogeneous task-handle lists, consumes the handles, returns the first completed `TaskResult[T, E]`, and requests cancellation for losing handles; loser cleanup error evidence remains a follow-up slice once fallible spawn and scope-failure plumbing land.
 
 ---
 

--- a/reviews/phase-32-milestone-async-3-task-race-basic-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-3-task-race-basic-review-pass-1.md
@@ -1,0 +1,80 @@
+
+
+Review complete. Here's my assessment:
+
+## SATISFIED
+
+### Correctness Against Model
+
+The implementation correctly implements the `task.race` primitive as defined in the model contract:
+
+**Model requirements verified:**
+- `task.race(handles)` accepts homogeneous `list[Task[T, E]]` (model line 376: `task.race(handles: list[Task[T, E]]) -> TaskResult[T, E]`)
+- Returns first completed `TaskResult[T, E]` — checked ✓
+- Consumes input handles via `mark_task_handle_names_moved` — checked ✓
+- Cancels losing tasks by default (model line 526: "losing tasks are cancelled by default") — checked ✓
+- Loser handles cannot be awaited later — ensured by affine consumption ✓
+
+**Type system integration:**
+- Result type is `Awaitable[TaskResult[T, E]]` — correctly wired ✓
+- Rejects non-async context (only valid inside `async def`) ✓
+- Rejects keyword arguments ✓
+- Rejects wrong arity ✓
+- Rejects non-list argument ✓
+- Rejects non-Task list element types ✓
+
+### Runtime Safety
+
+The `__sifr_task_race` helper is correctly structured:
+- Uses `tokio::sync::mpsc::unbounded_channel()` for race detection ✓
+- Only spawns observers for `Some(task_receiver)` (handles that are not already consumed/cancelled) ✓
+- First result via `receiver.recv().await` ✓
+- Aborts ALL `abort_handles` regardless of winner result ✓
+- Drains remaining observers to avoid orphaning tasks ✓
+- Returns `__SifrTaskResult::Cancelled` if no observers exist ✓
+
+No user-triggerable panics — all fallible paths are handled.
+
+### Ownership / Handle Consumption
+
+`mark_task_handle_names_moved` is called on the argument expression, correctly marking both:
+- Named `Task` bindings as moved
+- Named `List` bindings as moved
+
+The unit test `test_task_race_consumes_handle_collection_binding` verifies this.
+
+### Generated Rust Behavior
+
+The generated code correctly:
+- Includes `async fn __sifr_task_race<T: Send + 'static, E: Send + 'static>`
+- Accepts `Vec<__SifrTask<T, E>>`
+- Returns `__SifrTaskResult<T, E>`
+- Wires Tokio dependency when race is used ✓
+
+### Validation Coverage
+
+| Validation | Status |
+|---|---|
+| HIR unit test: handle collection consumed | ✓ |
+| Codegen unit test: lowers to private helper | ✓ |
+| E2E fixture: fast winner cancels slow loser | ✓ |
+| Phase docs updated | ✓ |
+| Manifest updated | ✓ |
+| Clippy (pedantic) | ✓ |
+| Format check | ✓ |
+| Quick profile | ✓ |
+
+### Non-Blocking Notes
+
+1. **Follow-up noted in phase docs:** Loser cleanup error evidence is deferred to a future slice once fallible spawn and scope-failure plumbing land. This is appropriate — the current implementation correctly drops/ignores cleanup failures from aborted tasks.
+
+2. **E2E fixture uses process ID in marker path:** This is defensive but unnecessary since the test never runs in parallel with itself. Could be simplified to a fixed path, but the PID approach is harmless.
+
+### Suitability
+
+This slice is ready to PR/merge. The implementation:
+- Correctly implements the conservative homogeneous-list `task.race` slice
+- Follows the established patterns from `task.gather`
+- Has appropriate test coverage
+- Passes all validation gates
+- Is correctly scoped to the basic race without loser cleanup error evidence

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -68,6 +68,7 @@
     "task_scope_unobserved_child_waits",
     "task_group_basic",
     "task_gather_ordered",
-    "task_handle_collection_consumed"
+    "task_handle_collection_consumed",
+    "task_race_cancels_losers"
   ]
 }


### PR DESCRIPTION
## Summary
- add conservative homogeneous-list `task.race(handles)` lowering and runtime helper
- consume race input handles/lists through existing affine move tracking
- add unit and e2e validation for race lowering and loser cancellation
- add the new fixture to the PR e2e manifest and record Phase 32 progress

## Validation
- cargo test -p sifr_hir test_task_race_consumes_handle_collection_binding
- cargo test -p sifr_codegen test_task_race_lowers_to_private_race_helper
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
- python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase-32-milestone-async-3-task-race-basic-review-pass-1.md: SATISFIED
