### PR TITLE
Add cancellation timeout validation fixtures

### DIFF
--- a/crates/sifr/tests/e2e/pass/cancellation_nested_scopes.sifr
+++ b/crates/sifr/tests/e2e/pass/cancellation_nested_scopes.sifr
@@ -1,0 +1,5 @@
+async def main() -> Result[None, TimeoutError]:
+    async with task.timeout(1.0):
+        async with task.timeout(1.0):
+            await task.sleep(0.0)
+    return None

--- a/crates/sifr/tests/e2e/pass/cancellation_scope_timeout.sifr
+++ b/crates/sifr/tests/e2e/pass/cancellation_scope_timeout.sifr
@@ -1,0 +1,4 @@
+async def main() -> Result[None, TimeoutError]:
+    async with task.timeout(1.0):
+        await task.sleep(0.0)
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -505,6 +505,7 @@ status: in_progress
 - In progress scope escape diagnostics slice: added negative validation that `TaskScope` bindings and task handles are unavailable after the built-in `async with task.scope()` lifetime ends.
 - In progress fallible task-result plumbing slice: private task receivers now carry `TaskResult[T, E]`, `scope.spawn` accepts no-argument fallible `Result[T, E]` coroutines, and observing the handle preserves the ordinary child error in `TaskResult.Err`.
 - In progress TaskGroup homogeneous-error slice: `task.TaskGroup()` records the first non-`Never` child error type and rejects later children with a different ordinary error type in v1.
+- In progress cancellation timeout validation slice: added PR-lane coverage for `async with task.timeout(...)` around await points and nested timeout scopes on the non-expiring path.
 
 ---
 

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -71,6 +71,8 @@
     "task_handle_collection_consumed",
     "task_race_cancels_losers",
     "task_select_first_completion",
-    "task_spawn_fallible_result"
+    "task_spawn_fallible_result",
+    "cancellation_scope_timeout",
+    "cancellation_nested_scopes"
   ]
 }


### PR DESCRIPTION
## Summary
- add named Phase 32 positive fixtures for timeout cancellation scope validation
- cover a non-expiring `task.timeout` await point and nested timeout scopes
- include the new fixtures in the PR e2e manifest and update phase progress

## Validation
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_scope_timeout.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_nested_scopes.sifr`
- `python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Opus review: `reviews/phase32_cancellation_timeout_validation.md`
- Verdict: SATISFIED
