### PR TITLE
Preserve channel endpoint state

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_close.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_close.sifr
@@ -1,0 +1,9 @@
+from sifr.sync import Channel, ChannelSender, ClosedError
+
+
+async def main() -> Result[None, ClosedError]:
+    sender: ChannelSender[int] = ChannelSender(Channel([], -1))
+    sender.close()
+    sent: Result[None, ClosedError] = await sender.send(1)
+    assert str(sent) == "Err(ClosedError)"
+    return None

--- a/crates/sifr/tests/e2e/pass/channel_fifo_order.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_fifo_order.sifr
@@ -1,0 +1,10 @@
+from sifr.sync import Channel, ChannelReceiver, ClosedError
+
+
+async def main() -> Result[None, ClosedError]:
+    receiver: ChannelReceiver[int] = ChannelReceiver(Channel([1, 2, 3], -1))
+    first: Result[int, ClosedError] = await receiver.receive()
+    second: Result[int, ClosedError] = await receiver.receive()
+    assert str(first) == "Ok(1)"
+    assert str(second) == "Ok(2)"
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -688,6 +688,7 @@ status: in_progress
 - PR [#1985](https://github.com/sifr-lang/sifr/pull/1985) channel non-send element validation slice: `ChannelSender[T].send(value: T)` rejects non-send values before they enter a channel, with `channel_non_send_element_rejected.sifr` covering the negative path.
 - PR [#1987](https://github.com/sifr-lang/sifr/pull/1987) ShareSafe validation slice: `Shared[T]` rejects mutable values without an explicit synchronization wrapper, with `shared_mut_without_lock_rejected.sifr` covering the negative path.
 - PR [#1989](https://github.com/sifr-lang/sifr/pull/1989) channel factory surface slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` return typed sender/receiver endpoint pairs, with runtime-backed shared queue semantics still deferred to a later channel slice.
+- In progress channel endpoint state slice: `ChannelSender.send`/`close` and `ChannelReceiver.receive` update each endpoint's stored channel state, with `channel_close.sifr` and `channel_fifo_order.sifr` covering close-after-send rejection and repeated receive FIFO order on a single receiver.
 
 ---
 

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -67,10 +67,15 @@ class ChannelSender[T]:
         return "ChannelSender"
 
     async def send(self, own value: T) -> Result[None, ClosedError]:
-        return self._channel.push(value)
+        channel: Channel[T] = self._channel
+        sent: Result[None, ClosedError] = channel.push(value)
+        self._channel = channel
+        return sent
 
     def close(self) -> None:
-        self._channel.close()
+        channel: Channel[T] = self._channel
+        channel.close()
+        self._channel = channel
 
     def clone(self) -> ChannelSender[T]:
         return ChannelSender(self._channel)
@@ -86,7 +91,10 @@ class ChannelReceiver[T]:
         return "ChannelReceiver"
 
     async def receive(self) -> Result[T, ClosedError]:
-        return self._channel.pop()
+        channel: Channel[T] = self._channel
+        received: Result[T, ClosedError] = channel.pop()
+        self._channel = channel
+        return received
 
 
 def channel[T]() -> tuple[ChannelSender[T], ChannelReceiver[T]]:

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -31,6 +31,8 @@
     "bounded_channel_basic",
     "channel_factory_basic",
     "bounded_channel_factory_basic",
+    "channel_close",
+    "channel_fifo_order",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- update ChannelSender.send/close and ChannelReceiver.receive to write mutated channel state back into the endpoint
- add channel_close and channel_fifo_order pass fixtures
- include the new endpoint-state fixtures in the quick e2e manifest and note the slice in Phase 32 progress

## Scope
This improves single-endpoint state for the current value-backed channel surface. Runtime-backed shared queues across sender/receiver pairs, sender clone sharing, drop semantics, backpressure, async iteration, and cancellation exactness remain deferred to later channel runtime slices.

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_close.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_fifo_order.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_basic.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus review: ready for PR in reviews/phase32_channel_endpoint_state.md
- Claude Opus follow-up: REVIEW_STATUS: SATISFIED (local artifact: reviews/phase32_channel_endpoint_state_r2.md, not committed)
