### PR TITLE
Add lock rwlock sync surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/lock_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/lock_basic.sifr
@@ -1,0 +1,7 @@
+from sifr.sync import Lock
+
+
+def main() -> None:
+    lock: Lock[int] = Lock(41)
+    guard = lock.lock()
+    assert guard.get() == 41

--- a/crates/sifr/tests/e2e/pass/rwlock_readers.sifr
+++ b/crates/sifr/tests/e2e/pass/rwlock_readers.sifr
@@ -1,0 +1,12 @@
+from sifr.sync import RwLock
+
+
+def main() -> None:
+    lock: RwLock[int] = RwLock(41)
+    first = lock.read()
+    second = lock.read()
+    assert first.get() == 41
+    assert second.get() == 41
+
+    writer = lock.write()
+    assert writer.get() == 41

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -678,6 +678,7 @@ status: in_progress
 **Implementation progress:**
 
 - PR [#1967](https://github.com/sifr-lang/sifr/pull/1967) `sync.Shared` surface slice: `sifr.sync.Shared[T]` is available as the first immutable sharing primitive, with basic construction/access validation and the `spawn_capture_immutable_shared_ok.sifr` milestone fixture in the quick lane.
+- In progress `sync.Lock`/`sync.RwLock` surface slice: basic lock/read/write guard types are available through `sifr.sync`, with `lock_basic.sifr` and `rwlock_readers.sifr` in the quick lane. Guard liveness diagnostics and contention semantics remain deferred to later milestone_async_5 slices.
 
 ---
 

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -8,3 +8,67 @@ class Shared[T]:
 
     def get(self) -> T:
         return self._value
+
+
+class WouldBlockError(Error):
+    pass
+
+
+class ClosedError(Error):
+    pass
+
+
+class LockGuard[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def get(self) -> T:
+        return self._value
+
+
+class Lock[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def lock(self) -> LockGuard[T]:
+        return LockGuard(self._value)
+
+    def try_lock(self) -> Result[LockGuard[T], WouldBlockError]:
+        return LockGuard(self._value)
+
+
+class RwLockReadGuard[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def get(self) -> T:
+        return self._value
+
+
+class RwLockWriteGuard[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def get(self) -> T:
+        return self._value
+
+
+class RwLock[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def read(self) -> RwLockReadGuard[T]:
+        return RwLockReadGuard(self._value)
+
+    def write(self) -> RwLockWriteGuard[T]:
+        return RwLockWriteGuard(self._value)

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -25,6 +25,8 @@
     "spawn_owned_move_value",
     "spawn_capture_immutable_shared_ok",
     "await_without_live_borrow",
+    "lock_basic",
+    "rwlock_readers",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",


### PR DESCRIPTION
## Summary
- add basic `sync.Lock[T]`, `LockGuard[T]`, `sync.RwLock[T]`, and rwlock guard surfaces
- add sync error surface types `WouldBlockError` and `ClosedError`
- add `lock_basic` and `rwlock_readers` pass fixtures to the quick lane
- document this as a surface slice with guard liveness and contention semantics deferred

## Validation
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/lock_basic.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/rwlock_readers.sifr`
- selected e2e pass manifest for `lock_basic` and `rwlock_readers`
- `cargo test -p sifr_driver stdlib -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Claude Opus review artifact: `reviews/phase32_lock_rwlock_surface.md`
- Verdict: `VERDICT: SATISFIED`