### PR TITLE
Cancel gather siblings on first failure

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_gather_error_cancels_siblings.sifr
+++ b/crates/sifr/tests/e2e/pass/task_gather_error_cancels_siblings.sifr
@@ -1,0 +1,35 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_task_gather_error_cancels_siblings_" + str(getpid()) + ".txt"
+
+
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("gather child failed")
+
+
+async def slow_writes_marker() -> Result[int, ValueError]:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "not cancelled")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    async with task.scope() as scope:
+        result = await task.gather([scope.spawn(fail_fast()), scope.spawn(slow_writes_marker())])
+
+    assert not exists(path)
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3749,6 +3749,8 @@ fn test_task_gather_lowers_to_private_gather_helper() {
 
     assert!(result.rust_source.contains("async fn __sifr_task_gather"));
     assert!(result.rust_source.contains("__sifr_task_gather(vec!["));
+    assert!(result.rust_source.contains("abort_handle.abort();"));
+    assert!(result.rust_source.contains("ordered_values.push(value);"));
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<Vec<i64>, std::convert::Infallible>"));

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -728,11 +728,11 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             type_params: vec![
                 crate::RustTypeParam {
                     name: "T".to_string(),
-                    bounds: vec![],
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
                 },
                 crate::RustTypeParam {
                     name: "E".to_string(),
-                    bounds: vec![],
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
                 },
             ],
             params: vec![RustParam::Named {
@@ -743,7 +743,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 "__SifrTaskResult<Vec<T>, E>".to_string(),
             )),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let mut values = Vec::new();\n        for handle in handles {\n            match handle.join().await {\n                __SifrTaskResult::Ok(value) => values.push(value),\n                __SifrTaskResult::Err(err) => return __SifrTaskResult::Err(err),\n                __SifrTaskResult::Cancelled => return __SifrTaskResult::Cancelled,\n            }\n        }\n        return __SifrTaskResult::Ok(values)".to_string(),
+                "let input_len = handles.len();\n        let mut values: Vec<Option<T>> = std::iter::repeat_with(|| None).take(input_len).collect();\n        let mut abort_handles = Vec::with_capacity(input_len);\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for (index, handle) in handles.into_iter().enumerate() {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            observer_count += 1;\n            let sender = sender.clone();\n            if let Some(task_receiver) = task_receiver {\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send((index, result));\n                });\n            } else {\n                let _ = sender.send((index, __SifrTaskResult::Cancelled));\n            }\n        }\n        drop(sender);\n        let mut remaining = observer_count;\n        while remaining > 0 {\n            let Some((index, result)) = receiver.recv().await else {\n                break;\n            };\n            remaining -= 1;\n            match result {\n                __SifrTaskResult::Ok(value) => values[index] = Some(value),\n                __SifrTaskResult::Err(err) => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Err(err);\n                }\n                __SifrTaskResult::Cancelled => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Cancelled;\n                }\n            }\n        }\n        let mut ordered_values = Vec::with_capacity(input_len);\n        for value in values {\n            let Some(value) = value else {\n                return __SifrTaskResult::Cancelled;\n            };\n            ordered_values.push(value);\n        }\n        return __SifrTaskResult::Ok(ordered_values)".to_string(),
             ))],
             is_async: true,
         },

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -512,6 +512,7 @@ status: in_progress
 - In progress unobserved scope-failure runtime validation slice: added runtime-failure coverage for unobserved fallible children in both `task.scope()` and `task.TaskGroup()` surfacing `ScopeFailure` at scope exit.
 - In progress TaskGroup fail-fast exit slice: `task.TaskGroup()` now constructs a fail-fast private scope runtime that cancels remaining children when a group child failure is observed during scope exit, with marker-file validation for sibling cancellation.
 - In progress structured-concurrency validation/demo slice: added milestone negative coverage for consumed cancelled task handles and TaskGroup scope-failure error typing, plus `demos/m32_structured_concurrency_demo.sifr`.
+- In progress gather fail-fast cancellation slice: `task.gather([...])` now observes all input handles, preserves ordered success values, and cancels unfinished siblings after the first failure-like child result.
 
 ---
 


### PR DESCRIPTION
## Summary
- make private task.gather observe all input handles and await them concurrently
- abort and drain remaining gathered children after the first Err/Cancelled result
- preserve ordered success values for successful gather results
- add marker-file e2e coverage for gather fail-fast sibling cancellation
- update Phase 32 progress notes

## Validation
- cargo fmt --check
- cargo test -p sifr_codegen test_task_gather_lowers_to_private_gather_helper -- --nocapture
- cargo test -p sifr_codegen task -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_error_cancels_siblings.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_ordered.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_collection_consumed.sifr
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile quick
- git diff --check

## Review
- Claude Opus reviewer round 1 timed out after 40+ minutes with empty artifact/log
- Claude Opus reviewer round 2: SATISFIED (reviews/phase32_gather_fail_fast_cancellation_r2.md)