### PR TITLE
Implement basic task spawn_blocking

### DIFF
--- a/crates/sifr/tests/e2e/fail/spawn_blocking_non_send_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/spawn_blocking_non_send_rejected.sifr
@@ -1,0 +1,13 @@
+# expect-error: SIFR-TYPE-0002
+class LocalCell(NonSend):
+    pass
+
+
+def build_cell() -> LocalCell:
+    return LocalCell()
+
+
+async def main() -> Result[None, ScopeFailure]:
+    handle = task.spawn_blocking(build_cell)
+    result = await handle
+    return None

--- a/crates/sifr/tests/e2e/pass/spawn_blocking_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/spawn_blocking_basic.sifr
@@ -1,0 +1,8 @@
+def compute_value() -> int:
+    return 42
+
+
+async def main() -> Result[None, ScopeFailure]:
+    handle = task.spawn_blocking(compute_value)
+    result = await handle
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1360,7 +1360,7 @@ fn module_uses_task_scope(module: &HirModule) -> bool {
         )
     }
     fn expr_uses_task_scope_runtime(expr: &HirExpr) -> bool {
-        matches!(expr, HirExpr::Call { func, .. } if func == "__sifr_task_gather" || func == "__sifr_task_race" || func == "__sifr_task_select")
+        matches!(expr, HirExpr::Call { func, .. } if func == "__sifr_task_gather" || func == "__sifr_task_race" || func == "__sifr_task_select" || func == "__sifr_spawn_blocking_infallible" || func == "__sifr_spawn_blocking_result")
     }
 
     for func in &module.functions {

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -3706,6 +3706,35 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
 }
 
 #[test]
+fn test_spawn_blocking_lowers_to_distinct_blocking_task_substrate() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                "def compute_value() -> int:\n    return 42\n\nasync def main() -> Result[None, ScopeFailure]:\n    handle = task.spawn_blocking(compute_value)\n    result = await handle\n    return None\n",
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(result
+        .rust_source
+        .contains("struct __SifrBlockingTask<T, E>"));
+    assert!(result
+        .rust_source
+        .contains("fn __sifr_spawn_blocking_infallible<"));
+    assert!(result
+        .rust_source
+        .contains("tokio::task::spawn_blocking(move || __SifrTaskResult::Ok(work()))"));
+    assert!(result
+        .rust_source
+        .contains("__sifr_spawn_blocking_infallible(compute_value);"));
+    assert!(result.required_crates.contains("tokio"));
+}
+
+#[test]
 fn test_scope_spawn_lowers_owned_coroutine_arguments() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -404,7 +404,10 @@ pub fn try_lower_leaf_expr(expr: &HirExpr) -> Option<RustExpr> {
             } = value.as_ref()
             {
                 try_lower_simple_method_call_expr(object, method, args)?
-            } else if matches!(resolve_alias_type(value.ty()), Type::Task(_, _)) {
+            } else if matches!(
+                resolve_alias_type(value.ty()),
+                Type::Task(_, _) | Type::BlockingTask(_, _)
+            ) {
                 RustExpr::MethodCall {
                     receiver: Box::new(try_lower_leaf_or_name_expr(value)?),
                     method: "join".to_string(),
@@ -554,6 +557,15 @@ fn try_lower_simple_call_expr(func: &str, args: &[HirExpr]) -> Option<RustExpr> 
                 try_lower_leaf_or_name_expr(first)?,
                 try_lower_leaf_or_name_expr(second)?,
             ],
+        });
+    }
+    if func == "__sifr_spawn_blocking_infallible" || func == "__sifr_spawn_blocking_result" {
+        let [worker] = args else {
+            return None;
+        };
+        return Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Ident(func.to_string())),
+            args: vec![try_lower_leaf_or_name_expr(worker)?],
         });
     }
     if func == "hash" {
@@ -1020,7 +1032,12 @@ fn try_lower_simple_method_call_expr(
             args: lowered_args,
         });
     }
-    if method == "join" && matches!(resolve_alias_type(object.ty()), Type::Task(_, _)) {
+    if (method == "join" || method == "cancel_and_join")
+        && matches!(
+            resolve_alias_type(object.ty()),
+            Type::Task(_, _) | Type::BlockingTask(_, _)
+        )
+    {
         let lowered_object = try_lower_leaf_or_name_expr(object)?;
         return Some(RustExpr::MethodCall {
             receiver: Box::new(lowered_object),
@@ -1028,7 +1045,12 @@ fn try_lower_simple_method_call_expr(
             args: vec![],
         });
     }
-    if method == "cancel" && matches!(resolve_alias_type(object.ty()), Type::Task(_, _)) {
+    if method == "cancel"
+        && matches!(
+            resolve_alias_type(object.ty()),
+            Type::Task(_, _) | Type::BlockingTask(_, _)
+        )
+    {
         let lowered_object = try_lower_leaf_or_name_expr(object)?;
         return Some(RustExpr::MethodCall {
             receiver: Box::new(lowered_object),

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -28,6 +28,13 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
                 task_error_type_to_rust_type(err),
             ],
         },
+        Type::BlockingTask(ok, err) => RustType::Generic {
+            base: "__SifrBlockingTask".to_string(),
+            params: vec![
+                sifr_type_to_rust_type(ok),
+                task_error_type_to_rust_type(err),
+            ],
+        },
         Type::TaskResult(ok, err) => RustType::Generic {
             base: "__SifrTaskResult".to_string(),
             params: vec![
@@ -369,6 +376,29 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
             ],
         },
         RustItem::Struct {
+            name: "__SifrBlockingTask<T, E>".to_string(),
+            visibility: Visibility::Private,
+            derives: vec![],
+            fields: vec![
+                (
+                    "handle".to_string(),
+                    RustType::Option(Box::new(RustType::Named(
+                        "tokio::task::JoinHandle<__SifrTaskResult<T, E>>".to_string(),
+                    ))),
+                ),
+                (
+                    "observed".to_string(),
+                    RustType::Named(
+                        "std::sync::Arc<std::sync::atomic::AtomicBool>".to_string(),
+                    ),
+                ),
+                (
+                    "_error".to_string(),
+                    RustType::Named("std::marker::PhantomData<E>".to_string()),
+                ),
+            ],
+        },
+        RustItem::Struct {
             name: "__SifrScopeChild".to_string(),
             visibility: Visibility::Private,
             derives: vec![],
@@ -564,6 +594,17 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     is_async: false,
                 },
                 RustItem::Fn {
+                    name: "cancel_and_join".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfValue],
+                    ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        abort_handle.abort();\n        if let Some(receiver) = receiver {\n            let _ = receiver.await;\n        }\n        return __SifrTaskResult::cancelled()".to_string(),
+                    ))],
+                    is_async: true,
+                },
+                RustItem::Fn {
                     name: "__sifr_timeout".to_string(),
                     visibility: Visibility::Private,
                     type_params: vec![],
@@ -579,6 +620,56 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     )),
                     body: vec![RustStmt::Expr(RustExpr::Ident(
                         "let __SifrTask { receiver, abort_handle, observed, _error } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(mut receiver) = receiver {\n            return tokio::select! {\n                biased;\n                result = &mut receiver => {\n                    match result {\n                        Ok(__SifrTaskResult::Ok(value)) => __SifrTaskResult::Ok(value),\n                        Ok(__SifrTaskResult::Err(failure)) => __SifrTaskResult::Err(failure.map_primary(__SifrTimeoutResult::Inner)),\n                        Ok(__SifrTaskResult::Cancelled(failure)) => __SifrTaskResult::Cancelled(failure),\n                        Err(_) => __SifrTaskResult::cancelled(),\n                    }\n                },\n                _ = tokio::time::sleep(duration) => {\n                    abort_handle.abort();\n                    let _ = receiver.await;\n                    __SifrTaskResult::Err(__SifrFailure::new(__SifrTimeoutResult::Timeout))\n                }\n            };\n        }\n        return __SifrTaskResult::cancelled()".to_string(),
+                    ))],
+                    is_async: true,
+                },
+            ],
+        },
+        RustItem::Impl {
+            target: "__SifrBlockingTask<T, E>".to_string(),
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec![],
+                },
+                crate::RustTypeParam {
+                    name: "E".to_string(),
+                    bounds: vec![],
+                },
+            ],
+            trait_: None,
+            items: vec![
+                RustItem::Fn {
+                    name: "join".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfValue],
+                    ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "let __SifrBlockingTask { handle, observed, .. } = self;\n        observed.store(true, std::sync::atomic::Ordering::SeqCst);\n        if let Some(handle) = handle {\n            return match handle.await {\n                Ok(result) => result,\n                Err(_) => __SifrTaskResult::cancelled(),\n            };\n        }\n        return __SifrTaskResult::cancelled()".to_string(),
+                    ))],
+                    is_async: true,
+                },
+                RustItem::Fn {
+                    name: "cancel".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfParam { mutable: false }],
+                    ret: Some(RustType::Unit),
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "if let Some(handle) = &self.handle {\n            handle.abort();\n        }"
+                            .to_string(),
+                    ))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "cancel_and_join".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfValue],
+                    ret: Some(RustType::Named("__SifrTaskResult<T, E>".to_string())),
+                    body: vec![RustStmt::Expr(RustExpr::Ident(
+                        "if let Some(handle) = &self.handle {\n            handle.abort();\n        }\n        return self.join().await".to_string(),
                     ))],
                     is_async: true,
                 },
@@ -997,6 +1088,66 @@ pub fn build_task_scope_items() -> Vec<RustItem> {
                     is_async: true,
                 },
             ],
+        },
+        RustItem::Fn {
+            name: "__sifr_spawn_blocking_infallible".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
+                },
+                crate::RustTypeParam {
+                    name: "F".to_string(),
+                    bounds: vec![
+                        "FnOnce() -> T".to_string(),
+                        "Send".to_string(),
+                        "'static".to_string(),
+                    ],
+                },
+            ],
+            params: vec![RustParam::Named {
+                name: "work".to_string(),
+                ty: RustType::Named("F".to_string()),
+            }],
+            ret: Some(RustType::Named(
+                "__SifrBlockingTask<T, std::convert::Infallible>".to_string(),
+            )),
+            body: vec![RustStmt::Expr(RustExpr::Ident(
+                "let observed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));\n        let handle = tokio::task::spawn_blocking(move || __SifrTaskResult::Ok(work()));\n        return __SifrBlockingTask { handle: Some(handle), observed, _error: std::marker::PhantomData }".to_string(),
+            ))],
+            is_async: false,
+        },
+        RustItem::Fn {
+            name: "__sifr_spawn_blocking_result".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![
+                crate::RustTypeParam {
+                    name: "T".to_string(),
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
+                },
+                crate::RustTypeParam {
+                    name: "E".to_string(),
+                    bounds: vec!["Send".to_string(), "'static".to_string()],
+                },
+                crate::RustTypeParam {
+                    name: "F".to_string(),
+                    bounds: vec![
+                        "FnOnce() -> Result<T, E>".to_string(),
+                        "Send".to_string(),
+                        "'static".to_string(),
+                    ],
+                },
+            ],
+            params: vec![RustParam::Named {
+                name: "work".to_string(),
+                ty: RustType::Named("F".to_string()),
+            }],
+            ret: Some(RustType::Named("__SifrBlockingTask<T, E>".to_string())),
+            body: vec![RustStmt::Expr(RustExpr::Ident(
+                "let observed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));\n        let handle = tokio::task::spawn_blocking(move || match work() { Ok(value) => __SifrTaskResult::Ok(value), Err(err) => __SifrTaskResult::Err(__SifrFailure::new(err)) });\n        return __SifrBlockingTask { handle: Some(handle), observed, _error: std::marker::PhantomData }".to_string(),
+            ))],
+            is_async: false,
         },
         RustItem::Fn {
             name: "__sifr_task_gather".to_string(),

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -274,7 +274,7 @@ impl RustEmitter {
 
         if matches!(
             crate::resolve_alias_type_for_plain_call(value.ty()),
-            Type::Task(_, _)
+            Type::Task(_, _) | Type::BlockingTask(_, _)
         ) {
             let Some(receiver) = crate::try_lower_leaf_or_name_expr_result(value)? else {
                 return Ok(None);

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1549,6 +1549,32 @@ fn test_task_handle_cancel_does_not_consume_handle_binding() {
 }
 
 #[test]
+fn test_spawn_blocking_lowers_to_blocking_task_handle() {
+    let source = "def compute_value() -> int:\n    return 42\n\nasync def main() -> Result[None, ScopeFailure]:\n    handle = task.spawn_blocking(compute_value)\n    result = await handle\n    return None\n";
+    let module = lower_source(source).expect("lowering should succeed");
+    let main = module
+        .functions
+        .iter()
+        .find(|function| function.name == "main")
+        .expect("main should exist");
+    let handle_assignment = main
+        .body
+        .iter()
+        .find(|stmt| matches!(stmt, HirStmt::Let { name, .. } if name == "handle"))
+        .expect("handle assignment should exist");
+    let HirStmt::Let { value, .. } = handle_assignment else {
+        panic!("expected handle assignment");
+    };
+    let HirExpr::Call { func, ty, .. } = value else {
+        panic!("expected spawn_blocking call");
+    };
+    assert_eq!(func, "__sifr_spawn_blocking_infallible");
+    assert!(
+        matches!(ty, Type::BlockingTask(ok, err) if matches!(ok.as_ref(), Type::Int) && matches!(err.as_ref(), Type::Never))
+    );
+}
+
+#[test]
 fn test_task_handle_cancel_after_await_rejects_moved_handle() {
     let source = concat!(
         "async def worker() -> int:\n    return 41\n\n",

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -1,6 +1,7 @@
 use super::expression_diagnostics;
 use super::expressions::lower_expr;
 use super::task_scope_calls::mark_task_handle_observed;
+use super::task_scope_calls::non_send_reason;
 use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
 use ruff_text_size::{Ranged, TextRange};
@@ -31,6 +32,7 @@ pub(super) fn lower_task_module_call(
         "gather" => lower_task_gather_call(call, ctx),
         "race" => lower_task_race_call(call, ctx),
         "select" => lower_task_select_call(call, ctx),
+        "spawn_blocking" => lower_task_spawn_blocking_call(call, ctx),
         "spawn" => {
             expression_diagnostics::type_mismatch(
                 ctx,
@@ -41,6 +43,100 @@ pub(super) fn lower_task_module_call(
         }
         _ => TaskCallLowering::NoMatch,
     }
+}
+
+fn lower_task_spawn_blocking_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "task.spawn_blocking() is only valid inside async functions".to_string(),
+            call.range(),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "task.spawn_blocking() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "task.spawn_blocking() takes exactly one sync function argument".to_string(),
+            call_arity_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+
+    let worker = lower_expr(&call.arguments.args[0], ctx);
+    let Some(worker) = worker else {
+        return TaskCallLowering::Rejected;
+    };
+    let Type::Function(ft) = worker.ty().resolve_alias() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "task.spawn_blocking() requires a sync function argument, got '{}'",
+                worker.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    };
+    if !ft.params.is_empty() {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "task.spawn_blocking() v1 requires a zero-argument function; wrap owned inputs in a dedicated helper before offloading".to_string(),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    }
+
+    let (ok_ty, err_ty, result_func) = match ft.return_type.resolve_alias() {
+        Type::Result(ok, err) => (
+            ok.as_ref().clone(),
+            err.as_ref().clone(),
+            "__sifr_spawn_blocking_result",
+        ),
+        other => (
+            other.clone(),
+            Type::Never,
+            "__sifr_spawn_blocking_infallible",
+        ),
+    };
+    if let Some(reason) = non_send_reason(&ok_ty) {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "task.spawn_blocking() cannot return non-send value type '{}': {reason}",
+                ok_ty.display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if !matches!(err_ty.resolve_alias(), Type::Never) {
+        if let Some(reason) = non_send_reason(&err_ty) {
+            expression_diagnostics::type_mismatch(
+                ctx,
+                format!(
+                    "task.spawn_blocking() cannot return non-send error type '{}': {reason}",
+                    err_ty.display_name()
+                ),
+                call.arguments.args[0].range(),
+            );
+            return TaskCallLowering::Rejected;
+        }
+    }
+
+    TaskCallLowering::Lowered(HirExpr::Call {
+        func: result_func.to_string(),
+        args: vec![worker],
+        ty: Type::BlockingTask(Box::new(ok_ty), Box::new(err_ty)),
+    })
 }
 
 fn lower_task_gather_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {

--- a/crates/sifr_hir/src/lower/task_handle_calls.rs
+++ b/crates/sifr_hir/src/lower/task_handle_calls.rs
@@ -7,7 +7,10 @@ use sifr_python_ast::ExprCall;
 use sifr_type_system::Type;
 
 pub(super) fn is_task_handle_type(ty: &Type) -> bool {
-    matches!(ty.resolve_alias(), Type::Task(_, _))
+    matches!(
+        ty.resolve_alias(),
+        Type::Task(_, _) | Type::BlockingTask(_, _)
+    )
 }
 
 pub(super) fn lower_task_handle_method_call(
@@ -16,7 +19,7 @@ pub(super) fn lower_task_handle_method_call(
     call: &ExprCall,
     ctx: &mut LowerCtx,
 ) -> Option<HirExpr> {
-    if method_name != "join" && method_name != "cancel" {
+    if method_name != "join" && method_name != "cancel" && method_name != "cancel_and_join" {
         return None;
     }
     if !call.arguments.keywords.is_empty() {
@@ -35,8 +38,9 @@ pub(super) fn lower_task_handle_method_call(
         );
         return None;
     }
-    let Type::Task(ok_ty, err_ty) = object.ty().resolve_alias() else {
-        return None;
+    let (ok_ty, err_ty) = match object.ty().resolve_alias() {
+        Type::Task(ok_ty, err_ty) | Type::BlockingTask(ok_ty, err_ty) => (ok_ty, err_ty),
+        _ => return None,
     };
     if method_name == "cancel" {
         return Some(HirExpr::MethodCall {

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -766,6 +766,7 @@ status: in_progress
 **Implementation progress:**
 
 - [#2015](https://github.com/sifr-lang/sifr/pull/2015): Added declaration-site `@io_bound` and `@cpu_bound` workload annotations with async-context diagnostics, plus quick-lane validation fixtures for annotated blocking and CPU-heavy calls.
+- Current slice: implement `task.spawn_blocking` for direct zero-argument sync functions with distinct `BlockingTask[T, E]` observation and non-send return rejection validation.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -29,6 +29,7 @@
     "cancellation_cleanup_runs",
     "io_bound_annotation_warning",
     "cpu_bound_annotation_warning",
+    "spawn_blocking_basic",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- add `task.spawn_blocking` for direct zero-argument sync function names
- lower `BlockingTask[T, E]` to a distinct `__SifrBlockingTask<T, E>` runtime substrate using Tokio `spawn_blocking`
- support blocking task observation through `await`, `join`, `cancel`, and `cancel_and_join`
- reject non-send blocking task result/error types
- add positive and negative validation fixtures plus quick-lane coverage

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo check -p sifr_hir -p sifr_codegen -p sifr_driver`
- `cargo test -p sifr_hir test_spawn_blocking_lowers_to_blocking_task_handle`
- `cargo test -p sifr_codegen test_spawn_blocking_lowers_to_distinct_blocking_task_substrate`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/spawn_blocking_basic.sifr`
- `cargo test -p sifr test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick` (48 pass fixtures, report_signature=bb590575ef45d2af, wall_time=138.72s)

## Review
- Opus review: `reviews/phase32_spawn_blocking_basic.md`
- `REVIEW_STATUS: SATISFIED`
