### PR TITLE
Validate spawn move boundary ownership

### DIFF
--- a/crates/sifr/tests/e2e.rs
+++ b/crates/sifr/tests/e2e.rs
@@ -1297,42 +1297,6 @@ fn compile_time_sifr_runtime_path() -> PathBuf {
         .join("sifr_runtime")
 }
 
-fn make_entry_function_public(source: &str, entry_fn: &str) -> String {
-    let marker = format!("fn {}(", entry_fn);
-    let mut output = String::new();
-    let mut changed = false;
-
-    for line in source.lines() {
-        let mut indent_len = 0;
-        for (index, ch) in line.char_indices() {
-            if ch == ' ' || ch == '\t' {
-                indent_len = index + ch.len_utf8();
-                continue;
-            }
-            break;
-        }
-
-        let indent = &line[..indent_len];
-        let body = &line[indent_len..];
-        if body.starts_with(&marker) {
-            output.push_str(indent);
-            output.push_str("pub ");
-            output.push_str(body);
-            output.push('\n');
-            changed = true;
-            continue;
-        }
-        output.push_str(line);
-        output.push('\n');
-    }
-
-    if changed {
-        output
-    } else {
-        source.to_string()
-    }
-}
-
 fn build_group_sources(group_cases: Vec<CompiledCase>) -> Result<BatchGroup, String> {
     let mut cases = group_cases;
     cases.sort_by(|left, right| left.fixture.name.cmp(&right.fixture.name));
@@ -1352,12 +1316,19 @@ fn build_group_sources(group_cases: Vec<CompiledCase>) -> Result<BatchGroup, Str
     for (ordinal, case) in cases.iter().enumerate() {
         let module_name = case.fixture.module_name(ordinal);
         let entry_fn = fixture_entry_name(&module_name);
+        let wrapper_fn = format!("{entry_fn}_batch_run");
         let rust_source = build_rust_source_from_module(&case.rust_source, &entry_fn)
             .map_err(|err| format!("fixture {}: {}", case.fixture.name, err))?;
 
         let _ = writeln!(generated_modules, "pub mod {module_name} {{");
-        generated_modules.push_str(&make_entry_function_public(&rust_source, &entry_fn));
+        generated_modules.push_str(&rust_source);
         generated_modules.push('\n');
+        let _ = writeln!(generated_modules, "pub fn {wrapper_fn}() {{");
+        let _ = writeln!(
+            generated_modules,
+            "    super::__SifrBatchTermination::__sifr_finish({entry_fn}());"
+        );
+        generated_modules.push_str("}\n");
         generated_modules.push_str("}\n\n");
 
         let _ = write!(
@@ -1367,7 +1338,7 @@ fn build_group_sources(group_cases: Vec<CompiledCase>) -> Result<BatchGroup, Str
         );
         case_signature.push('|');
 
-        case_modules.push((case.fixture.name.clone(), module_name, entry_fn));
+        case_modules.push((case.fixture.name.clone(), module_name, wrapper_fn));
     }
 
     let _union_stdlib = cases
@@ -1380,6 +1351,21 @@ fn build_group_sources(group_cases: Vec<CompiledCase>) -> Result<BatchGroup, Str
         .collect::<BTreeSet<_>>();
 
     let mut generated_main = String::new();
+    generated_main.push_str("trait __SifrBatchTermination {\n");
+    generated_main.push_str("    fn __sifr_finish(self);\n");
+    generated_main.push_str("}\n\n");
+    generated_main.push_str("impl __SifrBatchTermination for () {\n");
+    generated_main.push_str("    fn __sifr_finish(self) {}\n");
+    generated_main.push_str("}\n\n");
+    generated_main
+        .push_str("impl<E: std::fmt::Debug> __SifrBatchTermination for Result<(), E> {\n");
+    generated_main.push_str("    fn __sifr_finish(self) {\n");
+    generated_main.push_str("        if let Err(error) = self {\n");
+    generated_main.push_str("            eprintln!(\"{:?}\", error);\n");
+    generated_main.push_str("            std::process::exit(1);\n");
+    generated_main.push_str("        }\n");
+    generated_main.push_str("    }\n");
+    generated_main.push_str("}\n\n");
     generated_main.push_str("fn usage() -> ! {\n");
     generated_main.push_str("    eprintln!(\"usage: --case <fixture_name>\");\n");
     generated_main.push_str("    std::process::exit(2);\n");
@@ -1397,7 +1383,7 @@ fn build_group_sources(group_cases: Vec<CompiledCase>) -> Result<BatchGroup, Str
     for module in &case_modules {
         let _ = writeln!(
             generated_main,
-            "        \"{}\" => {}::{}(),",
+            "        \"{}\" => __SifrBatchTermination::__sifr_finish({}::{}()),",
             module.0, module.1, module.2
         );
     }
@@ -3641,6 +3627,41 @@ fn test_dependency_fingerprint_and_cache_key_determinism() {
     let key_b = cache_key_for_group(&group, &toolchain, "different");
     assert_ne!(key_a, key_b);
     assert!(group.id.len() > 0);
+}
+
+#[test]
+fn test_batch_group_dispatch_uses_entry_termination_trait() {
+    let case = FixtureCase {
+        name: "async_result_fixture".to_string(),
+        path: PathBuf::from("tests/e2e/pass/async_result_fixture.sifr"),
+        source: "async def main() -> Result[None, ValueError]:\n    return None".to_string(),
+        source_hash: "async-result".to_string(),
+        expected_stdout: None,
+        _expected_stderr: Vec::new(),
+    };
+    let compiled = CompiledCase {
+        fixture: case,
+        rust_source: "#[tokio::main]\nasync fn main() -> Result<(), ValueError> {\n    Ok(())\n}\n"
+            .to_string(),
+        stdlib_modules: BTreeSet::new(),
+        required_crates: BTreeSet::new(),
+        _compile_duration_ms: 0,
+    };
+    let group = build_group_sources(vec![compiled]).expect("batch group");
+
+    assert!(group
+        .generated_main
+        .contains("impl<E: std::fmt::Debug> __SifrBatchTermination for Result<(), E>"));
+    assert!(group
+        .generated_main
+        .contains("=> __SifrBatchTermination::__sifr_finish("));
+    assert!(group
+        .generated_main
+        .contains("pub fn sifr_case_async_result_fixture_0_"));
+    assert!(group
+        .generated_main
+        .contains("super::__SifrBatchTermination::__sifr_finish("));
+    assert!(!group.generated_main.contains("pub async fn"));
 }
 
 #[test]

--- a/crates/sifr/tests/e2e/fail/spawn_mutable_alias_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/spawn_mutable_alias_rejected.sifr
@@ -1,0 +1,10 @@
+async def worker(own items: list[int]) -> int:
+    return len(items)
+
+
+async def main() -> Result[None, ScopeFailure]:
+    items: list[int] = [1]
+    async with task.scope() as scope:
+        handle = scope.spawn(worker(items))
+        items.append(2)
+    return None

--- a/crates/sifr/tests/e2e/pass/spawn_owned_move_value.sifr
+++ b/crates/sifr/tests/e2e/pass/spawn_owned_move_value.sifr
@@ -1,0 +1,9 @@
+async def worker(own items: list[int]) -> int:
+    return len(items)
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker([1, 2, 3]))
+        result = await handle
+    return None

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3725,6 +3725,25 @@ fn test_scope_spawn_lowers_owned_coroutine_arguments() {
 }
 
 #[test]
+fn test_scope_spawn_lowers_owned_move_coroutine_arguments() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def worker(own items: list[int]) -> int:\n    return len(items)\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker([1, 2]))\n        result = await handle\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result
+        .rust_source
+        .contains("scope.__sifr_spawn_infallible(worker(vec![1 as i64, 2 as i64]));"));
+}
+
+#[test]
 fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1591,6 +1591,24 @@ fn test_scope_spawn_rejects_borrowed_parameter_argument() {
 }
 
 #[test]
+fn test_scope_spawn_consumes_owned_move_argument() {
+    let source = "async def worker(own items: list[int]) -> int:\n    return len(items)\n\nasync def main() -> Result[None, ScopeFailure]:\n    items: list[int] = [1]\n    async with task.scope() as scope:\n        handle = scope.spawn(worker(items))\n        items.append(2)\n    return None\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|e| {
+        e.message.contains("moved value")
+            && e.code == Some(DiagnosticCode::OWN_USE_AFTER_MOVE)
+            && e.primary_range
+                == Some(range_for_after_anchor(
+                    source,
+                    "handle = scope.spawn(worker(items))\n",
+                    "items",
+                ))
+    }));
+}
+
+#[test]
 fn test_task_timeout_consumes_handle_binding() {
     let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n        second = await handle\n    return None\n";
     let result = lower_source(source);

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -582,6 +582,7 @@ status: in_progress
 **Implementation progress:**
 
 - PR [#1957](https://github.com/sifr-lang/sifr/pull/1957) owned spawn-argument boundary slice: `scope.spawn(coro(...))` now accepts direct coroutine calls with simple owned arguments, while borrowed parameters crossing the task boundary are rejected before Rust codegen.
+- In progress spawn move-boundary validation slice: owned move arguments can cross into spawned coroutine calls, and the original binding is consumed so later mutation is rejected before Rust codegen.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -21,6 +21,7 @@
     "recursive_tree_traversal_runtime",
     "nested_function_basic",
     "nested_function_recursive_capture",
+    "spawn_owned_move_value",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",


### PR DESCRIPTION
## Summary
- add HIR/codegen validation that owned move arguments can cross into scope.spawn coroutine calls while later source use is rejected as use-after-move
- add pass/fail e2e fixtures for owned move spawn behavior and include the pass fixture in the quick e2e lane
- fix the e2e batch harness so async Result fixture entries keep private generated error types while preserving Err => nonzero exit semantics

## Validation
- cargo test -p sifr_hir scope_spawn -- --nocapture
- cargo test -p sifr_codegen scope_spawn -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/spawn_owned_move_value.sifr
- cargo test -p sifr --test e2e test_e2e_fail -- --nocapture
- cargo test -p sifr --test e2e test_batch_group_dispatch_uses_entry_termination_trait -- --nocapture
- scripts/run_all_tests.sh --profile quick
- git diff --check
- cargo fmt --check

## Review
- Opus review: reviews/phase32_spawn_move_boundary_validation.md SATISFIED
- Opus review round 2: reviews/phase32_spawn_move_boundary_validation_r2.md SATISFIED