### PR TITLE
Add basic async for lowering

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_for_non_async_iterable_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_for_non_async_iterable_rejected.sifr
@@ -1,0 +1,11 @@
+# expect-error[col=24]: SIFR-FLOW-0008
+
+class StreamError(Error):
+    pass
+
+
+async def main() -> Result[None, StreamError]:
+    values: list[int] = [1, 2, 3]
+    async for value in values:
+        assert value > 0
+    return None

--- a/crates/sifr/tests/e2e/fail/async_for_timeout_context_manager_return_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_for_timeout_context_manager_return_type_rejected.sifr
@@ -1,0 +1,26 @@
+# expect-error: SIFR-TYPE-0002
+
+class StreamError(Error):
+    pass
+
+
+class OneShotStream:
+    done: bool
+
+    def __init__(self):
+        self.done = False
+
+    async def anext(self) -> Result[Option[int], StreamError]:
+        if self.done:
+            return None
+        self.done = True
+        value: Option[int] = 1
+        return value
+
+
+async def main() -> Result[None, StreamError]:
+    stream: OneShotStream = OneShotStream()
+    async with task.timeout(1.0):
+        async for value in stream:
+            assert value == 1
+    return None

--- a/crates/sifr/tests/e2e/pass/async_for_stream_result.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_stream_result.sifr
@@ -1,0 +1,34 @@
+class StreamError(Error):
+    pass
+
+
+class CounterStream:
+    current: int
+    stop: int
+
+    def __init__(self, start: int, stop: int):
+        self.current = start
+        self.stop = stop
+
+    async def anext(self) -> Result[Option[int], StreamError]:
+        if self.current >= self.stop:
+            return None
+        value: int = self.current
+        self.current = self.current + 1
+        next_value: Option[int] = value
+        return next_value
+
+
+async def main() -> Result[None, StreamError]:
+    stream: CounterStream = CounterStream(0, 4)
+    total: int = 0
+    count: int = 0
+
+    async for value in stream:
+        total = total + value
+        count = count + 1
+
+    assert total == 6
+    assert count == 4
+    assert stream.current == 4
+    return None

--- a/crates/sifr_codegen/src/error_refs.rs
+++ b/crates/sifr_codegen/src/error_refs.rs
@@ -212,6 +212,20 @@ fn collect_stmt_error_refs(
                     collect_stmt_error_refs(else_body, referenced, builtin_error_classes);
                 }
             }
+            HirStmt::AsyncFor {
+                iter,
+                iter_error_ty,
+                body,
+                else_body,
+                ..
+            } => {
+                collect_expr_error_refs(iter, referenced, builtin_error_classes);
+                collect_type_error_refs(iter_error_ty, referenced, builtin_error_classes);
+                collect_stmt_error_refs(body, referenced, builtin_error_classes);
+                if let Some(else_body) = else_body {
+                    collect_stmt_error_refs(else_body, referenced, builtin_error_classes);
+                }
+            }
             HirStmt::TupleUnpack { value, .. } | HirStmt::StarUnpack { value, .. } => {
                 collect_expr_error_refs(value, referenced, builtin_error_classes);
             }

--- a/crates/sifr_codegen/src/helpers.rs
+++ b/crates/sifr_codegen/src/helpers.rs
@@ -457,7 +457,9 @@ pub(super) fn module_uses_bigint(module: &HirModule) -> bool {
     fn stmt_type_has_bigint(stmt: &HirStmt) -> bool {
         match stmt {
             HirStmt::Let { ty, .. } => type_has_bigint(ty),
-            HirStmt::For { target_ty, .. } => type_has_bigint(target_ty),
+            HirStmt::For { target_ty, .. } | HirStmt::AsyncFor { target_ty, .. } => {
+                type_has_bigint(target_ty)
+            }
             HirStmt::TupleUnpack { targets, .. } => {
                 targets.iter().any(|target| type_has_bigint(&target.ty))
             }

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -289,6 +289,12 @@ pub(crate) fn collect_mutated_vars(
         } => {
             mutated.borrow_mut().insert(name.clone());
         }
+        HirStmt::AsyncFor {
+            iter: HirExpr::Name { name, .. },
+            ..
+        } => {
+            mutated.borrow_mut().insert(name.clone());
+        }
         HirStmt::Delete {
             object: HirExpr::Name { name, .. },
             ..
@@ -432,7 +438,7 @@ pub(crate) fn collect_locally_defined_vars(stmts: &[HirStmt]) -> HashSet<String>
         HirStmt::Let { name, .. } => {
             defined.insert(name.clone());
         }
-        HirStmt::For { target, .. } => {
+        HirStmt::For { target, .. } | HirStmt::AsyncFor { target, .. } => {
             defined.insert(target.clone());
         }
         HirStmt::TupleUnpack { targets, .. } => {

--- a/crates/sifr_codegen/src/hir_analysis/traversal.rs
+++ b/crates/sifr_codegen/src/hir_analysis/traversal.rs
@@ -445,6 +445,12 @@ where
             body,
             else_body,
             ..
+        }
+        | HirStmt::AsyncFor {
+            iter,
+            body,
+            else_body,
+            ..
         } => {
             if matches!(walk_expr_until(iter, on_expr), TraversalControl::Stop) {
                 return TraversalControl::Stop;

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2251,6 +2251,18 @@ impl RustEmitter {
             }
         }
 
+        if let HirStmt::AsyncFor {
+            target, iter, body, ..
+        } = stmt
+        {
+            if let Some(lowered_stmt) = self.try_lower_async_for_stmt_for_ir(target, iter, body)? {
+                self.push_captured_stmt(&self.rewrite_stdlib_constant_idents_in_stmt(lowered_stmt));
+                self.lowering_stats.stmt_structured += 1;
+                self.lowering_stats.stmt_candidate_structured += 1;
+                return Ok(true);
+            }
+        }
+
         if let HirStmt::TupleUnpack { targets, value } = stmt {
             if let Some(lowered_value) = self.lower_stmt_expr_for_ir(value)? {
                 let lowered_stmts = crate::lower_tuple_unpack_targets(

--- a/crates/sifr_codegen/src/lower_stmt.rs
+++ b/crates/sifr_codegen/src/lower_stmt.rs
@@ -33,6 +33,7 @@ pub(crate) fn is_simple_stmt_candidate(stmt: &HirStmt) -> bool {
         | HirStmt::If { .. }
         | HirStmt::While { .. }
         | HirStmt::For { .. }
+        | HirStmt::AsyncFor { .. }
         | HirStmt::Pass
         | HirStmt::Continue
         | HirStmt::Break
@@ -285,6 +286,12 @@ fn validate_stmt_lowering_shape(stmt: &HirStmt) -> Result<(), CodegenError> {
             Ok(())
         }
         HirStmt::For {
+            iter,
+            body,
+            else_body,
+            ..
+        }
+        | HirStmt::AsyncFor {
             iter,
             body,
             else_body,
@@ -1472,6 +1479,7 @@ fn stmt_has_result_flow(stmt: &HirStmt) -> bool {
         | HirStmt::If { .. }
         | HirStmt::While { .. }
         | HirStmt::For { .. }
+        | HirStmt::AsyncFor { .. }
         | HirStmt::Break
         | HirStmt::Continue
         | HirStmt::TryExcept { .. }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -6448,6 +6448,16 @@ impl RustEmitter {
                     }],
                     true,
                 )
+            } else if let HirStmt::AsyncFor {
+                target, iter, body, ..
+            } = stmt
+            {
+                let Some(lowered_async_for) =
+                    self.try_lower_async_for_stmt_for_ir(target, iter, body)?
+                else {
+                    return Ok(None);
+                };
+                (vec![lowered_async_for], true)
             } else if let HirStmt::With { items, body } = stmt {
                 let Some(lowered_with) = self.try_lower_with_stmt_for_ir(items, body)? else {
                     return Ok(None);
@@ -7628,6 +7638,76 @@ impl RustEmitter {
             lowered_body.push(crate::RustStmt::Expr(crate::RustExpr::Ident(stmt)));
         }
         Ok(Some(RustStmt::Block(lowered_body)))
+    }
+
+    pub(crate) fn try_lower_async_for_stmt_for_ir(
+        &mut self,
+        target: &str,
+        iter: &HirExpr,
+        body: &[HirStmt],
+    ) -> Result<Option<RustStmt>, crate::CodegenError> {
+        let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
+            return Ok(None);
+        };
+        let target_pattern = if queries::stmts_reference_var(body, target) {
+            target.to_string()
+        } else {
+            format!("_{target}")
+        };
+        let loop_body = |receiver: crate::RustExpr| {
+            vec![
+                RustStmt::Let {
+                    mutable: false,
+                    name: "__sifr_async_next".to_string(),
+                    ty: None,
+                    value: crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(
+                        crate::RustExpr::MethodCall {
+                            receiver: Box::new(receiver),
+                            method: "anext".to_string(),
+                            args: vec![],
+                        },
+                    )))),
+                },
+                RustStmt::Match {
+                    expr: crate::RustExpr::Ident("__sifr_async_next".to_string()),
+                    arms: vec![
+                        crate::RustMatchArm {
+                            pattern: format!("Some({target_pattern})"),
+                            bindings: vec![target.to_string()],
+                            guard: None,
+                            body: lowered_body.clone(),
+                        },
+                        crate::RustMatchArm {
+                            pattern: "None".to_string(),
+                            bindings: vec![],
+                            guard: None,
+                            body: vec![RustStmt::Break],
+                        },
+                    ],
+                },
+            ]
+        };
+
+        if let HirExpr::Name { name, .. } = iter {
+            return Ok(Some(RustStmt::Loop {
+                body: loop_body(crate::RustExpr::Ident(name.clone())),
+            }));
+        }
+
+        let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter)? else {
+            return Ok(None);
+        };
+        Ok(Some(RustStmt::Block(vec![
+            RustStmt::Let {
+                mutable: true,
+                name: "__sifr_async_iter".to_string(),
+                ty: None,
+                value: lowered_iter,
+            },
+            RustStmt::Loop {
+                body: loop_body(crate::RustExpr::Ident("__sifr_async_iter".to_string())),
+            },
+        ])))
     }
 
     fn try_lower_borrowed_name_compare_condition_for_ir(

--- a/crates/sifr_hir/src/cfg.rs
+++ b/crates/sifr_hir/src/cfg.rs
@@ -417,9 +417,14 @@ impl CfgBuilder {
             }
             HirStmt::For {
                 body, else_body, ..
+            }
+            | HirStmt::AsyncFor {
+                body, else_body, ..
             } => {
-                let for_block =
-                    self.new_block(CfgBlockLabel::Statement("for"), top_level_stmt_index);
+                let for_block = self.new_block(
+                    CfgBlockLabel::Statement(stmt_label(stmt)),
+                    top_level_stmt_index,
+                );
                 let false_target = if let Some(else_body) = else_body {
                     self.build_stmt_list(else_body, next, loop_targets, false)
                 } else {
@@ -518,6 +523,7 @@ fn stmt_label(stmt: &HirStmt) -> &'static str {
         HirStmt::If { .. } => "if",
         HirStmt::While { .. } => "while",
         HirStmt::For { .. } => "for",
+        HirStmt::AsyncFor { .. } => "async_for",
         HirStmt::Break => "break",
         HirStmt::Continue => "continue",
         HirStmt::TupleUnpack { .. } => "tuple_unpack",

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -171,6 +171,15 @@ pub enum HirStmt {
         body: Vec<HirStmt>,
         else_body: Option<Vec<HirStmt>>,
     },
+    /// Async for loop over `AsyncIterator[T, E]`.
+    AsyncFor {
+        target: String,
+        target_ty: Type,
+        iter: HirExpr,
+        iter_error_ty: Type,
+        body: Vec<HirStmt>,
+        else_body: Option<Vec<HirStmt>>,
+    },
     /// Break statement
     Break,
     /// Continue statement

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -1,0 +1,153 @@
+use super::expressions::lower_expr;
+use super::statement_diagnostics;
+use super::statements::lower_stmts;
+use super::LowerCtx;
+use crate::hir_nodes::HirStmt;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Expr, StmtFor};
+use sifr_type_system::{FunctionType, Type};
+
+fn method_signature<'a>(
+    methods: &'a [(String, FunctionType)],
+    method_name: &str,
+) -> Option<&'a FunctionType> {
+    methods.iter().find_map(
+        |(name, ft)| {
+            if name == method_name {
+                Some(ft)
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn async_result_parts(ty: &Type) -> Option<(Type, Type)> {
+    let Type::Coroutine(ok_ty, err_ty) = ty.resolve_alias() else {
+        return None;
+    };
+    Some((ok_ty.as_ref().clone(), err_ty.as_ref().clone()))
+}
+
+fn option_value_type(ty: &Type) -> Option<Type> {
+    let Type::Union(members) = ty.resolve_alias() else {
+        return None;
+    };
+    let has_none = members
+        .iter()
+        .any(|member| matches!(member.resolve_alias(), Type::None));
+    if !has_none {
+        return None;
+    }
+    let non_none = members
+        .iter()
+        .filter(|member| !matches!(member.resolve_alias(), Type::None))
+        .cloned()
+        .collect::<Vec<_>>();
+    if non_none.len() == 1 {
+        non_none.into_iter().next()
+    } else {
+        None
+    }
+}
+
+fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {
+    match ty.resolve_alias() {
+        Type::AsyncIterator(item_ty, err_ty) | Type::AsyncGenerator(item_ty, err_ty) => {
+            Some((item_ty.as_ref().clone(), err_ty.as_ref().clone()))
+        }
+        Type::Class { methods, .. } | Type::Protocol { methods, .. } => {
+            let anext_ft = method_signature(methods, "anext")?;
+            if !anext_ft.params.is_empty() {
+                return None;
+            }
+            let (next_ty, err_ty) = async_result_parts(&anext_ft.return_type)?;
+            let item_ty = option_value_type(&next_ty)?;
+            Some((item_ty, err_ty))
+        }
+        _ => None,
+    }
+}
+
+fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
+    let Type::Result(_, err) = return_type.resolve_alias() else {
+        return false;
+    };
+    error_ty.is_assignable_to(err)
+}
+
+fn simple_for_target_name(target: &Expr, ctx: &mut LowerCtx) -> Option<(String, TextRange)> {
+    if let Expr::Name(name) = target {
+        Some((name.id.to_string(), target.range()))
+    } else {
+        statement_diagnostics::invalid_iteration(
+            ctx,
+            "async for target must be a simple name",
+            target.range(),
+        );
+        None
+    }
+}
+
+pub(super) fn lower_async_for(
+    for_stmt: &StmtFor,
+    func_type: &FunctionType,
+    ctx: &mut LowerCtx,
+) -> Option<HirStmt> {
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "async for is only valid inside async functions".to_string(),
+            for_stmt.range(),
+        );
+        return None;
+    }
+    if !for_stmt.orelse.is_empty() {
+        statement_diagnostics::unsupported_form(
+            ctx,
+            "async for else clauses are not supported in v1",
+            for_stmt.range(),
+        );
+        return None;
+    }
+
+    let iter = lower_expr(&for_stmt.iter, ctx)?;
+    let iter_ty = iter.ty().clone();
+    let Some((target_ty, iter_error_ty)) = async_iterator_parts(&iter_ty) else {
+        statement_diagnostics::invalid_iteration(
+            ctx,
+            &format!(
+                "async for requires AsyncIterator[T, E] with anext() -> Result[Option[T], E], got '{}'",
+                iter_ty.display_name()
+            ),
+            for_stmt.iter.range(),
+        );
+        return None;
+    };
+    if !return_type_accepts_error(&func_type.return_type, &iter_error_ty) {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "fallible async iterator requires the enclosing function to return a compatible Result error type".to_string(),
+            for_stmt.iter.range(),
+        );
+        return None;
+    }
+
+    let (target, _) = simple_for_target_name(&for_stmt.target, ctx)?;
+    ctx.scope.push();
+    ctx.scope.define(target.clone(), target_ty.clone());
+    ctx.loop_depth += 1;
+    let body = lower_stmts(&for_stmt.body, func_type, ctx);
+    ctx.loop_depth -= 1;
+    ctx.scope.pop();
+
+    Some(HirStmt::AsyncFor {
+        target,
+        target_ty,
+        iter,
+        iter_error_ty,
+        body,
+        else_body: None,
+    })
+}

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -517,6 +517,7 @@ fn stmt_contains_await(stmt: &HirStmt) -> bool {
                     .as_ref()
                     .is_some_and(|body| body.iter().any(stmt_contains_await))
         }
+        HirStmt::AsyncFor { .. } => true,
         HirStmt::AsyncWith { kind, body, .. } => {
             matches!(
                 kind,
@@ -595,6 +596,12 @@ fn stmt_contains_task_spawn(stmt: &HirStmt) -> bool {
             body,
             else_body,
             ..
+        }
+        | HirStmt::AsyncFor {
+            iter,
+            body,
+            else_body,
+            ..
         } => {
             expr_contains_task_spawn(iter)
                 || body.iter().any(stmt_contains_task_spawn)
@@ -654,6 +661,9 @@ fn stmt_contains_scope_early_exit(stmt: &HirStmt) -> bool {
             body, else_body, ..
         }
         | HirStmt::For {
+            body, else_body, ..
+        }
+        | HirStmt::AsyncFor {
             body, else_body, ..
         } => {
             body.iter().any(stmt_contains_scope_early_exit)

--- a/crates/sifr_hir/src/lower/classes.rs
+++ b/crates/sifr_hir/src/lower/classes.rs
@@ -1223,6 +1223,9 @@ pub(super) fn body_contains_field_assign(stmts: &[HirStmt]) -> bool {
             }
             | HirStmt::For {
                 body, else_body, ..
+            }
+            | HirStmt::AsyncFor {
+                body, else_body, ..
             } => {
                 body_contains_field_assign(body)
                     || else_body

--- a/crates/sifr_hir/src/lower/container_literal_specialization.rs
+++ b/crates/sifr_hir/src/lower/container_literal_specialization.rs
@@ -290,6 +290,9 @@ fn patch_stmt_container_specialization(stmt: &mut HirStmt, pending: &mut HashMap
         }
         | HirStmt::For {
             body, else_body, ..
+        }
+        | HirStmt::AsyncFor {
+            body, else_body, ..
         } => {
             apply_container_specialization_patches(body, pending);
             if let Some(body) = else_body {

--- a/crates/sifr_hir/src/lower/diagnostics.rs
+++ b/crates/sifr_hir/src/lower/diagnostics.rs
@@ -104,7 +104,9 @@ pub(super) fn collect_raise_error_types(
                     collect_raise_error_types(eb, errors);
                 }
             }
-            HirStmt::While { body, .. } | HirStmt::For { body, .. } => {
+            HirStmt::While { body, .. }
+            | HirStmt::For { body, .. }
+            | HirStmt::AsyncFor { body, .. } => {
                 collect_raise_error_types(body, errors);
             }
             _ => {}

--- a/crates/sifr_hir/src/lower/for_loop_safety.rs
+++ b/crates/sifr_hir/src/lower/for_loop_safety.rs
@@ -54,6 +54,9 @@ fn stmt_mutates_iter_source(stmt: &HirStmt, source_name: &str) -> bool {
         }
         | HirStmt::For {
             body, else_body, ..
+        }
+        | HirStmt::AsyncFor {
+            body, else_body, ..
         } => {
             loop_body_mutates_iter_source(body, source_name)
                 || else_body

--- a/crates/sifr_hir/src/lower/function_flow.rs
+++ b/crates/sifr_hir/src/lower/function_flow.rs
@@ -33,6 +33,9 @@ pub(super) fn collect_yield_types(stmts: &[HirStmt]) -> Vec<Type> {
                 }
                 | HirStmt::For {
                     body, else_body, ..
+                }
+                | HirStmt::AsyncFor {
+                    body, else_body, ..
                 } => {
                     walk(body, out);
                     if let Some(else_body) = else_body {

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -8,6 +8,7 @@ mod append_growth_shapes;
 mod arithmetic_warnings;
 mod assignment_widening;
 mod async_await;
+mod async_for;
 mod async_with;
 mod attribute_access;
 mod aug_assign_lowering;

--- a/crates/sifr_hir/src/lower/nonlocal_support.rs
+++ b/crates/sifr_hir/src/lower/nonlocal_support.rs
@@ -147,6 +147,12 @@ fn hir_stmt_calls_function(stmt: &HirStmt, func_name: &str) -> bool {
             body,
             else_body,
             ..
+        }
+        | HirStmt::AsyncFor {
+            iter,
+            body,
+            else_body,
+            ..
         } => {
             hir_expr_calls_function(iter, func_name)
                 || hir_body_calls_function(body, func_name)

--- a/crates/sifr_hir/src/lower/numeric_sentinels.rs
+++ b/crates/sifr_hir/src/lower/numeric_sentinels.rs
@@ -249,6 +249,9 @@ fn patch_stmt_numeric_sentinels(
         }
         HirStmt::For {
             body, else_body, ..
+        }
+        | HirStmt::AsyncFor {
+            body, else_body, ..
         } => {
             apply_numeric_sentinel_patches(body, pending);
             if let Some(body) = else_body {

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1,4 +1,5 @@
 use super::assignment_widening::reconcile_optional_reassignment;
+use super::async_for::lower_async_for;
 use super::async_with::lower_async_with;
 use super::aug_assign_lowering::lower_aug_assign as lower_aug_assign_impl;
 use super::binding_mutability::ensure_mutable_parameter_binding;
@@ -251,7 +252,13 @@ pub(super) fn lower_stmt(
         }
         Stmt::If(if_stmt) => lower_if(if_stmt, func_type, ctx),
         Stmt::While(while_stmt) => lower_while(while_stmt, func_type, ctx),
-        Stmt::For(for_stmt) => lower_for(for_stmt, func_type, ctx),
+        Stmt::For(for_stmt) => {
+            if for_stmt.is_async {
+                lower_async_for(for_stmt, func_type, ctx)
+            } else {
+                lower_for(for_stmt, func_type, ctx)
+            }
+        }
         Stmt::Break(break_stmt) => {
             if !ctx.in_loop() {
                 super::flow_diagnostics::break_outside_loop(ctx, break_stmt.range());

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -787,6 +787,7 @@ Implementation notes:
 
 - PR [#2028](https://github.com/sifr-lang/sifr/pull/2028) user-defined `async with` protocol slice: structural async context managers with `__aenter__() -> Result[T, E]` and `__aexit__(AsyncExitCause) -> Result[None, E]` now lower on the normal-exit path, with `async_with_basic.sifr` in the quick lane and `async_with_missing_protocol_rejected.sifr` covering missing protocol rejection. Abnormal-exit cleanup, cancellation causes, secondary cleanup evidence, and `async for` remain follow-up slices in this milestone.
 - PR [#2030](https://github.com/sifr-lang/sifr/pull/2030) named async context state slice: named user-defined async context managers are preserved across the normal-exit lowering so post-body state validates LIFO cleanup order through `async_with_nested_cleanup_order.sifr`.
+- Async iteration protocol slice: user-defined async iterators with `anext() -> Result[Option[T], E]` are lowered for normal exhaustion and fallible propagation through `async_for_stream_result.sifr`, with non-async iterable rejection and timeout await-point validation covered by fail fixtures.
 
 **Goal:** Complete general user-defined async control-flow protocols without dragging in broad ecosystem APIs.
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -35,6 +35,7 @@
     "threading_compat_basic",
     "async_with_basic",
     "async_with_nested_cleanup_order",
+    "async_for_stream_result",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- Add `HirStmt::AsyncFor` and lower `async for` over structural async iterators with `anext() -> Result[Option[T], E]`.
- Generate `loop` + `anext().await?` + `match Some/None` code for named and materialized non-name iterator sources.
- Wire the new HIR node through CFG, flow, traversal, mutation tracking, error refs, and codegen helpers.
- Add pass coverage for `async_for_stream_result.sifr` and fail coverage for non-async iterables plus timeout await-point validation.

## Validation
- `cargo fmt`
- `cargo check -p sifr_hir -p sifr_codegen`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_stream_result.sifr`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/async_for_non_async_iterable_rejected.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_basic.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_nested_cleanup_order.sifr`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/async_for_stream_result.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`
  - PASS, 54 pass fixtures, `report_signature=dd74546e2bc378d9`, wall_time=89.13s

## Review
- Opus review round 1: `REVIEW_STATUS: SATISFIED`
- Opus review round 2 after timeout await-point fix: `REVIEW_STATUS: SATISFIED`

## Follow-ups intentionally left for later slices
- `AsyncClosable.aclose()` early-exit cleanup.
- Channel-backed async iteration.
- Cancellation cleanup and secondary evidence.
- Async generators and async comprehensions.
