### PR TITLE
Surface unobserved task scope failures

### DIFF
--- a/crates/sifr/tests/e2e/fail/scope_spawn_capture_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/scope_spawn_capture_rejected.sifr
@@ -2,7 +2,7 @@ async def worker(value: int) -> int:
     return value
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker(1))
     return None

--- a/crates/sifr/tests/e2e/fail/scope_spawn_non_coroutine_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/scope_spawn_non_coroutine_rejected.sifr
@@ -1,4 +1,4 @@
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(1)
     return None

--- a/crates/sifr/tests/e2e/fail/task_escape_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_escape_scope_rejected.sifr
@@ -4,7 +4,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
 

--- a/crates/sifr/tests/e2e/fail/task_group_heterogeneous_error_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_group_heterogeneous_error_rejected.sifr
@@ -8,7 +8,7 @@ async def io_child() -> Result[int, IOError]:
     raise IOError("io")
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.TaskGroup() as group:
         first = group.spawn(value_child())
         second = group.spawn(io_child())

--- a/crates/sifr/tests/e2e/fail/task_group_spawn_after_failure_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_group_spawn_after_failure_rejected.sifr
@@ -4,7 +4,7 @@ async def child() -> Result[int, ValueError]:
     raise ValueError("child failed")
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.TaskGroup() as group:
         first = group.spawn(child())
         result = await first

--- a/crates/sifr/tests/e2e/fail/task_handle_cancel_after_await_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_handle_cancel_after_await_rejected.sifr
@@ -4,7 +4,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await handle

--- a/crates/sifr/tests/e2e/fail/task_handle_double_await_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_handle_double_await_rejected.sifr
@@ -4,7 +4,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         first = await handle

--- a/crates/sifr/tests/e2e/fail/task_handle_escape_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_handle_escape_scope_rejected.sifr
@@ -4,7 +4,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
 

--- a/crates/sifr/tests/e2e/fail/task_scope_unobserved_failure_scope_failure.sifr
+++ b/crates/sifr/tests/e2e/fail/task_scope_unobserved_failure_scope_failure.sifr
@@ -1,0 +1,10 @@
+# expect-error: SIFR-TYPE-0002
+
+async def worker() -> Result[int, ValueError]:
+    raise ValueError("boom")
+
+
+async def main() -> None:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+    return None

--- a/crates/sifr/tests/e2e/fail/task_timeout_double_observe_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_timeout_double_observe_rejected.sifr
@@ -4,7 +4,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await task.timeout(handle, 1.0)

--- a/crates/sifr/tests/e2e/pass/scope_spawn_core.sifr
+++ b/crates/sifr/tests/e2e/pass/scope_spawn_core.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
     return None

--- a/crates/sifr/tests/e2e/pass/scope_spawn_join.sifr
+++ b/crates/sifr/tests/e2e/pass/scope_spawn_join.sifr
@@ -2,7 +2,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await handle.join()

--- a/crates/sifr/tests/e2e/pass/task_cancel_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/task_cancel_basic.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         handle.cancel()

--- a/crates/sifr/tests/e2e/pass/task_gather_ordered.sifr
+++ b/crates/sifr/tests/e2e/pass/task_gather_ordered.sifr
@@ -8,7 +8,7 @@ async def second() -> int:
     return 2
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         result = await task.gather([scope.spawn(first()), scope.spawn(second())])
     return None

--- a/crates/sifr/tests/e2e/pass/task_group_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/task_group_basic.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.TaskGroup() as group:
         handle = group.spawn(worker())
         result = await handle.join()

--- a/crates/sifr/tests/e2e/pass/task_handle_await.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_await.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await handle

--- a/crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
@@ -8,7 +8,7 @@ async def second() -> int:
     return 2
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handles = [scope.spawn(first()), scope.spawn(second())]
         result = await task.gather(handles)

--- a/crates/sifr/tests/e2e/pass/task_handle_join.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_join.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await handle.join()

--- a/crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
+++ b/crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr
@@ -20,7 +20,7 @@ async def slow_writes_marker() -> int:
     return 2
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     path: str = marker_path()
     if exists(path):
         try:

--- a/crates/sifr/tests/e2e/pass/task_scope_unobserved_child_waits.sifr
+++ b/crates/sifr/tests/e2e/pass/task_scope_unobserved_child_waits.sifr
@@ -15,7 +15,7 @@ async def write_marker() -> None:
     return None
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     path: str = marker_path()
     if exists(path):
         try:

--- a/crates/sifr/tests/e2e/pass/task_select_first_completion.sifr
+++ b/crates/sifr/tests/e2e/pass/task_select_first_completion.sifr
@@ -20,7 +20,7 @@ async def slow_string_writes_marker() -> str:
     return "two"
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     path: str = marker_path()
     if exists(path):
         try:

--- a/crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr
+++ b/crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr
@@ -3,7 +3,7 @@ async def fail_later() -> Result[int, ValueError]:
     raise ValueError("task failed")
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(fail_later())
         result = await handle

--- a/crates/sifr/tests/e2e/pass/task_timeout_completion_wins_tie.sifr
+++ b/crates/sifr/tests/e2e/pass/task_timeout_completion_wins_tie.sifr
@@ -2,7 +2,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await task.timeout(handle, 0.0)

--- a/crates/sifr/tests/e2e/pass/task_timeout_expiry.sifr
+++ b/crates/sifr/tests/e2e/pass/task_timeout_expiry.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await task.timeout(handle, 0.0)

--- a/crates/sifr/tests/e2e/pass/task_timeout_success.sifr
+++ b/crates/sifr/tests/e2e/pass/task_timeout_success.sifr
@@ -3,7 +3,7 @@ async def worker() -> int:
     return 41
 
 
-async def main() -> None:
+async def main() -> Result[None, ScopeFailure]:
     async with task.scope() as scope:
         handle = scope.spawn(worker())
         result = await task.timeout(handle, 1.0)

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -53,6 +53,7 @@ pub(crate) fn collect_referenced_builtin_error_classes(
             "TOMLDecodeError",
             "RegexError",
             "TimeoutError",
+            "ScopeFailure",
         ] {
             referenced.insert(error_name.to_string());
         }
@@ -262,8 +263,15 @@ fn collect_stmt_error_refs(
                 collect_stmt_error_refs(body, referenced, builtin_error_classes);
             }
             HirStmt::AsyncWith { kind, body, .. } => {
-                if let sifr_hir::HirAsyncWithKind::TaskTimeout { duration } = kind {
-                    collect_expr_error_refs(duration, referenced, builtin_error_classes);
+                match kind {
+                    sifr_hir::HirAsyncWithKind::TaskTimeout { duration } => {
+                        referenced.insert("TimeoutError".to_string());
+                        collect_expr_error_refs(duration, referenced, builtin_error_classes);
+                    }
+                    sifr_hir::HirAsyncWithKind::TaskScope
+                    | sifr_hir::HirAsyncWithKind::TaskGroup => {
+                        referenced.insert("ScopeFailure".to_string());
+                    }
                 }
                 collect_stmt_error_refs(body, referenced, builtin_error_classes);
             }
@@ -502,7 +510,10 @@ fn collect_text_error_refs(
 #[cfg(test)]
 mod tests {
     use super::collect_referenced_builtin_error_classes;
-    use sifr_hir::{HirClass, HirClassKind, HirFunction, HirModule, HirParam, MethodKind};
+    use sifr_hir::{
+        HirAsyncWithKind, HirClass, HirClassKind, HirExpr, HirFunction, HirModule, HirParam,
+        HirStmt, MethodKind,
+    };
     use sifr_type_system::{ParamConvention, Type};
     use std::collections::{HashMap, HashSet};
 
@@ -607,5 +618,61 @@ mod tests {
         assert!(referenced.contains("ParseError"));
         assert!(referenced.contains("RegexError"));
         assert!(referenced.contains("JSONDecodeError"));
+    }
+
+    #[test]
+    fn intrinsic_helpers_reference_scope_failure() {
+        let intrinsic_functions = HashSet::from(["__sifr_spawn_infallible".to_string()]);
+
+        let referenced = collect_referenced_builtin_error_classes(
+            &empty_module(),
+            "",
+            &intrinsic_functions,
+            false,
+            &["ScopeFailure", "TimeoutError"],
+        );
+
+        assert!(referenced.contains("ScopeFailure"));
+        assert!(referenced.contains("TimeoutError"));
+    }
+
+    #[test]
+    fn async_task_runtime_helpers_reference_generated_error_types() {
+        let mut module = empty_module();
+        module.functions.push(HirFunction {
+            name: "main".to_string(),
+            params: Vec::new(),
+            return_type: Type::Result(Box::new(Type::None), Box::new(error_type("Error"))),
+            body: vec![
+                HirStmt::AsyncWith {
+                    kind: HirAsyncWithKind::TaskScope,
+                    target: Some("scope".to_string()),
+                    body: Vec::new(),
+                },
+                HirStmt::AsyncWith {
+                    kind: HirAsyncWithKind::TaskTimeout {
+                        duration: HirExpr::FloatLiteral(1.0),
+                    },
+                    target: None,
+                    body: Vec::new(),
+                },
+            ],
+            is_async: true,
+            method_kind: MethodKind::Regular,
+            decorators: Vec::new(),
+            type_params: Vec::new(),
+        });
+
+        let referenced = collect_referenced_builtin_error_classes(
+            &module,
+            "",
+            &HashSet::new(),
+            false,
+            &["Error", "ScopeFailure", "TimeoutError"],
+        );
+
+        assert!(referenced.contains("Error"));
+        assert!(referenced.contains("ScopeFailure"));
+        assert!(referenced.contains("TimeoutError"));
     }
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -574,6 +574,18 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             preamble_items.extend(build_error_type_items(error_name, &extra_fields, &defaults));
         }
     }
+    if referenced_error_classes.contains("Error") && !user_defined_error_classes.contains("Error") {
+        for &error_name in BUILTIN_ERROR_CLASSES {
+            if error_name == "Error" || IO_ERROR_SUBCLASSES.contains(&error_name) {
+                continue;
+            }
+            if referenced_error_classes.contains(error_name)
+                && !user_defined_error_classes.contains(error_name)
+            {
+                preamble_items.push(build_error_into_error_impl(error_name));
+            }
+        }
+    }
 
     // Emit file handle global state if open() built-in or any file handle intrinsic is used.
     if needs_file_handles {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3683,7 +3683,7 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n    return None\n",
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3693,14 +3693,15 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
     );
 
     assert!(result.rust_source.contains("struct __SifrTask<T, E>"));
-    assert!(result.rust_source.contains("fn spawn<"));
+    assert!(result.rust_source.contains("fn __sifr_spawn_infallible<"));
+    assert!(result.rust_source.contains("struct __SifrScopeChild"));
     assert!(result.rust_source.contains("tokio::sync::oneshot::channel"));
     assert!(result
         .rust_source
         .contains("scope.__sifr_spawn_infallible(worker());"));
     assert!(result
         .rust_source
-        .contains("scope.__sifr_join_all().await;"));
+        .contains("if let Err(__sifr_scope_failure) = scope.__sifr_join_all().await"));
     assert!(result.required_crates.contains("tokio"));
 }
 
@@ -3709,7 +3710,7 @@ fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.TaskGroup() as group:\n        handle = group.spawn(worker())\n        result = await handle.join()\n    return None\n",
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.TaskGroup() as group:\n        handle = group.spawn(worker())\n        result = await handle.join()\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3727,7 +3728,7 @@ fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
         .contains("group.__sifr_spawn_infallible(worker());"));
     assert!(result
         .rust_source
-        .contains("group.__sifr_join_all().await;"));
+        .contains("if let Err(__sifr_scope_failure) = group.__sifr_join_all().await"));
     assert!(result.required_crates.contains("tokio"));
 }
 
@@ -3736,7 +3737,7 @@ fn test_task_gather_lowers_to_private_gather_helper() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def first() -> int:\n    return 1\n\nasync def second() -> int:\n    return 2\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        result = await task.gather([scope.spawn(first()), scope.spawn(second())])\n    return None\n",
+                "async def first() -> int:\n    return 1\n\nasync def second() -> int:\n    return 2\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        result = await task.gather([scope.spawn(first()), scope.spawn(second())])\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3758,7 +3759,7 @@ fn test_scope_spawn_fallible_coroutine_lowers_to_result_spawn_helper() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> Result[int, ValueError]:\n    raise ValueError(\"bad\")\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
+                "async def worker() -> Result[int, ValueError]:\n    raise ValueError(\"bad\")\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3784,7 +3785,7 @@ fn test_task_race_lowers_to_private_race_helper() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def first() -> int:\n    return 1\n\nasync def second() -> int:\n    await task.sleep(1.0)\n    return 2\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        result = await task.race([scope.spawn(first()), scope.spawn(second())])\n    return None\n",
+                "async def first() -> int:\n    return 1\n\nasync def second() -> int:\n    await task.sleep(1.0)\n    return 2\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        result = await task.race([scope.spawn(first()), scope.spawn(second())])\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3806,7 +3807,7 @@ fn test_task_select_lowers_to_private_select_helper() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def first() -> int:\n    return 1\n\nasync def second() -> str:\n    await task.sleep(1.0)\n    return \"two\"\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        first_handle = scope.spawn(first())\n        second_handle = scope.spawn(second())\n        result = await task.select(first_handle, second_handle)\n    return None\n",
+                "async def first() -> int:\n    return 1\n\nasync def second() -> str:\n    await task.sleep(1.0)\n    return \"two\"\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        first_handle = scope.spawn(first())\n        second_handle = scope.spawn(second())\n        result = await task.select(first_handle, second_handle)\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3831,7 +3832,7 @@ fn test_task_handle_join_lowers_to_task_result_observation() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle.join()\n    return None\n",
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle.join()\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3853,7 +3854,7 @@ fn test_await_task_handle_desugars_to_join_observation() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await handle\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3872,7 +3873,7 @@ fn test_await_task_handle_desugars_to_join_observation() {
 fn test_task_handle_cancel_borrows_handle_and_aborts_child() {
     let source = concat!(
         "async def worker() -> int:\n    await task.sleep(10.0)\n    return 41\n\n",
-        "async def main() -> None:\n    async with task.scope() as scope:\n",
+        "async def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n",
         "        handle = scope.spawn(worker())\n        handle.",
         "cancel",
         "()\n        result = await handle\n    return None\n",
@@ -3900,7 +3901,7 @@ fn test_task_timeout_handle_lowers_to_private_timeout_result() {
     let result = generate_rust_with_metadata(
         &lower_module(
             parse_module(
-                "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n    return None\n",
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n    return None\n",
             )
             .expect("parse failed")
             .suite(),
@@ -3936,6 +3937,34 @@ fn test_task_timeout_context_manager_wraps_awaits() {
     assert!(result.rust_source.contains("return Err(TimeoutError::new"));
     assert!(result.rust_source.contains("struct TimeoutError"));
     assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_async_generated_errors_convert_to_error_return_type() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, Error]:\n    async with task.timeout(1.0):\n        await task.sleep(0.0)\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result
+        .rust_source
+        .contains("impl From<TimeoutError> for Error"));
+    assert!(result
+        .rust_source
+        .contains("impl From<ScopeFailure> for Error"));
+    assert!(result
+        .rust_source
+        .contains("return Err(TimeoutError::new(\"task timeout expired\".to_string()).into())"));
+    assert!(result
+        .rust_source
+        .contains("return Err(__sifr_scope_failure.into());"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -1932,13 +1932,18 @@ fn try_lower_simple_async_with_stmt(
         ),
         target,
     ) {
-        block.push(RustStmt::Expr(RustExpr::Await(Box::new(
-            RustExpr::MethodCall {
-                receiver: Box::new(RustExpr::Ident(target.to_string())),
-                method: "__sifr_join_all".to_string(),
-                args: vec![],
-            },
-        ))));
+        let propagates_scope_failure = ctx.return_type.is_some_and(|ty| {
+            matches!(ty.resolve_alias(), Type::Result(_, err) if matches!(err.resolve_alias(), Type::Class { name, .. } if name == "ScopeFailure" || name == "Error"))
+        });
+        let join_expr = format!("{target}.__sifr_join_all().await");
+        let stmt = if propagates_scope_failure {
+            format!(
+                "if let Err(__sifr_scope_failure) = {join_expr} {{ return Err(__sifr_scope_failure.into()); }}"
+            )
+        } else {
+            format!("let _ = {join_expr};")
+        };
+        block.push(RustStmt::Expr(RustExpr::Ident(stmt)));
     }
 
     Some(vec![RustStmt::Block(block)])

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -160,6 +160,32 @@ pub fn build_error_type_items(
     ]
 }
 
+pub fn build_error_into_error_impl(source_name: &str) -> RustItem {
+    RustItem::Impl {
+        target: "Error".to_string(),
+        type_params: vec![],
+        trait_: Some(format!("From<{source_name}>")),
+        items: vec![RustItem::Fn {
+            name: "from".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![RustParam::Named {
+                name: "err".to_string(),
+                ty: RustType::Named(source_name.to_string()),
+            }],
+            ret: Some(RustType::Named("Self".to_string())),
+            body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Self".to_string(), "new".to_string()])),
+                args: vec![RustExpr::Field {
+                    expr: Box::new(RustExpr::Ident("err".to_string())),
+                    field: "message".to_string(),
+                }],
+            }))],
+            is_async: false,
+        }],
+    }
+}
+
 pub fn build_task_scope_items() -> Vec<RustItem> {
     vec![
         RustItem::Struct {
@@ -178,9 +204,60 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     RustType::Named("tokio::task::AbortHandle".to_string()),
                 ),
                 (
+                    "observed".to_string(),
+                    RustType::Named(
+                        "std::sync::Arc<std::sync::atomic::AtomicBool>".to_string(),
+                    ),
+                ),
+                (
                     "_error".to_string(),
                     RustType::Named("std::marker::PhantomData<E>".to_string()),
                 ),
+            ],
+        },
+        RustItem::Struct {
+            name: "__SifrScopeChild".to_string(),
+            visibility: Visibility::Private,
+            derives: vec![],
+            fields: vec![
+                (
+                    "handle".to_string(),
+                    RustType::Named(
+                        "tokio::task::JoinHandle<__SifrScopeChildOutcome>".to_string(),
+                    ),
+                ),
+                (
+                    "observed".to_string(),
+                    RustType::Named(
+                        "std::sync::Arc<std::sync::atomic::AtomicBool>".to_string(),
+                    ),
+                ),
+            ],
+        },
+        RustItem::Enum {
+            name: "__SifrScopeChildOutcome".to_string(),
+            visibility: Visibility::Private,
+            derives: vec!["Debug".to_string()],
+            repr: None,
+            variants: vec![
+                crate::RustEnumVariant {
+                    name: "Ok".to_string(),
+                    tuple_fields: vec![],
+                    fields: vec![],
+                    value: None,
+                },
+                crate::RustEnumVariant {
+                    name: "Failed".to_string(),
+                    tuple_fields: vec![],
+                    fields: vec![],
+                    value: None,
+                },
+                crate::RustEnumVariant {
+                    name: "Cancelled".to_string(),
+                    tuple_fields: vec![],
+                    fields: vec![],
+                    value: None,
+                },
             ],
         },
         RustItem::Enum {
@@ -269,41 +346,9 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     type_params: vec![],
                     params: vec![RustParam::SelfValue],
                     ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
-                    body: vec![RustStmt::IfLet {
-                        pattern: "Some(receiver)".to_string(),
-                        expr: RustExpr::Field {
-                            expr: Box::new(RustExpr::Ident("self".to_string())),
-                            field: "receiver".to_string(),
-                        },
-                        then_body: vec![RustStmt::Match {
-                            expr: RustExpr::Await(Box::new(RustExpr::Ident(
-                                "receiver".to_string(),
-                            ))),
-                            arms: vec![
-                                RustMatchArm {
-                                    pattern: "Ok(result)".to_string(),
-                                    bindings: vec![],
-                                    guard: None,
-                                    body: vec![RustStmt::Return(Some(RustExpr::Ident(
-                                        "result".to_string(),
-                                    )))],
-                                },
-                                RustMatchArm {
-                                    pattern: "Err(_)".to_string(),
-                                    bindings: vec![],
-                                    guard: None,
-                                    body: vec![RustStmt::Return(Some(RustExpr::Path(vec![
-                                        "__SifrTaskResult".to_string(),
-                                        "Cancelled".to_string(),
-                                    ])))],
-                                },
-                            ],
-                        }],
-                        else_body: Some(vec![RustStmt::Return(Some(RustExpr::Path(vec![
-                            "__SifrTaskResult".to_string(),
-                            "Cancelled".to_string(),
-                        ])))]),
-                    }],
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "let __SifrTask { receiver, observed, .. } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(receiver) = receiver {\n            return match receiver.await {\n                Ok(result) => result,\n                Err(_) => __SifrTaskResult::Cancelled,\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                    ))],
                     is_async: true,
                 },
                 RustItem::Fn {
@@ -337,7 +382,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         "__SifrTaskResult<T, __SifrTimeoutResult<E>>".to_string(),
                     )),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let __SifrTask { receiver, abort_handle, _error } = self;\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(err)) => __SifrTaskResult::Err(__SifrTimeoutResult::Inner(err)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrTimeoutResult::Timeout)\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(err)) => __SifrTaskResult::Err(__SifrTimeoutResult::Inner(err)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrTimeoutResult::Timeout)\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -349,9 +394,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             derives: vec![],
             fields: vec![(
                 "children".to_string(),
-                RustType::Vec(Box::new(RustType::Named(
-                    "tokio::task::JoinHandle<()>".to_string(),
-                ))),
+                RustType::Vec(Box::new(RustType::Named("__SifrScopeChild".to_string()))),
             )],
         },
         RustItem::Impl {
@@ -419,10 +462,27 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         },
                         RustStmt::Let {
                             mutable: false,
+                            name: "observed".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false))"
+                                    .to_string(),
+                            ),
+                        },
+                        RustStmt::Let {
+                            mutable: false,
+                            name: "child_observed".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "std::sync::Arc::clone(&observed)".to_string(),
+                            ),
+                        },
+                        RustStmt::Let {
+                            mutable: false,
                             name: "child".to_string(),
                             ty: None,
                             value: RustExpr::Ident(
-                                "tokio::spawn(async move { let result = future.await; let _ = sender.send(__SifrTaskResult::Ok(result)); })"
+                                "tokio::spawn(async move { let result = future.await; let _ = sender.send(__SifrTaskResult::Ok(result)); __SifrScopeChildOutcome::Ok })"
                                     .to_string(),
                             ),
                         },
@@ -442,7 +502,16 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                                 field: "children".to_string(),
                             }),
                             method: "push".to_string(),
-                            args: vec![RustExpr::Ident("child".to_string())],
+                            args: vec![RustExpr::StructInit {
+                                name: "__SifrScopeChild".to_string(),
+                                fields: vec![
+                                    ("handle".to_string(), RustExpr::Ident("child".to_string())),
+                                    (
+                                        "observed".to_string(),
+                                        RustExpr::Ident("child_observed".to_string()),
+                                    ),
+                                ],
+                            }],
                         }),
                         RustStmt::Return(Some(RustExpr::StructInit {
                             name: "__SifrTask".to_string(),
@@ -457,6 +526,10 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                                 (
                                     "abort_handle".to_string(),
                                     RustExpr::Ident("abort_handle".to_string()),
+                                ),
+                                (
+                                    "observed".to_string(),
+                                    RustExpr::Ident("observed".to_string()),
                                 ),
                                 (
                                     "_error".to_string(),
@@ -515,10 +588,27 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         },
                         RustStmt::Let {
                             mutable: false,
+                            name: "observed".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false))"
+                                    .to_string(),
+                            ),
+                        },
+                        RustStmt::Let {
+                            mutable: false,
+                            name: "child_observed".to_string(),
+                            ty: None,
+                            value: RustExpr::Ident(
+                                "std::sync::Arc::clone(&observed)".to_string(),
+                            ),
+                        },
+                        RustStmt::Let {
+                            mutable: false,
                             name: "child".to_string(),
                             ty: None,
                             value: RustExpr::Ident(
-                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(err) }; let _ = sender.send(result); })"
+                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(err) }; let outcome = match &result { __SifrTaskResult::Ok(_) => __SifrScopeChildOutcome::Ok, __SifrTaskResult::Err(_) => __SifrScopeChildOutcome::Failed, __SifrTaskResult::Cancelled => __SifrScopeChildOutcome::Cancelled }; let _ = sender.send(result); outcome })"
                                     .to_string(),
                             ),
                         },
@@ -538,7 +628,16 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                                 field: "children".to_string(),
                             }),
                             method: "push".to_string(),
-                            args: vec![RustExpr::Ident("child".to_string())],
+                            args: vec![RustExpr::StructInit {
+                                name: "__SifrScopeChild".to_string(),
+                                fields: vec![
+                                    ("handle".to_string(), RustExpr::Ident("child".to_string())),
+                                    (
+                                        "observed".to_string(),
+                                        RustExpr::Ident("child_observed".to_string()),
+                                    ),
+                                ],
+                            }],
                         }),
                         RustStmt::Return(Some(RustExpr::StructInit {
                             name: "__SifrTask".to_string(),
@@ -553,6 +652,10 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                                 (
                                     "abort_handle".to_string(),
                                     RustExpr::Ident("abort_handle".to_string()),
+                                ),
+                                (
+                                    "observed".to_string(),
+                                    RustExpr::Ident("observed".to_string()),
                                 ),
                                 (
                                     "_error".to_string(),
@@ -572,25 +675,10 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     visibility: Visibility::Private,
                     type_params: vec![],
                     params: vec![RustParam::SelfParam { mutable: true }],
-                    ret: Some(RustType::Unit),
-                    body: vec![RustStmt::Loop {
-                        body: vec![RustStmt::IfLet {
-                            pattern: "Some(child)".to_string(),
-                            expr: RustExpr::MethodCall {
-                                receiver: Box::new(RustExpr::Field {
-                                    expr: Box::new(RustExpr::Ident("self".to_string())),
-                                    field: "children".to_string(),
-                                }),
-                                method: "pop".to_string(),
-                                args: vec![],
-                            },
-                            then_body: vec![RustStmt::LetPattern {
-                                pattern: "_".to_string(),
-                                value: RustExpr::Await(Box::new(RustExpr::Ident("child".to_string()))),
-                            }],
-                            else_body: Some(vec![RustStmt::Break]),
-                        }],
-                    }],
+                    ret: Some(RustType::Named("Result<(), ScopeFailure>".to_string())),
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "let mut failure: Option<ScopeFailure> = None;\n        while let Some(child) = self.children.pop() {\n            let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);\n            match child.handle.await {\n                Ok(__SifrScopeChildOutcome::Ok) => {}\n                Ok(__SifrScopeChildOutcome::Failed) if !observed && failure.is_none() => {\n                    failure = Some(ScopeFailure::new(\"unobserved child task failed\".to_string()));\n                }\n                Ok(__SifrScopeChildOutcome::Cancelled) if !observed && failure.is_none() => {\n                    failure = Some(ScopeFailure::new(\"unobserved child task was cancelled\".to_string()));\n                }\n                Err(join_error) if !observed && failure.is_none() => {\n                    let message = if join_error.is_cancelled() { \"unobserved child task was cancelled\" } else { \"unobserved child task failed\" };\n                    failure = Some(ScopeFailure::new(message.to_string()));\n                }\n                _ => {}\n            }\n        }\n        if let Some(failure) = failure {\n            return Err(failure);\n        }\n        return Ok(())".to_string(),
+                    ))],
                     is_async: true,
                 },
             ],
@@ -639,7 +727,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             }],
             ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, _error } = handle;\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
+                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
             ))],
             is_async: true,
         },
@@ -678,7 +766,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 "__SifrSelect2<__SifrTaskResult<A, EA>, __SifrTaskResult<B, EB>>".to_string(),
             )),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, _error: _second_error } = second;\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::Cancelled);\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
+                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, observed: first_observed, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, observed: second_observed, _error: _second_error } = second;\n        first_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        second_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::Cancelled);\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
             ))],
             is_async: true,
         },

--- a/crates/sifr_codegen/src/render.rs
+++ b/crates/sifr_codegen/src/render.rs
@@ -897,7 +897,7 @@ impl Renderer {
                     .join(", ")
             ),
             RustExpr::TimeoutAwait { duration, future } => format!(
-                "match tokio::time::timeout({}, {}).await {{ Ok(__sifr_timeout_value) => __sifr_timeout_value, Err(_) => return Err(TimeoutError::new(\"task timeout expired\".to_string())) }}",
+                "match tokio::time::timeout({}, {}).await {{ Ok(__sifr_timeout_value) => __sifr_timeout_value, Err(_) => return Err(TimeoutError::new(\"task timeout expired\".to_string()).into()) }}",
                 Self::render_expr_string(duration),
                 Self::render_expr_string(future)
             ),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7344,13 +7344,18 @@ impl RustEmitter {
             ),
             target,
         ) {
-            lowered_body.push(crate::RustStmt::Expr(crate::RustExpr::Await(Box::new(
-                crate::RustExpr::MethodCall {
-                    receiver: Box::new(crate::RustExpr::Ident(target.to_string())),
-                    method: "__sifr_join_all".to_string(),
-                    args: vec![],
-                },
-            ))));
+            let propagates_scope_failure = self.current_return_type.as_ref().is_some_and(|ty| {
+                matches!(ty.resolve_alias(), Type::Result(_, err) if matches!(err.resolve_alias(), Type::Class { name, .. } if name == "ScopeFailure" || name == "Error"))
+            });
+            let join_expr = format!("{target}.__sifr_join_all().await");
+            let stmt = if propagates_scope_failure {
+                format!(
+                    "if let Err(__sifr_scope_failure) = {join_expr} {{ return Err(__sifr_scope_failure.into()); }}"
+                )
+            } else {
+                format!("let _ = {join_expr};")
+            };
+            lowered_body.push(crate::RustStmt::Expr(crate::RustExpr::Ident(stmt)));
         }
         Ok(Some(RustStmt::Block(lowered_body)))
     }

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -66,11 +66,27 @@ fn timeout_error_type() -> Type {
     }
 }
 
+fn scope_failure_type() -> Type {
+    Type::Class {
+        name: "ScopeFailure".to_string(),
+        fields: vec![("message".to_string(), Type::Str)],
+        methods: vec![],
+        parent_class: Some("Error".to_string()),
+    }
+}
+
 fn return_type_accepts_timeout_error(return_type: &Type) -> bool {
     let Type::Result(_, err) = return_type.resolve_alias() else {
         return false;
     };
     timeout_error_type().is_assignable_to(err)
+}
+
+fn return_type_accepts_scope_failure(return_type: &Type) -> bool {
+    let Type::Result(_, err) = return_type.resolve_alias() else {
+        return false;
+    };
+    scope_failure_type().is_assignable_to(err)
 }
 
 fn expr_contains_await(expr: &crate::hir_nodes::HirExpr) -> bool {
@@ -186,6 +202,126 @@ fn expr_contains_await(expr: &crate::hir_nodes::HirExpr) -> bool {
     }
 }
 
+fn expr_contains_task_spawn(expr: &crate::hir_nodes::HirExpr) -> bool {
+    use crate::hir_nodes::HirExpr;
+
+    match expr {
+        HirExpr::MethodCall { method, .. }
+            if method == "__sifr_spawn_infallible" || method == "__sifr_spawn_result" =>
+        {
+            true
+        }
+        HirExpr::Await { value, .. }
+        | HirExpr::QuestionMark { expr: value, .. }
+        | HirExpr::OkWrap { value, .. }
+        | HirExpr::ErrWrap { value, .. }
+        | HirExpr::FieldAccess { object: value, .. } => expr_contains_task_spawn(value),
+        HirExpr::Call { args, .. }
+        | HirExpr::ConstructorCall { args, .. }
+        | HirExpr::IteratorCall { args, .. } => args.iter().any(expr_contains_task_spawn),
+        HirExpr::FString { parts, .. } => parts.iter().any(|part| match part {
+            crate::hir_nodes::HirFStringPart::Literal(_) => false,
+            crate::hir_nodes::HirFStringPart::Expr(expr) => expr_contains_task_spawn(expr),
+        }),
+        HirExpr::MethodCall { object, args, .. } => {
+            expr_contains_task_spawn(object) || args.iter().any(expr_contains_task_spawn)
+        }
+        HirExpr::BinOp { left, right, .. } => {
+            expr_contains_task_spawn(left) || expr_contains_task_spawn(right)
+        }
+        HirExpr::Compare {
+            left, comparators, ..
+        } => expr_contains_task_spawn(left) || comparators.iter().any(expr_contains_task_spawn),
+        HirExpr::BoolOp { values, .. }
+        | HirExpr::ListLiteral {
+            elements: values, ..
+        }
+        | HirExpr::TupleLiteral {
+            elements: values, ..
+        }
+        | HirExpr::SetLiteral {
+            elements: values, ..
+        } => values.iter().any(expr_contains_task_spawn),
+        HirExpr::UnaryOp { operand, .. } => expr_contains_task_spawn(operand),
+        HirExpr::IfExpr {
+            condition,
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            expr_contains_task_spawn(condition)
+                || expr_contains_task_spawn(then_expr)
+                || expr_contains_task_spawn(else_expr)
+        }
+        HirExpr::Index { object, index, .. } => {
+            expr_contains_task_spawn(object) || expr_contains_task_spawn(index)
+        }
+        HirExpr::Slice {
+            object,
+            start,
+            stop,
+            step,
+            ..
+        } => {
+            expr_contains_task_spawn(object)
+                || start.as_deref().is_some_and(expr_contains_task_spawn)
+                || stop.as_deref().is_some_and(expr_contains_task_spawn)
+                || step.as_deref().is_some_and(expr_contains_task_spawn)
+        }
+        HirExpr::DictLiteral { keys, values, .. } => {
+            keys.iter().any(expr_contains_task_spawn) || values.iter().any(expr_contains_task_spawn)
+        }
+        HirExpr::ContainsOp {
+            element,
+            collection,
+            ..
+        } => expr_contains_task_spawn(element) || expr_contains_task_spawn(collection),
+        HirExpr::RangeLiteral {
+            start, end, step, ..
+        } => {
+            expr_contains_task_spawn(start)
+                || expr_contains_task_spawn(end)
+                || step.as_deref().is_some_and(expr_contains_task_spawn)
+        }
+        HirExpr::WalrusExpr { value, .. } => expr_contains_task_spawn(value),
+        HirExpr::SuperCall { args, .. } => args.iter().any(expr_contains_task_spawn),
+        HirExpr::Lambda { body, .. } => expr_contains_task_spawn(body),
+        HirExpr::ListComp {
+            expr, generators, ..
+        }
+        | HirExpr::SetComp {
+            expr, generators, ..
+        } => {
+            expr_contains_task_spawn(expr)
+                || generators.iter().any(|(_, iter, filter)| {
+                    expr_contains_task_spawn(iter)
+                        || filter.as_ref().is_some_and(expr_contains_task_spawn)
+                })
+        }
+        HirExpr::DictComp {
+            key_expr,
+            val_expr,
+            generators,
+            ..
+        } => {
+            expr_contains_task_spawn(key_expr)
+                || expr_contains_task_spawn(val_expr)
+                || generators.iter().any(|(_, iter, filter)| {
+                    expr_contains_task_spawn(iter)
+                        || filter.as_ref().is_some_and(expr_contains_task_spawn)
+                })
+        }
+        HirExpr::GeneratorExpr {
+            expr, iter, filter, ..
+        } => {
+            expr_contains_task_spawn(expr)
+                || expr_contains_task_spawn(iter)
+                || filter.as_deref().is_some_and(expr_contains_task_spawn)
+        }
+        _ => false,
+    }
+}
+
 fn stmt_contains_await(stmt: &HirStmt) -> bool {
     match stmt {
         HirStmt::Expr { expr }
@@ -260,6 +396,83 @@ fn stmt_contains_await(stmt: &HirStmt) -> bool {
                 || arms.iter().any(|arm| {
                     arm.guard.as_ref().is_some_and(expr_contains_await)
                         || arm.body.iter().any(stmt_contains_await)
+                })
+        }
+        _ => false,
+    }
+}
+
+fn stmt_contains_task_spawn(stmt: &HirStmt) -> bool {
+    match stmt {
+        HirStmt::Expr { expr }
+        | HirStmt::Let { value: expr, .. }
+        | HirStmt::Assign { value: expr, .. }
+        | HirStmt::AugAssign { value: expr, .. }
+        | HirStmt::AttributeAugAssign { value: expr, .. }
+        | HirStmt::FieldAssign { value: expr, .. }
+        | HirStmt::NestedFieldAssign { value: expr, .. }
+        | HirStmt::Return { value: Some(expr) }
+        | HirStmt::Assert { test: expr, .. }
+        | HirStmt::Raise { value: expr }
+        | HirStmt::TupleUnpack { value: expr, .. }
+        | HirStmt::StarUnpack { value: expr, .. }
+        | HirStmt::SubscriptAssign { value: expr, .. }
+        | HirStmt::NestedSubscriptAssign { value: expr, .. }
+        | HirStmt::AttributeNestedSubscriptAssign { value: expr, .. }
+        | HirStmt::SubscriptAugAssign { value: expr, .. }
+        | HirStmt::AttributeSubscriptAssign { value: expr, .. }
+        | HirStmt::Yield { value: expr } => expr_contains_task_spawn(expr),
+        HirStmt::If {
+            condition,
+            then_body,
+            elif_clauses,
+            else_body,
+        } => {
+            expr_contains_task_spawn(condition)
+                || then_body.iter().any(stmt_contains_task_spawn)
+                || elif_clauses.iter().any(|(condition, body)| {
+                    expr_contains_task_spawn(condition) || body.iter().any(stmt_contains_task_spawn)
+                })
+                || else_body
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(stmt_contains_task_spawn))
+        }
+        HirStmt::While {
+            condition, body, ..
+        } => expr_contains_task_spawn(condition) || body.iter().any(stmt_contains_task_spawn),
+        HirStmt::For {
+            iter,
+            body,
+            else_body,
+            ..
+        } => {
+            expr_contains_task_spawn(iter)
+                || body.iter().any(stmt_contains_task_spawn)
+                || else_body
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(stmt_contains_task_spawn))
+        }
+        HirStmt::AsyncWith { body, .. } => body.iter().any(stmt_contains_task_spawn),
+        HirStmt::Delete { object, index } => {
+            expr_contains_task_spawn(object) || expr_contains_task_spawn(index)
+        }
+        HirStmt::With { items, body } => {
+            items
+                .iter()
+                .any(|(_, context_expr, _)| expr_contains_task_spawn(context_expr))
+                || body.iter().any(stmt_contains_task_spawn)
+        }
+        HirStmt::TryExcept { body, handlers, .. } => {
+            body.iter().any(stmt_contains_task_spawn)
+                || handlers
+                    .iter()
+                    .any(|handler| handler.body.iter().any(stmt_contains_task_spawn))
+        }
+        HirStmt::Match { subject, arms, .. } => {
+            expr_contains_task_spawn(subject)
+                || arms.iter().any(|arm| {
+                    arm.guard.as_ref().is_some_and(expr_contains_task_spawn)
+                        || arm.body.iter().any(stmt_contains_task_spawn)
                 })
         }
         _ => false,
@@ -390,6 +603,18 @@ pub(super) fn lower_async_with(
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,
                 "async with task.timeout(duration) can time out at await points; enclosing function must return Result[..., TimeoutError]"
+                    .to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        if matches!(kind, HirAsyncWithKind::TaskScope | HirAsyncWithKind::TaskGroup)
+            && body.iter().any(stmt_contains_task_spawn)
+            && !return_type_accepts_scope_failure(&func_type.return_type)
+        {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "async task scopes that spawn children can fail at exit; enclosing function must return Result[..., ScopeFailure] or Result[..., Error]"
                     .to_string(),
                 item.context_expr.range(),
             );

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1511,7 +1511,7 @@ fn test_use_after_move() {
 
 #[test]
 fn test_await_task_handle_consumes_handle_binding() {
-    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        first = await handle\n        second = await handle\n    return None\n";
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        first = await handle\n        second = await handle\n    return None\n";
     let result = lower_source(source);
     assert!(result.is_err());
     let errors = result.unwrap_err();
@@ -1524,7 +1524,7 @@ fn test_await_task_handle_consumes_handle_binding() {
 
 #[test]
 fn test_task_handle_join_consumes_handle_binding() {
-    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        first = await handle.join()\n        second = await handle\n    return None\n";
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        first = await handle.join()\n        second = await handle\n    return None\n";
     let result = lower_source(source);
     assert!(result.is_err());
     let errors = result.unwrap_err();
@@ -1539,7 +1539,7 @@ fn test_task_handle_join_consumes_handle_binding() {
 fn test_task_handle_cancel_does_not_consume_handle_binding() {
     let source = concat!(
         "async def worker() -> int:\n    return 41\n\n",
-        "async def main() -> None:\n    async with task.scope() as scope:\n",
+        "async def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n",
         "        handle = scope.spawn(worker())\n        handle.",
         "cancel",
         "()\n        result = await handle\n    return None\n",
@@ -1552,7 +1552,7 @@ fn test_task_handle_cancel_does_not_consume_handle_binding() {
 fn test_task_handle_cancel_after_await_rejects_moved_handle() {
     let source = concat!(
         "async def worker() -> int:\n    return 41\n\n",
-        "async def main() -> None:\n    async with task.scope() as scope:\n",
+        "async def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n",
         "        handle = scope.spawn(worker())\n        result = await handle\n        handle.",
         "cancel",
         "()\n    return None\n",
@@ -1569,7 +1569,7 @@ fn test_task_handle_cancel_after_await_rejects_moved_handle() {
 
 #[test]
 fn test_task_timeout_consumes_handle_binding() {
-    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n        second = await handle\n    return None\n";
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n        second = await handle\n    return None\n";
     let result = lower_source(source);
     assert!(result.is_err());
     let errors = result.unwrap_err();
@@ -1582,7 +1582,7 @@ fn test_task_timeout_consumes_handle_binding() {
 
 #[test]
 fn test_task_race_consumes_handle_collection_binding() {
-    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        handles = [scope.spawn(worker()), scope.spawn(worker())]\n        result = await task.race(handles)\n        second = await task.race(handles)\n    return None\n";
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handles = [scope.spawn(worker()), scope.spawn(worker())]\n        result = await task.race(handles)\n        second = await task.race(handles)\n    return None\n";
     let result = lower_source(source);
     assert!(result.is_err());
     let errors = result.unwrap_err();
@@ -1600,7 +1600,7 @@ fn test_task_race_consumes_handle_collection_binding() {
 
 #[test]
 fn test_task_select_consumes_handle_bindings() {
-    let source = "async def first() -> int:\n    return 1\n\nasync def second() -> str:\n    return \"two\"\n\nasync def main() -> None:\n    async with task.scope() as scope:\n        one = scope.spawn(first())\n        two = scope.spawn(second())\n        selected = await task.select(one, two)\n        late = await one\n    return None\n";
+    let source = "async def first() -> int:\n    return 1\n\nasync def second() -> str:\n    return \"two\"\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        one = scope.spawn(first())\n        two = scope.spawn(second())\n        selected = await task.select(one, two)\n        late = await one\n    return None\n";
     let result = lower_source(source);
     assert!(result.is_err());
     let errors = result.unwrap_err();

--- a/demos/m32_task_core_demo.sifr
+++ b/demos/m32_task_core_demo.sifr
@@ -8,7 +8,7 @@ async def slow_worker() -> int:
     return 7
 
 
-async def main() -> Result[None, TimeoutError]:
+async def main() -> Result[None, Error]:
     async with task.timeout(1.0):
         await task.sleep(0.0)
 

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -508,6 +508,7 @@ status: in_progress
 - In progress cancellation timeout validation slice: added PR-lane coverage for `async with task.timeout(...)` around await points and nested timeout scopes on the non-expiring path.
 - In progress TaskGroup openness slice: task handles spawned from a named `TaskGroup` remember their owner, and v1 conservatively rejects later `group.spawn(...)` on a path after one of that group's child handles has been observed.
 - In progress cancellation/error type surface slice: registered `ScopeFailure`, `TaskCancelled`, and `SecondaryError` as ordinary built-in error classes, and registered `CancellationError` as a non-`Error` control-evidence class so it cannot be used as a `Result` error.
+- In progress scope-failure exit slice: task scopes now track whether child handles were observed, return `ScopeFailure` for unobserved child failure or cancellation at scope exit, and require enclosing async functions that spawn children to return `Result[..., ScopeFailure]` or `Result[..., Error]`.
 
 ---
 


### PR DESCRIPTION
## Summary
- track task-handle observation in the private task scope runtime and surface unobserved child failure/cancellation as `ScopeFailure` at scope exit
- require spawned task scopes to return `Result[..., ScopeFailure]` or `Result[..., Error]`, with generated conversion support for umbrella `Error` returns
- update async task fixtures, demo, codegen/HIR tests, and Phase 32 progress notes

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr_codegen error_refs -- --nocapture`
- `cargo test -p sifr_codegen async_generated -- --nocapture`
- `cargo test -p sifr_codegen task -- --nocapture`
- `cargo run -q -p sifr -- run demos/m32_task_core_demo.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/scope_spawn_core.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture task_scope_unobserved_failure_scope_failure`
- `scripts/run_all_tests.sh --profile quick`
- `git diff --check`

## Review
- Opus review round 1: found missing generated `ScopeFailure`/`TimeoutError` type and `Result[..., Error]` conversion issues
- Opus review round 2: `SATISFIED`