### PR TITLE
Track lock rwlock surface PR

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -678,7 +678,7 @@ status: in_progress
 **Implementation progress:**
 
 - PR [#1967](https://github.com/sifr-lang/sifr/pull/1967) `sync.Shared` surface slice: `sifr.sync.Shared[T]` is available as the first immutable sharing primitive, with basic construction/access validation and the `spawn_capture_immutable_shared_ok.sifr` milestone fixture in the quick lane.
-- In progress `sync.Lock`/`sync.RwLock` surface slice: basic lock/read/write guard types are available through `sifr.sync`, with `lock_basic.sifr` and `rwlock_readers.sifr` in the quick lane. Guard liveness diagnostics and contention semantics remain deferred to later milestone_async_5 slices.
+- PR [#1971](https://github.com/sifr-lang/sifr/pull/1971) `sync.Lock`/`sync.RwLock` surface slice: basic lock/read/write guard types are available through `sifr.sync`, with `lock_basic.sifr` and `rwlock_readers.sifr` in the quick lane. Guard liveness diagnostics and contention semantics remain deferred to later milestone_async_5 slices.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the in-progress lock/rwlock surface note with the merged PR #1971 link

## Validation
- `git diff --check`