### PR TITLE
Implement user async context manager normal exit

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_with_missing_protocol_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_with_missing_protocol_rejected.sifr
@@ -1,0 +1,17 @@
+# expect-error: SIFR-TYPE-0002
+
+class ResourceError(Error):
+    pass
+
+
+class NotAsyncContextManager:
+    value: int
+
+    def __init__(self, value: int):
+        self.value = value
+
+
+async def main() -> Result[None, ResourceError]:
+    async with NotAsyncContextManager(1) as value:
+        observed: int = value
+    return None

--- a/crates/sifr/tests/e2e/fail/async_with_unsupported_context.sifr
+++ b/crates/sifr/tests/e2e/fail/async_with_unsupported_context.sifr
@@ -1,5 +1,9 @@
 # expect-error: SIFR-TYPE-0002
 
+class PlainContext:
+    pass
+
+
 async def main() -> None:
-    async with other.scope() as scope:
-        return None
+    async with PlainContext() as scope:
+        observed: int = 1

--- a/crates/sifr/tests/e2e/pass/async_with_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/async_with_basic.sifr
@@ -1,0 +1,31 @@
+class ResourceError(Error):
+    pass
+
+
+class AsyncResource:
+    value: int
+    entered: bool
+    exited: bool
+
+    def __init__(self, value: int):
+        self.value = value
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> Result[int, ResourceError]:
+        self.entered = True
+        return self.value
+
+    async def __aexit__(self, _cause: AsyncExitCause) -> Result[None, ResourceError]:
+        assert self.entered
+        assert not self.exited
+        self.exited = True
+        return None
+
+
+async def main() -> Result[None, ResourceError]:
+    observed: int = 0
+    async with AsyncResource(41) as value:
+        observed = value + 1
+    assert observed == 42
+    return None

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -60,6 +60,9 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
     if uses_task_scope || super::module_uses_cancellation_error_type(module) {
         emitted_items.extend(super::build_cancellation_error_type_items());
     }
+    if super::module_uses_async_exit_cause_type(module) {
+        emitted_items.extend(super::build_async_exit_cause_type_items());
+    }
     if uses_task_scope {
         emitted_items.extend(super::build_task_scope_items());
     }

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -278,6 +278,9 @@ fn collect_stmt_error_refs(
                         referenced.insert("TimeoutError".to_string());
                         collect_expr_error_refs(duration, referenced, builtin_error_classes);
                     }
+                    sifr_hir::HirAsyncWithKind::UserDefined { context, .. } => {
+                        collect_expr_error_refs(context, referenced, builtin_error_classes);
+                    }
                     sifr_hir::HirAsyncWithKind::TaskScope
                     | sifr_hir::HirAsyncWithKind::TaskGroup => {
                         referenced.insert("ScopeFailure".to_string());

--- a/crates/sifr_codegen/src/hir_analysis/traversal.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal.rs
@@ -585,10 +585,18 @@ where
             }
         }
         HirStmt::AsyncWith { kind, body, .. } => {
-            if let sifr_hir::HirAsyncWithKind::TaskTimeout { duration } = kind {
-                if matches!(walk_expr_until(duration, on_expr), TraversalControl::Stop) {
-                    return TraversalControl::Stop;
+            match kind {
+                sifr_hir::HirAsyncWithKind::TaskTimeout { duration } => {
+                    if matches!(walk_expr_until(duration, on_expr), TraversalControl::Stop) {
+                        return TraversalControl::Stop;
+                    }
                 }
+                sifr_hir::HirAsyncWithKind::UserDefined { context, .. } => {
+                    if matches!(walk_expr_until(context, on_expr), TraversalControl::Stop) {
+                        return TraversalControl::Stop;
+                    }
+                }
+                sifr_hir::HirAsyncWithKind::TaskScope | sifr_hir::HirAsyncWithKind::TaskGroup => {}
             }
             if matches!(
                 walk_stmts_until(body, config, on_stmt, on_expr),

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -493,6 +493,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     let uses_task_scope = module_uses_task_scope(module);
     let uses_failure_type = module_uses_failure_type(module);
     let uses_cancellation_error_type = module_uses_cancellation_error_type(module);
+    let uses_async_exit_cause_type = module_uses_async_exit_cause_type(module);
     let uses_timeout_result_type = module_uses_timeout_result_type(module);
     let mut referenced_error_classes = collect_referenced_builtin_error_classes(
         module,
@@ -612,6 +613,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     }
     if uses_task_scope || uses_cancellation_error_type {
         preamble_items.extend(build_cancellation_error_type_items());
+    }
+    if uses_async_exit_cause_type {
+        preamble_items.extend(build_async_exit_cause_type_items());
     }
     if uses_timeout_result_type && !uses_task_scope {
         preamble_items.extend(build_timeout_result_type_items());
@@ -1254,6 +1258,13 @@ fn type_contains_cancellation_error(ty: &Type) -> bool {
     )
 }
 
+fn type_contains_async_exit_cause(ty: &Type) -> bool {
+    type_contains_by(
+        ty,
+        |candidate| matches!(candidate, Type::Class { name, .. } if name == "AsyncExitCause"),
+    )
+}
+
 fn module_uses_failure_type(module: &HirModule) -> bool {
     module.functions.iter().any(function_uses_failure_type)
         || module.classes.iter().any(|class| {
@@ -1290,6 +1301,27 @@ fn module_uses_cancellation_error_type(module: &HirModule) -> bool {
             .any(|(_, ty, _)| type_contains_cancellation_error(ty))
 }
 
+fn module_uses_async_exit_cause_type(module: &HirModule) -> bool {
+    module
+        .functions
+        .iter()
+        .any(function_uses_async_exit_cause_type)
+        || module.classes.iter().any(|class| {
+            class
+                .fields
+                .iter()
+                .any(|(_, field_ty)| type_contains_async_exit_cause(field_ty))
+                || class
+                    .methods
+                    .iter()
+                    .any(function_uses_async_exit_cause_type)
+        })
+        || module
+            .constants
+            .iter()
+            .any(|(_, ty, _)| type_contains_async_exit_cause(ty))
+}
+
 fn module_uses_timeout_result_type(module: &HirModule) -> bool {
     module
         .functions
@@ -1313,6 +1345,13 @@ fn function_uses_cancellation_error_type(func: &HirFunction) -> bool {
         .iter()
         .any(|param| type_contains_cancellation_error(&param.ty))
         || type_contains_cancellation_error(&func.return_type)
+}
+
+fn function_uses_async_exit_cause_type(func: &HirFunction) -> bool {
+    func.params
+        .iter()
+        .any(|param| type_contains_async_exit_cause(&param.ty))
+        || type_contains_async_exit_cause(&func.return_type)
 }
 
 fn function_uses_failure_type(func: &HirFunction) -> bool {
@@ -2162,10 +2201,17 @@ impl RustEmitter {
         ) || matches!(
             stmt,
             HirStmt::AsyncWith {
-                kind: sifr_hir::HirAsyncWithKind::TaskTimeout { .. },
+                kind: sifr_hir::HirAsyncWithKind::TaskTimeout { .. }
+                    | sifr_hir::HirAsyncWithKind::UserDefined { .. },
                 body,
                 ..
             } if body_contains_await(body)
+        ) || matches!(
+            stmt,
+            HirStmt::AsyncWith {
+                kind: sifr_hir::HirAsyncWithKind::UserDefined { .. },
+                ..
+            }
         ) || matches!(stmt, HirStmt::Let { ty, .. } if self.type_contains_generic_class(ty));
         if !should_bypass_simple_lowering {
             if let Some(lowered_stmts) = try_lower_simple_stmt_with_scope_result_and_bindings(

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -334,8 +334,14 @@ fn validate_stmt_lowering_shape(stmt: &HirStmt) -> Result<(), CodegenError> {
             validate_stmt_block_lowering_shape(body)
         }
         HirStmt::AsyncWith { kind, body, .. } => {
-            if let sifr_hir::HirAsyncWithKind::TaskTimeout { duration } = kind {
-                validate_expr_lowering_shape(duration)?;
+            match kind {
+                sifr_hir::HirAsyncWithKind::TaskTimeout { duration } => {
+                    validate_expr_lowering_shape(duration)?;
+                }
+                sifr_hir::HirAsyncWithKind::UserDefined { context, .. } => {
+                    validate_expr_lowering_shape(context)?;
+                }
+                sifr_hir::HirAsyncWithKind::TaskScope | sifr_hir::HirAsyncWithKind::TaskGroup => {}
             }
             validate_stmt_block_lowering_shape(body)
         }
@@ -1907,6 +1913,10 @@ fn try_lower_simple_async_with_stmt(
     bindings: SimpleStmtBindings<'_>,
     ctx: SimpleStmtLoweringCtx<'_>,
 ) -> Option<Vec<RustStmt>> {
+    if matches!(kind, sifr_hir::HirAsyncWithKind::UserDefined { .. }) {
+        return None;
+    }
+
     if let sifr_hir::HirAsyncWithKind::TaskTimeout { duration } = kind {
         let _ = try_lower_leaf_or_name_expr(duration)?;
     }

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -346,6 +346,53 @@ pub fn build_cancellation_error_type_items() -> Vec<RustItem> {
     ]
 }
 
+pub fn build_async_exit_cause_type_items() -> Vec<RustItem> {
+    vec![RustItem::Enum {
+        name: "AsyncExitCause".to_string(),
+        visibility: Visibility::Private,
+        derives: vec!["Clone".to_string(), "Debug".to_string()],
+        repr: None,
+        variants: vec![
+            crate::RustEnumVariant {
+                name: "Normal".to_string(),
+                tuple_fields: vec![],
+                fields: vec![],
+                value: None,
+            },
+            crate::RustEnumVariant {
+                name: "Return".to_string(),
+                tuple_fields: vec![],
+                fields: vec![],
+                value: None,
+            },
+            crate::RustEnumVariant {
+                name: "OrdinaryError".to_string(),
+                tuple_fields: vec![RustType::Named("String".to_string())],
+                fields: vec![],
+                value: None,
+            },
+            crate::RustEnumVariant {
+                name: "Timeout".to_string(),
+                tuple_fields: vec![],
+                fields: vec![],
+                value: None,
+            },
+            crate::RustEnumVariant {
+                name: "Cancellation".to_string(),
+                tuple_fields: vec![],
+                fields: vec![],
+                value: None,
+            },
+            crate::RustEnumVariant {
+                name: "RuntimeFault".to_string(),
+                tuple_fields: vec![RustType::Named("String".to_string())],
+                fields: vec![],
+                value: None,
+            },
+        ],
+    }]
+}
+
 pub fn build_task_scope_items() -> Vec<RustItem> {
     vec![
         RustItem::Struct {

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7488,6 +7488,51 @@ impl RustEmitter {
         target: Option<&str>,
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
+        if let sifr_hir::HirAsyncWithKind::UserDefined { context, .. } = kind {
+            let Some(lowered_context) = self.lower_stmt_expr_for_ir(context)? else {
+                return Ok(None);
+            };
+            let Some(mut lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+                return Ok(None);
+            };
+            let enter_call = crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(
+                crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Ident("__sifr_async_cm".to_string())),
+                    method: "__aenter__".to_string(),
+                    args: vec![],
+                },
+            ))));
+            let enter_stmt = crate::RustStmt::Let {
+                mutable: false,
+                name: target.unwrap_or("_").to_string(),
+                ty: None,
+                value: enter_call,
+            };
+            let exit_stmt = crate::RustStmt::Expr(crate::RustExpr::Try(Box::new(
+                crate::RustExpr::Await(Box::new(crate::RustExpr::MethodCall {
+                    receiver: Box::new(crate::RustExpr::Ident("__sifr_async_cm".to_string())),
+                    method: "__aexit__".to_string(),
+                    args: vec![crate::RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(crate::RustExpr::Ident(
+                            "AsyncExitCause::Normal".to_string(),
+                        )),
+                    }],
+                })),
+            )));
+            let mut stmts = Vec::with_capacity(lowered_body.len() + 3);
+            stmts.push(crate::RustStmt::Let {
+                mutable: true,
+                name: "__sifr_async_cm".to_string(),
+                ty: None,
+                value: lowered_context,
+            });
+            stmts.push(enter_stmt);
+            stmts.append(&mut lowered_body);
+            stmts.push(exit_stmt);
+            return Ok(Some(RustStmt::Block(stmts)));
+        }
+
         let timeout_duration = if let sifr_hir::HirAsyncWithKind::TaskTimeout { duration } = kind {
             let Some(duration) =
                 crate::try_lower_task_duration_expr(duration, "__sifr_task_timeout_seconds")

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -101,12 +101,20 @@ pub struct HirFunction {
     pub type_params: Vec<String>,
 }
 
-/// Built-in async-with forms recognized before general async context managers.
+/// Async-with forms recognized by the compiler.
 #[derive(Debug, Clone)]
 pub enum HirAsyncWithKind {
     TaskScope,
     TaskGroup,
-    TaskTimeout { duration: HirExpr },
+    TaskTimeout {
+        duration: HirExpr,
+    },
+    UserDefined {
+        context: HirExpr,
+        enter_value_ty: Type,
+        enter_error_ty: Type,
+        exit_error_ty: Type,
+    },
 }
 
 /// A function parameter with its type, convention, and optional default value.

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -89,6 +89,151 @@ fn return_type_accepts_scope_failure(return_type: &Type) -> bool {
     scope_failure_type().is_assignable_to(err)
 }
 
+fn async_exit_cause_type() -> Type {
+    Type::Class {
+        name: "AsyncExitCause".to_string(),
+        fields: vec![],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
+    let Type::Result(_, err) = return_type.resolve_alias() else {
+        return false;
+    };
+    error_ty.is_assignable_to(err)
+}
+
+fn method_signature<'a>(
+    methods: &'a [(String, FunctionType)],
+    method_name: &str,
+) -> Option<&'a FunctionType> {
+    methods.iter().find_map(
+        |(name, ft)| {
+            if name == method_name {
+                Some(ft)
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn async_context_methods(ty: &Type) -> Option<(&FunctionType, &FunctionType)> {
+    match ty.resolve_alias() {
+        Type::Class { methods, .. } | Type::Protocol { methods, .. } => Some((
+            method_signature(methods, "__aenter__")?,
+            method_signature(methods, "__aexit__")?,
+        )),
+        _ => None,
+    }
+}
+
+fn async_result_parts(ty: &Type) -> Option<(Type, Type)> {
+    let Type::Coroutine(ok_ty, err_ty) = ty.resolve_alias() else {
+        return None;
+    };
+    Some((ok_ty.as_ref().clone(), err_ty.as_ref().clone()))
+}
+
+fn lower_user_async_with(
+    with_stmt: &StmtWith,
+    item: &sifr_python_ast::WithItem,
+    func_type: &FunctionType,
+    ctx: &mut LowerCtx,
+) -> Option<HirStmt> {
+    ctx.with_pushed_scope(|ctx| {
+        let context = lower_expr(&item.context_expr, ctx)?;
+        let context_ty = context.ty().clone();
+        let Some((enter_ft, exit_ft)) = async_context_methods(&context_ty) else {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                format!(
+                    "async with requires an async context manager with __aenter__() and __aexit__(AsyncExitCause), got '{}'",
+                    context_ty.display_name()
+                ),
+                item.context_expr.range(),
+            );
+            return None;
+        };
+        if !enter_ft.params.is_empty() {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "__aenter__ for async with must take no arguments".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        if exit_ft.params.len() != 1 || !async_exit_cause_type().is_assignable_to(&exit_ft.params[0].1) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "__aexit__ for async with must take exactly one AsyncExitCause argument".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        let Some((enter_value_ty, enter_error_ty)) = async_result_parts(&enter_ft.return_type)
+        else {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "__aenter__ for async with must be async and return Result[T, E]".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        };
+        let Some((exit_value_ty, exit_error_ty)) = async_result_parts(&exit_ft.return_type) else {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "__aexit__ for async with must be async and return Result[None, E]".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        };
+        if !matches!(exit_value_ty.resolve_alias(), Type::None) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "__aexit__ for async with must return Result[None, E]".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        if !return_type_accepts_error(&func_type.return_type, &enter_error_ty)
+            || !return_type_accepts_error(&func_type.return_type, &exit_error_ty)
+        {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "fallible async context manager enter/exit requires the enclosing function to return a compatible Result error type".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        let target = simple_with_target_name(item.optional_vars.as_deref(), ctx);
+        if let Some(name) = &target {
+            ctx.scope.define(name.clone(), enter_value_ty.clone());
+        }
+        let body = lower_stmts(&with_stmt.body, func_type, ctx);
+        if body.iter().any(stmt_contains_scope_early_exit) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "user-defined async context managers cannot use return, raise, or yield inside the body until abnormal-exit cleanup lowering is implemented".to_string(),
+                item.context_expr.range(),
+            );
+            return None;
+        }
+        Some(HirStmt::AsyncWith {
+            kind: HirAsyncWithKind::UserDefined {
+                context,
+                enter_value_ty,
+                enter_error_ty,
+                exit_error_ty,
+            },
+            target,
+            body,
+        })
+    })
+}
+
 fn expr_contains_await(expr: &crate::hir_nodes::HirExpr) -> bool {
     use crate::hir_nodes::HirExpr;
 
@@ -373,8 +518,10 @@ fn stmt_contains_await(stmt: &HirStmt) -> bool {
                     .is_some_and(|body| body.iter().any(stmt_contains_await))
         }
         HirStmt::AsyncWith { kind, body, .. } => {
-            matches!(kind, HirAsyncWithKind::TaskTimeout { .. })
-                || body.iter().any(stmt_contains_await)
+            matches!(
+                kind,
+                HirAsyncWithKind::TaskTimeout { .. } | HirAsyncWithKind::UserDefined { .. }
+            ) || body.iter().any(stmt_contains_await)
         }
         HirStmt::Delete { object, index } => {
             expr_contains_await(object) || expr_contains_await(index)
@@ -550,7 +697,7 @@ pub(super) fn lower_async_with(
     if with_stmt.items.len() != 1 {
         statement_diagnostics::unsupported_form(
             ctx,
-            "async with supports exactly one built-in context item in v1",
+            "async with supports exactly one context item in v1",
             with_stmt.range(),
         );
         return None;
@@ -558,12 +705,7 @@ pub(super) fn lower_async_with(
 
     let item = &with_stmt.items[0];
     let Some((task_fn, call)) = async_task_call_name(&item.context_expr) else {
-        ctx.error_with_code_at(
-            DiagnosticCode::TYPE_MISMATCH,
-            "async with only supports task.scope(), task.TaskGroup(), and task.timeout(duration) in v1".to_string(),
-            item.context_expr.range(),
-        );
-        return None;
+        return lower_user_async_with(with_stmt, item, func_type, ctx);
     };
 
     if !call.arguments.keywords.is_empty() {

--- a/crates/sifr_hir/src/lower/nonlocal_support.rs
+++ b/crates/sifr_hir/src/lower/nonlocal_support.rs
@@ -185,11 +185,17 @@ fn hir_stmt_calls_function(stmt: &HirStmt, func_name: &str) -> bool {
                 || hir_body_calls_function(body, func_name)
         }
         HirStmt::AsyncWith { kind, body, .. } => {
-            matches!(
-                kind,
-                crate::hir_nodes::HirAsyncWithKind::TaskTimeout { duration }
-                    if hir_expr_calls_function(duration, func_name)
-            ) || hir_body_calls_function(body, func_name)
+            let context_calls = match kind {
+                crate::hir_nodes::HirAsyncWithKind::TaskTimeout { duration } => {
+                    hir_expr_calls_function(duration, func_name)
+                }
+                crate::hir_nodes::HirAsyncWithKind::UserDefined { context, .. } => {
+                    hir_expr_calls_function(context, func_name)
+                }
+                crate::hir_nodes::HirAsyncWithKind::TaskScope
+                | crate::hir_nodes::HirAsyncWithKind::TaskGroup => false,
+            };
+            context_calls || hir_body_calls_function(body, func_name)
         }
         HirStmt::Match { subject, arms, .. } => {
             hir_expr_calls_function(subject, func_name)

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -127,6 +127,16 @@ pub(super) fn register_builtins(ctx: &mut LowerCtx) {
             FunctionType::new(vec![("message".to_string(), Type::Str)], class_ty),
         );
     }
+    {
+        let class_ty = Type::Class {
+            name: "AsyncExitCause".to_string(),
+            fields: vec![],
+            methods: vec![],
+            parent_class: None,
+        };
+        ctx.class_types
+            .insert("AsyncExitCause".to_string(), class_ty);
+    }
 
     // --- JSON integer boundary errors (parent: Error, profile-specific fields) ---
     {

--- a/internal_docs/async_concurrency_model.md
+++ b/internal_docs/async_concurrency_model.md
@@ -670,6 +670,8 @@ protocol AsyncContextManager[T, EnterE, ExitE]:
 
 `__aenter__` and `__aexit__` are the async context-manager methods. If `__aenter__` fails, `__aexit__` is not called, because the resource was not acquired.
 
+Implementation status: the first milestone_async_7a compiler slice supports the normal-exit path for user-defined async context managers that structurally provide async `__aenter__` and `__aexit__` methods. Abnormal body exit, cancellation-specific causes, secondary cleanup evidence, and `async for` cleanup are still tracked as follow-up slices in the same milestone.
+
 ```sifr
 enum AsyncExitCause:
     Normal

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -783,6 +783,10 @@ status: completed
 
 status: proposed
 
+Implementation notes:
+
+- In progress user-defined `async with` protocol slice: structural async context managers with `__aenter__() -> Result[T, E]` and `__aexit__(AsyncExitCause) -> Result[None, E]` now lower on the normal-exit path, with `async_with_basic.sifr` in the quick lane and `async_with_missing_protocol_rejected.sifr` covering missing protocol rejection. Abnormal-exit cleanup, cancellation causes, secondary cleanup evidence, and `async for` remain follow-up slices in this milestone.
+
 **Goal:** Complete general user-defined async control-flow protocols without dragging in broad ecosystem APIs.
 
 **Depends on:** `milestone_async_5` and `milestone_async_6`

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -33,6 +33,7 @@
     "blocking_task_cancel_join",
     "thread_pool_executor_basic",
     "threading_compat_basic",
+    "async_with_basic",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- add structural user-defined async context-manager lowering for the normal-exit path
- register and emit AsyncExitCause for __aexit__(AsyncExitCause)
- add async_with_basic quick-lane coverage and missing-protocol fail coverage
- document the slice boundary for remaining milestone_async_7a cleanup/cancellation/async-for work

## Validation
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_basic.sifr
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- scripts/run_all_tests.sh --profile quick (PASS, 52 pass fixtures, report_signature=50a6605415014401, wall_time=89.71s)

## Review
- Opus review: reviews/phase32_async_with_basic.md
- REVIEW_STATUS: SATISFIED