### PR TITLE
Validate channel sender clone close

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_sender_close_clone_closes_all.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_sender_close_clone_closes_all.sifr
@@ -1,0 +1,17 @@
+from sifr.sync import ChannelReceiver, ChannelSender, ClosedError, channel
+
+
+async def main() -> Result[None, ClosedError]:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+    cloned_sender: ChannelSender[int] = sender.clone()
+
+    sent_before_close: Result[None, ClosedError] = await cloned_sender.send(11)
+    sender.close()
+    received: Result[int, ClosedError] = await receiver.receive()
+    sent_after_close: Result[None, ClosedError] = await cloned_sender.send(12)
+
+    assert str(sent_before_close) == "Ok(())"
+    assert str(received) == "Ok(11)"
+    assert str(sent_after_close) == "Err(ClosedError)"
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -691,6 +691,7 @@ status: in_progress
 - PR [#1991](https://github.com/sifr-lang/sifr/pull/1991) channel endpoint state slice: `ChannelSender.send`/`close` and `ChannelReceiver.receive` update each endpoint's stored channel state, with `channel_close.sifr` and `channel_fifo_order.sifr` covering close-after-send rejection and repeated receive FIFO order on a single receiver.
 - PR [#1993](https://github.com/sifr-lang/sifr/pull/1993) channel close-drain fixture slice: a closed channel keeps buffered values receivable and reports `ClosedError` once drained, with `channel_drop_last_sender_closes_after_drain.sifr` covering the current value-backed surface.
 - PR [#1995](https://github.com/sifr-lang/sifr/pull/1995) shared channel runtime slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` now use shared queue endpoint state in generated Rust, and the factory fixtures prove values sent through the paired sender are received through the paired receiver.
+- Current slice: add `channel_sender_close_clone_closes_all.sifr` to validate that cloned senders share channel state, sender `close()` closes the whole channel, and buffered messages remain receivable after close.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -34,6 +34,7 @@
     "channel_close",
     "channel_fifo_order",
     "channel_drop_last_sender_closes_after_drain",
+    "channel_sender_close_clone_closes_all",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add channel_sender_close_clone_closes_all.sifr to validate cloned sender shared state and close propagation
- add the fixture to the quick e2e manifest
- record the active Phase 32 clone-close validation slice

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_sender_close_clone_closes_all.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_factory_basic.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_close.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick (39 pass fixtures, 0 failures, wall_time=126.42s)

## Review
- Opus review: reviews/phase32_channel_sender_clone_close.md
- REVIEW_STATUS: SATISFIED