### PR TITLE
Reject lock guard return escape

### DIFF
--- a/crates/sifr/tests/e2e/fail/lock_guard_escape_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/lock_guard_escape_rejected.sifr
@@ -1,0 +1,13 @@
+# expect-error[col=12]: SIFR-OWN-0003
+from sifr.sync import Lock, LockGuard
+
+
+def make_guard(own lock: Lock[int]) -> LockGuard[int]:
+    guard = lock.lock()
+    return guard
+
+
+def main() -> None:
+    lock: Lock[int] = Lock(1)
+    guard = make_guard(lock)
+    assert guard.get() == 1

--- a/crates/sifr_hir/src/lower/async_await.rs
+++ b/crates/sifr_hir/src/lower/async_await.rs
@@ -1,7 +1,7 @@
 use super::expression_diagnostics;
 use super::expressions::lower_expr;
 use super::ownership_diagnostics;
-use super::task_scope_calls::mark_task_handle_observed;
+use super::task_scope_calls::{is_lock_guard_type, mark_task_handle_observed};
 use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
 use ruff_text_size::Ranged;
@@ -52,19 +52,6 @@ pub(super) fn lower_await(await_expr: &ExprAwait, ctx: &mut LowerCtx) -> Option<
         value: Box::new(value),
         ty,
     })
-}
-
-fn is_lock_guard_type(ty: &Type) -> bool {
-    let Type::Class { name, .. } = ty.resolve_alias() else {
-        return false;
-    };
-    let public_name = name
-        .strip_prefix("__compat_sifr_sync_")
-        .unwrap_or(name.as_str());
-    matches!(
-        public_name,
-        "LockGuard" | "RwLockReadGuard" | "RwLockWriteGuard"
-    )
 }
 
 fn await_result_type(ty: &Type) -> Option<Type> {

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1688,6 +1688,19 @@ fn test_lock_guard_across_await_rejected() {
 }
 
 #[test]
+fn test_lock_guard_return_escape_rejected() {
+    let source = "class LockGuard[T]:\n    pass\n\ndef make_guard() -> LockGuard[int]:\n    guard: LockGuard[int] = LockGuard()\n    return guard\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|e| {
+        e.message.contains("cannot return lock guard")
+            && e.code == Some(DiagnosticCode::OWN_BORROWED_PARAMETER_ESCAPES)
+            && e.primary_range == Some(range_for_after(source, "return ", "guard"))
+    }));
+}
+
+#[test]
 fn test_task_timeout_consumes_handle_binding() {
     let source = "async def worker() -> int:\n    return 41\n\nasync def main() -> Result[None, ScopeFailure]:\n    async with task.scope() as scope:\n        handle = scope.spawn(worker())\n        result = await task.timeout(handle, 1.0)\n        second = await handle\n    return None\n";
     let result = lower_source(source);

--- a/crates/sifr_hir/src/lower/ownership_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/ownership_diagnostics.rs
@@ -75,6 +75,15 @@ pub(super) fn borrowed_parameter_return_escape(ctx: &mut LowerCtx, name: &str, r
     );
 }
 
+pub(super) fn lock_guard_return_escape(ctx: &mut LowerCtx, range: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::OWN_BORROWED_PARAMETER_ESCAPES,
+        "cannot return lock guard: lock guards cannot escape their local critical section"
+            .to_string(),
+        range,
+    );
+}
+
 pub(super) fn moved_across_loop(ctx: &mut LowerCtx, name: &str, range: TextRange) {
     ctx.error_with_code_at(
         DiagnosticCode::OWN_MOVED_ACROSS_LOOP,

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -45,7 +45,7 @@ use super::sequence_guard_updates::{
 use super::sequence_pointers::record_sequence_pointer_fact;
 use super::sequence_shapes::sequence_shape_fact;
 use super::statement_diagnostics;
-use super::task_scope_calls::task_group_spawn_owner;
+use super::task_scope_calls::{is_lock_guard_type, task_group_spawn_owner};
 use super::typing_and_functions::{
     ast_convention_to_param, register_local_function_signature, register_local_function_symbol,
     resolve_annotation_expr,
@@ -1673,6 +1673,9 @@ pub(super) fn lower_return(
                 let range = val.range();
                 ownership_diagnostics::borrowed_parameter_return_escape(ctx, name, range);
             }
+        }
+        if !ctx.allow_intrinsic_imports && is_lock_guard_type(&expr_ty) {
+            ownership_diagnostics::lock_guard_return_escape(ctx, val.range());
         }
 
         // If the function returns Result[T, E] and the value is T (not Result), wrap in Ok()

--- a/crates/sifr_hir/src/lower/task_scope_calls.rs
+++ b/crates/sifr_hir/src/lower/task_scope_calls.rs
@@ -221,6 +221,13 @@ fn class_has_non_send_marker(name: &str, parent_chain: Option<&str>) -> bool {
         || parent_chain.is_some_and(|parents| parents.split('|').any(|parent| parent == "NonSend"))
 }
 
+pub(super) fn is_lock_guard_type(ty: &Type) -> bool {
+    let Type::Class { name, .. } = ty.resolve_alias() else {
+        return false;
+    };
+    is_lock_guard_type_name(name)
+}
+
 fn is_lock_guard_type_name(name: &str) -> bool {
     matches!(
         public_type_name(name),

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -683,6 +683,7 @@ status: in_progress
 - PR [#1975](https://github.com/sifr-lang/sifr/pull/1975) channel endpoint surface slice: `sync.Channel[T]`, `sync.ChannelSender[T]`, and `sync.ChannelReceiver[T]` are available through `sifr.sync`, with direct-construction surface fixtures `channel_basic.sifr` and `bounded_channel_basic.sifr` in the quick lane. `sync.channel[T]()`/`sync.bounded_channel[T](capacity)` factories, runtime-backed shared queues, sender clone sharing, close/drop semantics, backpressure, FIFO guarantees, async iteration, and cancellation exactness remain deferred to later milestone_async_5 channel slices.
 - PR [#1977](https://github.com/sifr-lang/sifr/pull/1977) lock-guard await validation slice: live `LockGuard`, `RwLockReadGuard`, and `RwLockWriteGuard` bindings are rejected at await points with `SIFR-OWN-0009`, with `lock_guard_across_await_rejected.sifr` covering the negative path.
 - PR [#1979](https://github.com/sifr-lang/sifr/pull/1979) lock-guard task-boundary validation slice: `LockGuard`, `RwLockReadGuard`, and `RwLockWriteGuard` values are rejected when passed into `scope.spawn` with `SIFR-OWN-0010`, with `lock_across_task_boundary_rejected.sifr` covering the negative path.
+- In progress lock-guard return-escape validation slice: user code cannot return `LockGuard`, `RwLockReadGuard`, or `RwLockWriteGuard` values from functions, with `lock_guard_escape_rejected.sifr` covering the negative path.
 
 ---
 


### PR DESCRIPTION
## Summary
- reject user functions that return LockGuard/RwLockReadGuard/RwLockWriteGuard values
- reuse the lock-guard helper for await, spawn-boundary, and return validation
- add HIR and e2e fail coverage for lock_guard_escape_rejected.sifr
- record milestone_async_5 progress in the phase tracker

## Validation
- cargo fmt
- python3 scripts/check_hir_maintainability_guardrails.py
- git diff --check
- cargo test -p sifr_hir test_lock_guard_return_escape_rejected -- --nocapture
- cargo test -p sifr_hir test_scope_spawn_rejects_lock_guard_argument -- --nocapture
- cargo test -p sifr --test e2e test_e2e_fail -- --exact
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus review: REVIEW_STATUS: SATISFIED (reviews/phase32_lock_guard_return_escape_validation.md, local artifact only)