### PR TITLE
Add sync channel milestone demo

### DIFF
--- a/demos/m32_sync_channel_demo.sifr
+++ b/demos/m32_sync_channel_demo.sifr
@@ -1,0 +1,107 @@
+from sifr.sync import (
+    ChannelReceiver,
+    ChannelSender,
+    ClosedError,
+    Lock,
+    Notify,
+    RwLock,
+    Semaphore,
+    Shared,
+    bounded_channel,
+    channel,
+)
+
+
+async def drain_two(own mut receiver: ChannelReceiver[int]) -> Result[int, ClosedError]:
+    first: Result[int, ClosedError] = await receiver.receive()
+    await task.sleep(0.0)
+    second: Result[int, ClosedError] = await receiver.receive()
+    assert str(first) == "Ok(1)"
+    assert str(second) == "Ok(2)"
+    return 2
+
+
+def shared_and_guard_demo() -> None:
+    # Immutable shared state can cross task boundaries without mutation.
+    shared: Shared[int] = Shared(41)
+    assert shared.get() == 41
+
+    # Mutable state is accessed through lock guards.
+    lock: Lock[int] = Lock(10)
+    guard = lock.lock()
+    assert guard.get() == 10
+
+    readers: RwLock[int] = RwLock(20)
+    first_reader = readers.read()
+    second_reader = readers.read()
+    writer = readers.write()
+    assert first_reader.get() == 20
+    assert second_reader.get() == 20
+    assert writer.get() == 20
+    return None
+
+
+async def main() -> Result[None, Error]:
+    shared_and_guard_demo()
+
+    # Semaphore and notify cover basic async coordination surfaces.
+    semaphore: Semaphore = Semaphore(1)
+    permit = await semaphore.acquire()
+
+    notify: Notify = Notify()
+    notify.notify_one()
+    await notify.notified()
+    notify.notify_all()
+
+    # Channel factories pair a clonable sender with a single receiver.
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+    cloned_sender: ChannelSender[int] = sender.clone()
+    sent: Result[None, ClosedError] = await cloned_sender.send(7)
+    received: Result[int, ClosedError] = await receiver.receive()
+    assert str(sent) == "Ok(())"
+    assert str(received) == "Ok(7)"
+
+    # Bounded channels apply backpressure until another task drains capacity.
+    bounded: tuple[ChannelSender[int], ChannelReceiver[int]] = bounded_channel(1)
+    bounded_sender, bounded_receiver = bounded
+    async with task.scope() as scope:
+        first_send: Result[None, ClosedError] = await bounded_sender.send(1)
+        drain = scope.spawn(drain_two(bounded_receiver))
+        second_send: Result[None, ClosedError] = await bounded_sender.send(2)
+        drained = await drain
+        assert str(first_send) == "Ok(())"
+        assert str(second_send) == "Ok(())"
+        assert str(drained) == "Ok(2)"
+
+    # Closing a sender rejects later sends but still allows queued values to drain.
+    closing: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    closing_sender, closing_receiver = closing
+    queued: Result[None, ClosedError] = await closing_sender.send(30)
+    closing_sender.close()
+    drained_value: Result[int, ClosedError] = await closing_receiver.receive()
+    rejected: Result[None, ClosedError] = await closing_sender.send(40)
+    assert str(queued) == "Ok(())"
+    assert str(drained_value) == "Ok(30)"
+    assert str(rejected) == "Err(ClosedError)"
+
+    # Cancelling a pending receive leaves later messages available in order.
+    cancel_case: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    cancel_sender, cancel_receiver = cancel_case
+    cancelled: bool = False
+    try:
+        async with task.timeout(0.0):
+            pending: Result[int, ClosedError] = await cancel_receiver.receive()
+    except TimeoutError:
+        cancelled = True
+    cancel_first: Result[None, ClosedError] = await cancel_sender.send(50)
+    cancel_second: Result[None, ClosedError] = await cancel_sender.send(60)
+    cancel_received_first: Result[int, ClosedError] = await cancel_receiver.receive()
+    cancel_received_second: Result[int, ClosedError] = await cancel_receiver.receive()
+    assert cancelled
+    assert str(cancel_first) == "Ok(())"
+    assert str(cancel_second) == "Ok(())"
+    assert str(cancel_received_first) == "Ok(50)"
+    assert str(cancel_received_second) == "Ok(60)"
+
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -696,6 +696,7 @@ status: in_progress
 - PR [#2001](https://github.com/sifr-lang/sifr/pull/2001) bounded channel backpressure validation slice: `channel_backpressure.sifr` validates bounded channel send/receive coordination across a task boundary.
 - PR [#2003](https://github.com/sifr-lang/sifr/pull/2003) channel pending receive cancellation validation slice: `channel_cancel_pending_receive.sifr` validates that timing out a pending same-task receive leaves the receiver usable and does not poison later channel delivery.
 - PR [#2005](https://github.com/sifr-lang/sifr/pull/2005) channel cancelled receive no-loss validation slice: `channel_cancel_receive_no_loss.sifr` validates that a cancelled pending receive does not consume or reorder later messages.
+- Current slice: add `demos/m32_sync_channel_demo.sifr` to showcase the milestone_async_5 shared-state, guard, semaphore, notify, channel, backpressure, close/drain, and cancellation surfaces together.
 
 ---
 


### PR DESCRIPTION
## Summary
- add demos/m32_sync_channel_demo.sifr covering shared state, lock/rwlock guards, semaphore, notify, channel factories, sender clones, bounded backpressure, close/drain, and cancellation no-loss
- add the current-slice note to the Phase 32 tracker

## Validation
- cargo run -q -p sifr -- run demos/m32_sync_channel_demo.sifr
- cargo fmt --check
- git diff --check
- scripts/run_all_tests.sh --profile quick (43 pass fixtures, wall_time=115.18s)

## Review
- Opus review: reviews/phase32_sync_channel_demo.md
- REVIEW_STATUS: SATISFIED