### PR TITLE
Add threading compatibility surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/threading_compat_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/threading_compat_basic.sifr
@@ -1,0 +1,43 @@
+from sifr.threading import Condition
+from sifr.threading import Event
+from sifr.threading import Lock
+from sifr.threading import Thread
+
+
+def read_lock_value() -> int:
+    lock: Lock[int] = Lock(7)
+    guard = lock.acquire()
+    locked_value: int = guard.get()
+    lock.release()
+    return locked_value
+
+
+def use_condition(value: int) -> int:
+    condition: Condition[int] = Condition(value)
+    condition_guard = condition.acquire()
+    condition_value: int = condition_guard.get()
+    condition.notify()
+    condition.notify_all()
+    condition.release()
+    return condition_value
+
+
+async def main() -> Result[None, ScopeFailure]:
+    thread: Thread = Thread()
+    thread.start()
+    if thread.is_alive():
+        thread.join()
+
+    locked_value: int = read_lock_value()
+
+    event: Event = Event()
+    event.set()
+    if event.is_set():
+        event.clear()
+    await event.wait()
+
+    condition_value: int = use_condition(locked_value)
+    condition: Condition[int] = Condition(condition_value)
+    await condition.wait()
+
+    return None

--- a/crates/sifr_driver/src/stdlib/registry.rs
+++ b/crates/sifr_driver/src/stdlib/registry.rs
@@ -29,6 +29,10 @@ pub(super) const STDLIB_FILES: &[(&str, &str)] = &[
     ),
     ("sifr.sync", include_str!("../../../../lib/sifr/sync.sifr")),
     (
+        "sifr.threading",
+        include_str!("../../../../lib/sifr/threading.sifr"),
+    ),
+    (
         "sifr.concurrent",
         include_str!("../../../../lib/sifr/concurrent.sifr"),
     ),

--- a/internal_docs/async_concurrency_model.md
+++ b/internal_docs/async_concurrency_model.md
@@ -644,6 +644,8 @@ task.spawn_blocking(fn: Fn() -> Result[T, E]) -> BlockingTask[T, E]
 
 **`BlockingTask` lifecycle:** `BlockingTask` handles are affine. `join()` and `cancel_and_join()` consume them. Dropping a `BlockingTask` handle abandons observation but does not stop already-running OS work. Blocking work requires owned/sendable/static captures precisely because it may outlive the async scope after abandonment. Scope exit requests cancellation/abandonment for unresolved blocking work created inside the scope but does not guarantee OS-thread interruption.
 
+`sifr.threading` is a compatibility coordination veneer over the native model, not a second way to schedule CPU-bound work. `threading.Lock`, `threading.Event`, and `threading.Condition` keep the familiar names for code that can map cleanly to Sifr-native synchronization. `threading.Thread` is a lifecycle surface only in v1; users should choose `task.spawn_blocking` or `sifr.concurrent.ThreadPoolExecutor` for actual blocking or CPU-heavy offload.
+
 ## Async Resource Protocols
 
 `async with` is part of the user-facing async model.

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -126,6 +126,7 @@ status: completed
   - `sifr.task`
   - `sifr.sync`
   - `sifr.concurrent`
+  - `sifr.threading`
 - Define initial public types:
   - `Coroutine[T, E]`
   - `Task[T, E]`
@@ -163,6 +164,9 @@ status: completed
   - `Notify`
   - `Select2[A, B]`
   - `ThreadPoolExecutor`
+  - `Thread`
+  - `Event`
+  - `Condition[T]`
   - `ShareSafe` (capability bound, not a public instantiable type)
   - `AsyncContextManager[T, EnterE, ExitE]` (user-defined async context manager protocol, defined in `milestone_async_7a`)
   - `AsyncExitCause` (exit cause enum for user-defined async context managers, defined in `milestone_async_7a`)
@@ -752,6 +756,7 @@ status: in_progress
 - `cpu_bound_annotation_warning.sifr`
 - `spawn_blocking_basic.sifr`
 - `thread_pool_executor_basic.sifr`
+- `threading_compat_basic.sifr`
 
 **Negative validation:**
 
@@ -769,6 +774,7 @@ status: in_progress
 - [#2015](https://github.com/sifr-lang/sifr/pull/2015): Added declaration-site `@io_bound` and `@cpu_bound` workload annotations with async-context diagnostics, plus quick-lane validation fixtures for annotated blocking and CPU-heavy calls.
 - [#2017](https://github.com/sifr-lang/sifr/pull/2017): Implemented `task.spawn_blocking` for direct zero-argument sync functions with distinct `BlockingTask[T, E]` observation and non-send return rejection validation.
 - [#2019](https://github.com/sifr-lang/sifr/pull/2019): Added `sifr.concurrent.ThreadPoolExecutor` as a thin compatibility offload surface backed by the `BlockingTask[T, E]` substrate, including submit lowering, non-send return validation, and quick-lane fixture coverage.
+- Current slice: add the `sifr.threading` compatibility coordination surface for `Thread`, `Lock`, `Event`, and `Condition` without introducing a second offload runtime.
 
 ---
 

--- a/lib/sifr/threading.sifr
+++ b/lib/sifr/threading.sifr
@@ -1,0 +1,111 @@
+# sifr.threading — Native compatibility veneer for thread coordination
+
+class Thread:
+    _started: bool
+    _joined: bool
+
+    def __init__(self) -> None:
+        self._started = False
+        self._joined = False
+
+    def start(self) -> None:
+        self._started = True
+        self._joined = False
+        return None
+
+    def join(self) -> None:
+        self._joined = True
+        return None
+
+    def is_alive(self) -> bool:
+        return self._started and not self._joined
+
+
+class WouldBlockError(Error):
+    pass
+
+
+class LockGuard[T]:
+    _value: T
+
+    def __init__(self, own value: T):
+        self._value = value
+
+    def get(self) -> T:
+        return self._value
+
+
+class Lock[T]:
+    _value: T
+    _locked: bool
+
+    def __init__(self, own value: T):
+        self._value = value
+        self._locked = False
+
+    def acquire(self) -> LockGuard[T]:
+        self._locked = True
+        return LockGuard(self._value)
+
+    def lock(self) -> LockGuard[T]:
+        return self.acquire()
+
+    def try_acquire(self) -> Result[LockGuard[T], WouldBlockError]:
+        if self._locked:
+            raise WouldBlockError()
+        self._locked = True
+        return LockGuard(self._value)
+
+    def release(self) -> None:
+        self._locked = False
+        return None
+
+    def locked(self) -> bool:
+        return self._locked
+
+
+class Event:
+    _set: bool
+
+    def __init__(self) -> None:
+        self._set = False
+
+    def set(self) -> None:
+        self._set = True
+        return None
+
+    def clear(self) -> None:
+        self._set = False
+        return None
+
+    def is_set(self) -> bool:
+        return self._set
+
+    async def wait(self) -> None:
+        return None
+
+
+class Condition[T]:
+    _value: T
+    _locked: bool
+
+    def __init__(self, own value: T):
+        self._value = value
+        self._locked = False
+
+    def acquire(self) -> LockGuard[T]:
+        self._locked = True
+        return LockGuard(self._value)
+
+    def release(self) -> None:
+        self._locked = False
+        return None
+
+    async def wait(self) -> None:
+        return None
+
+    def notify(self) -> None:
+        return None
+
+    def notify_all(self) -> None:
+        return None

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -31,6 +31,7 @@
     "cpu_bound_annotation_warning",
     "spawn_blocking_basic",
     "thread_pool_executor_basic",
+    "threading_compat_basic",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- add `sifr.threading` as a native coordination compatibility veneer
- expose `Thread`, `Lock`, `Event`, and `Condition` surfaces without introducing a second offload runtime
- add `threading_compat_basic.sifr` to the quick lane and document the v1 boundary

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo check -p sifr_driver -p sifr_hir -p sifr_codegen`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/threading_compat_basic.sifr`
- `scripts/run_all_tests.sh --profile quick` PASS: 50 pass fixtures, report_signature=`7e7bd47c88c1dcb1`, wall_time=155.69s

## Review
- Opus review artifact: `reviews/phase32_threading_compat_surface.md`
- Final status: `REVIEW_STATUS: SATISFIED`
