### PR TITLE
Record spawn argument boundary PR

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -581,7 +581,7 @@ status: in_progress
 
 **Implementation progress:**
 
-- In progress owned spawn-argument boundary slice: `scope.spawn(coro(...))` now accepts direct coroutine calls with simple owned arguments, while borrowed parameters crossing the task boundary are rejected before Rust codegen.
+- PR [#1957](https://github.com/sifr-lang/sifr/pull/1957) owned spawn-argument boundary slice: `scope.spawn(coro(...))` now accepts direct coroutine calls with simple owned arguments, while borrowed parameters crossing the task boundary are rejected before Rust codegen.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace the temporary owned spawn-argument tracker wording with the merged PR #1957 link.

## Validation
- git diff --check