### PR TITLE
Cancel TaskGroup siblings at scope exit

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_group_error_cancels_siblings.sifr
+++ b/crates/sifr/tests/e2e/pass/task_group_error_cancels_siblings.sifr
@@ -1,0 +1,37 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_task_group_error_cancels_siblings_" + str(getpid()) + ".txt"
+
+
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+
+
+async def slow_writes_marker() -> int:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "not cancelled")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    async with task.TaskGroup() as group:
+        slow = group.spawn(slow_writes_marker())
+        failing = group.spawn(fail_fast())
+        result = await failing
+
+    assert not exists(path)
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3722,7 +3722,8 @@ fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
     assert!(result.rust_source.contains("struct __SifrTaskScope"));
     assert!(result
         .rust_source
-        .contains("let mut group = __SifrTaskScope::new();"));
+        .contains("let mut group = __SifrTaskScope::new_task_group();"));
+    assert!(result.rust_source.contains("fail_fast"));
     assert!(result
         .rust_source
         .contains("group.__sifr_spawn_infallible(worker());"));

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -1904,6 +1904,11 @@ fn try_lower_simple_async_with_stmt(
 
     let mut block = Vec::new();
     if let Some(target) = target {
+        let constructor = if matches!(kind, sifr_hir::HirAsyncWithKind::TaskGroup) {
+            "new_task_group"
+        } else {
+            "new"
+        };
         block.push(RustStmt::Let {
             mutable: true,
             name: target.to_string(),
@@ -1911,7 +1916,7 @@ fn try_lower_simple_async_with_stmt(
             value: RustExpr::FnCall {
                 func: Box::new(RustExpr::Path(vec![
                     "__SifrTaskScope".to_string(),
-                    "new".to_string(),
+                    constructor.to_string(),
                 ])),
                 args: vec![],
             },

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -392,10 +392,13 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             name: "__SifrTaskScope".to_string(),
             visibility: Visibility::Private,
             derives: vec![],
-            fields: vec![(
-                "children".to_string(),
-                RustType::Vec(Box::new(RustType::Named("__SifrScopeChild".to_string()))),
-            )],
+            fields: vec![
+                (
+                    "children".to_string(),
+                    RustType::Vec(Box::new(RustType::Named("__SifrScopeChild".to_string()))),
+                ),
+                ("fail_fast".to_string(), RustType::Bool),
+            ],
         },
         RustItem::Impl {
             target: "__SifrTaskScope".to_string(),
@@ -410,13 +413,49 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     ret: Some(RustType::Named("Self".to_string())),
                     body: vec![RustStmt::Return(Some(RustExpr::StructInit {
                         name: "Self".to_string(),
-                        fields: vec![(
-                            "children".to_string(),
-                            RustExpr::FnCall {
-                                func: Box::new(RustExpr::Path(vec!["Vec".to_string(), "new".to_string()])),
-                                args: vec![],
-                            },
-                        )],
+                        fields: vec![
+                            (
+                                "children".to_string(),
+                                RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "Vec".to_string(),
+                                        "new".to_string(),
+                                    ])),
+                                    args: vec![],
+                                },
+                            ),
+                            (
+                                "fail_fast".to_string(),
+                                RustExpr::Literal(crate::RustLiteral::Bool(false)),
+                            ),
+                        ],
+                    }))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "new_task_group".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![],
+                    ret: Some(RustType::Named("Self".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "Self".to_string(),
+                        fields: vec![
+                            (
+                                "children".to_string(),
+                                RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec![
+                                        "Vec".to_string(),
+                                        "new".to_string(),
+                                    ])),
+                                    args: vec![],
+                                },
+                            ),
+                            (
+                                "fail_fast".to_string(),
+                                RustExpr::Literal(crate::RustLiteral::Bool(true)),
+                            ),
+                        ],
                     }))],
                     is_async: false,
                 },
@@ -677,7 +716,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     params: vec![RustParam::SelfParam { mutable: true }],
                     ret: Some(RustType::Named("Result<(), ScopeFailure>".to_string())),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let mut failure: Option<ScopeFailure> = None;\n        while let Some(child) = self.children.pop() {\n            let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);\n            match child.handle.await {\n                Ok(__SifrScopeChildOutcome::Ok) => {}\n                Ok(__SifrScopeChildOutcome::Failed) if !observed && failure.is_none() => {\n                    failure = Some(ScopeFailure::new(\"unobserved child task failed\".to_string()));\n                }\n                Ok(__SifrScopeChildOutcome::Cancelled) if !observed && failure.is_none() => {\n                    failure = Some(ScopeFailure::new(\"unobserved child task was cancelled\".to_string()));\n                }\n                Err(join_error) if !observed && failure.is_none() => {\n                    let message = if join_error.is_cancelled() { \"unobserved child task was cancelled\" } else { \"unobserved child task failed\" };\n                    failure = Some(ScopeFailure::new(message.to_string()));\n                }\n                _ => {}\n            }\n        }\n        if let Some(failure) = failure {\n            return Err(failure);\n        }\n        return Ok(())".to_string(),
+                        "let mut failure: Option<ScopeFailure> = None;\n        let mut policy_cancelling = false;\n        while let Some(child) = self.children.pop() {\n            let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);\n            let policy_observed = self.fail_fast && policy_cancelling;\n            let mut group_failure_seen = false;\n            match child.handle.await {\n                Ok(__SifrScopeChildOutcome::Ok) => {}\n                Ok(__SifrScopeChildOutcome::Failed) => {\n                    group_failure_seen = self.fail_fast;\n                    if !observed && failure.is_none() {\n                        failure = Some(ScopeFailure::new(\"unobserved child task failed\".to_string()));\n                    }\n                }\n                Ok(__SifrScopeChildOutcome::Cancelled) => {\n                    group_failure_seen = self.fail_fast;\n                    if !observed && !policy_observed && failure.is_none() {\n                        failure = Some(ScopeFailure::new(\"unobserved child task was cancelled\".to_string()));\n                    }\n                }\n                Err(join_error) => {\n                    group_failure_seen = self.fail_fast && !join_error.is_cancelled();\n                    if !observed && !policy_observed && failure.is_none() {\n                        let message = if join_error.is_cancelled() { \"unobserved child task was cancelled\" } else { \"unobserved child task failed\" };\n                        failure = Some(ScopeFailure::new(message.to_string()));\n                    }\n                }\n            }\n            if group_failure_seen {\n                policy_cancelling = true;\n                for pending in &self.children {\n                    pending.handle.abort();\n                }\n            }\n        }\n        if let Some(failure) = failure {\n            return Err(failure);\n        }\n        return Ok(())".to_string(),
                     ))],
                     is_async: true,
                 },

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7321,6 +7321,11 @@ impl RustEmitter {
             return Ok(None);
         };
         if let Some(target) = target {
+            let constructor = if matches!(kind, sifr_hir::HirAsyncWithKind::TaskGroup) {
+                "new_task_group"
+            } else {
+                "new"
+            };
             lowered_body.insert(
                 0,
                 crate::RustStmt::Let {
@@ -7330,7 +7335,7 @@ impl RustEmitter {
                     value: crate::RustExpr::FnCall {
                         func: Box::new(crate::RustExpr::Path(vec![
                             "__SifrTaskScope".to_string(),
-                            "new".to_string(),
+                            constructor.to_string(),
                         ])),
                         args: vec![],
                     },

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -510,6 +510,7 @@ status: in_progress
 - In progress cancellation/error type surface slice: registered `ScopeFailure`, `TaskCancelled`, and `SecondaryError` as ordinary built-in error classes, and registered `CancellationError` as a non-`Error` control-evidence class so it cannot be used as a `Result` error.
 - In progress scope-failure exit slice: task scopes now track whether child handles were observed, return `ScopeFailure` for unobserved child failure or cancellation at scope exit, and require enclosing async functions that spawn children to return `Result[..., ScopeFailure]` or `Result[..., Error]`.
 - In progress unobserved scope-failure runtime validation slice: added runtime-failure coverage for unobserved fallible children in both `task.scope()` and `task.TaskGroup()` surfacing `ScopeFailure` at scope exit.
+- In progress TaskGroup fail-fast exit slice: `task.TaskGroup()` now constructs a fail-fast private scope runtime that cancels remaining children when a group child failure is observed during scope exit, with marker-file validation for sibling cancellation.
 
 ---
 


### PR DESCRIPTION
## Summary
- lower task.TaskGroup() to a fail-fast scope runtime while preserving task.scope() wait-all behavior
- abort remaining TaskGroup children after a child failure/cancellation is observed during scope exit
- add marker-file e2e coverage proving a slow sibling is cancelled after an observed failing task
- update Phase 32 progress notes

## Validation
- cargo fmt --check
- cargo test -p sifr_codegen task -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_group_error_cancels_siblings.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_group_basic.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_scope_unobserved_child_waits.sifr
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile quick
- git diff --check

## Review
- Claude Opus reviewer: SATISFIED (reviews/phase32_taskgroup_fail_fast_exit.md)