### PR TITLE
Track channel cancelled receive no loss slice

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -695,7 +695,7 @@ status: in_progress
 - PR [#1999](https://github.com/sifr-lang/sifr/pull/1999) channel receiver-drop validation slice: `channel_drop_receiver_closes_senders.sifr` validates that dropping the receiver endpoint closes the channel immediately to senders.
 - PR [#2001](https://github.com/sifr-lang/sifr/pull/2001) bounded channel backpressure validation slice: `channel_backpressure.sifr` validates bounded channel send/receive coordination across a task boundary.
 - PR [#2003](https://github.com/sifr-lang/sifr/pull/2003) channel pending receive cancellation validation slice: `channel_cancel_pending_receive.sifr` validates that timing out a pending same-task receive leaves the receiver usable and does not poison later channel delivery.
-- Current slice: add `channel_cancel_receive_no_loss.sifr` to validate that a cancelled pending receive transfers the receiver endpoint back to user code and does not lose a later message.
+- PR [#2005](https://github.com/sifr-lang/sifr/pull/2005) channel cancelled receive no-loss validation slice: `channel_cancel_receive_no_loss.sifr` validates that a cancelled pending receive does not consume or reorder later messages.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the current-slice note with merged PR #2005 for the cancelled receive no-loss fixture

## Validation
- git diff --check