### PR TITLE
Validate BlockingTask cancellation joins

### DIFF
--- a/crates/sifr/tests/e2e/pass/blocking_task_cancel_join.sifr
+++ b/crates/sifr/tests/e2e/pass/blocking_task_cancel_join.sifr
@@ -1,0 +1,28 @@
+from sifr.concurrent import ThreadPoolExecutor
+
+
+def compute_value() -> int:
+    return 41
+
+
+def compute_other() -> int:
+    return 7
+
+
+async def main() -> Result[None, ScopeFailure]:
+    joined_handle = task.spawn_blocking(compute_value)
+    joined_result = await joined_handle.join()
+
+    cancelled_handle = task.spawn_blocking(compute_value)
+    cancelled_handle.cancel()
+    cancelled_result = await cancelled_handle
+
+    cancel_join_handle = task.spawn_blocking(compute_other)
+    cancel_join_result = await cancel_join_handle.cancel_and_join()
+
+    executor: ThreadPoolExecutor = ThreadPoolExecutor()
+    executor_handle = executor.submit(compute_value)
+    executor_handle.cancel()
+    executor_result = await executor_handle.cancel_and_join()
+
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -755,6 +755,7 @@ status: in_progress
 - `io_bound_annotation_warning.sifr`
 - `cpu_bound_annotation_warning.sifr`
 - `spawn_blocking_basic.sifr`
+- `blocking_task_cancel_join.sifr`
 - `thread_pool_executor_basic.sifr`
 - `threading_compat_basic.sifr`
 
@@ -775,6 +776,7 @@ status: in_progress
 - [#2017](https://github.com/sifr-lang/sifr/pull/2017): Implemented `task.spawn_blocking` for direct zero-argument sync functions with distinct `BlockingTask[T, E]` observation and non-send return rejection validation.
 - [#2019](https://github.com/sifr-lang/sifr/pull/2019): Added `sifr.concurrent.ThreadPoolExecutor` as a thin compatibility offload surface backed by the `BlockingTask[T, E]` substrate, including submit lowering, non-send return validation, and quick-lane fixture coverage.
 - [#2021](https://github.com/sifr-lang/sifr/pull/2021): Added the `sifr.threading` compatibility coordination surface for `Thread`, `Lock`, `Event`, and `Condition` without introducing a second offload runtime.
+- Current slice: add explicit `BlockingTask` join/cancel/cancel-and-join validation for `task.spawn_blocking` and `ThreadPoolExecutor.submit`.
 
 ---
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -30,6 +30,7 @@
     "io_bound_annotation_warning",
     "cpu_bound_annotation_warning",
     "spawn_blocking_basic",
+    "blocking_task_cancel_join",
     "thread_pool_executor_basic",
     "threading_compat_basic",
     "lock_basic",


### PR DESCRIPTION
## Summary
- add `blocking_task_cancel_join.sifr` to exercise `BlockingTask.join`, `cancel`, await-after-cancel, and `cancel_and_join`
- cover both `task.spawn_blocking` and `ThreadPoolExecutor.submit` handles
- add the fixture to the quick lane and Phase 32 validation list

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/blocking_task_cancel_join.sifr`
- `scripts/run_all_tests.sh --profile quick` PASS: 51 pass fixtures, report_signature=`91356c449370bb37`, wall_time=144.16s

## Review
- Opus review artifact: `reviews/phase32_blocking_task_cancel_validation.md`
- Final status: `REVIEW_STATUS: SATISFIED`
