### PR TITLE
Carry cancellation as Failure evidence

### DIFF
--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -57,6 +57,9 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     if uses_task_scope || super::module_uses_failure_type(module) {
         emitted_items.extend(super::build_failure_type_items());
     }
+    if uses_task_scope || super::module_uses_cancellation_error_type(module) {
+        emitted_items.extend(super::build_cancellation_error_type_items());
+    }
     if uses_task_scope {
         emitted_items.extend(super::build_task_scope_items());
     }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -478,6 +478,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     // Emit built-in error class struct definitions for referenced error types.
     let uses_task_scope = module_uses_task_scope(module);
     let uses_failure_type = module_uses_failure_type(module);
+    let uses_cancellation_error_type = module_uses_cancellation_error_type(module);
     let uses_timeout_result_type = module_uses_timeout_result_type(module);
     let mut referenced_error_classes = collect_referenced_builtin_error_classes(
         module,
@@ -594,6 +595,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     }
     if uses_task_scope || uses_failure_type {
         preamble_items.extend(build_failure_type_items());
+    }
+    if uses_task_scope || uses_cancellation_error_type {
+        preamble_items.extend(build_cancellation_error_type_items());
     }
     if uses_timeout_result_type && !uses_task_scope {
         preamble_items.extend(build_timeout_result_type_items());
@@ -956,20 +960,21 @@ fn type_contains_timeout_result(ty: &Type) -> bool {
     type_contains_by(ty, |candidate| matches!(candidate, Type::TimeoutResult(_)))
 }
 
+fn type_contains_cancellation_error(ty: &Type) -> bool {
+    type_contains_by(
+        ty,
+        |candidate| matches!(candidate, Type::Class { name, .. } if name == "CancellationError"),
+    )
+}
+
 fn module_uses_failure_type(module: &HirModule) -> bool {
-    module
-        .functions
-        .iter()
-        .any(|func| function_uses_failure_type(func))
+    module.functions.iter().any(function_uses_failure_type)
         || module.classes.iter().any(|class| {
             class
                 .fields
                 .iter()
                 .any(|(_, field_ty)| type_contains_failure(field_ty))
-                || class
-                    .methods
-                    .iter()
-                    .any(|method| function_uses_failure_type(method))
+                || class.methods.iter().any(function_uses_failure_type)
         })
         || module
             .constants
@@ -977,25 +982,50 @@ fn module_uses_failure_type(module: &HirModule) -> bool {
             .any(|(_, ty, _)| type_contains_failure(ty))
 }
 
+fn module_uses_cancellation_error_type(module: &HirModule) -> bool {
+    module
+        .functions
+        .iter()
+        .any(function_uses_cancellation_error_type)
+        || module.classes.iter().any(|class| {
+            class
+                .fields
+                .iter()
+                .any(|(_, field_ty)| type_contains_cancellation_error(field_ty))
+                || class
+                    .methods
+                    .iter()
+                    .any(function_uses_cancellation_error_type)
+        })
+        || module
+            .constants
+            .iter()
+            .any(|(_, ty, _)| type_contains_cancellation_error(ty))
+}
+
 fn module_uses_timeout_result_type(module: &HirModule) -> bool {
     module
         .functions
         .iter()
-        .any(|func| function_uses_timeout_result_type(func))
+        .any(function_uses_timeout_result_type)
         || module.classes.iter().any(|class| {
             class
                 .fields
                 .iter()
                 .any(|(_, field_ty)| type_contains_timeout_result(field_ty))
-                || class
-                    .methods
-                    .iter()
-                    .any(|method| function_uses_timeout_result_type(method))
+                || class.methods.iter().any(function_uses_timeout_result_type)
         })
         || module
             .constants
             .iter()
             .any(|(_, ty, _)| type_contains_timeout_result(ty))
+}
+
+fn function_uses_cancellation_error_type(func: &HirFunction) -> bool {
+    func.params
+        .iter()
+        .any(|param| type_contains_cancellation_error(&param.ty))
+        || type_contains_cancellation_error(&func.return_type)
 }
 
 fn function_uses_failure_type(func: &HirFunction) -> bool {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3901,6 +3901,10 @@ fn test_task_handle_join_lowers_to_task_result_observation() {
 
     assert!(result.rust_source.contains("enum __SifrTaskResult<T, E>"));
     assert!(result.rust_source.contains("async fn join(self)"));
+    assert!(result
+        .rust_source
+        .contains("Cancelled(__SifrFailure<CancellationError>)"));
+    assert!(result.rust_source.contains("fn cancelled() -> Self"));
     assert!(result.rust_source.contains("handle.join().await"));
     assert!(result
         .rust_source
@@ -3951,6 +3955,8 @@ fn test_task_handle_cancel_borrows_handle_and_aborts_child() {
     assert!(result
         .rust_source
         .contains(&format!("handle.{}{}", "can", "cel();")));
+    assert!(result.rust_source.contains("struct CancellationError"));
+    assert!(result.rust_source.contains("__SifrTaskResult::cancelled()"));
     assert!(result.rust_source.contains("handle.join().await"));
 }
 
@@ -3981,6 +3987,27 @@ fn test_task_timeout_handle_lowers_to_private_timeout_result() {
     assert!(result.rust_source.contains(
         "let result: __SifrTaskResult<i64, __SifrTimeoutResult<std::convert::Infallible>>"
     ));
+}
+
+#[test]
+fn test_failure_cancellation_error_annotation_lowers_to_private_evidence_type() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "def observe(failure: Failure[CancellationError]) -> None:\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result.rust_source.contains("struct __SifrFailure<E>"));
+    assert!(result.rust_source.contains("struct CancellationError"));
+    assert!(result
+        .rust_source
+        .contains("fn observe(failure: &__SifrFailure<CancellationError>)"));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -294,6 +294,34 @@ pub fn build_timeout_result_type_items() -> Vec<RustItem> {
     }]
 }
 
+pub fn build_cancellation_error_type_items() -> Vec<RustItem> {
+    vec![
+        RustItem::Struct {
+            name: "CancellationError".to_string(),
+            visibility: Visibility::Private,
+            derives: vec!["Debug".to_string()],
+            fields: vec![],
+        },
+        RustItem::Impl {
+            target: "CancellationError".to_string(),
+            type_params: vec![],
+            trait_: None,
+            items: vec![RustItem::Fn {
+                name: "new".to_string(),
+                visibility: Visibility::Private,
+                type_params: vec![],
+                params: vec![],
+                ret: Some(RustType::Named("Self".to_string())),
+                body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                    name: "Self".to_string(),
+                    fields: vec![],
+                }))],
+                is_async: false,
+            }],
+        },
+    ]
+}
+
 pub fn build_task_scope_items() -> Vec<RustItem> {
     vec![
         RustItem::Struct {
@@ -388,11 +416,54 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 },
                 crate::RustEnumVariant {
                     name: "Cancelled".to_string(),
-                    tuple_fields: vec![],
+                    tuple_fields: vec![RustType::Named(
+                        "__SifrFailure<CancellationError>".to_string(),
+                    )],
                     fields: vec![],
                     value: None,
                 },
             ],
+        },
+        RustItem::Impl {
+            target: "__SifrTaskResult<T, E>".to_string(),
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec![],
+                },
+                crate::RustTypeParam {
+                    name: "E".to_string(),
+                    bounds: vec![],
+                },
+            ],
+            trait_: None,
+            items: vec![RustItem::Fn {
+                name: "cancelled".to_string(),
+                visibility: Visibility::Private,
+                type_params: vec![],
+                params: vec![],
+                ret: Some(RustType::Named("Self".to_string())),
+                body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Path(vec![
+                        "Self".to_string(),
+                        "Cancelled".to_string(),
+                    ])),
+                    args: vec![RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "__SifrFailure".to_string(),
+                            "new".to_string(),
+                        ])),
+                        args: vec![RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "CancellationError".to_string(),
+                                "new".to_string(),
+                            ])),
+                            args: vec![],
+                        }],
+                    }],
+                }))],
+                is_async: false,
+            }],
         },
         RustItem::Enum {
             name: "__SifrSelect2<A, B>".to_string(),
@@ -455,7 +526,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     params: vec![RustParam::SelfValue],
                     ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let __SifrTask { receiver, observed, .. } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(receiver) = receiver {\n            return match receiver.await {\n                Ok(result) => result,\n                Err(_) => __SifrTaskResult::Cancelled,\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                        "let __SifrTask { receiver, observed, .. } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(receiver) = receiver {\n            return match receiver.await {\n                Ok(result) => result,\n                Err(_) => __SifrTaskResult::cancelled(),\n            };\n        }\n        return __SifrTaskResult::cancelled()".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -490,7 +561,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                         "__SifrTaskResult<T, __SifrTimeoutResult<E>>".to_string(),
                     )),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
-                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(failure)) => __SifrTaskResult::Err(failure.map_primary(__SifrTimeoutResult::Inner)),\n                        Ok(__SifrTaskResult::Cancelled) | Err(_) => __SifrTaskResult::Cancelled,\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrFailure::new(__SifrTimeoutResult::Timeout))\n                }\n            };\n        }\n        return __SifrTaskResult::Cancelled".to_string(),
+                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(failure)) => __SifrTaskResult::Err(failure.map_primary(__SifrTimeoutResult::Inner)),\n                        Ok(__SifrTaskResult::Cancelled(failure)) => __SifrTaskResult::Cancelled(failure),\n                        Err(_) => __SifrTaskResult::cancelled(),\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrFailure::new(__SifrTimeoutResult::Timeout))\n                }\n            };\n        }\n        return __SifrTaskResult::cancelled()".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -755,7 +826,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                             name: "child".to_string(),
                             ty: None,
                             value: RustExpr::Ident(
-                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(__SifrFailure::new(err)) }; let outcome = match &result { __SifrTaskResult::Ok(_) => __SifrScopeChildOutcome::Ok, __SifrTaskResult::Err(_) => __SifrScopeChildOutcome::Failed, __SifrTaskResult::Cancelled => __SifrScopeChildOutcome::Cancelled }; let _ = sender.send(result); outcome })"
+                                "tokio::spawn(async move { let result = match future.await { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(__SifrFailure::new(err)) }; let outcome = match &result { __SifrTaskResult::Ok(_) => __SifrScopeChildOutcome::Ok, __SifrTaskResult::Err(_) => __SifrScopeChildOutcome::Failed, __SifrTaskResult::Cancelled(_) => __SifrScopeChildOutcome::Cancelled }; let _ = sender.send(result); outcome })"
                                     .to_string(),
                             ),
                         },
@@ -931,7 +1002,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 "__SifrTaskResult<Vec<T>, E>".to_string(),
             )),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let input_len = handles.len();\n        let mut values: Vec<Option<T>> = std::iter::repeat_with(|| None).take(input_len).collect();\n        let mut abort_handles = Vec::with_capacity(input_len);\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for (index, handle) in handles.into_iter().enumerate() {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            observer_count += 1;\n            let sender = sender.clone();\n            if let Some(task_receiver) = task_receiver {\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send((index, result));\n                });\n            } else {\n                let _ = sender.send((index, __SifrTaskResult::Cancelled));\n            }\n        }\n        drop(sender);\n        let mut remaining = observer_count;\n        while remaining > 0 {\n            let Some((index, result)) = receiver.recv().await else {\n                break;\n            };\n            remaining -= 1;\n            match result {\n                __SifrTaskResult::Ok(value) => values[index] = Some(value),\n                __SifrTaskResult::Err(err) => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Err(err);\n                }\n                __SifrTaskResult::Cancelled => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Cancelled;\n                }\n            }\n        }\n        let mut ordered_values = Vec::with_capacity(input_len);\n        for value in values {\n            let Some(value) = value else {\n                return __SifrTaskResult::Cancelled;\n            };\n            ordered_values.push(value);\n        }\n        return __SifrTaskResult::Ok(ordered_values)".to_string(),
+                "let input_len = handles.len();\n        let mut values: Vec<Option<T>> = std::iter::repeat_with(|| None).take(input_len).collect();\n        let mut abort_handles = Vec::with_capacity(input_len);\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for (index, handle) in handles.into_iter().enumerate() {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            observer_count += 1;\n            let sender = sender.clone();\n            if let Some(task_receiver) = task_receiver {\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::cancelled(),\n                    };\n                    let _ = sender.send((index, result));\n                });\n            } else {\n                let _ = sender.send((index, __SifrTaskResult::cancelled()));\n            }\n        }\n        drop(sender);\n        let mut remaining = observer_count;\n        while remaining > 0 {\n            let Some((index, result)) = receiver.recv().await else {\n                break;\n            };\n            remaining -= 1;\n            match result {\n                __SifrTaskResult::Ok(value) => values[index] = Some(value),\n                __SifrTaskResult::Err(err) => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Err(err);\n                }\n                __SifrTaskResult::Cancelled(failure) => {\n                    for abort_handle in &abort_handles {\n                        abort_handle.abort();\n                    }\n                    while remaining > 0 {\n                        if receiver.recv().await.is_none() {\n                            break;\n                        }\n                        remaining -= 1;\n                    }\n                    return __SifrTaskResult::Cancelled(failure);\n                }\n            }\n        }\n        let mut ordered_values = Vec::with_capacity(input_len);\n        for value in values {\n            let Some(value) = value else {\n                return __SifrTaskResult::cancelled();\n            };\n            ordered_values.push(value);\n        }\n        return __SifrTaskResult::Ok(ordered_values)".to_string(),
             ))],
             is_async: true,
         },
@@ -954,7 +1025,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             }],
             ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::Cancelled,\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::Cancelled;\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
+                "let mut abort_handles = Vec::new();\n        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();\n        let mut observer_count = 0usize;\n        for handle in handles {\n            let __SifrTask { receiver: task_receiver, abort_handle, observed, _error } = handle;\n            observed.store(true, std::sync::atomic::Ordering::SeqCst);\n            abort_handles.push(abort_handle);\n            if let Some(task_receiver) = task_receiver {\n                observer_count += 1;\n                let sender = sender.clone();\n                tokio::spawn(async move {\n                    let result = match task_receiver.await {\n                        Ok(result) => result,\n                        Err(_) => __SifrTaskResult::cancelled(),\n                    };\n                    let _ = sender.send(result);\n                });\n            }\n        }\n        drop(sender);\n        let Some(first) = receiver.recv().await else {\n            return __SifrTaskResult::cancelled();\n        };\n        for abort_handle in &abort_handles {\n            abort_handle.abort();\n        }\n        let mut remaining = observer_count.saturating_sub(1);\n        while remaining > 0 {\n            if receiver.recv().await.is_none() {\n                break;\n            }\n            remaining -= 1;\n        }\n        return first".to_string(),
             ))],
             is_async: true,
         },
@@ -993,7 +1064,7 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                 "__SifrSelect2<__SifrTaskResult<A, EA>, __SifrTaskResult<B, EB>>".to_string(),
             )),
             body: vec![RustStmt::Expr(RustExpr::Ident(
-                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, observed: first_observed, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, observed: second_observed, _error: _second_error } = second;\n        first_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        second_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::Cancelled);\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::Cancelled,\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
+                "let __SifrTask { receiver: first_receiver, abort_handle: first_abort, observed: first_observed, _error: _first_error } = first;\n        let __SifrTask { receiver: second_receiver, abort_handle: second_abort, observed: second_observed, _error: _second_error } = second;\n        first_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        second_observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        let (Some(mut first_receiver), Some(mut second_receiver)) = (first_receiver, second_receiver) else {\n            return __SifrSelect2::First(__SifrTaskResult::cancelled());\n        };\n        return tokio::select! {\n            biased;\n            first_result = &mut first_receiver => {\n                second_abort.abort();\n                let _ = second_receiver.await;\n                let result = match first_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::cancelled(),\n                };\n                __SifrSelect2::First(result)\n            },\n            second_result = &mut second_receiver => {\n                first_abort.abort();\n                let _ = first_receiver.await;\n                let result = match second_result {\n                    Ok(result) => result,\n                    Err(_) => __SifrTaskResult::cancelled(),\n                };\n                __SifrSelect2::Second(result)\n            }\n        }".to_string(),
             ))],
             is_async: true,
         },

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -522,6 +522,7 @@ status: in_progress
 - PR [#1944](https://github.com/sifr-lang/sifr/pull/1944) try/finally cleanup prerequisite slice: `try/finally` without `except` now lowers the body followed by the `finally` body on non-early-exit paths, covering the basic cleanup execution needed before cancellation-specific cleanup lowering can be completed.
 - PR [#1945](https://github.com/sifr-lang/sifr/pull/1945) Failure type surface slice: added first-class `Failure[E]` type annotation support, private `__SifrFailure<E>` codegen with `primary` and `secondary` fields, and validation that `Failure[E]` is evidence rather than a valid ordinary `Result[..., E]` error channel.
 - PR [#1947](https://github.com/sifr-lang/sifr/pull/1947) task-result Failure payload slice: private `__SifrTaskResult<T, E>` now carries ordinary child failures as `__SifrFailure<E>` evidence, fallible task spawns wrap primary child errors, and timeout maps child failure evidence into `TimeoutResult.Inner(E)` while preserving secondary evidence storage.
+- In progress cancelled Failure payload slice: private `__SifrTaskResult<T, E>` now materializes cancellation as `Cancelled(__SifrFailure<CancellationError>)`, preserving the design split between ordinary `E` failures and non-`Error` child-cancellation evidence.
 
 ---
 


### PR DESCRIPTION
## Summary
- materialize task cancellation as `Cancelled(__SifrFailure<CancellationError>)` in the private task-result runtime
- add a private generated `CancellationError` evidence type without making it an ordinary `Error`
- update join, timeout, gather, race, and select cancellation paths to produce or preserve cancellation evidence
- add codegen coverage for cancellation payload shape and `Failure[CancellationError]` annotations

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p sifr_codegen -- -D warnings`
- `cargo test -p sifr_codegen task_handle -- --nocapture`
- `cargo test -p sifr_codegen failure_cancellation_error_annotation -- --nocapture`
- `cargo test -p sifr_codegen task_timeout_handle_lowers_to_private_timeout_result -- --nocapture`
- `cargo test -p sifr_codegen task_gather_lowers_to_private_gather_helper -- --nocapture`
- `cargo test -p sifr_codegen task_race_lowers_to_private_race_helper -- --nocapture`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_cancel_basic.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_timeout_expiry.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_error_cancels_siblings.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_error_type_surface.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_race_cancels_losers.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_select_first_completion.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_timeout_success.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/cancellation_error_not_result_error.sifr` (expected type error observed)
- `scripts/run_all_tests.sh --profile quick`

## Review
- Opus reviewer satisfied: `reviews/phase32_cancelled_failure_payload.md`