### PR TITLE
Consume task handle lists in for loops

### DIFF
--- a/crates/sifr/tests/e2e/pass/task_handle_collection_loop_consumed.sifr
+++ b/crates/sifr/tests/e2e/pass/task_handle_collection_loop_consumed.sifr
@@ -1,0 +1,16 @@
+async def first() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def second() -> int:
+    await task.sleep(0.0)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handles = [scope.spawn(first()), scope.spawn(second())]
+        for handle in handles:
+            result = await handle
+    return None

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -2546,6 +2546,10 @@ fn try_lower_simple_for_iter_expr(iter: &HirExpr, target_ty: &Type) -> Option<Ru
     };
     let iter_plan =
         crate::helpers::plan_iterator_ownership_with_element_hint(iter_source, Some(target_ty));
+    let consumes_task_handle_collection = matches!(
+        resolve_alias_type(iter_source.ty()),
+        Type::List(element_ty) if matches!(element_ty.resolve_alias(), Type::Task(_, _))
+    );
     let apply_copy_clone_yield = |iter_expr: RustExpr| match iter_plan.yield_mode {
         crate::helpers::YieldMode::Copy => RustExpr::MethodCall {
             receiver: Box::new(iter_expr),
@@ -2560,6 +2564,11 @@ fn try_lower_simple_for_iter_expr(iter: &HirExpr, target_ty: &Type) -> Option<Ru
         crate::helpers::YieldMode::Move | crate::helpers::YieldMode::Borrow => iter_expr,
     };
     Some(match resolve_alias_type(iter_source.ty()) {
+        Type::List(_) if consumes_task_handle_collection => RustExpr::MethodCall {
+            receiver: Box::new(lowered_iter),
+            method: "into_iter".to_string(),
+            args: vec![],
+        },
         Type::List(_) | Type::Set(_) | Type::Iterable(_) => match iter_plan.source_access_mode {
             crate::helpers::SourceAccessMode::Consume => RustExpr::MethodCall {
                 receiver: Box::new(lowered_iter),
@@ -8878,6 +8887,40 @@ mod tests {
     }
 
     #[test]
+    fn lowers_simple_for_over_task_handle_list_by_value() {
+        let handle_ty = Type::Task(Box::new(Type::Int), Box::new(Type::Never));
+        let for_stmt = HirStmt::For {
+            target: "handle".to_string(),
+            target_ty: handle_ty.clone(),
+            iter: HirExpr::Name {
+                name: "handles".to_string(),
+                ty: Type::List(Box::new(handle_ty)),
+            },
+            body: vec![HirStmt::Pass],
+            else_body: None,
+        };
+
+        let lowered = try_lower_simple_stmt(&for_stmt, false, &HashSet::new(), &HashSet::new())
+            .expect("for with task handle list lowered");
+        assert_eq!(lowered.len(), 1);
+        assert!(matches!(
+            lowered[0],
+            RustStmt::For {
+                var: ref var_name,
+                iter: RustExpr::MethodCall {
+                    receiver: ref recv,
+                    ref method,
+                    ref args,
+                },
+                ..
+            } if var_name == "handle"
+                && matches!(recv.as_ref(), RustExpr::Ident(name) if name == "handles")
+                && method == "into_iter"
+                && args.is_empty()
+        ));
+    }
+
+    #[test]
     fn lowers_simple_for_with_dict_iter_to_keys_cloned() {
         let for_stmt = HirStmt::For {
             target: "k".to_string(),
@@ -8912,7 +8955,7 @@ mod tests {
                     && method == "keys"
                     && args.is_empty()
             )
-                && method == "copied"
+                && method == "cloned"
                 && args.is_empty()
         ));
     }

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1599,6 +1599,24 @@ fn test_task_race_consumes_handle_collection_binding() {
 }
 
 #[test]
+fn test_for_loop_consumes_task_handle_collection_binding() {
+    let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handles = [scope.spawn(worker()), scope.spawn(worker())]\n        for handle in handles:\n            result = await handle\n        second = await task.gather(handles)\n    return None\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|e| {
+        e.message.contains("moved value")
+            && e.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && e.primary_range
+                == Some(range_for_after(
+                    source,
+                    "second = await task.gather(",
+                    "handles",
+                ))
+    }));
+}
+
+#[test]
 fn test_task_select_consumes_handle_bindings() {
     let source = "async def first() -> int:\n    return 1\n\nasync def second() -> str:\n    return \"two\"\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        one = scope.spawn(first())\n        two = scope.spawn(second())\n        selected = await task.select(one, two)\n        late = await one\n    return None\n";
     let result = lower_source(source);

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1970,6 +1970,9 @@ pub(super) fn lower_for(
         args: vec![iterable_expr],
         ty: Type::Iterator(Box::new(elem_ty.clone())),
     };
+    let consumes_task_handle_collection = iter_source_name.is_some()
+        && matches!(iter_source_ty.resolve_alias(), Type::List(_))
+        && matches!(elem_ty.resolve_alias(), Type::Task(_, _));
 
     // Extract the target variable name(s)
     let (target_name, target_tuple_range): (String, Option<TextRange>) =
@@ -2007,6 +2010,12 @@ pub(super) fn lower_for(
                 return None;
             }
         };
+
+    if consumes_task_handle_collection {
+        if let Some(source_name) = iter_source_name.as_deref() {
+            ctx.scope.mark_moved(source_name);
+        }
+    }
 
     // Snapshot moved state before loop to detect moves inside the body
     let moved_before_loop = ctx.scope.save_moved_state();

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -470,6 +470,7 @@ status: in_progress
 - `task_gather_ordered.sifr`
 - `task_gather_cleanup_error_secondary.sifr`
 - `task_handle_collection_consumed.sifr`
+- `task_handle_collection_loop_consumed.sifr`
 - `task_scope_unobserved_child_waits.sifr`
 - `task_scope_unobserved_failure_scope_failure.sifr`
 - `task_select_first_completion.sifr`
@@ -517,6 +518,7 @@ status: in_progress
 - PR [#1940](https://github.com/sifr-lang/sifr/pull/1940) scope early-exit guard slice: task scopes that spawn children now reject `return`, `raise`, and `yield` inside the scope until abnormal-exit cleanup lowering can guarantee `__sifr_join_all()` runs on every exit path; local loop `break`/`continue` remain allowed because they do not exit the scope.
 - PR [#1941](https://github.com/sifr-lang/sifr/pull/1941) TaskGroup exit-order cancellation slice: fail-fast TaskGroup scope exit now observes children concurrently so a failed child cancels unfinished siblings regardless of spawn order.
 - PR [#1942](https://github.com/sifr-lang/sifr/pull/1942) task-scope basic validation slice: added the canonical `task_scope_basic.sifr` milestone fixture for a normal multi-child scoped-task path with both `join()` and direct handle await observation.
+- PR [#1943](https://github.com/sifr-lang/sifr/pull/1943) task-handle loop-consumption slice: simple `for handle in handles: await handle` now consumes a named task-handle list instead of cloning one-shot handles, with ownership diagnostics preventing reuse of the consumed collection.
 
 ---
 


### PR DESCRIPTION
## Summary
- consume named `list[Task[...]]` sources in `for` loops so one-shot task handles are moved with `into_iter()` instead of cloned
- mark those collections moved in HIR so later reuse is rejected with ownership diagnostics
- add e2e/unit coverage for explicit task-handle loop consumption and align an existing dict-iteration codegen assertion with cloned key iteration

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_hir task_handle_collection -- --nocapture`
- `cargo test -p sifr_codegen lowers_simple_for -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_handle_collection_loop_consumed.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/task_handle_collection_loop_consumed.sifr`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

Reviewer: Opus SATISFIED in `reviews/phase32_task_handle_loop_consumption.md`.