### PR TITLE
Add task scope basic validation

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_scope_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/task_scope_basic.sifr
@@ -1,0 +1,17 @@
+async def first() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def second() -> int:
+    await task.sleep(0.0)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        first_handle = scope.spawn(first())
+        second_handle = scope.spawn(second())
+        first_result = await first_handle.join()
+        second_result = await second_handle
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -516,6 +516,7 @@ status: in_progress
 - In progress cancellation group-sibling validation slice: added `cancellation_group_sibling.sifr` as direct milestone coverage for TaskGroup sibling cancellation through the cancellation validation naming.
 - PR [#1940](https://github.com/sifr-lang/sifr/pull/1940) scope early-exit guard slice: task scopes that spawn children now reject `return`, `raise`, and `yield` inside the scope until abnormal-exit cleanup lowering can guarantee `__sifr_join_all()` runs on every exit path; local loop `break`/`continue` remain allowed because they do not exit the scope.
 - PR [#1941](https://github.com/sifr-lang/sifr/pull/1941) TaskGroup exit-order cancellation slice: fail-fast TaskGroup scope exit now observes children concurrently so a failed child cancels unfinished siblings regardless of spawn order.
+- PR [#1942](https://github.com/sifr-lang/sifr/pull/1942) task-scope basic validation slice: added the canonical `task_scope_basic.sifr` milestone fixture for a normal multi-child scoped-task path with both `join()` and direct handle await observation.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the canonical task_scope_basic.sifr milestone fixture
- cover a normal multi-child task.scope path with both join() and direct handle await observation
- update Phase 32 progress notes

## Validation
- cargo fmt --check
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_scope_basic.sifr
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Opus round 1 requested less-duplicative coverage
- Opus round 2: SATISFIED