### PR TITLE
Carry task failures as Failure payloads

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -53,13 +53,14 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     if !emitter.enum_items.is_empty() {
         emitted_items.extend(emitter.enum_items.clone());
     }
-    if super::module_uses_task_scope(module) {
-        emitted_items.extend(super::build_task_scope_items());
-    }
-    if super::module_uses_failure_type(module) {
+    let uses_task_scope = super::module_uses_task_scope(module);
+    if uses_task_scope || super::module_uses_failure_type(module) {
         emitted_items.extend(super::build_failure_type_items());
     }
-    if super::module_uses_timeout_result_type(module) && !super::module_uses_task_scope(module) {
+    if uses_task_scope {
+        emitted_items.extend(super::build_task_scope_items());
+    }
+    if super::module_uses_timeout_result_type(module) && !uses_task_scope {
         emitted_items.extend(super::build_timeout_result_type_items());
     }
     if !emitter.body_items.is_empty() {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -476,13 +476,19 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     let needs_random_module_state = emitter.runtime_needs.random_module_state();
 
     // Emit built-in error class struct definitions for referenced error types.
-    let referenced_error_classes = collect_referenced_builtin_error_classes(
+    let uses_task_scope = module_uses_task_scope(module);
+    let uses_failure_type = module_uses_failure_type(module);
+    let uses_timeout_result_type = module_uses_timeout_result_type(module);
+    let mut referenced_error_classes = collect_referenced_builtin_error_classes(
         module,
         &stdlib_preamble,
         &emitter.intrinsic_functions,
         needs_file_handles,
         BUILTIN_ERROR_CLASSES,
     );
+    if uses_task_scope || uses_failure_type {
+        referenced_error_classes.insert("SecondaryError".to_string());
+    }
     let user_defined_error_classes: HashSet<String> = module
         .classes
         .iter()
@@ -586,10 +592,10 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             }
         }
     }
-    if module_uses_failure_type(module) {
+    if uses_task_scope || uses_failure_type {
         preamble_items.extend(build_failure_type_items());
     }
-    if module_uses_timeout_result_type(module) && !module_uses_task_scope(module) {
+    if uses_timeout_result_type && !uses_task_scope {
         preamble_items.extend(build_timeout_result_type_items());
     }
 
@@ -608,7 +614,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     if needs_random_module_state {
         preamble_items.extend(build_random_module_state_items());
     }
-    if module_uses_task_scope(module) {
+    if uses_task_scope {
         preamble_items.extend(build_task_scope_items());
     }
 

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3777,10 +3777,40 @@ fn test_scope_spawn_fallible_coroutine_lowers_to_result_spawn_helper() {
     assert!(result
         .rust_source
         .contains("scope.__sifr_spawn_result(worker());"));
+    assert!(result.rust_source.contains("enum __SifrTaskResult<T, E>"));
+    assert!(result.rust_source.contains("Err(__SifrFailure<E>)"));
+    assert!(result
+        .rust_source
+        .contains("__SifrTaskResult::Err(__SifrFailure::new(err))"));
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<i64, ValueError>"));
     assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_task_gather_fallible_tasks_keeps_error_parameter_unwrapped() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> Result[int, ValueError]:\n    raise ValueError(\"bad\")\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        result = await task.gather([scope.spawn(worker()), scope.spawn(worker())])\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("async fn __sifr_task_gather"));
+    assert!(result.rust_source.contains("__SifrTaskResult<Vec<T>, E>"));
+    assert!(result.rust_source.contains("Err(__SifrFailure<E>)"));
+    assert!(result
+        .rust_source
+        .contains("__SifrTaskResult::Err(__SifrFailure::new(err))"));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<Vec<i64>, ValueError>"));
 }
 
 #[test]
@@ -3803,6 +3833,31 @@ fn test_task_race_lowers_to_private_race_helper() {
         .rust_source
         .contains("let result: __SifrTaskResult<i64, std::convert::Infallible>"));
     assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
+fn test_task_race_fallible_tasks_keeps_error_parameter_unwrapped() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker() -> Result[int, ValueError]:\n    raise ValueError(\"bad\")\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        result = await task.race([scope.spawn(worker()), scope.spawn(worker())])\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("async fn __sifr_task_race"));
+    assert!(result.rust_source.contains("__SifrTaskResult<T, E>"));
+    assert!(result.rust_source.contains("Err(__SifrFailure<E>)"));
+    assert!(result
+        .rust_source
+        .contains("__SifrTaskResult::Err(__SifrFailure::new(err))"));
+    assert!(result
+        .rust_source
+        .contains("let result: __SifrTaskResult<i64, ValueError>"));
 }
 
 #[test]
@@ -3917,6 +3972,12 @@ fn test_task_timeout_handle_lowers_to_private_timeout_result() {
     assert!(result.rust_source.contains("async fn __sifr_timeout"));
     assert!(result.rust_source.contains("biased;"));
     assert!(result.rust_source.contains("handle.__sifr_timeout"));
+    assert!(result
+        .rust_source
+        .contains("failure.map_primary(__SifrTimeoutResult::Inner)"));
+    assert!(result
+        .rust_source
+        .contains("__SifrFailure::new(__SifrTimeoutResult::Timeout)"));
     assert!(result.rust_source.contains(
         "let result: __SifrTaskResult<i64, __SifrTimeoutResult<std::convert::Infallible>>"
     ));

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -191,18 +191,84 @@ pub fn build_error_into_error_impl(source_name: &str) -> RustItem {
 }
 
 pub fn build_failure_type_items() -> Vec<RustItem> {
-    vec![RustItem::Struct {
-        name: "__SifrFailure<E>".to_string(),
-        visibility: Visibility::Private,
-        derives: vec!["Debug".to_string()],
-        fields: vec![
-            ("primary".to_string(), RustType::Named("E".to_string())),
-            (
-                "secondary".to_string(),
-                RustType::Vec(Box::new(RustType::Named("SecondaryError".to_string()))),
-            ),
-        ],
-    }]
+    vec![
+        RustItem::Struct {
+            name: "__SifrFailure<E>".to_string(),
+            visibility: Visibility::Private,
+            derives: vec!["Debug".to_string()],
+            fields: vec![
+                ("primary".to_string(), RustType::Named("E".to_string())),
+                (
+                    "secondary".to_string(),
+                    RustType::Vec(Box::new(RustType::Named("SecondaryError".to_string()))),
+                ),
+            ],
+        },
+        RustItem::Impl {
+            target: "__SifrFailure<E>".to_string(),
+            type_params: vec![crate::RustTypeParam {
+                name: "E".to_string(),
+                bounds: vec![],
+            }],
+            trait_: None,
+            items: vec![
+                RustItem::Fn {
+                    name: "new".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::Named {
+                        name: "primary".to_string(),
+                        ty: RustType::Named("E".to_string()),
+                    }],
+                    ret: Some(RustType::Named("Self".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "Self".to_string(),
+                        fields: vec![
+                            (
+                                "primary".to_string(),
+                                RustExpr::Ident("primary".to_string()),
+                            ),
+                            (
+                                "secondary".to_string(),
+                                RustExpr::Ident("Vec::new()".to_string()),
+                            ),
+                        ],
+                    }))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "map_primary".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![crate::RustTypeParam {
+                        name: "F".to_string(),
+                        bounds: vec![],
+                    }],
+                    params: vec![
+                        RustParam::SelfValue,
+                        RustParam::Named {
+                            name: "f".to_string(),
+                            ty: RustType::Named("impl FnOnce(E) -> F".to_string()),
+                        },
+                    ],
+                    ret: Some(RustType::Named("__SifrFailure<F>".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "__SifrFailure".to_string(),
+                        fields: vec![
+                            (
+                                "primary".to_string(),
+                                RustExpr::Ident("f(self.primary)".to_string()),
+                            ),
+                            (
+                                "secondary".to_string(),
+                                RustExpr::Ident("self.secondary".to_string()),
+                            ),
+                        ],
+                    }))],
+                    is_async: false,
+                },
+            ],
+        },
+    ]
 }
 
 pub fn build_timeout_result_type_items() -> Vec<RustItem> {
@@ -316,7 +382,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 },
                 crate::RustEnumVariant {
                     name: "Err".to_string(),
-                    tuple_fields: vec![RustType::Named("E".to_string())],
+                    tuple_fields: vec![RustType::Named("__SifrFailure<E>".to_string())],
                     fields: vec![],
                     value: None,
                 },
@@ -424,7 +490,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         "__SifrTaskResult<T, __SifrTimeoutResult<E>>".to_string(),
                     )),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(err)) => __SifrTaskResult::Err(__SifrTimeoutResult::Inner(err)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrTimeoutResult::Timeout)\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(failure)) => __SifrTaskResult::Err(failure.map_primary(__SifrTimeoutResult::Inner)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrFailure::new(__SifrTimeoutResult::Timeout))\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -689,7 +755,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                             name: "child".to_string(),
                             ty: None,
                             value: RustExpr::Ident(
-                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(err) }; let outcome = match &result { __SifrTaskResult::Ok(_) => __SifrScopeChildOutcome::Ok, __SifrTaskResult::Err(_) => __SifrScopeChildOutcome::Failed, __SifrTaskResult::Cancelled => __SifrScopeChildOutcome::Cancelled }; let _ = sender.send(result); outcome })"
+                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(__SifrFailure::new(err)) }; let outcome = match &result { __SifrTaskResult::Ok(_) => __SifrScopeChildOutcome::Ok, __SifrTaskResult::Err(_) => __SifrScopeChildOutcome::Failed, __SifrTaskResult::Cancelled => __SifrScopeChildOutcome::Cancelled }; let _ = sender.send(result); outcome })"
                                     .to_string(),
                             ),
                         },

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -521,6 +521,7 @@ status: in_progress
 - PR [#1943](https://github.com/sifr-lang/sifr/pull/1943) task-handle loop-consumption slice: simple `for handle in handles: await handle` now consumes a named task-handle list instead of cloning one-shot handles, with ownership diagnostics preventing reuse of the consumed collection.
 - PR [#1944](https://github.com/sifr-lang/sifr/pull/1944) try/finally cleanup prerequisite slice: `try/finally` without `except` now lowers the body followed by the `finally` body on non-early-exit paths, covering the basic cleanup execution needed before cancellation-specific cleanup lowering can be completed.
 - PR [#1945](https://github.com/sifr-lang/sifr/pull/1945) Failure type surface slice: added first-class `Failure[E]` type annotation support, private `__SifrFailure<E>` codegen with `primary` and `secondary` fields, and validation that `Failure[E]` is evidence rather than a valid ordinary `Result[..., E]` error channel.
+- In progress task-result Failure payload slice: private `__SifrTaskResult<T, E>` now carries ordinary child failures as `__SifrFailure<E>` evidence, fallible task spawns wrap primary child errors, and timeout maps child failure evidence into `TimeoutResult.Inner(E)` while preserving secondary evidence storage.
 
 ---
 


### PR DESCRIPTION
## Summary
- change private task results so `Err` carries `__SifrFailure<E>` evidence
- wrap fallible spawned coroutine errors as primary failures
- preserve failure evidence when timeout maps child errors into `TimeoutResult.Inner`
- add codegen coverage for fallible spawn, timeout, gather, and race error payload shapes

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sifr_codegen private_timeout_result -- --nocapture`
- `cargo test -p sifr_codegen result_spawn_helper -- --nocapture`
- `cargo test -p sifr_codegen fallible_tasks_keeps_error_parameter_unwrapped -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_spawn_fallible_result.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_error_cancels_siblings.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_timeout_expiry.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_timeout_success.sifr`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Opus review round 2 satisfied: `reviews/phase32_taskresult_failure_payload_r2.md`