### PR TITLE
Add structured concurrency validation demo

### DIFF
--- a/crates/sifr/tests/e2e/fail/cancelled_task_use_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/cancelled_task_use_rejected.sifr
@@ -1,0 +1,18 @@
+# expect-error: SIFR-OWN-0001
+
+async def fast() -> int:
+    return 1
+
+
+async def slow() -> int:
+    await task.sleep(1.0)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        first = scope.spawn(fast())
+        second = scope.spawn(slow())
+        selected = await task.select(first, second)
+        late = await second
+    return None

--- a/crates/sifr/tests/e2e/fail/task_group_error_type_not_carried_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_group_error_type_not_carried_rejected.sifr
@@ -1,0 +1,11 @@
+# expect-error: SIFR-TYPE-0002
+
+async def child() -> Result[int, ValueError]:
+    raise ValueError("child failed")
+
+
+async def main() -> Result[None, ValueError]:
+    async with task.TaskGroup() as group:
+        handle = group.spawn(child())
+        result = await handle
+    return None

--- a/demos/m32_structured_concurrency_demo.sifr
+++ b/demos/m32_structured_concurrency_demo.sifr
@@ -1,0 +1,61 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_m32_structured_concurrency_demo_" + str(getpid()) + ".txt"
+
+
+async def one() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def two() -> int:
+    await task.sleep(0.0)
+    return 2
+
+
+async def fast() -> int:
+    await task.sleep(0.0)
+    return 10
+
+
+async def slow_writes_marker() -> int:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "not cancelled")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 20
+
+
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+
+
+async def main() -> Result[None, Error]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    # Scoped gather preserves deterministic input ownership and ordering.
+    async with task.scope() as scope:
+        gathered = await task.gather([scope.spawn(one()), scope.spawn(two())])
+
+    # Select consumes both handles and cancels the losing child.
+    async with task.scope() as scope:
+        selected = await task.select(scope.spawn(fast()), scope.spawn(slow_writes_marker()))
+
+    # TaskGroup observes the failing child and cancels unfinished siblings at exit.
+    async with task.TaskGroup() as group:
+        slow = group.spawn(slow_writes_marker())
+        failing = group.spawn(fail_fast())
+        failure = await failing
+
+    assert not exists(path)
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -511,6 +511,7 @@ status: in_progress
 - In progress scope-failure exit slice: task scopes now track whether child handles were observed, return `ScopeFailure` for unobserved child failure or cancellation at scope exit, and require enclosing async functions that spawn children to return `Result[..., ScopeFailure]` or `Result[..., Error]`.
 - In progress unobserved scope-failure runtime validation slice: added runtime-failure coverage for unobserved fallible children in both `task.scope()` and `task.TaskGroup()` surfacing `ScopeFailure` at scope exit.
 - In progress TaskGroup fail-fast exit slice: `task.TaskGroup()` now constructs a fail-fast private scope runtime that cancels remaining children when a group child failure is observed during scope exit, with marker-file validation for sibling cancellation.
+- In progress structured-concurrency validation/demo slice: added milestone negative coverage for consumed cancelled task handles and TaskGroup scope-failure error typing, plus `demos/m32_structured_concurrency_demo.sifr`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add milestone_async_3 negative validation for using a consumed/cancelled task handle after select
- add TaskGroup scope-failure typing validation when the enclosing Result does not carry ScopeFailure
- add demos/m32_structured_concurrency_demo.sifr covering gather, select loser cancellation, and TaskGroup fail-fast sibling cancellation
- update Phase 32 progress notes

## Validation
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/cancelled_task_use_rejected.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_group_error_type_not_carried_rejected.sifr
- cargo run -q -p sifr -- run demos/m32_structured_concurrency_demo.sifr
- cargo test -p sifr test_e2e_fail -- --nocapture
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile quick
- git diff --check

## Review
- Claude Opus reviewer: SATISFIED (reviews/phase32_structured_concurrency_validation_demo.md)