### PR TITLE
Add sync Shared surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/shared_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/shared_basic.sifr
@@ -1,0 +1,6 @@
+from sifr.sync import Shared
+
+
+def main() -> None:
+    shared: Shared[int] = Shared(41)
+    assert shared.get() == 41

--- a/crates/sifr/tests/e2e/pass/spawn_capture_immutable_shared_ok.sifr
+++ b/crates/sifr/tests/e2e/pass/spawn_capture_immutable_shared_ok.sifr
@@ -1,0 +1,13 @@
+from sifr.sync import Shared
+
+
+async def worker(own shared: Shared[int]) -> int:
+    return shared.get()
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        shared: Shared[int] = Shared(41)
+        handle = scope.spawn(worker(shared))
+        result = await handle
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -237,6 +237,10 @@ pub struct StdlibCode {
     pub generator_functions: HashMap<String, HashSet<String>>,
     /// Set of class names that have generic type parameters across all stdlib modules.
     pub generic_classes: HashSet<String>,
+    /// Map of stdlib generic class name -> declared type parameter names.
+    pub generic_class_params: HashMap<String, Vec<String>>,
+    /// Map of stdlib generic class name -> template HIR class for concrete type-argument inference.
+    pub generic_class_templates: HashMap<String, sifr_hir::HirClass>,
     /// Map of `module_name` -> (`class_name` -> ordered class fields).
     /// Multi-module project codegen also uses this for local helper modules.
     pub module_class_fields: HashMap<String, HashMap<String, Vec<(String, Type)>>>,
@@ -316,6 +320,12 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     emitter
         .generic_classes
         .extend(stdlib_code.generic_classes.iter().cloned());
+    emitter
+        .generic_class_params
+        .extend(stdlib_code.generic_class_params.clone());
+    emitter
+        .generic_class_templates
+        .extend(stdlib_code.generic_class_templates.clone());
 
     // Pre-register stdlib constants and function signatures so user code can reference them correctly
     for import in &module.imports {

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -199,6 +199,8 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<RenderedDiagnost
                 transitive_deps: stdlib_code.transitive_deps.clone(),
                 generator_functions: stdlib_code.generator_functions.clone(),
                 generic_classes: stdlib_code.generic_classes.clone(),
+                generic_class_params: stdlib_code.generic_class_params.clone(),
+                generic_class_templates: stdlib_code.generic_class_templates.clone(),
                 module_class_fields: stdlib_code.module_class_fields.clone(),
             };
             let codegen_result = run_codegen_with_boundary(
@@ -285,6 +287,12 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<RenderedDiagnost
             for class in &result.module.classes {
                 if !class.type_params.is_empty() {
                     stdlib_code.generic_classes.insert(class.name.clone());
+                    stdlib_code
+                        .generic_class_params
+                        .insert(class.name.clone(), class.type_params.clone());
+                    stdlib_code
+                        .generic_class_templates
+                        .insert(class.name.clone(), class.clone());
                 }
             }
             let class_fields = result

--- a/crates/sifr_driver/src/stdlib/registry.rs
+++ b/crates/sifr_driver/src/stdlib/registry.rs
@@ -27,6 +27,7 @@ pub(super) const STDLIB_FILES: &[(&str, &str)] = &[
         "sifr.collections",
         include_str!("../../../../lib/sifr/collections.sifr"),
     ),
+    ("sifr.sync", include_str!("../../../../lib/sifr/sync.sifr")),
     (
         "sifr.string",
         include_str!("../../../../lib/sifr/string.sifr"),

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -586,12 +586,11 @@ status: in_progress
 - PR [#1961](https://github.com/sifr-lang/sifr/pull/1961) borrow-across-await validation slice: async functions reject live mutable-borrow parameters at await points, while completed same-task mutable borrows can be followed by ordinary awaits.
 - PR [#1963](https://github.com/sifr-lang/sifr/pull/1963) scoped-borrow spawn validation slice: the deferred v1 scoped-borrow model is covered by an explicit fail fixture that rejects borrowed parameters crossing `scope.spawn`.
 - PR [#1965](https://github.com/sifr-lang/sifr/pull/1965) non-send task-boundary slice: `scope.spawn` derives structural sendability for direct coroutine arguments and rejects classes containing the zero-runtime `NonSend` marker with `SIFR-OWN-0010`.
-
 ---
 
 ### milestone_async_5: Synchronization Primitives and Channels
 
-status: proposed
+status: in_progress
 
 **Goal:** Provide explicit primitives for sharing and coordination when concurrency requires it.
 
@@ -674,6 +673,10 @@ status: proposed
 **Demo:**
 
 - `demos/m32_sync_channel_demo.sifr`
+
+**Implementation progress:**
+
+- In progress `sync.Shared` surface slice: `sifr.sync.Shared[T]` is available as the first immutable sharing primitive, with basic construction/access validation and the `spawn_capture_immutable_shared_ok.sifr` milestone fixture in the quick lane.
 
 ---
 

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -1,0 +1,10 @@
+# sifr.sync — Explicit synchronization and sharing primitives
+
+class Shared[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def get(self) -> T:
+        return self._value

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -22,6 +22,7 @@
     "nested_function_basic",
     "nested_function_recursive_capture",
     "spawn_owned_move_value",
+    "spawn_capture_immutable_shared_ok",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",


### PR DESCRIPTION
## Summary
- add the first `sifr.sync` stdlib surface with generic `Shared[T]`
- carry stdlib generic class params/templates into codegen so imported generic stdlib types render with concrete type arguments
- add basic Shared validation plus the `spawn_capture_immutable_shared_ok` milestone fixture to the quick e2e lane
- mark milestone_async_5 as in progress with this surface slice documented

## Validation
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/shared_basic.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/spawn_capture_immutable_shared_ok.sifr`
- selected e2e pass manifest for `shared_basic` and `spawn_capture_immutable_shared_ok`
- `cargo test -p sifr_driver stdlib -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Claude Opus review artifact: `reviews/phase32_sync_shared_surface.md`
- Verdict: `VERDICT: SATISFIED`