### PR TITLE
Close async iterators on async for break

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_for_closable_break_return_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_for_closable_break_return_type_rejected.sifr
@@ -1,0 +1,30 @@
+# expect-error[col=24]: SIFR-TYPE-0002
+
+class StreamCloseError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+    closed: bool
+
+    def __init__(self):
+        self.current = 0
+        self.closed = False
+
+    async def anext(self) -> Result[Option[int], StreamCloseError]:
+        if self.current > 0:
+            return None
+        self.current = self.current + 1
+        value: Option[int] = self.current
+        return value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        self.closed = True
+        return None
+
+
+async def main() -> None:
+    stream: ClosableCounter = ClosableCounter()
+    async for value in stream:
+        break

--- a/crates/sifr/tests/e2e/pass/async_for_closable_iterator_cleanup.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_closable_iterator_cleanup.sifr
@@ -1,0 +1,39 @@
+class StreamCloseError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+    stop: int
+    closed: bool
+
+    def __init__(self, start: int, stop: int):
+        self.current = start
+        self.stop = stop
+        self.closed = False
+
+    async def anext(self) -> Result[Option[int], StreamCloseError]:
+        if self.current >= self.stop:
+            return None
+        value: int = self.current
+        self.current = self.current + 1
+        next_value: Option[int] = value
+        return next_value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        self.closed = True
+        return None
+
+
+async def main() -> Result[None, StreamCloseError]:
+    stream: ClosableCounter = ClosableCounter(0, 5)
+    total: int = 0
+
+    async for value in stream:
+        if value == 3:
+            break
+        total = total + value
+
+    assert total == 3
+    assert stream.closed
+    return None

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2262,13 +2262,18 @@ impl RustEmitter {
             target,
             iter,
             iter_error_ty,
+            close_error_ty,
             body,
             ..
         } = stmt
         {
-            if let Some(lowered_stmt) =
-                self.try_lower_async_for_stmt_for_ir(target, iter, iter_error_ty, body)?
-            {
+            if let Some(lowered_stmt) = self.try_lower_async_for_stmt_for_ir(
+                target,
+                iter,
+                iter_error_ty,
+                close_error_ty.as_ref(),
+                body,
+            )? {
                 self.push_captured_stmt(&self.rewrite_stdlib_constant_idents_in_stmt(lowered_stmt));
                 self.lowering_stats.stmt_structured += 1;
                 self.lowering_stats.stmt_candidate_structured += 1;

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -6452,12 +6452,18 @@ impl RustEmitter {
                 target,
                 iter,
                 iter_error_ty,
+                close_error_ty,
                 body,
                 ..
             } = stmt
             {
-                let Some(lowered_async_for) =
-                    self.try_lower_async_for_stmt_for_ir(target, iter, iter_error_ty, body)?
+                let Some(lowered_async_for) = self.try_lower_async_for_stmt_for_ir(
+                    target,
+                    iter,
+                    iter_error_ty,
+                    close_error_ty.as_ref(),
+                    body,
+                )?
                 else {
                     return Ok(None);
                 };
@@ -7649,6 +7655,7 @@ impl RustEmitter {
         target: &str,
         iter: &HirExpr,
         iter_error_ty: &Type,
+        close_error_ty: Option<&Type>,
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         let Some(lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
@@ -7661,6 +7668,11 @@ impl RustEmitter {
         };
         let infallible_iter = matches!(iter_error_ty.resolve_alias(), Type::Never);
         let loop_body = |receiver: crate::RustExpr| {
+            let lowered_body = if let Some(close_error_ty) = close_error_ty {
+                inject_async_for_break_cleanup(&lowered_body, &receiver, close_error_ty)
+            } else {
+                lowered_body.clone()
+            };
             let next_call = crate::RustExpr::Await(Box::new(crate::RustExpr::MethodCall {
                 receiver: Box::new(receiver),
                 method: "anext".to_string(),
@@ -9746,4 +9758,90 @@ fn result_int_to_sifr_int_rust_type(ty: &Type) -> crate::RustType {
         Box::new(crate::RustType::Named("SifrInt".to_string())),
         Box::new(crate::sifr_type_to_rust_type(err_ty)),
     )
+}
+
+fn inject_async_for_break_cleanup(
+    stmts: &[RustStmt],
+    receiver: &RustExpr,
+    close_error_ty: &Type,
+) -> Vec<RustStmt> {
+    stmts
+        .iter()
+        .flat_map(|stmt| inject_async_for_break_cleanup_stmt(stmt, receiver, close_error_ty))
+        .collect()
+}
+
+fn inject_async_for_break_cleanup_stmt(
+    stmt: &RustStmt,
+    receiver: &RustExpr,
+    close_error_ty: &Type,
+) -> Vec<RustStmt> {
+    match stmt {
+        RustStmt::Break => vec![
+            RustStmt::Expr(async_for_close_call(receiver.clone(), close_error_ty)),
+            RustStmt::Break,
+        ],
+        RustStmt::If {
+            cond,
+            then_body,
+            else_body,
+        } => vec![RustStmt::If {
+            cond: cond.clone(),
+            then_body: inject_async_for_break_cleanup(then_body, receiver, close_error_ty),
+            else_body: else_body
+                .as_ref()
+                .map(|body| inject_async_for_break_cleanup(body, receiver, close_error_ty)),
+        }],
+        RustStmt::IfLet {
+            pattern,
+            expr,
+            then_body,
+            else_body,
+        } => vec![RustStmt::IfLet {
+            pattern: pattern.clone(),
+            expr: expr.clone(),
+            then_body: inject_async_for_break_cleanup(then_body, receiver, close_error_ty),
+            else_body: else_body
+                .as_ref()
+                .map(|body| inject_async_for_break_cleanup(body, receiver, close_error_ty)),
+        }],
+        RustStmt::Match { expr, arms } => vec![RustStmt::Match {
+            expr: expr.clone(),
+            arms: arms
+                .iter()
+                .map(|arm| crate::RustMatchArm {
+                    pattern: arm.pattern.clone(),
+                    bindings: arm.bindings.clone(),
+                    guard: arm.guard.clone(),
+                    body: inject_async_for_break_cleanup(&arm.body, receiver, close_error_ty),
+                })
+                .collect(),
+        }],
+        RustStmt::With { items, body } => vec![RustStmt::With {
+            items: items.clone(),
+            body: inject_async_for_break_cleanup(body, receiver, close_error_ty),
+        }],
+        RustStmt::Block(body) => vec![RustStmt::Block(inject_async_for_break_cleanup(
+            body,
+            receiver,
+            close_error_ty,
+        ))],
+        RustStmt::For { .. } | RustStmt::While { .. } | RustStmt::Loop { .. } => {
+            vec![stmt.clone()]
+        }
+        _ => vec![stmt.clone()],
+    }
+}
+
+fn async_for_close_call(receiver: RustExpr, close_error_ty: &Type) -> RustExpr {
+    let close_call = RustExpr::Await(Box::new(RustExpr::MethodCall {
+        receiver: Box::new(receiver),
+        method: "aclose".to_string(),
+        args: vec![],
+    }));
+    if matches!(close_error_ty.resolve_alias(), Type::Never) {
+        close_call
+    } else {
+        RustExpr::Try(Box::new(close_call))
+    }
 }

--- a/crates/sifr_hir/src/hir_nodes.rs
+++ b/crates/sifr_hir/src/hir_nodes.rs
@@ -177,6 +177,7 @@ pub enum HirStmt {
         target_ty: Type,
         iter: HirExpr,
         iter_error_ty: Type,
+        close_error_ty: Option<Type>,
         body: Vec<HirStmt>,
         else_body: Option<Vec<HirStmt>>,
     },

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -70,6 +70,22 @@ fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {
     }
 }
 
+fn async_closable_error_type(ty: &Type) -> Option<Type> {
+    let (Type::Class { methods, .. } | Type::Protocol { methods, .. }) = ty.resolve_alias() else {
+        return None;
+    };
+    let aclose_ft = method_signature(methods, "aclose")?;
+    if !aclose_ft.params.is_empty() {
+        return None;
+    }
+    let (close_ok_ty, close_error_ty) = async_result_parts(&aclose_ft.return_type)?;
+    if matches!(close_ok_ty.resolve_alias(), Type::None) {
+        Some(close_error_ty)
+    } else {
+        None
+    }
+}
+
 fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
     if matches!(error_ty.resolve_alias(), Type::Never) {
         return true;
@@ -78,6 +94,48 @@ fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
         return false;
     };
     error_ty.is_assignable_to(err)
+}
+
+fn stmts_contain_break_for_current_loop(stmts: &[HirStmt]) -> bool {
+    stmts.iter().any(stmt_contains_break_for_current_loop)
+}
+
+fn stmt_contains_break_for_current_loop(stmt: &HirStmt) -> bool {
+    match stmt {
+        HirStmt::Break => true,
+        HirStmt::If {
+            then_body,
+            elif_clauses,
+            else_body,
+            ..
+        } => {
+            stmts_contain_break_for_current_loop(then_body)
+                || elif_clauses
+                    .iter()
+                    .any(|(_, body)| stmts_contain_break_for_current_loop(body))
+                || else_body
+                    .as_ref()
+                    .is_some_and(|body| stmts_contain_break_for_current_loop(body))
+        }
+        HirStmt::TryExcept { body, handlers, .. } => {
+            stmts_contain_break_for_current_loop(body)
+                || handlers
+                    .iter()
+                    .any(|handler| stmts_contain_break_for_current_loop(&handler.body))
+        }
+        HirStmt::TryFinally { body, finalbody } => {
+            stmts_contain_break_for_current_loop(body)
+                || stmts_contain_break_for_current_loop(finalbody)
+        }
+        HirStmt::Match { arms, .. } => arms
+            .iter()
+            .any(|arm| stmts_contain_break_for_current_loop(&arm.body)),
+        HirStmt::AsyncWith { body, .. } | HirStmt::With { body, .. } => {
+            stmts_contain_break_for_current_loop(body)
+        }
+        HirStmt::While { .. } | HirStmt::For { .. } | HirStmt::AsyncFor { .. } => false,
+        _ => false,
+    }
 }
 
 fn simple_for_target_name(target: &Expr, ctx: &mut LowerCtx) -> Option<(String, TextRange)> {
@@ -128,6 +186,7 @@ pub(super) fn lower_async_for(
         );
         return None;
     };
+    let close_error_ty = async_closable_error_type(&iter_ty);
     if !return_type_accepts_error(&func_type.return_type, &iter_error_ty) {
         ctx.error_with_code_at(
             DiagnosticCode::TYPE_MISMATCH,
@@ -144,12 +203,25 @@ pub(super) fn lower_async_for(
     let body = lower_stmts(&for_stmt.body, func_type, ctx);
     ctx.loop_depth -= 1;
     ctx.scope.pop();
+    if let Some(close_error_ty) = &close_error_ty {
+        if stmts_contain_break_for_current_loop(&body)
+            && !return_type_accepts_error(&func_type.return_type, close_error_ty)
+        {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                "closable async iterator break cleanup requires the enclosing function to return a compatible Result error type".to_string(),
+                for_stmt.iter.range(),
+            );
+            return None;
+        }
+    }
 
     Some(HirStmt::AsyncFor {
         target,
         target_ty,
         iter,
         iter_error_ty,
+        close_error_ty,
         body,
         else_body: None,
     })

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -37,6 +37,7 @@
     "async_with_nested_cleanup_order",
     "async_for_stream_result",
     "async_for_channel",
+    "async_for_closable_iterator_cleanup",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- record optional `aclose()` close error type on async-for HIR nodes
- inject `await aclose()` before breaks that exit a closable async-for loop, while skipping nested-loop breaks
- add positive and negative e2e coverage for closable async-for break cleanup

## Validation
- `cargo fmt --check`
- `cargo check -p sifr_hir -p sifr_codegen`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_closable_iterator_cleanup.sifr`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/async_for_closable_iterator_cleanup.sifr | rg -n "aclose|loop|break|__sifr_async_next" -C 3`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_stream_result.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick` (56 pass fixtures, `report_signature=00ba689e632ea829`, wall_time=107.53s)

## Review
- Opus review: `REVIEW_STATUS: SATISFIED` (`reviews/phase32_async_for_closable_break.md`, local artifact only)