### PR TITLE
Add TaskGroup sibling cancellation validation

### DIFF
--- a/crates/sifr/tests/e2e/pass/cancellation_group_sibling.sifr
+++ b/crates/sifr/tests/e2e/pass/cancellation_group_sibling.sifr
@@ -1,0 +1,37 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_cancellation_group_sibling_" + str(getpid()) + ".txt"
+
+
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+
+
+async def sibling_writes_marker() -> Result[int, ValueError]:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "sibling was not cancelled")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    async with task.TaskGroup() as group:
+        sibling = group.spawn(sibling_writes_marker())
+        failing = group.spawn(fail_fast())
+        result = await failing
+
+    assert not exists(path)
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -513,6 +513,7 @@ status: in_progress
 - In progress TaskGroup fail-fast exit slice: `task.TaskGroup()` now constructs a fail-fast private scope runtime that cancels remaining children when a group child failure is observed during scope exit, with marker-file validation for sibling cancellation.
 - In progress structured-concurrency validation/demo slice: added milestone negative coverage for consumed cancelled task handles and TaskGroup scope-failure error typing, plus `demos/m32_structured_concurrency_demo.sifr`.
 - In progress gather fail-fast cancellation slice: `task.gather([...])` now observes all input handles, preserves ordered success values, and cancels unfinished siblings after the first failure-like child result.
+- In progress cancellation group-sibling validation slice: added `cancellation_group_sibling.sifr` as direct milestone coverage for TaskGroup sibling cancellation through the cancellation validation naming.
 
 ---
 


### PR DESCRIPTION
## Summary
- add milestone_async_3 positive fixture cancellation_group_sibling.sifr
- validate TaskGroup sibling cancellation with marker-file proof
- update Phase 32 progress notes

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_group_sibling.sifr
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile quick
- git diff --check

## Review
- Claude Opus reviewer: SATISFIED (reviews/phase32_cancellation_group_sibling_validation.md)