### PR TITLE
Add blocking offload milestone demo

### DIFF
--- a/demos/m32_blocking_offload_demo.sifr
+++ b/demos/m32_blocking_offload_demo.sifr
@@ -1,0 +1,78 @@
+from sifr.concurrent import ThreadPoolExecutor
+from sifr.threading import Condition
+from sifr.threading import Event
+from sifr.threading import Lock
+from sifr.threading import Thread
+
+
+@cpu_bound
+def compute_score() -> int:
+    total: int = 0
+    for value in range(0, 7):
+        total = total + value
+    return total
+
+
+@io_bound
+def read_legacy_counter() -> int:
+    return 21
+
+
+def double_counter() -> int:
+    value: int = read_legacy_counter()
+    return value * 2
+
+
+def read_lock_value() -> int:
+    lock: Lock[int] = Lock(42)
+    guard = lock.acquire()
+    value: int = guard.get()
+    lock.release()
+    return value
+
+
+def condition_value() -> int:
+    condition: Condition[int] = Condition(9)
+    guard = condition.acquire()
+    value: int = guard.get()
+    condition.notify()
+    condition.notify_all()
+    condition.release()
+    return value
+
+
+async def main() -> Result[None, ScopeFailure]:
+    score_handle = task.spawn_blocking(compute_score)
+    score_result = await score_handle.join()
+    assert str(score_result) == "Ok(21)"
+
+    executor: ThreadPoolExecutor = ThreadPoolExecutor()
+    counter_handle = executor.submit(double_counter)
+    counter_result = await counter_handle
+    assert str(counter_result) == "Ok(42)"
+
+    cancelled_handle = task.spawn_blocking(compute_score)
+    cancelled_handle.cancel()
+    cancelled_result = await cancelled_handle.cancel_and_join()
+
+    thread: Thread = Thread()
+    thread.start()
+    assert thread.is_alive()
+    thread.join()
+    assert not thread.is_alive()
+
+    event: Event = Event()
+    event.set()
+    assert event.is_set()
+    event.clear()
+    await event.wait()
+
+    guarded_value: int = read_lock_value()
+    assert guarded_value == 42
+
+    protected_value: int = condition_value()
+    waiting_condition: Condition[int] = Condition(protected_value)
+    await waiting_condition.wait()
+    assert protected_value == 9
+
+    return None

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -777,6 +777,7 @@ status: in_progress
 - [#2019](https://github.com/sifr-lang/sifr/pull/2019): Added `sifr.concurrent.ThreadPoolExecutor` as a thin compatibility offload surface backed by the `BlockingTask[T, E]` substrate, including submit lowering, non-send return validation, and quick-lane fixture coverage.
 - [#2021](https://github.com/sifr-lang/sifr/pull/2021): Added the `sifr.threading` compatibility coordination surface for `Thread`, `Lock`, `Event`, and `Condition` without introducing a second offload runtime.
 - [#2023](https://github.com/sifr-lang/sifr/pull/2023): Added explicit `BlockingTask` join/cancel/cancel-and-join validation for `task.spawn_blocking` and `ThreadPoolExecutor.submit`.
+- Current slice: add `demos/m32_blocking_offload_demo.sifr` to showcase annotated workloads, explicit blocking offload, blocking-task cancellation, and threading compatibility surfaces.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `demos/m32_blocking_offload_demo.sifr`
- demonstrate workload annotations, `task.spawn_blocking`, `ThreadPoolExecutor`, BlockingTask cancellation/observation, and `sifr.threading` coordination surfaces
- update the Phase 32 tracker with the demo slice

## Validation
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run demos/m32_blocking_offload_demo.sifr`
- `scripts/run_all_tests.sh --profile quick` PASS: 51 pass fixtures, report_signature=`91356c449370bb37`, wall_time=67.41s

## Review
- Opus review artifact: `reviews/phase32_blocking_offload_demo.md`
- Final status: `REVIEW_STATUS: SATISFIED`
