### PR TITLE
Validate bounded channel backpressure

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_backpressure.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_backpressure.sifr
@@ -1,0 +1,25 @@
+from sifr.sync import ChannelReceiver, ChannelSender, ClosedError, bounded_channel
+
+
+async def drain_two(own mut receiver: ChannelReceiver[int]) -> Result[int, ClosedError]:
+    first: Result[int, ClosedError] = await receiver.receive()
+    await task.sleep(0.0)
+    second: Result[int, ClosedError] = await receiver.receive()
+    assert str(first) == "Ok(1)"
+    assert str(second) == "Ok(2)"
+    return 3
+
+
+async def main() -> Result[None, ScopeFailure]:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = bounded_channel(1)
+    sender, receiver = endpoints
+
+    async with task.scope() as scope:
+        first_send: Result[None, ClosedError] = await sender.send(1)
+        handle = scope.spawn(drain_two(receiver))
+        second_send: Result[None, ClosedError] = await sender.send(2)
+        drained = await handle
+        assert str(first_send) == "Ok(())"
+        assert str(second_send) == "Ok(())"
+        assert str(drained) == "Ok(3)"
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -693,6 +693,7 @@ status: in_progress
 - PR [#1995](https://github.com/sifr-lang/sifr/pull/1995) shared channel runtime slice: `sync.channel[T]()` and `sync.bounded_channel[T](capacity)` now use shared queue endpoint state in generated Rust, and the factory fixtures prove values sent through the paired sender are received through the paired receiver.
 - PR [#1997](https://github.com/sifr-lang/sifr/pull/1997) channel sender clone-close validation slice: `channel_sender_close_clone_closes_all.sifr` validates that cloned senders share channel state, sender `close()` closes the whole channel, and buffered messages remain receivable after close.
 - PR [#1999](https://github.com/sifr-lang/sifr/pull/1999) channel receiver-drop validation slice: `channel_drop_receiver_closes_senders.sifr` validates that dropping the receiver endpoint closes the channel immediately to senders.
+- Current slice: add `channel_backpressure.sifr` to validate bounded channel send/receive coordination across a task boundary.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -36,6 +36,7 @@
     "channel_drop_last_sender_closes_after_drain",
     "channel_sender_close_clone_closes_all",
     "channel_drop_receiver_closes_senders",
+    "channel_backpressure",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add channel_backpressure.sifr to validate bounded channel send/receive coordination across a task boundary
- add the fixture to the quick e2e manifest
- record the active Phase 32 backpressure validation slice

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_backpressure.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick (41 pass fixtures, 0 failures, wall_time=119.94s)

## Review
- Opus review: reviews/phase32_channel_backpressure.md
- REVIEW_STATUS: SATISFIED