### PR TITLE
Validate structured cancellation cleanup

### DIFF
--- a/crates/sifr/tests/e2e/pass/cancellation_cleanup_runs.sifr
+++ b/crates/sifr/tests/e2e/pass/cancellation_cleanup_runs.sifr
@@ -1,0 +1,35 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_cancellation_cleanup_runs_" + str(getpid()) + ".txt"
+
+
+async def main() -> Result[None, Error]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    try:
+        async with task.timeout(0.0):
+            try:
+                await task.sleep(10.0)
+            finally:
+                try:
+                    _written: None = write_text(path, "cleanup")
+                except IOError as e:
+                    _write_message: str = str(e.message)
+    except TimeoutError:
+        _timed_out: bool = True
+
+    assert exists(path)
+
+    try:
+        _removed: None = remove_file(path)
+    except IOError as e:
+        _remove_message: str = str(e.message)
+    return None

--- a/crates/sifr/tests/e2e/pass/task_gather_cleanup_error_secondary.sifr
+++ b/crates/sifr/tests/e2e/pass/task_gather_cleanup_error_secondary.sifr
@@ -1,0 +1,17 @@
+async def fail_first() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("first")
+
+
+async def fail_second() -> Result[int, ValueError]:
+    await task.sleep(0.0)
+    raise ValueError("second")
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        result = await task.gather([scope.spawn(fail_first()), scope.spawn(fail_second())])
+        summary: str = str(result)
+        assert summary.find("Err(") is not None
+        assert summary.find("sibling task failed") is not None
+    return None

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -232,6 +232,10 @@ fn collect_stmt_error_refs(
                     collect_stmt_error_refs(&handler.body, referenced, builtin_error_classes);
                 }
             }
+            HirStmt::TryFinally { body, finalbody } => {
+                collect_stmt_error_refs(body, referenced, builtin_error_classes);
+                collect_stmt_error_refs(finalbody, referenced, builtin_error_classes);
+            }
             HirStmt::SubscriptAssign { index, value, .. }
             | HirStmt::SubscriptAugAssign { index, value, .. }
             | HirStmt::AttributeSubscriptAssign { index, value, .. } => {

--- a/crates/sifr_codegen/src/hir_analysis/traversal.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal.rs
@@ -495,6 +495,20 @@ where
                 }
             }
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            if matches!(
+                walk_stmts_until(body, config, on_stmt, on_expr),
+                TraversalControl::Stop
+            ) {
+                return TraversalControl::Stop;
+            }
+            if matches!(
+                walk_stmts_until(finalbody, config, on_stmt, on_expr),
+                TraversalControl::Stop
+            ) {
+                return TraversalControl::Stop;
+            }
+        }
         HirStmt::SubscriptAssign { index, value, .. }
         | HirStmt::SubscriptAugAssign { index, value, .. }
         | HirStmt::AttributeSubscriptAssign { index, value, .. } => {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -4159,6 +4159,33 @@ fn test_try_except_with_async_body_lowers_to_async_try_closure() {
 }
 
 #[test]
+fn test_try_finally_runs_cleanup_before_timeout_propagates() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "async def main() -> Result[None, Error]:\n    try:\n        async with task.timeout(0.0):\n            try:\n                await task.sleep(10.0)\n            finally:\n                marker: int = 1\n    except TimeoutError:\n        return None\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    let cleanup_pos = result
+        .rust_source
+        .find("let marker: i64 = 1 as i64;")
+        .expect("cleanup marker should be emitted");
+    let rethrow_pos = result
+        .rust_source
+        .find("if let Err(__sifr_finally_err) = __sifr_try_finally_res")
+        .expect("try/finally should rethrow after cleanup");
+
+    assert!(result.rust_source.contains("let __sifr_try_finally_res"));
+    assert!(cleanup_pos < rethrow_pos);
+}
+
+#[test]
 fn test_async_generated_errors_convert_to_error_return_type() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -49,7 +49,8 @@ pub(crate) fn is_simple_stmt_candidate(stmt: &HirStmt) -> bool {
         | HirStmt::AsyncWith { .. }
         | HirStmt::Match { .. }
         | HirStmt::NestedFunction { .. }
-        | HirStmt::TryExcept { .. } => true,
+        | HirStmt::TryExcept { .. }
+        | HirStmt::TryFinally { .. } => true,
     }
 }
 
@@ -363,6 +364,10 @@ fn validate_stmt_lowering_shape(stmt: &HirStmt) -> Result<(), CodegenError> {
                 validate_stmt_block_lowering_shape(&handler.body)?;
             }
             Ok(())
+        }
+        HirStmt::TryFinally { body, finalbody } => {
+            validate_stmt_block_lowering_shape(body)?;
+            validate_stmt_block_lowering_shape(finalbody)
         }
         HirStmt::Pass | HirStmt::Continue | HirStmt::Break | HirStmt::Return { value: None } => {
             Ok(())
@@ -860,6 +865,7 @@ pub(crate) fn try_lower_simple_stmt_with_ctx_and_bindings(
         HirStmt::TryExcept { body, handlers, .. } => {
             try_lower_simple_try_except_stmt(body, handlers, in_loop_with_else, bindings, ctx)
         }
+        HirStmt::TryFinally { .. } => None,
         HirStmt::Pass => Some(vec![]),
         HirStmt::Continue => Some(vec![RustStmt::Continue]),
         HirStmt::Break => {
@@ -1463,6 +1469,7 @@ fn stmt_has_result_flow(stmt: &HirStmt) -> bool {
         | HirStmt::Break
         | HirStmt::Continue
         | HirStmt::TryExcept { .. }
+        | HirStmt::TryFinally { .. }
         | HirStmt::With { .. }
         | HirStmt::AsyncWith { .. }
         | HirStmt::Match { .. }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -6467,6 +6467,13 @@ impl RustEmitter {
                     return Ok(None);
                 };
                 (lowered_try_except, true)
+            } else if let HirStmt::TryFinally { body, finalbody } = stmt {
+                let Some(lowered_try_finally) =
+                    self.try_lower_try_finally_stmt_for_ir(body, finalbody)?
+                else {
+                    return Ok(None);
+                };
+                (lowered_try_finally, true)
             } else {
                 return Ok(None);
             };
@@ -8802,6 +8809,172 @@ impl RustEmitter {
                 pattern: "Err(__sifr_try_err)".to_string(),
                 expr: RustExpr::Ident("__sifr_try_res".to_string()),
                 then_body: handler_chain,
+                else_body: None,
+            });
+        }
+        Ok(Some(lowered))
+    }
+
+    fn current_result_error_type_name_for_ir(&self) -> String {
+        self.try_closure_error_type
+            .last()
+            .cloned()
+            .or_else(|| {
+                let Type::Result(_, err_ty) = self.current_return_type.as_ref()? else {
+                    return None;
+                };
+                Some(crate::render_type(&crate::sifr_type_to_rust_type(err_ty)))
+            })
+            .unwrap_or_else(|| "Error".to_string())
+    }
+
+    fn try_lower_try_finally_stmt_for_ir(
+        &mut self,
+        body: &[HirStmt],
+        finalbody: &[HirStmt],
+    ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
+        let err_ty = self.current_result_error_type_name_for_ir();
+        let capture_returns =
+            queries::body_contains_return(body) && self.current_return_type.is_some();
+        let direct_return_capture =
+            capture_returns && queries::block_control_flow_effect(body).always_exits();
+        let ok_ty = if capture_returns {
+            if let Some(return_ty) = self.current_return_type.as_ref() {
+                if direct_return_capture {
+                    crate::render_type(&crate::sifr_type_to_rust_type(return_ty))
+                } else {
+                    format!(
+                        "Option<{}>",
+                        crate::render_type(&crate::sifr_type_to_rust_type(return_ty))
+                    )
+                }
+            } else {
+                "()".to_string()
+            }
+        } else {
+            "()".to_string()
+        };
+
+        let mut closure_body = {
+            if capture_returns {
+                self.try_closure_depth += 1;
+                self.try_closure_option_wrap.push(!direct_return_capture);
+            }
+            self.try_closure_error_type.push(err_ty.clone());
+            let lowered = self.try_lower_stmt_block_for_ir(body)?;
+            if capture_returns {
+                self.try_closure_depth -= 1;
+                self.try_closure_option_wrap.pop();
+            }
+            self.try_closure_error_type.pop();
+            let Some(lowered) = lowered else {
+                return Ok(None);
+            };
+            lowered
+        };
+
+        if !capture_returns {
+            closure_body.push(RustStmt::Return(Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Ident("Ok".to_string())),
+                args: vec![RustExpr::Literal(crate::RustLiteral::Unit)],
+            })));
+        } else if direct_return_capture {
+            closure_body.push(RustStmt::Expr(RustExpr::FormatMacro {
+                name: "unreachable".to_string(),
+                format_str: "sifr try/finally return capture fell through".to_string(),
+                args: vec![],
+            }));
+        } else {
+            closure_body.push(RustStmt::Return(Some(RustExpr::FnCall {
+                func: Box::new(RustExpr::Ident("Ok".to_string())),
+                args: vec![RustExpr::Literal(crate::RustLiteral::None)],
+            })));
+        }
+
+        let closure_is_async = Self::rust_stmts_contain_await(&closure_body);
+        let try_call = RustExpr::FnCall {
+            func: Box::new(RustExpr::Paren(Box::new(RustExpr::ClosureBlock {
+                params: vec![],
+                body: closure_body,
+                is_move: false,
+                is_async: closure_is_async,
+            }))),
+            args: vec![],
+        };
+        let try_value = if closure_is_async {
+            RustExpr::Await(Box::new(try_call))
+        } else {
+            try_call
+        };
+
+        let mut lowered = vec![RustStmt::Let {
+            mutable: false,
+            name: "__sifr_try_finally_res".to_string(),
+            ty: Some(crate::RustType::Result(
+                Box::new(crate::RustType::Named(ok_ty.clone())),
+                Box::new(crate::RustType::Named(err_ty)),
+            )),
+            value: try_value,
+        }];
+
+        let saved_timeout_durations = std::mem::take(&mut self.active_timeout_durations);
+        let finalbody_result = self.try_lower_stmt_block_for_ir(finalbody);
+        self.active_timeout_durations = saved_timeout_durations;
+        let Some(finalbody_lowered) = finalbody_result? else {
+            return Ok(None);
+        };
+        lowered.extend(finalbody_lowered);
+
+        if capture_returns {
+            let mut arms = vec![crate::RustMatchArm {
+                pattern: if direct_return_capture {
+                    "Ok(__sifr_ret_val)".to_string()
+                } else {
+                    "Ok(Some(__sifr_ret_val))".to_string()
+                },
+                bindings: vec!["__sifr_ret_val".to_string()],
+                guard: None,
+                body: vec![RustStmt::Return(Some(RustExpr::Ident(
+                    "__sifr_ret_val".to_string(),
+                )))],
+            }];
+            if !direct_return_capture {
+                arms.push(crate::RustMatchArm {
+                    pattern: "Ok(None)".to_string(),
+                    bindings: vec![],
+                    guard: None,
+                    body: vec![],
+                });
+            }
+            arms.push(crate::RustMatchArm {
+                pattern: "Err(__sifr_finally_err)".to_string(),
+                bindings: vec!["__sifr_finally_err".to_string()],
+                guard: None,
+                body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Ident("Err".to_string())),
+                    args: vec![RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
+                        method: "into".to_string(),
+                        args: vec![],
+                    }],
+                }))],
+            });
+            lowered.push(RustStmt::Match {
+                expr: RustExpr::Ident("__sifr_try_finally_res".to_string()),
+                arms,
+            });
+        } else {
+            lowered.push(RustStmt::IfLet {
+                pattern: "Err(__sifr_finally_err)".to_string(),
+                expr: RustExpr::Ident("__sifr_try_finally_res".to_string()),
+                then_body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Ident("Err".to_string())),
+                    args: vec![RustExpr::MethodCall {
+                        receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
+                        method: "into".to_string(),
+                        args: vec![],
+                    }],
+                }))],
                 else_body: None,
             });
         }

--- a/crates/sifr_hir/src/cfg.rs
+++ b/crates/sifr_hir/src/cfg.rs
@@ -469,6 +469,16 @@ impl CfgBuilder {
                 }
                 block
             }
+            HirStmt::TryFinally { body, finalbody } => {
+                let block = self.new_block(
+                    CfgBlockLabel::Statement("try_finally"),
+                    top_level_stmt_index,
+                );
+                let final_entry = self.build_stmt_list(finalbody, next, loop_targets, false);
+                let body_entry = self.build_stmt_list(body, final_entry, loop_targets, false);
+                self.set_terminator(block, CfgTerminator::Goto(body_entry));
+                block
+            }
             HirStmt::With { body, .. } => {
                 let body_entry = self.build_stmt_list(body, next, loop_targets, false);
                 let block = self.new_block(CfgBlockLabel::Statement("with"), top_level_stmt_index);
@@ -516,6 +526,7 @@ fn stmt_label(stmt: &HirStmt) -> &'static str {
         HirStmt::Assert { .. } => "assert",
         HirStmt::Raise { .. } => "raise",
         HirStmt::TryExcept { .. } => "try_except",
+        HirStmt::TryFinally { .. } => "try_finally",
         HirStmt::FieldAssign { .. } => "field_assign",
         HirStmt::NestedFieldAssign { .. } => "nested_field_assign",
         HirStmt::SubscriptAssign { .. } => "subscript_assign",

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -195,6 +195,11 @@ pub enum HirStmt {
         /// Error types that can arise from the try body (collected during lowering)
         body_error_types: Vec<String>,
     },
+    /// Try/finally: finalbody runs before normal completion, return, or error propagation.
+    TryFinally {
+        body: Vec<HirStmt>,
+        finalbody: Vec<HirStmt>,
+    },
     /// Field assignment: self.field = value (inside methods)
     FieldAssign {
         object: String,

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -391,6 +391,9 @@ fn stmt_contains_await(stmt: &HirStmt) -> bool {
                     .iter()
                     .any(|handler| handler.body.iter().any(stmt_contains_await))
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            body.iter().any(stmt_contains_await) || finalbody.iter().any(stmt_contains_await)
+        }
         HirStmt::Match { subject, arms, .. } => {
             expr_contains_await(subject)
                 || arms.iter().any(|arm| {
@@ -468,6 +471,10 @@ fn stmt_contains_task_spawn(stmt: &HirStmt) -> bool {
                     .iter()
                     .any(|handler| handler.body.iter().any(stmt_contains_task_spawn))
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            body.iter().any(stmt_contains_task_spawn)
+                || finalbody.iter().any(stmt_contains_task_spawn)
+        }
         HirStmt::Match { subject, arms, .. } => {
             expr_contains_task_spawn(subject)
                 || arms.iter().any(|arm| {
@@ -515,6 +522,10 @@ fn stmt_contains_scope_early_exit(stmt: &HirStmt) -> bool {
                 || handlers
                     .iter()
                     .any(|handler| handler.body.iter().any(stmt_contains_scope_early_exit))
+        }
+        HirStmt::TryFinally { body, finalbody } => {
+            body.iter().any(stmt_contains_scope_early_exit)
+                || finalbody.iter().any(stmt_contains_scope_early_exit)
         }
         HirStmt::Match { arms, .. } => arms
             .iter()

--- a/crates/sifr_hir/src/lower/classes.rs
+++ b/crates/sifr_hir/src/lower/classes.rs
@@ -1235,6 +1235,9 @@ pub(super) fn body_contains_field_assign(stmts: &[HirStmt]) -> bool {
                         .iter()
                         .any(|handler| body_contains_field_assign(&handler.body))
             }
+            HirStmt::TryFinally { body, finalbody } => {
+                body_contains_field_assign(body) || body_contains_field_assign(finalbody)
+            }
             HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => {
                 body_contains_field_assign(body)
             }

--- a/crates/sifr_hir/src/lower/container_literal_specialization.rs
+++ b/crates/sifr_hir/src/lower/container_literal_specialization.rs
@@ -302,6 +302,10 @@ fn patch_stmt_container_specialization(stmt: &mut HirStmt, pending: &mut HashMap
                 apply_container_specialization_patches(&mut handler.body, pending);
             }
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            apply_container_specialization_patches(body, pending);
+            apply_container_specialization_patches(finalbody, pending);
+        }
         HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => {
             apply_container_specialization_patches(body, pending);
         }

--- a/crates/sifr_hir/src/lower/for_loop_safety.rs
+++ b/crates/sifr_hir/src/lower/for_loop_safety.rs
@@ -66,6 +66,10 @@ fn stmt_mutates_iter_source(stmt: &HirStmt, source_name: &str) -> bool {
                     .iter()
                     .any(|handler| loop_body_mutates_iter_source(&handler.body, source_name))
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            loop_body_mutates_iter_source(body, source_name)
+                || loop_body_mutates_iter_source(finalbody, source_name)
+        }
         HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => {
             loop_body_mutates_iter_source(body, source_name)
         }

--- a/crates/sifr_hir/src/lower/function_flow.rs
+++ b/crates/sifr_hir/src/lower/function_flow.rs
@@ -45,6 +45,10 @@ pub(super) fn collect_yield_types(stmts: &[HirStmt]) -> Vec<Type> {
                         walk(&handler.body, out);
                     }
                 }
+                HirStmt::TryFinally { body, finalbody } => {
+                    walk(body, out);
+                    walk(finalbody, out);
+                }
                 HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => walk(body, out),
                 HirStmt::Match { arms, .. } => {
                     for arm in arms {

--- a/crates/sifr_hir/src/lower/nonlocal_support.rs
+++ b/crates/sifr_hir/src/lower/nonlocal_support.rs
@@ -206,6 +206,10 @@ fn hir_stmt_calls_function(stmt: &HirStmt, func_name: &str) -> bool {
                     .iter()
                     .any(|handler| hir_body_calls_function(&handler.body, func_name))
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            hir_body_calls_function(body, func_name)
+                || hir_body_calls_function(finalbody, func_name)
+        }
         HirStmt::Break | HirStmt::Continue | HirStmt::Pass | HirStmt::NestedFunction { .. } => {
             false
         }

--- a/crates/sifr_hir/src/lower/numeric_sentinels.rs
+++ b/crates/sifr_hir/src/lower/numeric_sentinels.rs
@@ -261,6 +261,10 @@ fn patch_stmt_numeric_sentinels(
                 apply_numeric_sentinel_patches(&mut handler.body, pending);
             }
         }
+        HirStmt::TryFinally { body, finalbody } => {
+            apply_numeric_sentinel_patches(body, pending);
+            apply_numeric_sentinel_patches(finalbody, pending);
+        }
         HirStmt::With { body, .. } | HirStmt::AsyncWith { body, .. } => {
             apply_numeric_sentinel_patches(body, pending);
         }

--- a/crates/sifr_hir/src/lower/statement_diagnostics_tests.rs
+++ b/crates/sifr_hir/src/lower/statement_diagnostics_tests.rs
@@ -157,7 +157,7 @@ def main():
 }
 
 #[test]
-fn try_finally_without_except_lowers_body_then_finalbody() {
+fn try_finally_without_except_preserves_cleanup_boundary() {
     let source = "\
 def main():
     value: int = 1
@@ -170,20 +170,21 @@ def main():
     let module = lower_module(parsed.suite()).expect("lowering should succeed");
     let body = &module.module.functions[0].body;
 
-    assert_eq!(body.len(), 3);
+    assert_eq!(body.len(), 2);
     assert!(matches!(body[0], HirStmt::Let { .. }));
+    let HirStmt::TryFinally {
+        body: try_body,
+        finalbody,
+    } = &body[1]
+    else {
+        panic!("expected try/finally HIR node");
+    };
     assert!(matches!(
-        body[1],
-        HirStmt::Assign {
-            ref name,
-            ..
-        } if name == "value"
+        try_body.as_slice(),
+        [HirStmt::Assign { name, .. }] if name == "value"
     ));
     assert!(matches!(
-        body[2],
-        HirStmt::Assign {
-            ref name,
-            ..
-        } if name == "value"
+        finalbody.as_slice(),
+        [HirStmt::Assign { name, .. }] if name == "value"
     ));
 }

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -158,18 +158,18 @@ pub(super) fn lower_stmts(
         }
         if let Stmt::Try(try_stmt) = stmt {
             if !try_stmt.finalbody.is_empty() {
-                if try_stmt.handlers.is_empty() {
-                    let body = lower_stmts(&try_stmt.body, func_type, ctx);
-                    result.extend(body);
-                    if !try_stmt.orelse.is_empty() {
-                        let orelse = lower_stmts(&try_stmt.orelse, func_type, ctx);
-                        result.extend(orelse);
-                    }
-                } else if let Some(hir_stmt) = lower_stmt(stmt, func_type, ctx) {
-                    result.push(hir_stmt);
+                let has_handlers = !try_stmt.handlers.is_empty();
+                let mut body = if has_handlers {
+                    lower_stmt(stmt, func_type, ctx).into_iter().collect()
+                } else {
+                    lower_stmts(&try_stmt.body, func_type, ctx)
+                };
+                if !has_handlers && !try_stmt.orelse.is_empty() {
+                    let orelse = lower_stmts(&try_stmt.orelse, func_type, ctx);
+                    body.extend(orelse);
                 }
                 let finalbody = lower_stmts(&try_stmt.finalbody, func_type, ctx);
-                result.extend(finalbody);
+                result.push(HirStmt::TryFinally { body, finalbody });
                 apply_numeric_sentinel_patches(
                     &mut result,
                     &mut ctx.pending_numeric_sentinel_patches,

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -526,6 +526,7 @@ status: in_progress
 - PR [#1951](https://github.com/sifr-lang/sifr/pull/1951) gather secondary-evidence slice: `task.gather([...])` now drains remaining child observations after fail-fast cancellation and records later sibling failures or cancellations as `SecondaryError` evidence on the selected primary `Failure`.
 - PR [#1953](https://github.com/sifr-lang/sifr/pull/1953) race secondary-evidence slice: `task.race([...])` now drains losing child observations after cancelling losers and attaches loser failure or cancellation evidence to a failure-like winning result.
 - PR [#1955](https://github.com/sifr-lang/sifr/pull/1955) select secondary-evidence slice: `task.select(a, b)` now awaits the losing child after cancellation, attaches loser failure or cancellation evidence to a failure-like selected result, and leaves explicit failure-like loser results visible to scope exit when the selected result is successful.
+- Current slice: add the remaining milestone_async_3 validation fixtures for gather secondary evidence and cancellation cleanup execution before closing the structured concurrency milestone.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -25,6 +25,8 @@
     "spawn_owned_move_value",
     "spawn_capture_immutable_shared_ok",
     "await_without_live_borrow",
+    "task_gather_cleanup_error_secondary",
+    "cancellation_cleanup_runs",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- preserve try/finally as a HIR cleanup boundary so timeout cancellation runs finalbody before propagating TimeoutError
- add missing milestone_async_3 fixtures for gather secondary evidence and cancellation cleanup execution
- include the new fixtures in the quick validation manifest and record the current Phase 32 slice

## Validation
- cargo check -p sifr_hir -p sifr_codegen
- cargo fmt --check
- git diff --check
- cargo test -p sifr_hir try_finally_without_except_preserves_cleanup_boundary
- cargo test -p sifr_codegen test_try_finally_runs_cleanup_before_timeout_propagates
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/task_gather_cleanup_error_secondary.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/cancellation_cleanup_runs.sifr
- scripts/run_all_tests.sh --profile quick (45 pass fixtures, wall_time=115.94s)

## Review
- Opus: REVIEW_STATUS: SATISFIED (reviews/phase32_structured_missing_validations.md)