### PR TITLE
Add cancellation error type surface

### DIFF
--- a/crates/sifr/tests/e2e/fail/cancellation_error_not_result_error.sifr
+++ b/crates/sifr/tests/e2e/fail/cancellation_error_not_result_error.sifr
@@ -1,0 +1,4 @@
+# expect-error: SIFR-RESULT-0002
+
+def bad() -> Result[None, CancellationError]:
+    return None

--- a/crates/sifr/tests/e2e/pass/cancellation_error_type_surface.sifr
+++ b/crates/sifr/tests/e2e/pass/cancellation_error_type_surface.sifr
@@ -1,0 +1,14 @@
+def scope_failure_surface() -> Result[None, ScopeFailure]:
+    return None
+
+
+def task_cancelled_surface() -> Result[None, TaskCancelled]:
+    return None
+
+
+def secondary_error_surface() -> Result[None, SecondaryError]:
+    return None
+
+
+def main() -> None:
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -165,6 +165,9 @@ const BUILTIN_ERROR_CLASSES: &[&str] = &[
     "NotImplementedError",
     "DecimalConversionError",
     "TimeoutError",
+    "ScopeFailure",
+    "TaskCancelled",
+    "SecondaryError",
 ];
 
 const IO_ERROR_SUBCLASSES: &[&str] = &[

--- a/crates/sifr_codegen/src/stdlib_filter.rs
+++ b/crates/sifr_codegen/src/stdlib_filter.rs
@@ -69,6 +69,9 @@ const GLOBAL_INFRA_TYPES: &[&str] = &[
     "IsADirectoryError",
     "NotADirectoryError",
     "DirectoryNotEmptyError",
+    "ScopeFailure",
+    "TaskCancelled",
+    "SecondaryError",
 ];
 
 /// Strip per-module shared imports/infrastructure and return dependency flags.

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -55,6 +55,9 @@ fn can_construct_error_from_message_for_ir(ty_name: &str) -> bool {
             | "HashlibError"
             | "DecimalConversionError"
             | "TimeoutError"
+            | "ScopeFailure"
+            | "TaskCancelled"
+            | "SecondaryError"
     )
 }
 

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -78,6 +78,9 @@ pub(super) fn register_builtins(ctx: &mut LowerCtx) {
         "OverflowError",
         "DecimalConversionError",
         "TimeoutError",
+        "ScopeFailure",
+        "TaskCancelled",
+        "SecondaryError",
     ];
     for &error_name in &other_mid_level_errors {
         let fields = vec![("message".to_string(), Type::Str)];
@@ -92,6 +95,20 @@ pub(super) fn register_builtins(ctx: &mut LowerCtx) {
         ctx.error_types.insert(error_name.to_string());
         ctx.functions.insert(
             error_name.to_string(),
+            FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
+        );
+    }
+    {
+        let class_ty = Type::Class {
+            name: "CancellationError".to_string(),
+            fields: vec![("message".to_string(), Type::Str)],
+            methods: vec![],
+            parent_class: None,
+        };
+        ctx.class_types
+            .insert("CancellationError".to_string(), class_ty.clone());
+        ctx.functions.insert(
+            "CancellationError".to_string(),
             FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
         );
     }

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -507,6 +507,7 @@ status: in_progress
 - In progress TaskGroup homogeneous-error slice: `task.TaskGroup()` records the first non-`Never` child error type and rejects later children with a different ordinary error type in v1.
 - In progress cancellation timeout validation slice: added PR-lane coverage for `async with task.timeout(...)` around await points and nested timeout scopes on the non-expiring path.
 - In progress TaskGroup openness slice: task handles spawned from a named `TaskGroup` remember their owner, and v1 conservatively rejects later `group.spawn(...)` on a path after one of that group's child handles has been observed.
+- In progress cancellation/error type surface slice: registered `ScopeFailure`, `TaskCancelled`, and `SecondaryError` as ordinary built-in error classes, and registered `CancellationError` as a non-`Error` control-evidence class so it cannot be used as a `Result` error.
 
 ---
 

--- a/verification/validation_lanes/pr_e2e_manifest.json
+++ b/verification/validation_lanes/pr_e2e_manifest.json
@@ -73,6 +73,7 @@
     "task_select_first_completion",
     "task_spawn_fallible_result",
     "cancellation_scope_timeout",
-    "cancellation_nested_scopes"
+    "cancellation_nested_scopes",
+    "cancellation_error_type_surface"
   ]
 }


### PR DESCRIPTION
## Summary
- register `ScopeFailure`, `TaskCancelled`, and `SecondaryError` as ordinary built-in error classes
- register `CancellationError` as a non-`Error` builtin control-evidence class
- add pass/fail fixtures and PR-lane coverage for the new surface

## Validation
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_error_type_surface.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `python3 -m json.tool verification/validation_lanes/pr_e2e_manifest.json >/dev/null`
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Opus review: `reviews/phase32_cancellation_error_type_surface.md`
- Verdict: SATISFIED
