### PR TITLE
Reject task scope early exits

### DIFF
--- a/crates/sifr/tests/e2e/fail/task_scope_early_return_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_scope_early_return_rejected.sifr
@@ -1,0 +1,12 @@
+# expect-error: SIFR-TYPE-0002
+
+async def slow() -> int:
+    await task.sleep(0.20)
+    return 1
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(slow())
+        return None
+    return None

--- a/crates/sifr/tests/e2e/fail/task_scope_raise_in_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_scope_raise_in_scope_rejected.sifr
@@ -1,0 +1,11 @@
+# expect-error: SIFR-TYPE-0002
+
+async def worker() -> int:
+    return 1
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        raise ValueError("early exit")
+    return None

--- a/crates/sifr/tests/e2e/fail/task_scope_yield_in_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/task_scope_yield_in_scope_rejected.sifr
@@ -1,0 +1,11 @@
+# expect-error: SIFR-TYPE-0002
+
+async def worker() -> int:
+    return 1
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        yield 1
+    return None

--- a/crates/sifr/tests/e2e/pass/task_scope_loop_control_allowed.sifr
+++ b/crates/sifr/tests/e2e/pass/task_scope_loop_control_allowed.sifr
@@ -1,0 +1,16 @@
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def main() -> Result[None, ScopeFailure]:
+    total: int = 0
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        for value in range(3):
+            if value == 1:
+                continue
+            total = total + value
+            if total > 1:
+                break
+    return None

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -479,6 +479,50 @@ fn stmt_contains_task_spawn(stmt: &HirStmt) -> bool {
     }
 }
 
+fn stmt_contains_scope_early_exit(stmt: &HirStmt) -> bool {
+    match stmt {
+        HirStmt::Return { .. } | HirStmt::Raise { .. } | HirStmt::Yield { .. } => true,
+        HirStmt::If {
+            then_body,
+            elif_clauses,
+            else_body,
+            ..
+        } => {
+            then_body.iter().any(stmt_contains_scope_early_exit)
+                || elif_clauses
+                    .iter()
+                    .any(|(_, body)| body.iter().any(stmt_contains_scope_early_exit))
+                || else_body
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(stmt_contains_scope_early_exit))
+        }
+        HirStmt::While {
+            body, else_body, ..
+        }
+        | HirStmt::For {
+            body, else_body, ..
+        } => {
+            body.iter().any(stmt_contains_scope_early_exit)
+                || else_body
+                    .as_ref()
+                    .is_some_and(|body| body.iter().any(stmt_contains_scope_early_exit))
+        }
+        HirStmt::AsyncWith { body, .. } | HirStmt::With { body, .. } => {
+            body.iter().any(stmt_contains_scope_early_exit)
+        }
+        HirStmt::TryExcept { body, handlers, .. } => {
+            body.iter().any(stmt_contains_scope_early_exit)
+                || handlers
+                    .iter()
+                    .any(|handler| handler.body.iter().any(stmt_contains_scope_early_exit))
+        }
+        HirStmt::Match { arms, .. } => arms
+            .iter()
+            .any(|arm| arm.body.iter().any(stmt_contains_scope_early_exit)),
+        _ => false,
+    }
+}
+
 pub(super) fn lower_async_with(
     with_stmt: &StmtWith,
     func_type: &FunctionType,
@@ -615,6 +659,18 @@ pub(super) fn lower_async_with(
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,
                 "async task scopes that spawn children can fail at exit; enclosing function must return Result[..., ScopeFailure] or Result[..., Error]"
+                    .to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        if matches!(kind, HirAsyncWithKind::TaskScope | HirAsyncWithKind::TaskGroup)
+            && body.iter().any(stmt_contains_task_spawn)
+            && body.iter().any(stmt_contains_scope_early_exit)
+        {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "async task scopes that spawn children cannot use return, raise, or yield inside the scope until abnormal-exit cleanup lowering is implemented"
                     .to_string(),
                 item.context_expr.range(),
             );

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -514,6 +514,7 @@ status: in_progress
 - In progress structured-concurrency validation/demo slice: added milestone negative coverage for consumed cancelled task handles and TaskGroup scope-failure error typing, plus `demos/m32_structured_concurrency_demo.sifr`.
 - In progress gather fail-fast cancellation slice: `task.gather([...])` now observes all input handles, preserves ordered success values, and cancels unfinished siblings after the first failure-like child result.
 - In progress cancellation group-sibling validation slice: added `cancellation_group_sibling.sifr` as direct milestone coverage for TaskGroup sibling cancellation through the cancellation validation naming.
+- PR [#1940](https://github.com/sifr-lang/sifr/pull/1940) scope early-exit guard slice: task scopes that spawn children now reject `return`, `raise`, and `yield` inside the scope until abnormal-exit cleanup lowering can guarantee `__sifr_join_all()` runs on every exit path; local loop `break`/`continue` remain allowed because they do not exit the scope.
 
 ---
 


### PR DESCRIPTION
## Summary
- reject return, raise, and yield inside task.scope()/TaskGroup bodies that spawn children until abnormal-exit cleanup lowering guarantees scope joins run
- keep local loop break/continue allowed inside spawning task scopes
- add fail coverage for return/raise/yield and pass coverage for nested loop control
- update Phase 32 progress notes

## Validation
- cargo fmt --check
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_scope_early_return_rejected.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_scope_raise_in_scope_rejected.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/task_scope_yield_in_scope_rejected.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_scope_loop_control_allowed.sifr
- cargo test -p sifr test_e2e_fail -- --nocapture
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Opus round 1 requested narrower loop-control handling
- Opus round 2: SATISFIED