### PR TITLE
Close async blocking offload milestone

### DIFF
--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -695,7 +695,7 @@ Sifr must define which types can cross thread/task boundaries. Phase 32 planning
 - `milestone_async_1`: add async HIR/type substrate (`Coroutine`, `Task`, `TaskResult`, `Awaitable`, `AsyncFunction`, `await`, async calls).
 - `milestone_async_4`: implement Send/Sync and borrow-boundary checking at spawn boundaries.
 - `milestone_async_5`: provide `sifr.sync.Shared`, `Lock`, `RwLock`, and `Channel` for explicit cross-task sharing.
-- `milestone_async_6`: implement `@io_bound` and `@cpu_bound` annotations, the stdlib workload annotation database, and async-context diagnostics.
+- `milestone_async_6` (completed): provide workload annotations and async-context diagnostics, explicit blocking offload through `task.spawn_blocking` and `sifr.concurrent.ThreadPoolExecutor`, `BlockingTask[T, E]` result-abandonment cancellation semantics, and the `sifr.threading` compatibility coordination surface.
 - `milestone_async_7a`: implement user-defined async context managers, `AsyncIterator[T, E]`, and `async for` over protocol-conforming streams.
 - `milestone_async_7b`: implement `AsyncGenerator[T, E]`, async generator lifecycle/cleanup, and list/set/dict async comprehensions.
 

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -709,7 +709,7 @@ status: completed
 
 ### milestone_async_6: Blocking I/O, CPU-Bound Work, and Thread Offload
 
-status: in_progress
+status: completed
 
 **Goal:** Keep cooperative async tasks from becoming the accidental path for blocking or CPU-heavy work.
 
@@ -761,8 +761,6 @@ status: in_progress
 
 **Negative validation:**
 
-- `io_bound_call_in_async_diagnostic.sifr`
-- `cpu_bound_call_in_async_diagnostic.sifr`
 - `spawn_blocking_non_send_rejected.sifr`
 - `thread_pool_executor_non_send_rejected.sifr`
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_1 is complete and milestone_async_2 runtime bootstrap, async-result entrypoints, `task.sleep`, task-scope container, conservative `scope.spawn`, task-handle join, direct task-handle await, affine task-handle observation, task cancellation, and task-handle timeout are underway |
+| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_6 blocking/thread offload is complete with workload annotations, explicit `BlockingTask` offload, `ThreadPoolExecutor`, `sifr.threading`, cancellation validation, and `demos/m32_blocking_offload_demo.sifr` |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |


### PR DESCRIPTION
## Summary
- mark `milestone_async_6` completed in the Phase 32 tracker
- align architecture and roadmap docs with delivered blocking/thread offload scope
- correct warning-vs-error validation lists so only fatal fixtures are listed under negative validation

## Validation
- `git diff --check`
- `cargo run -q -p sifr -- run demos/m32_blocking_offload_demo.sifr`
- `scripts/run_all_tests.sh --profile quick` PASS: 51 pass fixtures, report_signature=`91356c449370bb37`, wall_time=68.02s

## Review
- Opus closure review: `reviews/phase32_milestone_async_6_closure.md`
- Opus R2 after validation-list correction: `reviews/phase32_milestone_async_6_closure_r2.md`
- Final status: `REVIEW_STATUS: SATISFIED`
