### PR TITLE
Make TaskGroup exit fail fast by completion

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_group_fail_fast_spawn_order.sifr
+++ b/crates/sifr/tests/e2e/pass/task_group_fail_fast_spawn_order.sifr
@@ -1,0 +1,37 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_task_group_fail_fast_spawn_order_" + str(getpid()) + ".txt"
+
+
+async def fail_fast() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("group child failed")
+
+
+async def slow_writes_marker() -> int:
+    await task.sleep(0.20)
+    try:
+        _written: None = write_text(marker_path(), "sibling was not cancelled")
+    except IOError as e:
+        _message: str = str(e.message)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    async with task.TaskGroup() as group:
+        failing = group.spawn(fail_fast())
+        sibling = group.spawn(slow_writes_marker())
+        result = await failing
+
+    assert not exists(path)
+    return None

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -716,7 +716,87 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     params: vec![RustParam::SelfParam { mutable: true }],
                     ret: Some(RustType::Named("Result<(), ScopeFailure>".to_string())),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let mut failure: Option<ScopeFailure> = None;\n        let mut policy_cancelling = false;\n        while let Some(child) = self.children.pop() {\n            let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);\n            let policy_observed = self.fail_fast && policy_cancelling;\n            let mut group_failure_seen = false;\n            match child.handle.await {\n                Ok(__SifrScopeChildOutcome::Ok) => {}\n                Ok(__SifrScopeChildOutcome::Failed) => {\n                    group_failure_seen = self.fail_fast;\n                    if !observed && failure.is_none() {\n                        failure = Some(ScopeFailure::new(\"unobserved child task failed\".to_string()));\n                    }\n                }\n                Ok(__SifrScopeChildOutcome::Cancelled) => {\n                    group_failure_seen = self.fail_fast;\n                    if !observed && !policy_observed && failure.is_none() {\n                        failure = Some(ScopeFailure::new(\"unobserved child task was cancelled\".to_string()));\n                    }\n                }\n                Err(join_error) => {\n                    group_failure_seen = self.fail_fast && !join_error.is_cancelled();\n                    if !observed && !policy_observed && failure.is_none() {\n                        let message = if join_error.is_cancelled() { \"unobserved child task was cancelled\" } else { \"unobserved child task failed\" };\n                        failure = Some(ScopeFailure::new(message.to_string()));\n                    }\n                }\n            }\n            if group_failure_seen {\n                policy_cancelling = true;\n                for pending in &self.children {\n                    pending.handle.abort();\n                }\n            }\n        }\n        if let Some(failure) = failure {\n            return Err(failure);\n        }\n        return Ok(())".to_string(),
+                        r#"if self.fail_fast {
+            let mut failure: Option<ScopeFailure> = None;
+            let mut policy_cancelling = false;
+            let mut abort_handles = Vec::with_capacity(self.children.len());
+            let mut join_set = tokio::task::JoinSet::new();
+            for child in self.children.drain(..) {
+                abort_handles.push(child.handle.abort_handle());
+                join_set.spawn(async move {
+                    let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);
+                    (observed, child.handle.await)
+                });
+            }
+            while let Some(joined) = join_set.join_next().await {
+                let mut group_failure_seen = false;
+                match joined {
+                    Ok((observed, Ok(__SifrScopeChildOutcome::Ok))) => {}
+                    Ok((observed, Ok(__SifrScopeChildOutcome::Failed))) => {
+                        group_failure_seen = true;
+                        if !observed && failure.is_none() {
+                            failure = Some(ScopeFailure::new("unobserved child task failed".to_string()));
+                        }
+                    }
+                    Ok((observed, Ok(__SifrScopeChildOutcome::Cancelled))) => {
+                        group_failure_seen = true;
+                        if !observed && !policy_cancelling && failure.is_none() {
+                            failure = Some(ScopeFailure::new("unobserved child task was cancelled".to_string()));
+                        }
+                    }
+                    Ok((observed, Err(join_error))) => {
+                        group_failure_seen = !join_error.is_cancelled();
+                        if !observed && !policy_cancelling && failure.is_none() {
+                            let message = if join_error.is_cancelled() { "unobserved child task was cancelled" } else { "unobserved child task failed" };
+                            failure = Some(ScopeFailure::new(message.to_string()));
+                        }
+                    }
+                    Err(_) => {
+                        group_failure_seen = true;
+                        if !policy_cancelling && failure.is_none() {
+                            failure = Some(ScopeFailure::new("task group child observer failed".to_string()));
+                        }
+                    }
+                }
+                if group_failure_seen && !policy_cancelling {
+                    policy_cancelling = true;
+                    for abort_handle in &abort_handles {
+                        abort_handle.abort();
+                    }
+                }
+            }
+            if let Some(failure) = failure {
+                return Err(failure);
+            }
+            return Ok(());
+        }
+        let mut failure: Option<ScopeFailure> = None;
+        while let Some(child) = self.children.pop() {
+            let observed = child.observed.load(std::sync::atomic::Ordering::SeqCst);
+            match child.handle.await {
+                Ok(__SifrScopeChildOutcome::Ok) => {}
+                Ok(__SifrScopeChildOutcome::Failed) => {
+                    if !observed && failure.is_none() {
+                        failure = Some(ScopeFailure::new("unobserved child task failed".to_string()));
+                    }
+                }
+                Ok(__SifrScopeChildOutcome::Cancelled) => {
+                    if !observed && failure.is_none() {
+                        failure = Some(ScopeFailure::new("unobserved child task was cancelled".to_string()));
+                    }
+                }
+                Err(join_error) => {
+                    if !observed && failure.is_none() {
+                        let message = if join_error.is_cancelled() { "unobserved child task was cancelled" } else { "unobserved child task failed" };
+                        failure = Some(ScopeFailure::new(message.to_string()));
+                    }
+                }
+            }
+        }
+        if let Some(failure) = failure {
+            return Err(failure);
+        }
+        return Ok(())"#.to_string(),
                     ))],
                     is_async: true,
                 },

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -515,6 +515,7 @@ status: in_progress
 - In progress gather fail-fast cancellation slice: `task.gather([...])` now observes all input handles, preserves ordered success values, and cancels unfinished siblings after the first failure-like child result.
 - In progress cancellation group-sibling validation slice: added `cancellation_group_sibling.sifr` as direct milestone coverage for TaskGroup sibling cancellation through the cancellation validation naming.
 - PR [#1940](https://github.com/sifr-lang/sifr/pull/1940) scope early-exit guard slice: task scopes that spawn children now reject `return`, `raise`, and `yield` inside the scope until abnormal-exit cleanup lowering can guarantee `__sifr_join_all()` runs on every exit path; local loop `break`/`continue` remain allowed because they do not exit the scope.
+- PR [#1941](https://github.com/sifr-lang/sifr/pull/1941) TaskGroup exit-order cancellation slice: fail-fast TaskGroup scope exit now observes children concurrently so a failed child cancels unfinished siblings regardless of spawn order.
 
 ---
 


### PR DESCRIPTION
## Summary
- make fail-fast TaskGroup scope exit observe child completion concurrently instead of sequential LIFO order
- cancel unfinished siblings as soon as a child failure/cancellation policy trigger is observed
- preserve plain task.scope() sequential wait behavior
- add regression coverage for failing child spawned before a slow sibling

## Validation
- cargo fmt --check
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_group_fail_fast_spawn_order.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_group_error_cancels_siblings.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_group_sibling.sifr
- cargo test -p sifr_codegen task_group -- --nocapture
- cargo clippy --workspace -- -D warnings
- python3 scripts/check_hir_maintainability_guardrails.py
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Opus round 1 requested a policy-cancellation guard for the observer fault arm
- Opus round 2: SATISFIED