### PR TITLE
Track borrow across await PR

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -583,7 +583,7 @@ status: in_progress
 
 - PR [#1957](https://github.com/sifr-lang/sifr/pull/1957) owned spawn-argument boundary slice: `scope.spawn(coro(...))` now accepts direct coroutine calls with simple owned arguments, while borrowed parameters crossing the task boundary are rejected before Rust codegen.
 - PR [#1959](https://github.com/sifr-lang/sifr/pull/1959) spawn move-boundary validation slice: owned move arguments can cross into spawned coroutine calls, and the original binding is consumed so later mutation is rejected before Rust codegen.
-- In progress borrow-across-await validation slice: async functions reject live mutable-borrow parameters at await points, while completed same-task mutable borrows can be followed by ordinary awaits.
+- PR [#1961](https://github.com/sifr-lang/sifr/pull/1961) borrow-across-await validation slice: async functions reject live mutable-borrow parameters at await points, while completed same-task mutable borrows can be followed by ordinary awaits.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the in-progress Phase 32 borrow-across-await tracker note with the merged PR #1961 link

## Validation
- git diff --check