### PR TITLE
Add channel send type validation

### DIFF
--- a/crates/sifr/tests/e2e/fail/channel_send_wrong_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/channel_send_wrong_type_rejected.sifr
@@ -1,0 +1,8 @@
+# expect-error[col=30]: SIFR-TYPE-0002
+from sifr.sync import Channel, ChannelSender, ClosedError
+
+
+async def main() -> Result[None, ClosedError]:
+    sender: ChannelSender[int] = ChannelSender(Channel([], -1))
+    sent = await sender.send("bad")
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -684,6 +684,7 @@ status: in_progress
 - PR [#1977](https://github.com/sifr-lang/sifr/pull/1977) lock-guard await validation slice: live `LockGuard`, `RwLockReadGuard`, and `RwLockWriteGuard` bindings are rejected at await points with `SIFR-OWN-0009`, with `lock_guard_across_await_rejected.sifr` covering the negative path.
 - PR [#1979](https://github.com/sifr-lang/sifr/pull/1979) lock-guard task-boundary validation slice: `LockGuard`, `RwLockReadGuard`, and `RwLockWriteGuard` values are rejected when passed into `scope.spawn` with `SIFR-OWN-0010`, with `lock_across_task_boundary_rejected.sifr` covering the negative path.
 - PR [#1981](https://github.com/sifr-lang/sifr/pull/1981) lock-guard return-escape validation slice: user code cannot return `LockGuard`, `RwLockReadGuard`, or `RwLockWriteGuard` values from functions, with `lock_guard_escape_rejected.sifr` covering the negative path.
+- In progress channel send type validation slice: `ChannelSender[T].send(value: T)` rejects mismatched value types, with `channel_send_wrong_type_rejected.sifr` covering the negative path.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the milestone_async_5 negative fixture for sending the wrong value type through ChannelSender[T]
- record the validation slice in the phase tracker

## Validation
- cargo fmt
- git diff --check
- cargo test -p sifr --test e2e test_e2e_fail -- --exact
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus review: REVIEW_STATUS: SATISFIED (reviews/phase32_channel_send_type_validation.md, local artifact only)