### PR TITLE
Add channel close-drain fixture

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_drop_last_sender_closes_after_drain.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_drop_last_sender_closes_after_drain.sifr
@@ -1,0 +1,10 @@
+from sifr.sync import Channel, ClosedError
+
+
+def main() -> None:
+    channel: Channel[int] = Channel([7], -1)
+    channel.close()
+    drained: Result[int, ClosedError] = channel.pop()
+    exhausted: Result[int, ClosedError] = channel.pop()
+    assert str(drained) == "Ok(7)"
+    assert str(exhausted) == "Err(ClosedError)"

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -689,6 +689,7 @@ status: in_progress
 - PR [#1987](https://github.com/sifr-lang/sifr/pull/1987) ShareSafe validation slice: `Shared[T]` rejects mutable values without an explicit synchronization wrapper, with `shared_mut_without_lock_rejected.sifr` covering the negative path.
 - PR [#1989](https://github.com/sifr-lang/sifr/pull/1989) channel factory surface slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` return typed sender/receiver endpoint pairs, with runtime-backed shared queue semantics still deferred to a later channel slice.
 - PR [#1991](https://github.com/sifr-lang/sifr/pull/1991) channel endpoint state slice: `ChannelSender.send`/`close` and `ChannelReceiver.receive` update each endpoint's stored channel state, with `channel_close.sifr` and `channel_fifo_order.sifr` covering close-after-send rejection and repeated receive FIFO order on a single receiver.
+- In progress channel close-drain fixture slice: a closed channel keeps buffered values receivable and reports `ClosedError` once drained, with `channel_drop_last_sender_closes_after_drain.sifr` covering the current value-backed surface.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -33,6 +33,7 @@
     "bounded_channel_factory_basic",
     "channel_close",
     "channel_fifo_order",
+    "channel_drop_last_sender_closes_after_drain",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add channel_drop_last_sender_closes_after_drain pass fixture for closed-channel drain behavior on the current value-backed Channel surface
- include the fixture in the quick e2e manifest
- note the in-progress close-drain fixture slice in Phase 32 progress

## Scope
This is validation evidence for direct Channel.close/pop behavior. Real sender drop detection, shared queues, clone sharing, backpressure, async iteration, and cancellation exactness remain deferred.

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_drop_last_sender_closes_after_drain.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus review: PR-ready in reviews/phase32_channel_close_drain_fixture.md
- Claude Opus follow-up: REVIEW_STATUS: SATISFIED (local artifact: reviews/phase32_channel_close_drain_fixture_r2.md, not committed)
