### PR TITLE
Validate unobserved task scope failures

### DIFF
--- a/crates/sifr/tests/e2e/runtime_fail/task_group_unobserved_failure_scope_failure.sifr
+++ b/crates/sifr/tests/e2e/runtime_fail/task_group_unobserved_failure_scope_failure.sifr
@@ -1,0 +1,11 @@
+# expect-stderr: unobserved child task failed
+
+async def fail_later() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.TaskGroup() as group:
+        handle = group.spawn(fail_later())
+    return None

--- a/crates/sifr/tests/e2e/runtime_fail/task_scope_unobserved_failure_scope_failure.sifr
+++ b/crates/sifr/tests/e2e/runtime_fail/task_scope_unobserved_failure_scope_failure.sifr
@@ -1,0 +1,11 @@
+# expect-stderr: unobserved child task failed
+
+async def fail_later() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("scope child failed")
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(fail_later())
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -509,6 +509,7 @@ status: in_progress
 - In progress TaskGroup openness slice: task handles spawned from a named `TaskGroup` remember their owner, and v1 conservatively rejects later `group.spawn(...)` on a path after one of that group's child handles has been observed.
 - In progress cancellation/error type surface slice: registered `ScopeFailure`, `TaskCancelled`, and `SecondaryError` as ordinary built-in error classes, and registered `CancellationError` as a non-`Error` control-evidence class so it cannot be used as a `Result` error.
 - In progress scope-failure exit slice: task scopes now track whether child handles were observed, return `ScopeFailure` for unobserved child failure or cancellation at scope exit, and require enclosing async functions that spawn children to return `Result[..., ScopeFailure]` or `Result[..., Error]`.
+- In progress unobserved scope-failure runtime validation slice: added runtime-failure coverage for unobserved fallible children in both `task.scope()` and `task.TaskGroup()` surfacing `ScopeFailure` at scope exit.
 
 ---
 


### PR DESCRIPTION
## Summary
- add runtime-fail coverage for unobserved fallible children in `task.scope()`
- add matching runtime-fail coverage for `task.TaskGroup()`
- record the validation slice in Phase 32 progress notes

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p sifr -- test_e2e_runtime_fail -- --nocapture task_scope_unobserved_failure_scope_failure task_group_unobserved_failure_scope_failure`
- direct `sifr run` of both new runtime-fail fixtures, both exiting with `ScopeFailure { message: "unobserved child task failed" }`
- `scripts/run_all_tests.sh --profile quick`
- `git diff --check`

## Review
- Opus review: `SATISFIED`