### PR TITLE
Preserve named async context manager state

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_with_nested_cleanup_order.sifr
+++ b/crates/sifr/tests/e2e/pass/async_with_nested_cleanup_order.sifr
@@ -1,0 +1,47 @@
+class ResourceError(Error):
+    pass
+
+
+class OrderedResource:
+    value: int
+    entered: bool
+    exited: bool
+
+    def __init__(self, value: int):
+        self.value = value
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> Result[int, ResourceError]:
+        assert not self.entered
+        assert not self.exited
+        self.entered = True
+        return self.value
+
+    async def __aexit__(self, _cause: AsyncExitCause) -> Result[None, ResourceError]:
+        assert self.entered
+        assert not self.exited
+        self.exited = True
+        return None
+
+
+async def main() -> Result[None, ResourceError]:
+    outer: OrderedResource = OrderedResource(1)
+    inner: OrderedResource = OrderedResource(2)
+
+    async with outer as outer_value:
+        assert outer_value == 1
+        assert outer.entered
+        assert not outer.exited
+
+        async with inner as inner_value:
+            assert inner_value == 2
+            assert inner.entered
+            assert not inner.exited
+            assert not outer.exited
+
+        assert inner.exited
+        assert not outer.exited
+
+    assert outer.exited
+    return None

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -279,6 +279,16 @@ pub(crate) fn collect_mutated_vars(
         | HirStmt::AttributeSubscriptAssign { object, .. } => {
             mutated.borrow_mut().insert(object.clone());
         }
+        HirStmt::AsyncWith {
+            kind:
+                sifr_hir::HirAsyncWithKind::UserDefined {
+                    context: HirExpr::Name { name, .. },
+                    ..
+                },
+            ..
+        } => {
+            mutated.borrow_mut().insert(name.clone());
+        }
         HirStmt::Delete {
             object: HirExpr::Name { name, .. },
             ..

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7489,10 +7489,42 @@ impl RustEmitter {
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         if let sifr_hir::HirAsyncWithKind::UserDefined { context, .. } = kind {
-            let Some(lowered_context) = self.lower_stmt_expr_for_ir(context)? else {
+            let Some(mut lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
                 return Ok(None);
             };
-            let Some(mut lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+            if let HirExpr::Name { name, .. } = context {
+                let enter_stmt = crate::RustStmt::Let {
+                    mutable: false,
+                    name: target.unwrap_or("_").to_string(),
+                    ty: None,
+                    value: crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(
+                        crate::RustExpr::MethodCall {
+                            receiver: Box::new(crate::RustExpr::Ident(name.clone())),
+                            method: "__aenter__".to_string(),
+                            args: vec![],
+                        },
+                    )))),
+                };
+                let exit_stmt = crate::RustStmt::Expr(crate::RustExpr::Try(Box::new(
+                    crate::RustExpr::Await(Box::new(crate::RustExpr::MethodCall {
+                        receiver: Box::new(crate::RustExpr::Ident(name.clone())),
+                        method: "__aexit__".to_string(),
+                        args: vec![crate::RustExpr::Ref {
+                            mutable: false,
+                            expr: Box::new(crate::RustExpr::Ident(
+                                "AsyncExitCause::Normal".to_string(),
+                            )),
+                        }],
+                    })),
+                )));
+                let mut stmts = Vec::with_capacity(lowered_body.len() + 2);
+                stmts.push(enter_stmt);
+                stmts.append(&mut lowered_body);
+                stmts.push(exit_stmt);
+                return Ok(Some(RustStmt::Block(stmts)));
+            }
+
+            let Some(lowered_context) = self.lower_stmt_expr_for_ir(context)? else {
                 return Ok(None);
             };
             let enter_call = crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -786,6 +786,7 @@ status: proposed
 Implementation notes:
 
 - PR [#2028](https://github.com/sifr-lang/sifr/pull/2028) user-defined `async with` protocol slice: structural async context managers with `__aenter__() -> Result[T, E]` and `__aexit__(AsyncExitCause) -> Result[None, E]` now lower on the normal-exit path, with `async_with_basic.sifr` in the quick lane and `async_with_missing_protocol_rejected.sifr` covering missing protocol rejection. Abnormal-exit cleanup, cancellation causes, secondary cleanup evidence, and `async for` remain follow-up slices in this milestone.
+- Named async context state slice: named user-defined async context managers are preserved across the normal-exit lowering so post-body state validates LIFO cleanup order through `async_with_nested_cleanup_order.sifr`.
 
 **Goal:** Complete general user-defined async control-flow protocols without dragging in broad ecosystem APIs.
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -34,6 +34,7 @@
     "thread_pool_executor_basic",
     "threading_compat_basic",
     "async_with_basic",
+    "async_with_nested_cleanup_order",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- Preserve named user-defined async context manager bindings during normal-exit lowering instead of moving them into a temporary.
- Mark named async-with context bindings mutable for generated `__aenter__` / `__aexit__` calls.
- Add `async_with_nested_cleanup_order.sifr` to validate named state visibility and nested LIFO cleanup order.
- Update the phase 32 tracker and quick validation manifest.

## Validation
- `cargo fmt`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_nested_cleanup_order.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_basic.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`
  - PASS, 53 pass fixtures, `report_signature=492b90b46a81609b`, wall_time=103.34s

## Review
- Opus review: `REVIEW_STATUS: SATISFIED`
