### PR TITLE
Plumb fallible task results

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr
+++ b/crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr
@@ -1,0 +1,10 @@
+async def fail_later() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("task failed")
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(fail_later())
+        result = await handle
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3695,7 +3695,9 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
     assert!(result.rust_source.contains("struct __SifrTask<T, E>"));
     assert!(result.rust_source.contains("fn spawn<"));
     assert!(result.rust_source.contains("tokio::sync::oneshot::channel"));
-    assert!(result.rust_source.contains("scope.spawn(worker());"));
+    assert!(result
+        .rust_source
+        .contains("scope.__sifr_spawn_infallible(worker());"));
     assert!(result
         .rust_source
         .contains("scope.__sifr_join_all().await;"));
@@ -3720,7 +3722,9 @@ fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
     assert!(result
         .rust_source
         .contains("let mut group = __SifrTaskScope::new();"));
-    assert!(result.rust_source.contains("group.spawn(worker());"));
+    assert!(result
+        .rust_source
+        .contains("group.__sifr_spawn_infallible(worker());"));
     assert!(result
         .rust_source
         .contains("group.__sifr_join_all().await;"));
@@ -3746,6 +3750,32 @@ fn test_task_gather_lowers_to_private_gather_helper() {
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<Vec<i64>, std::convert::Infallible>"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_scope_spawn_fallible_coroutine_lowers_to_result_spawn_helper() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> Result[int, ValueError]:\n    raise ValueError(\"bad\")\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result
+        .rust_source
+        .contains("tokio::sync::oneshot::Receiver<__SifrTaskResult<T, E>>"));
+    assert!(result
+        .rust_source
+        .contains("scope.__sifr_spawn_result(worker());"));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<i64, ValueError>"));
     assert!(result.required_crates.contains("tokio"));
 }
 

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -988,7 +988,7 @@ fn try_lower_simple_method_call_expr(
     method: &str,
     args: &[HirExpr],
 ) -> Option<RustExpr> {
-    if method == "spawn"
+    if (method == "__sifr_spawn_infallible" || method == "__sifr_spawn_result")
         && matches!(resolve_alias_type(object.ty()), Type::Class { name, .. } if name == "TaskScope" || name == "TaskGroup")
     {
         let lowered_object = try_lower_leaf_or_name_expr(object)?;

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -170,7 +170,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 (
                     "receiver".to_string(),
                     RustType::Option(Box::new(RustType::Named(
-                        "tokio::sync::oneshot::Receiver<T>".to_string(),
+                        "tokio::sync::oneshot::Receiver<__SifrTaskResult<T, E>>".to_string(),
                     ))),
                 ),
                 (
@@ -281,16 +281,12 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                             ))),
                             arms: vec![
                                 RustMatchArm {
-                                    pattern: "Ok(value)".to_string(),
+                                    pattern: "Ok(result)".to_string(),
                                     bindings: vec![],
                                     guard: None,
-                                    body: vec![RustStmt::Return(Some(RustExpr::FnCall {
-                                        func: Box::new(RustExpr::Path(vec![
-                                            "__SifrTaskResult".to_string(),
-                                            "Ok".to_string(),
-                                        ])),
-                                        args: vec![RustExpr::Ident("value".to_string())],
-                                    }))],
+                                    body: vec![RustStmt::Return(Some(RustExpr::Ident(
+                                        "result".to_string(),
+                                    )))],
                                 },
                                 RustMatchArm {
                                     pattern: "Err(_)".to_string(),
@@ -341,7 +337,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         "__SifrTaskResult<T, __SifrTimeoutResult<E>>".to_string(),
                     )),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let __SifrTask { receiver, abort_handle, _error } = self;\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(value) => __SifrTaskResult::Ok(value),\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrTimeoutResult::Timeout)\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                        "let __SifrTask { receiver, abort_handle, _error } = self;\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(err)) => __SifrTaskResult::Err(__SifrTimeoutResult::Inner(err)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrTimeoutResult::Timeout)\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -382,7 +378,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     is_async: false,
                 },
                 RustItem::Fn {
-                    name: "spawn".to_string(),
+                    name: "__sifr_spawn_infallible".to_string(),
                     visibility: Visibility::Private,
                     type_params: vec![
                         crate::RustTypeParam {
@@ -426,7 +422,103 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                             name: "child".to_string(),
                             ty: None,
                             value: RustExpr::Ident(
-                                "tokio::spawn(async move { let result = future.await; let _ = sender.send(result); })"
+                                "tokio::spawn(async move { let result = future.await; let _ = sender.send(__SifrTaskResult::Ok(result)); })"
+                                    .to_string(),
+                            ),
+                        },
+                        RustStmt::Let {
+                            mutable: false,
+                            name: "abort_handle".to_string(),
+                            ty: None,
+                            value: RustExpr::MethodCall {
+                                receiver: Box::new(RustExpr::Ident("child".to_string())),
+                                method: "abort_handle".to_string(),
+                                args: vec![],
+                            },
+                        },
+                        RustStmt::Expr(RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Field {
+                                expr: Box::new(RustExpr::Ident("self".to_string())),
+                                field: "children".to_string(),
+                            }),
+                            method: "push".to_string(),
+                            args: vec![RustExpr::Ident("child".to_string())],
+                        }),
+                        RustStmt::Return(Some(RustExpr::StructInit {
+                            name: "__SifrTask".to_string(),
+                            fields: vec![
+                                (
+                                    "receiver".to_string(),
+                                    RustExpr::FnCall {
+                                        func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                                        args: vec![RustExpr::Ident("receiver".to_string())],
+                                    },
+                                ),
+                                (
+                                    "abort_handle".to_string(),
+                                    RustExpr::Ident("abort_handle".to_string()),
+                                ),
+                                (
+                                    "_error".to_string(),
+                                    RustExpr::Path(vec![
+                                        "std".to_string(),
+                                        "marker".to_string(),
+                                        "PhantomData".to_string(),
+                                    ]),
+                                ),
+                            ],
+                        })),
+                    ],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "__sifr_spawn_result".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![
+                        crate::RustTypeParam {
+                            name: "T".to_string(),
+                            bounds: vec!["Send".to_string(), "'static".to_string()],
+                        },
+                        crate::RustTypeParam {
+                            name: "E".to_string(),
+                            bounds: vec!["Send".to_string(), "'static".to_string()],
+                        },
+                        crate::RustTypeParam {
+                            name: "F".to_string(),
+                            bounds: vec![
+                                "std::future::Future<Output = Result<T, E>>".to_string(),
+                                "Send".to_string(),
+                                "'static".to_string(),
+                            ],
+                        },
+                    ],
+                    params: vec![
+                        RustParam::SelfParam { mutable: true },
+                        RustParam::Named {
+                            name: "future".to_string(),
+                            ty: RustType::Named("F".to_string()),
+                        },
+                    ],
+                    ret: Some(RustType::Named("__SifrTask<T, E>".to_string())),
+                    body: vec![
+                        RustStmt::LetPattern {
+                            pattern: "(sender, receiver)".to_string(),
+                            value: RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec![
+                                    "tokio".to_string(),
+                                    "sync".to_string(),
+                                    "oneshot".to_string(),
+                                    "channel".to_string(),
+                                ])),
+                                args: vec![],
+                            },
+                        },
+                        RustStmt::Let {
+                            mutable: false,
+                            name: "child".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(err) }; let _ = sender.send(result); })"
                                     .to_string(),
                             ),
                         },
@@ -547,7 +639,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             }],
             ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, _error } = handle;\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(value) => __SifrTaskResult::Ok(value),\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
+                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, _error } = handle;\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
             ))],
             is_async: true,
         },
@@ -586,7 +678,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 "__SifrSelect2<__SifrTaskResult<A, EA>, __SifrTaskResult<B, EB>>".to_string(),
             )),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, _error: _second_error } = second;\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::Cancelled);\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(value) => __SifrTaskResult::Ok(value),\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(value) => __SifrTaskResult::Ok(value),\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
+                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, _error: _second_error } = second;\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::Cancelled);\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
             ))],
             is_async: true,
         },

--- a/crates/sifr_hir/src/lower/task_scope_calls.rs
+++ b/crates/sifr_hir/src/lower/task_scope_calls.rs
@@ -12,7 +12,7 @@ pub(super) fn is_task_scope_type(ty: &Type) -> bool {
 
 pub(super) fn lower_task_scope_spawn_call(
     object: HirExpr,
-    attr: &ExprAttribute,
+    _attr: &ExprAttribute,
     call: &ExprCall,
     ctx: &mut LowerCtx,
 ) -> Option<HirExpr> {
@@ -55,14 +55,6 @@ pub(super) fn lower_task_scope_spawn_call(
     };
     let task_ok_ty = ok_ty.clone();
     let task_err_ty = err_ty.clone();
-    if !matches!(task_err_ty.resolve_alias(), Type::Never) {
-        expression_diagnostics::type_mismatch(
-            ctx,
-            "scope.spawn() currently accepts only infallible coroutine arguments until task error plumbing lands".to_string(),
-            call.arguments.args[0].range(),
-        );
-        return None;
-    }
     if !matches!(&coroutine, HirExpr::Call { args, .. } if args.is_empty()) {
         expression_diagnostics::type_mismatch(
             ctx,
@@ -74,7 +66,11 @@ pub(super) fn lower_task_scope_spawn_call(
 
     Some(HirExpr::MethodCall {
         object: Box::new(object),
-        method: attr.attr.to_string(),
+        method: if matches!(task_err_ty.resolve_alias(), Type::Never) {
+            "__sifr_spawn_infallible".to_string()
+        } else {
+            "__sifr_spawn_result".to_string()
+        },
         args: vec![coroutine],
         ty: Type::Task(task_ok_ty, task_err_ty),
     })

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -503,6 +503,7 @@ status: in_progress
 - In progress race slice: `task.race([...])` accepts homogeneous task-handle lists, consumes the handles, returns the first completed `TaskResult[T, E]`, and requests cancellation for losing handles; loser cleanup error evidence remains a follow-up slice once fallible spawn and scope-failure plumbing land.
 - In progress select slice: `task.select(a, b)` accepts heterogeneous task handles, consumes both handles, returns `Select2[TaskResult[A, EA], TaskResult[B, EB]]`, and requests cancellation for the losing handle; loser cleanup error evidence remains a follow-up slice once fallible spawn and scope-failure plumbing land.
 - In progress scope escape diagnostics slice: added negative validation that `TaskScope` bindings and task handles are unavailable after the built-in `async with task.scope()` lifetime ends.
+- In progress fallible task-result plumbing slice: private task receivers now carry `TaskResult[T, E]`, `scope.spawn` accepts no-argument fallible `Result[T, E]` coroutines, and observing the handle preserves the ordinary child error in `TaskResult.Err`.
 
 ---
 

--- a/reviews/phase-32-milestone-async-3-fallible-task-results-review-pass-1.md
+++ b/reviews/phase-32-milestone-async-3-fallible-task-results-review-pass-1.md
@@ -1,0 +1,56 @@
+
+
+Reviewing the fallible task-result plumbing slice...
+
+**SATISFIED**
+
+---
+
+## Key Changes
+
+| File | Change |
+|------|--------|
+| `preamble.rs` | `__SifrTask` receiver: `Receiver<T>` → `Receiver<__SifrTaskResult<T, E>>` |
+| `preamble.rs` | Added `__sifr_spawn_result` for fallible coroutines; `__sifr_spawn_infallible` wraps raw success as `TaskResult::Ok` |
+| `preamble.rs` | Updated `join()`, `__sifr_timeout`, `__sifr_task_gather`, `__sifr_task_race`, `__sifr_task_select` to handle new `TaskResult` receiver shape |
+| `task_scope_calls.rs` | Removed infallible-only guard; dispatches to `__sifr_spawn_infallible` or `__sifr_spawn_result` based on coroutine error type |
+| `lower_expr.rs` | Recognizes both private spawn helpers in codegen |
+| `pr_e2e_manifest.json` + `32_async_ecosystem.md` | Fixture and progress tracking |
+
+---
+
+## Cancellation & Timeout Behavior
+
+**Cancellation** is preserved across all updated helpers:
+- `__sifr_task_race`: aborts losers before awaiting their receivers → correct
+- `__sifr_task_select`: aborts loser before awaiting → correct
+- `__sifr_timeout`: abort then await for cleanup (`let _ = receiver.await`) → correct
+
+**Timeout** correctly distinguishes:
+- `TaskResult::Ok(value)` → child succeeded before deadline → returns `TaskResult::Ok(value)`
+- `TaskResult::Err(err)` → child failed before deadline → wraps as `TimeoutResult::Inner(err)`
+- `TaskResult::Cancelled` or `Err(_)` → child was cancelled/aborter → returns `Cancelled`
+
+The `Err(_)` case in the timeout select arm correctly maps both "receiver closed without send" (sender dropped) and "task was aborted" to `Cancelled`. When `abort()` is called, the oneshot becomes closed, so the await returns `Err(RecvError)`.
+
+---
+
+## Fallible Spawn Soundness
+
+`__sifr_spawn_result` maintains the conservative no-capture boundary:
+
+```rust
+F: std::future::Future<Output = Result<T, E>> + Send + 'static
+```
+
+The HIR layer preserves the no-argument check (`if !matches!(&coroutine, HirExpr::Call { args, .. } if args.is_empty())`), so fallible spawn is sound within the existing conservative boundary.
+
+---
+
+## Non-Blocking Notes
+
+**Note 1 — E2E fixture has no result assertion:**
+`task_spawn_fallible_result.sifr` spawns a fallible coroutine and awaits the handle, but never matches/asserts on `TaskResult.Err`. The test passes by running without panicking, but a follow-up slice should add the match block to validate `ValueError` propagates as `TaskResult.Err`.
+
+**Note 2 — `__sifr_task_gather` returns type:**
+The signature returns `TaskResult<Vec<T>, E>` with `E` as the child error type. After this slice, child tasks return `TaskResult[T, E]` from `join()`. This is correct for the homogeneous gather case (all children share error type `E`).

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -70,6 +70,7 @@
     "task_gather_ordered",
     "task_handle_collection_consumed",
     "task_race_cancels_losers",
-    "task_select_first_completion"
+    "task_select_first_completion",
+    "task_spawn_fallible_result"
   ]
 }


### PR DESCRIPTION
## Summary
- change private task receivers to carry `TaskResult[T, E]`
- add fallible no-arg coroutine spawn plumbing via `__sifr_spawn_result`
- preserve infallible spawn behavior via `__sifr_spawn_infallible`
- update join/timeout/gather/race/select helpers for the new receiver shape
- add codegen coverage, e2e validation, PR manifest entry, and Phase 32 progress note

## Validation
- cargo test -p sifr_codegen test_scope_spawn_fallible_coroutine_lowers_to_result_spawn_helper
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_ordered.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_select_first_completion.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_timeout_success.sifr
- python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase-32-milestone-async-3-fallible-task-results-review-pass-1.md: SATISFIED
