### PR TITLE
Add channel factory surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/bounded_channel_factory_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/bounded_channel_factory_basic.sifr
@@ -1,0 +1,8 @@
+from sifr.sync import ChannelReceiver, ChannelSender, bounded_channel
+
+
+def main() -> None:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = bounded_channel(2)
+    sender, receiver = endpoints
+    assert str(sender) == "ChannelSender"
+    assert str(receiver) == "ChannelReceiver"

--- a/crates/sifr/tests/e2e/pass/channel_factory_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_factory_basic.sifr
@@ -1,0 +1,8 @@
+from sifr.sync import ChannelReceiver, ChannelSender, channel
+
+
+def main() -> None:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+    assert str(sender) == "ChannelSender"
+    assert str(receiver) == "ChannelReceiver"

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -687,6 +687,7 @@ status: in_progress
 - PR [#1983](https://github.com/sifr-lang/sifr/pull/1983) channel send type validation slice: `ChannelSender[T].send(value: T)` rejects mismatched value types, with `channel_send_wrong_type_rejected.sifr` covering the negative path.
 - PR [#1985](https://github.com/sifr-lang/sifr/pull/1985) channel non-send element validation slice: `ChannelSender[T].send(value: T)` rejects non-send values before they enter a channel, with `channel_non_send_element_rejected.sifr` covering the negative path.
 - PR [#1987](https://github.com/sifr-lang/sifr/pull/1987) ShareSafe validation slice: `Shared[T]` rejects mutable values without an explicit synchronization wrapper, with `shared_mut_without_lock_rejected.sifr` covering the negative path.
+- In progress channel factory surface slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` return typed sender/receiver endpoint pairs, with runtime-backed shared queue semantics still deferred to a later channel slice.
 
 ---
 

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -89,6 +89,18 @@ class ChannelReceiver[T]:
         return self._channel.pop()
 
 
+def channel[T]() -> tuple[ChannelSender[T], ChannelReceiver[T]]:
+    sender_channel: Channel[T] = Channel([], -1)
+    receiver_channel: Channel[T] = Channel([], -1)
+    return (ChannelSender(sender_channel), ChannelReceiver(receiver_channel))
+
+
+def bounded_channel[T](capacity: int) -> tuple[ChannelSender[T], ChannelReceiver[T]]:
+    sender_channel: Channel[T] = Channel([], capacity)
+    receiver_channel: Channel[T] = Channel([], capacity)
+    return (ChannelSender(sender_channel), ChannelReceiver(receiver_channel))
+
+
 class LockGuard[T]:
     _value: T
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -29,6 +29,8 @@
     "rwlock_readers",
     "channel_basic",
     "bounded_channel_basic",
+    "channel_factory_basic",
+    "bounded_channel_factory_basic",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add sync.channel[T]() and sync.bounded_channel[T](capacity) factory functions returning typed endpoint pairs
- add channel_factory_basic and bounded_channel_factory_basic pass fixtures
- include the new factory fixtures in the quick e2e manifest and note the slice in Phase 32 progress

## Scope
This is the factory surface/type-validation slice. Runtime-backed shared queue semantics, sender clone sharing, close/drop behavior, backpressure, FIFO, async iteration, and cancellation exactness remain deferred to later channel runtime slices.

## Validation
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/channel_factory_basic.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/pass/bounded_channel_factory_basic.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_factory_basic.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/bounded_channel_factory_basic.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus review: REVIEW_STATUS: SATISFIED (local artifact: reviews/phase32_channel_factory_surface.md, not committed)
