### PR TITLE
Run simple try-finally cleanup bodies

### DIFF
--- a/crates/sifr/tests/e2e/pass/cpython_glob_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/cpython_glob_subset.sifr
@@ -48,7 +48,10 @@ def collect_glob_actual() -> list[bool]:
         _ = str(e.message)
         actual = [False, False, False, False, False, False, False, False]
     finally:
-        _clean: str = run_command("rm -rf " + base)
+        try:
+            _clean: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _clean_message: str = str(e.message)
     return actual
 
 

--- a/crates/sifr/tests/e2e/pass/iterable_stdlib.sifr
+++ b/crates/sifr/tests/e2e/pass/iterable_stdlib.sifr
@@ -51,7 +51,10 @@ def collect_runtime_iterator_actual() -> list[bool]:
         _ = str(e.message)
         actual = [False, False]
     finally:
-        _rm: str = run_command("rm -rf " + base)
+        try:
+            _rm: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _rm_message: str = str(e.message)
 
     return actual
 

--- a/crates/sifr/tests/e2e/pass/iterator_integration.sifr
+++ b/crates/sifr/tests/e2e/pass/iterator_integration.sifr
@@ -65,7 +65,10 @@ def main():
         actual.append(False)
         actual.append(False)
     finally:
-        _rm: str = run_command("rm -rf " + base)
+        try:
+            _rm: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _rm_message: str = str(e.message)
 
     expected: list[bool] = [True, True, True, True, True, True]
     assert_bool_vector_eq(actual, expected)

--- a/crates/sifr/tests/e2e/pass/pathlib_glob_semantics.sifr
+++ b/crates/sifr/tests/e2e/pass/pathlib_glob_semantics.sifr
@@ -35,6 +35,9 @@ def main():
         _ = str(e.message)
         actual = [False, False, False]
     finally:
-        _clean: str = run_command("rm -rf " + base)
+        try:
+            _clean: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _clean_message: str = str(e.message)
 
     assert_bool_vector_eq(actual, expected)

--- a/crates/sifr/tests/e2e/pass/regex_filesystem_iterators.sifr
+++ b/crates/sifr/tests/e2e/pass/regex_filesystem_iterators.sifr
@@ -64,7 +64,10 @@ def collect_filesystem_actual() -> list[bool]:
         _ = str(e.message)
         actual = [False, False, False, False]
     finally:
-        _clean: str = run_command("rm -rf " + base)
+        try:
+            _clean: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _clean_message: str = str(e.message)
     return actual
 
 

--- a/crates/sifr/tests/e2e/pass/stdlib_glob_consolidated.sifr
+++ b/crates/sifr/tests/e2e/pass/stdlib_glob_consolidated.sifr
@@ -54,7 +54,10 @@ def main():
         _ = str(e.message)
         actual = [False, False, False, False, False]
     finally:
-        _clean: str = run_command("rm -rf " + base)
+        try:
+            _clean: str = run_command("rm -rf " + base)
+        except IOError as e:
+            _clean_message: str = str(e.message)
 
     assert_bool_vector_eq(actual, expected)
     assert str("stdlib_glob_consolidated: pass") == "stdlib_glob_consolidated: pass"

--- a/crates/sifr/tests/e2e/pass/try_finally_cleanup_runs.sifr
+++ b/crates/sifr/tests/e2e/pass/try_finally_cleanup_runs.sifr
@@ -1,0 +1,33 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_try_finally_cleanup_runs_" + str(getpid()) + ".txt"
+
+
+def main() -> None:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    try:
+        _body: int = 1
+    finally:
+        try:
+            _written: None = write_text(path, "cleanup")
+        except IOError as e:
+            _write_message: str = str(e.message)
+
+    assert exists(path)
+
+    try:
+        _removed: None = remove_file(path)
+    except IOError as e:
+        _remove_message: str = str(e.message)
+
+
+main()

--- a/crates/sifr_hir/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_hir/src/lower/statement_diagnostics_tests.rs
@@ -1,4 +1,4 @@
-use crate::{lower_module, HirDiagnostic};
+use crate::{lower_module, HirDiagnostic, HirStmt};
 use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_parser::parse_module;
@@ -154,4 +154,36 @@ def main():
             && error.primary_range.map(|range| range.start())
                 == Some(range_for(source, "try:").start())
     }));
+}
+
+#[test]
+fn try_finally_without_except_lowers_body_then_finalbody() {
+    let source = "\
+def main():
+    value: int = 1
+    try:
+        value = 2
+    finally:
+        value = 3
+";
+    let parsed = parse_module(source).expect("parse failed");
+    let module = lower_module(parsed.suite()).expect("lowering should succeed");
+    let body = &module.module.functions[0].body;
+
+    assert_eq!(body.len(), 3);
+    assert!(matches!(body[0], HirStmt::Let { .. }));
+    assert!(matches!(
+        body[1],
+        HirStmt::Assign {
+            ref name,
+            ..
+        } if name == "value"
+    ));
+    assert!(matches!(
+        body[2],
+        HirStmt::Assign {
+            ref name,
+            ..
+        } if name == "value"
+    ));
 }

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -156,6 +156,31 @@ pub(super) fn lower_stmts(
                 continue;
             }
         }
+        if let Stmt::Try(try_stmt) = stmt {
+            if !try_stmt.finalbody.is_empty() {
+                if try_stmt.handlers.is_empty() {
+                    let body = lower_stmts(&try_stmt.body, func_type, ctx);
+                    result.extend(body);
+                    if !try_stmt.orelse.is_empty() {
+                        let orelse = lower_stmts(&try_stmt.orelse, func_type, ctx);
+                        result.extend(orelse);
+                    }
+                } else if let Some(hir_stmt) = lower_stmt(stmt, func_type, ctx) {
+                    result.push(hir_stmt);
+                }
+                let finalbody = lower_stmts(&try_stmt.finalbody, func_type, ctx);
+                result.extend(finalbody);
+                apply_numeric_sentinel_patches(
+                    &mut result,
+                    &mut ctx.pending_numeric_sentinel_patches,
+                );
+                apply_container_specialization_patches(
+                    &mut result,
+                    &mut ctx.pending_container_specialization_patches,
+                );
+                continue;
+            }
+        }
         if let Some(hir_stmt) = lower_stmt(stmt, func_type, ctx) {
             result.push(hir_stmt);
         }

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -519,6 +519,7 @@ status: in_progress
 - PR [#1941](https://github.com/sifr-lang/sifr/pull/1941) TaskGroup exit-order cancellation slice: fail-fast TaskGroup scope exit now observes children concurrently so a failed child cancels unfinished siblings regardless of spawn order.
 - PR [#1942](https://github.com/sifr-lang/sifr/pull/1942) task-scope basic validation slice: added the canonical `task_scope_basic.sifr` milestone fixture for a normal multi-child scoped-task path with both `join()` and direct handle await observation.
 - PR [#1943](https://github.com/sifr-lang/sifr/pull/1943) task-handle loop-consumption slice: simple `for handle in handles: await handle` now consumes a named task-handle list instead of cloning one-shot handles, with ownership diagnostics preventing reuse of the consumed collection.
+- PR [#1944](https://github.com/sifr-lang/sifr/pull/1944) try/finally cleanup prerequisite slice: `try/finally` without `except` now lowers the body followed by the `finally` body on non-early-exit paths, covering the basic cleanup execution needed before cancellation-specific cleanup lowering can be completed.
 
 ---
 


### PR DESCRIPTION
## Summary
- lower `try/finally` without `except` as body/else followed by the `finally` body on normal paths
- add focused HIR and e2e coverage proving simple cleanup runs
- update existing glob/iterator fixtures so now-executed cleanup handles fallible `run_command` calls explicitly

## Scope note
This is a cleanup prerequisite for Phase 32. Early return, raise, and active cancellation unwinding through `finally` remain follow-up work.

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_hir try_finally_without_except_lowers_body_then_finalbody -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/try_finally_cleanup_runs.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/iterator_integration.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/stdlib_glob_consolidated.sifr`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

Reviewer: Opus SATISFIED in `reviews/phase32_try_finally_cleanup_prereq.md`.