### PR TITLE
Track ThreadPoolExecutor async slice

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -768,7 +768,7 @@ status: in_progress
 
 - [#2015](https://github.com/sifr-lang/sifr/pull/2015): Added declaration-site `@io_bound` and `@cpu_bound` workload annotations with async-context diagnostics, plus quick-lane validation fixtures for annotated blocking and CPU-heavy calls.
 - [#2017](https://github.com/sifr-lang/sifr/pull/2017): Implemented `task.spawn_blocking` for direct zero-argument sync functions with distinct `BlockingTask[T, E]` observation and non-send return rejection validation.
-- Current slice: add `sifr.concurrent.ThreadPoolExecutor` as a thin compatibility offload surface backed by the `BlockingTask[T, E]` substrate.
+- [#2019](https://github.com/sifr-lang/sifr/pull/2019): Added `sifr.concurrent.ThreadPoolExecutor` as a thin compatibility offload surface backed by the `BlockingTask[T, E]` substrate, including submit lowering, non-send return validation, and quick-lane fixture coverage.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the Phase 32 ThreadPoolExecutor current-slice note with merged PR #2019

## Validation
- `git diff --check`
