### PR TITLE
Add channel-backed async for iteration

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_for_channel.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_channel.sifr
@@ -1,0 +1,21 @@
+from sifr.sync import ChannelReceiver, ChannelSender, channel
+
+
+async def main() -> None:
+    endpoints: tuple[ChannelSender[int], ChannelReceiver[int]] = channel()
+    sender, receiver = endpoints
+
+    first = await sender.send(10)
+    second = await sender.send(20)
+    sender.close()
+
+    total: int = 0
+    count: int = 0
+    async for value in receiver:
+        total = total + value
+        count = count + 1
+
+    assert str(first) == "Ok(())"
+    assert str(second) == "Ok(())"
+    assert total == 30
+    assert count == 2

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -1050,6 +1050,13 @@ impl<T: Clone> ChannelReceiver<T> {
             }
         }
     }
+
+    async fn anext(&mut self) -> Option<T> {
+        match self.receive().await {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        }
+    }
 }
 
 impl<T: Clone> Drop for ChannelReceiver<T> {
@@ -2252,10 +2259,16 @@ impl RustEmitter {
         }
 
         if let HirStmt::AsyncFor {
-            target, iter, body, ..
+            target,
+            iter,
+            iter_error_ty,
+            body,
+            ..
         } = stmt
         {
-            if let Some(lowered_stmt) = self.try_lower_async_for_stmt_for_ir(target, iter, body)? {
+            if let Some(lowered_stmt) =
+                self.try_lower_async_for_stmt_for_ir(target, iter, iter_error_ty, body)?
+            {
                 self.push_captured_stmt(&self.rewrite_stdlib_constant_idents_in_stmt(lowered_stmt));
                 self.lowering_stats.stmt_structured += 1;
                 self.lowering_stats.stmt_candidate_structured += 1;

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -6449,11 +6449,15 @@ impl RustEmitter {
                     true,
                 )
             } else if let HirStmt::AsyncFor {
-                target, iter, body, ..
+                target,
+                iter,
+                iter_error_ty,
+                body,
+                ..
             } = stmt
             {
                 let Some(lowered_async_for) =
-                    self.try_lower_async_for_stmt_for_ir(target, iter, body)?
+                    self.try_lower_async_for_stmt_for_ir(target, iter, iter_error_ty, body)?
                 else {
                     return Ok(None);
                 };
@@ -7644,6 +7648,7 @@ impl RustEmitter {
         &mut self,
         target: &str,
         iter: &HirExpr,
+        iter_error_ty: &Type,
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
@@ -7654,19 +7659,24 @@ impl RustEmitter {
         } else {
             format!("_{target}")
         };
+        let infallible_iter = matches!(iter_error_ty.resolve_alias(), Type::Never);
         let loop_body = |receiver: crate::RustExpr| {
+            let next_call = crate::RustExpr::Await(Box::new(crate::RustExpr::MethodCall {
+                receiver: Box::new(receiver),
+                method: "anext".to_string(),
+                args: vec![],
+            }));
+            let next_value = if infallible_iter {
+                next_call
+            } else {
+                crate::RustExpr::Try(Box::new(next_call))
+            };
             vec![
                 RustStmt::Let {
                     mutable: false,
                     name: "__sifr_async_next".to_string(),
                     ty: None,
-                    value: crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(
-                        crate::RustExpr::MethodCall {
-                            receiver: Box::new(receiver),
-                            method: "anext".to_string(),
-                            args: vec![],
-                        },
-                    )))),
+                    value: next_value,
                 },
                 RustStmt::Match {
                     expr: crate::RustExpr::Ident("__sifr_async_next".to_string()),

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -71,6 +71,9 @@ fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {
 }
 
 fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
+    if matches!(error_ty.resolve_alias(), Type::Never) {
+        return true;
+    }
     let Type::Result(_, err) = return_type.resolve_alias() else {
         return false;
     };

--- a/lib/sifr/sync.sifr
+++ b/lib/sifr/sync.sifr
@@ -96,6 +96,9 @@ class ChannelReceiver[T]:
         self._channel = channel
         return received
 
+    async def anext(self) -> Option[T]:
+        return None
+
 
 def channel[T]() -> tuple[ChannelSender[T], ChannelReceiver[T]]:
     sender_channel: Channel[T] = Channel([], -1)

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -36,6 +36,7 @@
     "async_with_basic",
     "async_with_nested_cleanup_order",
     "async_for_stream_result",
+    "async_for_channel",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- expose `ChannelReceiver[T].anext() -> Option[T]` for infallible async iteration
- lower `async for` over `Never` iterators without `?`, while keeping fallible iterator propagation unchanged
- add `async_for_channel.sifr` to the quick e2e lane

## Validation
- `cargo fmt --check`
- `cargo check -p sifr_hir -p sifr_codegen`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_channel.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_stream_result.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick` (55 pass fixtures, `report_signature=eb2af48c6c733f87`, wall_time=116.22s)

## Review
- Opus review: `REVIEW_STATUS: SATISFIED` (`reviews/phase32_async_for_channel.md`, local artifact only)