### PR TITLE
Add task scope escape negative validation

### DIFF
--- a/crates/sifr/tests/e2e/fail/task_escape_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_escape_scope_rejected.sifr
@@ -1,0 +1,12 @@
+# expect-error[col=12]: SIFR-NAME-0001
+
+async def worker() -> int:
+    return 41
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+
+    late = scope.spawn(worker())
+    return None

--- a/crates/sifr/tests/e2e/fail/task_handle_escape_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_handle_escape_scope_rejected.sifr
@@ -1,0 +1,12 @@
+# expect-error[col=20]: SIFR-NAME-0001
+
+async def worker() -> int:
+    return 41
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+
+    result = await handle
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -502,6 +502,7 @@ status: in_progress
 - In progress gather collection-consumption slice: added validation for gathering a named task-handle list so the milestone's explicit handle-collection consumption path is covered.
 - In progress race slice: `task.race([...])` accepts homogeneous task-handle lists, consumes the handles, returns the first completed `TaskResult[T, E]`, and requests cancellation for losing handles; loser cleanup error evidence remains a follow-up slice once fallible spawn and scope-failure plumbing land.
 - In progress select slice: `task.select(a, b)` accepts heterogeneous task handles, consumes both handles, returns `Select2[TaskResult[A, EA], TaskResult[B, EB]]`, and requests cancellation for the losing handle; loser cleanup error evidence remains a follow-up slice once fallible spawn and scope-failure plumbing land.
+- In progress scope escape diagnostics slice: added negative validation that `TaskScope` bindings and task handles are unavailable after the built-in `async with task.scope()` lifetime ends.
 
 ---
 

--- a/reviews/phase-32-milestone-async-3-scope-escape-negatives-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-3-scope-escape-negatives-review-pass-1.md
@@ -1,0 +1,32 @@
+
+
+**SATISFIED**, with non-blocking notes.
+
+## Assessment
+
+The PR is a clean, well-scoped validation slice. All checks pass:
+
+| Check | Result |
+|---|---|
+| `test_e2e_fail` | ✅ Both fixtures included and passing |
+| `cargo fmt --check` | ✅ No formatting issues |
+| `cargo clippy --workspace -- -D warnings` | ✅ No clippy warnings |
+| Diagnostic code accuracy | ✅ `SIFR-NAME-0001` is active and fires for both cases |
+| Column accuracy | ✅ `col=12` for `scope`, `col=20` for `handle` — both empirically verified |
+| Phase doc note | ✅ Factual, non-misleading |
+
+## Non-blocking notes
+
+1. **No associated review doc**: `reviews/phase-32-milestone-async-3-scope-escape-negatives-review-pass-1.md` exists but is empty. This is fine for a small validation-only slice, but worth noting it was skipped intentionally, not accidentally.
+
+2. **Diagnostic specificity is deferred**: `SIFR-NAME-0001` ("undefined variable") is accurate but does not surface the scope-escape *intent* — the user sees "undefined variable `scope`" rather than "scope binding is unavailable after async-with lifetime". This is acceptable for the current slice because:
+   - The rejection behavior is correct.
+   - A dedicated scope-escape diagnostic would require a new `SIFR-SCOPE-####` code with engine support, which is out of scope for this slice.
+   - The phase doc note acknowledges this as a "diagnostics slice" rather than a runtime enforcement slice.
+   - This aligns with the precedent set by `runtime_leak_rejected.sifr`, which also uses `SIFR-NAME-0001` for lifetime-enforcement rather than a dedicated code.
+
+3. **Fixture placement**: Both fixtures land in `crates/sifr/tests/e2e/fail/` alongside other `SIFR-NAME-0001` fixtures (`undefined_var.sifr`, `runtime_leak_rejected.sifr`, `enum_invalid_variant.sifr`). This is consistent with existing conventions. No change needed.
+
+## Summary
+
+This is a valid, minimal negative-validation slice. The diagnostics fire correctly, all checks pass, and the phase doc is updated. Merge when ready.


### PR DESCRIPTION
## Summary
- add negative validation that `TaskScope` bindings cannot be used after the `async with task.scope()` lifetime ends
- add negative validation that task handles bound inside a task scope cannot be awaited after the scope lifetime ends
- record the milestone_async_3 scope escape validation progress note

## Validation
- cargo test -p sifr -- test_e2e_fail
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase-32-milestone-async-3-scope-escape-negatives-review-pass-1.md: SATISFIED
