### PR TITLE
Validate deferred scoped-borrow spawn

### DIFF
--- a/crates/sifr/tests/e2e/fail/spawn_scoped_borrow_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/spawn_scoped_borrow_deferred.sifr
@@ -1,0 +1,15 @@
+# expect-error[col=30]: SIFR-TYPE-0002
+async def worker(items: list[int]) -> int:
+    return len(items)
+
+
+async def launch(items: list[int]) -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker(items))
+    return None
+
+
+async def main() -> None:
+    values: list[int] = [1, 2, 3]
+    result = await launch(values)
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -584,6 +584,7 @@ status: in_progress
 - PR [#1957](https://github.com/sifr-lang/sifr/pull/1957) owned spawn-argument boundary slice: `scope.spawn(coro(...))` now accepts direct coroutine calls with simple owned arguments, while borrowed parameters crossing the task boundary are rejected before Rust codegen.
 - PR [#1959](https://github.com/sifr-lang/sifr/pull/1959) spawn move-boundary validation slice: owned move arguments can cross into spawned coroutine calls, and the original binding is consumed so later mutation is rejected before Rust codegen.
 - PR [#1961](https://github.com/sifr-lang/sifr/pull/1961) borrow-across-await validation slice: async functions reject live mutable-borrow parameters at await points, while completed same-task mutable borrows can be followed by ordinary awaits.
+- In progress scoped-borrow spawn validation slice: the deferred v1 scoped-borrow model is covered by an explicit fail fixture that rejects borrowed parameters crossing `scope.spawn`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add explicit fail fixture for borrowed parameters crossing scope.spawn under the deferred scoped-borrow model
- mark the Phase 32 milestone_async_4 scoped-borrow spawn validation slice in progress

## Validation
- git diff --check
- cargo test -p sifr_hir scope_spawn -- --nocapture
- cargo test -p sifr --test e2e test_e2e_fail -- --nocapture
- scripts/run_all_tests.sh --profile quick

## Review
- Opus review: reviews/phase32_scoped_borrow_spawn_validation.md SATISFIED