### PR TITLE
Add semaphore notify sync surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/notify_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/notify_basic.sifr
@@ -1,0 +1,9 @@
+from sifr.sync import Notify
+
+
+async def main() -> None:
+    notify: Notify = Notify()
+    notify.notify_one()
+    await notify.notified()
+    notify.notify_all()
+    return None

--- a/crates/sifr/tests/e2e/pass/semaphore_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/semaphore_basic.sifr
@@ -1,0 +1,7 @@
+from sifr.sync import ClosedError, Semaphore
+
+
+async def main() -> Result[None, ClosedError]:
+    semaphore: Semaphore = Semaphore(1)
+    permit = await semaphore.acquire()
+    return None

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -1780,6 +1780,40 @@ impl RustEmitter {
                     future: Box::new(future),
                 }));
             }
+            if let HirExpr::Call { func, args, .. } = value.as_ref() {
+                if func == "__sifr_task_sleep" {
+                    let [duration] = args.as_slice() else {
+                        return Ok(None);
+                    };
+                    let Some(duration_expr) =
+                        crate::try_lower_task_duration_expr(duration, "__sifr_task_sleep_seconds")
+                    else {
+                        return Ok(None);
+                    };
+                    return Ok(Some(crate::RustExpr::Await(Box::new(
+                        crate::RustExpr::FnCall {
+                            func: Box::new(crate::RustExpr::Path(vec![
+                                "tokio".to_string(),
+                                "time".to_string(),
+                                "sleep".to_string(),
+                            ])),
+                            args: vec![duration_expr],
+                        },
+                    ))));
+                }
+            }
+            let Some(lowered_value) = self.lower_stmt_expr_for_ir(value)? else {
+                return Ok(None);
+            };
+            let awaited_value = match crate::resolve_alias_type_for_plain_call(value.ty()) {
+                Type::Task(_, _) | Type::BlockingTask(_, _) => crate::RustExpr::MethodCall {
+                    receiver: Box::new(lowered_value),
+                    method: "join".to_string(),
+                    args: vec![],
+                },
+                _ => lowered_value,
+            };
+            return Ok(Some(crate::RustExpr::Await(Box::new(awaited_value))));
         }
 
         let skip_leaf_registry_lowering = matches!(

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -6,7 +6,7 @@ use crate::stdlib::registry::STDLIB_FILES;
 use crate::stdlib::types::StdlibCompiled;
 use sifr_codegen::StdlibCode;
 use sifr_diagnostics::DiagnosticCode;
-use sifr_hir::{lower_module_stdlib_with_externals, ExternalDefs, HirParam};
+use sifr_hir::{lower_module_stdlib_with_externals, ExternalDefs, HirFunction, HirParam};
 use sifr_python_parser::parse_module;
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 use std::collections::{HashMap, HashSet};
@@ -158,12 +158,7 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<RenderedDiagnost
                 let mut methods: Vec<(String, FunctionType)> = class
                     .methods
                     .iter()
-                    .map(|method| {
-                        (
-                            method.name.clone(),
-                            function_type_from_params(&method.params, &method.return_type),
-                        )
-                    })
+                    .map(|method| (method.name.clone(), method_type_from_hir(method)))
                     .collect();
                 for (dunder_name, op_func) in &class.operator_impls {
                     methods.push((
@@ -370,6 +365,22 @@ fn function_type_from_params(params: &[HirParam], return_type: &Type) -> Functio
     FunctionType {
         params: named_params(params),
         return_type: Box::new(return_type.clone()),
+    }
+}
+
+fn method_type_from_hir(method: &HirFunction) -> FunctionType {
+    let return_type = if method.is_async {
+        coroutine_type_from_surface_return(&method.return_type)
+    } else {
+        method.return_type.clone()
+    };
+    function_type_from_params(&method.params, &return_type)
+}
+
+fn coroutine_type_from_surface_return(surface_return_type: &Type) -> Type {
+    match surface_return_type.resolve_alias() {
+        Type::Result(ok, err) => Type::Coroutine(ok.clone(), err.clone()),
+        other => Type::Coroutine(Box::new(other.clone()), Box::new(Type::Never)),
     }
 }
 

--- a/crates/sifr_hir/src/lower/classes.rs
+++ b/crates/sifr_hir/src/lower/classes.rs
@@ -8,6 +8,7 @@ use sifr_python_ast::{Expr, Stmt, StmtClassDef};
 use sifr_type_system::{FunctionType, ParamConvention, Type};
 use std::collections::HashMap;
 
+use super::async_await::coroutine_result_type;
 use super::class_field_inference::collect_constructor_self_field_assignments;
 use super::diagnostics::{
     collect_enum_variants, get_newtype_inner, get_parent_class, has_decorator, is_enum_class,
@@ -32,6 +33,14 @@ fn class_method_signature<'a>(
             }
         },
     )
+}
+
+fn method_signature_return_type(func: &sifr_python_ast::StmtFunctionDef, return_ty: Type) -> Type {
+    if func.is_async {
+        coroutine_result_type(&return_ty)
+    } else {
+        return_ty
+    }
 }
 
 fn option_member_type(ty: &Type) -> Option<Type> {
@@ -373,7 +382,7 @@ pub(super) fn collect_class_type(
                 } else {
                     Type::None
                 };
-                let ft = FunctionType::new(params, return_ty);
+                let ft = FunctionType::new(params, method_signature_return_type(func, return_ty));
                 // Register method as ClassName.method_name for lookup
                 ctx.functions
                     .insert(format!("{class_name}.{method_name}"), ft.clone());
@@ -414,7 +423,10 @@ pub(super) fn collect_class_type(
                 } else {
                     Type::None
                 };
-                methods.push((method_name, FunctionType::new(params, return_ty)));
+                methods.push((
+                    method_name,
+                    FunctionType::new(params, method_signature_return_type(func, return_ty)),
+                ));
             }
         }
         let proto_ty = Type::Protocol {
@@ -625,7 +637,10 @@ pub(super) fn collect_class_type(
                         ctx.function_defaults
                             .insert(format!("{class_name}.{method_name}"), defaults);
                     }
-                    methods.push((method_name, FunctionType::new(params, return_ty)));
+                    methods.push((
+                        method_name,
+                        FunctionType::new(params, method_signature_return_type(func, return_ty)),
+                    ));
 
                     collect_constructor_self_field_assignments(
                         &func.body,

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -679,6 +679,7 @@ status: in_progress
 
 - PR [#1967](https://github.com/sifr-lang/sifr/pull/1967) `sync.Shared` surface slice: `sifr.sync.Shared[T]` is available as the first immutable sharing primitive, with basic construction/access validation and the `spawn_capture_immutable_shared_ok.sifr` milestone fixture in the quick lane.
 - PR [#1971](https://github.com/sifr-lang/sifr/pull/1971) `sync.Lock`/`sync.RwLock` surface slice: basic lock/read/write guard types are available through `sifr.sync`, with `lock_basic.sifr` and `rwlock_readers.sifr` in the quick lane. Guard liveness diagnostics and contention semantics remain deferred to later milestone_async_5 slices.
+- In progress `sync.Semaphore`/`sync.Notify` surface slice: basic permit and notification coordination surfaces are available through `sifr.sync`, async stdlib class methods are preserved as coroutine-returning method signatures, and `semaphore_basic.sifr` plus `notify_basic.sifr` are in the quick lane. Real blocking/wakeup semantics and cancellation-aware coordination remain deferred to later milestone_async_5 slices.
 
 ---
 

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -72,3 +72,40 @@ class RwLock[T]:
 
     def write(self) -> RwLockWriteGuard[T]:
         return RwLockWriteGuard(self._value)
+
+
+class SemaphorePermit:
+    pass
+
+
+class Semaphore:
+    _permits: int
+
+    def __init__(self, permits: int):
+        self._permits = permits
+
+    async def acquire(self) -> Result[SemaphorePermit, ClosedError]:
+        if self._permits > 0:
+            self._permits = self._permits - 1
+            return SemaphorePermit()
+        return SemaphorePermit()
+
+    def try_acquire(self) -> Result[SemaphorePermit, WouldBlockError]:
+        if self._permits > 0:
+            self._permits = self._permits - 1
+            return SemaphorePermit()
+        raise WouldBlockError()
+
+
+class Notify:
+    def __init__(self) -> None:
+        pass
+
+    async def notified(self) -> None:
+        return None
+
+    def notify_one(self) -> None:
+        return None
+
+    def notify_all(self) -> None:
+        return None

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -27,6 +27,8 @@
     "await_without_live_borrow",
     "lock_basic",
     "rwlock_readers",
+    "semaphore_basic",
+    "notify_basic",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",


### PR DESCRIPTION
## Summary
- add the Phase 32 `sifr.sync` `Semaphore`, `SemaphorePermit`, and `Notify` surface types
- preserve async class method signatures as coroutine-returning method types in HIR and stdlib bootstrap metadata
- lower structured `await` over method-call expressions while preserving task sleep and task-handle await handling
- add `semaphore_basic` and `notify_basic` pass fixtures to the quick lane and update the phase tracker

## Validation
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/semaphore_basic.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/notify_basic.sifr`
- selected `scripts/run_e2e_pass.sh --fixture-manifest ...` for `semaphore_basic` and `notify_basic`
- `cargo test -p sifr_hir async -- --nocapture`
- `cargo test -p sifr_driver stdlib -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

## Review
- Claude Opus reviewer artifact: `reviews/phase32_semaphore_notify_surface.md`
- Verdict: SATISFIED

## Scope note
This is a surface and compiler-support slice. Real blocking/wakeup behavior, closed-state semantics, and cancellation-aware coordination remain deferred to later milestone_async_5 slices, as recorded in the phase tracker.