### PR TITLE
Validate channel receiver drop closes senders

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_drop_receiver_closes_senders.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_drop_receiver_closes_senders.sifr
@@ -1,0 +1,15 @@
+from sifr.sync import ChannelReceiver, ChannelSender, ClosedError, channel
+
+
+def sender_after_receiver_drop() -> ChannelSender[int]:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+    assert str(receiver) == "ChannelReceiver"
+    return sender
+
+
+async def main() -> Result[None, ClosedError]:
+    sender: ChannelSender[int] = sender_after_receiver_drop()
+    sent: Result[None, ClosedError] = await sender.send(9)
+    assert str(sent) == "Err(ClosedError)"
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -692,6 +692,7 @@ status: in_progress
 - PR [#1993](https://github.com/sifr-lang/sifr/pull/1993) channel close-drain fixture slice: a closed channel keeps buffered values receivable and reports `ClosedError` once drained, with `channel_drop_last_sender_closes_after_drain.sifr` covering the current value-backed surface.
 - PR [#1995](https://github.com/sifr-lang/sifr/pull/1995) shared channel runtime slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` now use shared queue endpoint state in generated Rust, and the factory fixtures prove values sent through the paired sender are received through the paired receiver.
 - PR [#1997](https://github.com/sifr-lang/sifr/pull/1997) channel sender clone-close validation slice: `channel_sender_close_clone_closes_all.sifr` validates that cloned senders share channel state, sender `close()` closes the whole channel, and buffered messages remain receivable after close.
+- Current slice: add `channel_drop_receiver_closes_senders.sifr` to validate that dropping the receiver endpoint closes the channel immediately to senders.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -35,6 +35,7 @@
     "channel_fifo_order",
     "channel_drop_last_sender_closes_after_drain",
     "channel_sender_close_clone_closes_all",
+    "channel_drop_receiver_closes_senders",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add channel_drop_receiver_closes_senders.sifr to validate receiver endpoint drop closes the channel to senders
- add the fixture to the quick e2e manifest
- record the active Phase 32 receiver-drop validation slice

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_drop_receiver_closes_senders.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick (40 pass fixtures, 0 failures, wall_time=75.41s)

## Review
- Opus review: reviews/phase32_channel_drop_receiver.md
- REVIEW_STATUS: SATISFIED