### PR TITLE
Validate channel cancelled receive no loss

### DIFF
--- a/crates/sifr/tests/e2e/pass/channel_cancel_receive_no_loss.sifr
+++ b/crates/sifr/tests/e2e/pass/channel_cancel_receive_no_loss.sifr
@@ -1,0 +1,25 @@
+from sifr.sync import ChannelReceiver, ChannelSender, ClosedError, channel
+
+
+async def main() -> Result[None, Error]:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+    cancelled: bool = False
+
+    try:
+        async with task.timeout(0.0):
+            pending: Result[int, ClosedError] = await receiver.receive()
+    except TimeoutError:
+        cancelled = True
+
+    first_send: Result[None, ClosedError] = await sender.send(10)
+    second_send: Result[None, ClosedError] = await sender.send(20)
+    first_received: Result[int, ClosedError] = await receiver.receive()
+    second_received: Result[int, ClosedError] = await receiver.receive()
+
+    assert cancelled
+    assert str(first_send) == "Ok(())"
+    assert str(second_send) == "Ok(())"
+    assert str(first_received) == "Ok(10)"
+    assert str(second_received) == "Ok(20)"
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -695,6 +695,7 @@ status: in_progress
 - PR [#1999](https://github.com/sifr-lang/sifr/pull/1999) channel receiver-drop validation slice: `channel_drop_receiver_closes_senders.sifr` validates that dropping the receiver endpoint closes the channel immediately to senders.
 - PR [#2001](https://github.com/sifr-lang/sifr/pull/2001) bounded channel backpressure validation slice: `channel_backpressure.sifr` validates bounded channel send/receive coordination across a task boundary.
 - PR [#2003](https://github.com/sifr-lang/sifr/pull/2003) channel pending receive cancellation validation slice: `channel_cancel_pending_receive.sifr` validates that timing out a pending same-task receive leaves the receiver usable and does not poison later channel delivery.
+- Current slice: add `channel_cancel_receive_no_loss.sifr` to validate that a cancelled pending receive transfers the receiver endpoint back to user code and does not lose a later message.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -38,6 +38,7 @@
     "channel_drop_receiver_closes_senders",
     "channel_backpressure",
     "channel_cancel_pending_receive",
+    "channel_cancel_receive_no_loss",
     "semaphore_basic",
     "notify_basic",
     "stdlib_json_consolidated",


### PR DESCRIPTION
## Summary
- add channel_cancel_receive_no_loss.sifr to validate cancelled pending receives do not consume later messages
- add the fixture to the quick e2e manifest
- mark the active slice in the Phase 32 tracker

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/channel_cancel_receive_no_loss.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick (43 pass fixtures, wall_time=106.15s)

## Review
- Opus review: reviews/phase32_channel_cancel_receive_no_loss.md
- REVIEW_STATUS: SATISFIED