### PR TITLE
Close async iterators before async-for returns

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_for_closable_nested_return_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_for_closable_nested_return_type_rejected.sifr
@@ -1,0 +1,33 @@
+# expect-error[col=24]: SIFR-TYPE-0002
+
+class StreamCloseError(Error):
+    pass
+
+
+class StreamIterError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+
+    def __init__(self):
+        self.current = 0
+
+    async def anext(self) -> Result[Option[int], StreamIterError]:
+        if self.current > 0:
+            return None
+        self.current = self.current + 1
+        value: Option[int] = self.current
+        return value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        return None
+
+
+async def first_value() -> Result[int, StreamIterError]:
+    stream: ClosableCounter = ClosableCounter()
+    async for value in stream:
+        while value > 0:
+            return value
+    return 0

--- a/crates/sifr/tests/e2e/fail/async_for_closable_return_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_for_closable_return_type_rejected.sifr
@@ -1,0 +1,32 @@
+# expect-error[col=24]: SIFR-TYPE-0002
+
+class StreamCloseError(Error):
+    pass
+
+
+class StreamIterError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+
+    def __init__(self):
+        self.current = 0
+
+    async def anext(self) -> Result[Option[int], StreamIterError]:
+        if self.current > 0:
+            return None
+        self.current = self.current + 1
+        value: Option[int] = self.current
+        return value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        return None
+
+
+async def first_value() -> Result[int, StreamIterError]:
+    stream: ClosableCounter = ClosableCounter()
+    async for value in stream:
+        return value
+    return 0

--- a/crates/sifr/tests/e2e/pass/async_for_closable_iterator_nested_return_cleanup.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_closable_iterator_nested_return_cleanup.sifr
@@ -1,0 +1,39 @@
+class StreamCloseError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+    stop: int
+    closed: bool
+
+    def __init__(self, start: int, stop: int):
+        self.current = start
+        self.stop = stop
+        self.closed = False
+
+    async def anext(self) -> Result[Option[int], StreamCloseError]:
+        if self.current >= self.stop:
+            return None
+        value: int = self.current
+        self.current = self.current + 1
+        next_value: Option[int] = value
+        return next_value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        self.closed = True
+        return None
+
+
+async def first_value_from_nested_loop() -> Result[int, StreamCloseError]:
+    stream: ClosableCounter = ClosableCounter(0, 3)
+    async for value in stream:
+        while value == 0:
+            return value
+    return 99
+
+
+async def main() -> Result[None, StreamCloseError]:
+    result = await first_value_from_nested_loop()
+    assert str(result) == "Ok(0)"
+    return None

--- a/crates/sifr/tests/e2e/pass/async_for_closable_iterator_return_cleanup.sifr
+++ b/crates/sifr/tests/e2e/pass/async_for_closable_iterator_return_cleanup.sifr
@@ -1,0 +1,38 @@
+class StreamCloseError(Error):
+    pass
+
+
+class ClosableCounter:
+    current: int
+    stop: int
+    closed: bool
+
+    def __init__(self, start: int, stop: int):
+        self.current = start
+        self.stop = stop
+        self.closed = False
+
+    async def anext(self) -> Result[Option[int], StreamCloseError]:
+        if self.current >= self.stop:
+            return None
+        value: int = self.current
+        self.current = self.current + 1
+        next_value: Option[int] = value
+        return next_value
+
+    async def aclose(self) -> Result[None, StreamCloseError]:
+        self.closed = True
+        return None
+
+
+async def first_value() -> Result[int, StreamCloseError]:
+    stream: ClosableCounter = ClosableCounter(0, 3)
+    async for value in stream:
+        return value
+    return 99
+
+
+async def main() -> Result[None, StreamCloseError]:
+    result = await first_value()
+    assert str(result) == "Ok(0)"
+    return None

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7669,7 +7669,7 @@ impl RustEmitter {
         let infallible_iter = matches!(iter_error_ty.resolve_alias(), Type::Never);
         let loop_body = |receiver: crate::RustExpr| {
             let lowered_body = if let Some(close_error_ty) = close_error_ty {
-                inject_async_for_break_cleanup(&lowered_body, &receiver, close_error_ty)
+                inject_async_for_early_exit_cleanup(&lowered_body, &receiver, close_error_ty)
             } else {
                 lowered_body.clone()
             };
@@ -9760,26 +9760,56 @@ fn result_int_to_sifr_int_rust_type(ty: &Type) -> crate::RustType {
     )
 }
 
-fn inject_async_for_break_cleanup(
+fn inject_async_for_early_exit_cleanup(
     stmts: &[RustStmt],
     receiver: &RustExpr,
     close_error_ty: &Type,
 ) -> Vec<RustStmt> {
+    inject_async_for_early_exit_cleanup_with_breaks(stmts, receiver, close_error_ty, true)
+}
+
+fn inject_async_for_early_exit_cleanup_with_breaks(
+    stmts: &[RustStmt],
+    receiver: &RustExpr,
+    close_error_ty: &Type,
+    include_breaks: bool,
+) -> Vec<RustStmt> {
     stmts
         .iter()
-        .flat_map(|stmt| inject_async_for_break_cleanup_stmt(stmt, receiver, close_error_ty))
+        .flat_map(|stmt| {
+            inject_async_for_early_exit_cleanup_stmt(stmt, receiver, close_error_ty, include_breaks)
+        })
         .collect()
 }
 
-fn inject_async_for_break_cleanup_stmt(
+fn inject_async_for_early_exit_cleanup_stmt(
     stmt: &RustStmt,
     receiver: &RustExpr,
     close_error_ty: &Type,
+    include_breaks: bool,
 ) -> Vec<RustStmt> {
     match stmt {
-        RustStmt::Break => vec![
+        RustStmt::Break if include_breaks => vec![
             RustStmt::Expr(async_for_close_call(receiver.clone(), close_error_ty)),
             RustStmt::Break,
+        ],
+        RustStmt::Return(Some(value)) => vec![RustStmt::Return(Some(RustExpr::Block {
+            stmts: vec![
+                RustStmt::Let {
+                    mutable: false,
+                    name: "__sifr_async_for_return".to_string(),
+                    ty: None,
+                    value: value.clone(),
+                },
+                RustStmt::Expr(async_for_close_call(receiver.clone(), close_error_ty)),
+            ],
+            expr: Some(Box::new(RustExpr::Ident(
+                "__sifr_async_for_return".to_string(),
+            ))),
+        }))],
+        RustStmt::Return(None) => vec![
+            RustStmt::Expr(async_for_close_call(receiver.clone(), close_error_ty)),
+            RustStmt::Return(None),
         ],
         RustStmt::If {
             cond,
@@ -9787,10 +9817,20 @@ fn inject_async_for_break_cleanup_stmt(
             else_body,
         } => vec![RustStmt::If {
             cond: cond.clone(),
-            then_body: inject_async_for_break_cleanup(then_body, receiver, close_error_ty),
-            else_body: else_body
-                .as_ref()
-                .map(|body| inject_async_for_break_cleanup(body, receiver, close_error_ty)),
+            then_body: inject_async_for_early_exit_cleanup_with_breaks(
+                then_body,
+                receiver,
+                close_error_ty,
+                include_breaks,
+            ),
+            else_body: else_body.as_ref().map(|body| {
+                inject_async_for_early_exit_cleanup_with_breaks(
+                    body,
+                    receiver,
+                    close_error_ty,
+                    include_breaks,
+                )
+            }),
         }],
         RustStmt::IfLet {
             pattern,
@@ -9800,10 +9840,20 @@ fn inject_async_for_break_cleanup_stmt(
         } => vec![RustStmt::IfLet {
             pattern: pattern.clone(),
             expr: expr.clone(),
-            then_body: inject_async_for_break_cleanup(then_body, receiver, close_error_ty),
-            else_body: else_body
-                .as_ref()
-                .map(|body| inject_async_for_break_cleanup(body, receiver, close_error_ty)),
+            then_body: inject_async_for_early_exit_cleanup_with_breaks(
+                then_body,
+                receiver,
+                close_error_ty,
+                include_breaks,
+            ),
+            else_body: else_body.as_ref().map(|body| {
+                inject_async_for_early_exit_cleanup_with_breaks(
+                    body,
+                    receiver,
+                    close_error_ty,
+                    include_breaks,
+                )
+            }),
         }],
         RustStmt::Match { expr, arms } => vec![RustStmt::Match {
             expr: expr.clone(),
@@ -9813,22 +9863,59 @@ fn inject_async_for_break_cleanup_stmt(
                     pattern: arm.pattern.clone(),
                     bindings: arm.bindings.clone(),
                     guard: arm.guard.clone(),
-                    body: inject_async_for_break_cleanup(&arm.body, receiver, close_error_ty),
+                    body: inject_async_for_early_exit_cleanup_with_breaks(
+                        &arm.body,
+                        receiver,
+                        close_error_ty,
+                        include_breaks,
+                    ),
                 })
                 .collect(),
         }],
         RustStmt::With { items, body } => vec![RustStmt::With {
             items: items.clone(),
-            body: inject_async_for_break_cleanup(body, receiver, close_error_ty),
+            body: inject_async_for_early_exit_cleanup_with_breaks(
+                body,
+                receiver,
+                close_error_ty,
+                include_breaks,
+            ),
         }],
-        RustStmt::Block(body) => vec![RustStmt::Block(inject_async_for_break_cleanup(
-            body,
-            receiver,
-            close_error_ty,
-        ))],
-        RustStmt::For { .. } | RustStmt::While { .. } | RustStmt::Loop { .. } => {
-            vec![stmt.clone()]
-        }
+        RustStmt::Block(body) => vec![RustStmt::Block(
+            inject_async_for_early_exit_cleanup_with_breaks(
+                body,
+                receiver,
+                close_error_ty,
+                include_breaks,
+            ),
+        )],
+        RustStmt::For { var, iter, body } => vec![RustStmt::For {
+            var: var.clone(),
+            iter: iter.clone(),
+            body: inject_async_for_early_exit_cleanup_with_breaks(
+                body,
+                receiver,
+                close_error_ty,
+                false,
+            ),
+        }],
+        RustStmt::While { cond, body } => vec![RustStmt::While {
+            cond: cond.clone(),
+            body: inject_async_for_early_exit_cleanup_with_breaks(
+                body,
+                receiver,
+                close_error_ty,
+                false,
+            ),
+        }],
+        RustStmt::Loop { body } => vec![RustStmt::Loop {
+            body: inject_async_for_early_exit_cleanup_with_breaks(
+                body,
+                receiver,
+                close_error_ty,
+                false,
+            ),
+        }],
         _ => vec![stmt.clone()],
     }
 }

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -96,46 +96,65 @@ fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
     error_ty.is_assignable_to(err)
 }
 
-fn stmts_contain_break_for_current_loop(stmts: &[HirStmt]) -> bool {
-    stmts.iter().any(stmt_contains_break_for_current_loop)
+fn stmts_contain_early_exit_for_current_loop(stmts: &[HirStmt]) -> bool {
+    stmts
+        .iter()
+        .any(|stmt| stmt_contains_early_exit_for_current_loop(stmt, true))
 }
 
-fn stmt_contains_break_for_current_loop(stmt: &HirStmt) -> bool {
+fn stmt_contains_early_exit_for_current_loop(stmt: &HirStmt, count_break: bool) -> bool {
     match stmt {
-        HirStmt::Break => true,
+        HirStmt::Break => count_break,
+        HirStmt::Return { .. } => true,
         HirStmt::If {
             then_body,
             elif_clauses,
             else_body,
             ..
         } => {
-            stmts_contain_break_for_current_loop(then_body)
-                || elif_clauses
-                    .iter()
-                    .any(|(_, body)| stmts_contain_break_for_current_loop(body))
-                || else_body
-                    .as_ref()
-                    .is_some_and(|body| stmts_contain_break_for_current_loop(body))
+            stmts_contain_early_exit_for_current_loop_with_breaks(then_body, count_break)
+                || elif_clauses.iter().any(|(_, body)| {
+                    stmts_contain_early_exit_for_current_loop_with_breaks(body, count_break)
+                })
+                || else_body.as_ref().is_some_and(|body| {
+                    stmts_contain_early_exit_for_current_loop_with_breaks(body, count_break)
+                })
         }
         HirStmt::TryExcept { body, handlers, .. } => {
-            stmts_contain_break_for_current_loop(body)
-                || handlers
-                    .iter()
-                    .any(|handler| stmts_contain_break_for_current_loop(&handler.body))
+            stmts_contain_early_exit_for_current_loop_with_breaks(body, count_break)
+                || handlers.iter().any(|handler| {
+                    stmts_contain_early_exit_for_current_loop_with_breaks(
+                        &handler.body,
+                        count_break,
+                    )
+                })
         }
         HirStmt::TryFinally { body, finalbody } => {
-            stmts_contain_break_for_current_loop(body)
-                || stmts_contain_break_for_current_loop(finalbody)
+            stmts_contain_early_exit_for_current_loop_with_breaks(body, count_break)
+                || stmts_contain_early_exit_for_current_loop_with_breaks(finalbody, count_break)
         }
-        HirStmt::Match { arms, .. } => arms
-            .iter()
-            .any(|arm| stmts_contain_break_for_current_loop(&arm.body)),
+        HirStmt::Match { arms, .. } => arms.iter().any(|arm| {
+            stmts_contain_early_exit_for_current_loop_with_breaks(&arm.body, count_break)
+        }),
         HirStmt::AsyncWith { body, .. } | HirStmt::With { body, .. } => {
-            stmts_contain_break_for_current_loop(body)
+            stmts_contain_early_exit_for_current_loop_with_breaks(body, count_break)
         }
-        HirStmt::While { .. } | HirStmt::For { .. } | HirStmt::AsyncFor { .. } => false,
+        HirStmt::While { body, .. }
+        | HirStmt::For { body, .. }
+        | HirStmt::AsyncFor { body, .. } => {
+            stmts_contain_early_exit_for_current_loop_with_breaks(body, false)
+        }
         _ => false,
     }
+}
+
+fn stmts_contain_early_exit_for_current_loop_with_breaks(
+    stmts: &[HirStmt],
+    count_break: bool,
+) -> bool {
+    stmts
+        .iter()
+        .any(|stmt| stmt_contains_early_exit_for_current_loop(stmt, count_break))
 }
 
 fn simple_for_target_name(target: &Expr, ctx: &mut LowerCtx) -> Option<(String, TextRange)> {
@@ -204,12 +223,12 @@ pub(super) fn lower_async_for(
     ctx.loop_depth -= 1;
     ctx.scope.pop();
     if let Some(close_error_ty) = &close_error_ty {
-        if stmts_contain_break_for_current_loop(&body)
+        if stmts_contain_early_exit_for_current_loop(&body)
             && !return_type_accepts_error(&func_type.return_type, close_error_ty)
         {
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,
-                "closable async iterator break cleanup requires the enclosing function to return a compatible Result error type".to_string(),
+                "closable async iterator early-exit cleanup requires the enclosing function to return a compatible Result error type".to_string(),
                 for_stmt.iter.range(),
             );
             return None;

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -38,6 +38,8 @@
     "async_for_stream_result",
     "async_for_channel",
     "async_for_closable_iterator_cleanup",
+    "async_for_closable_iterator_return_cleanup",
+    "async_for_closable_iterator_nested_return_cleanup",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- extend AsyncClosable async-for cleanup from break to return paths
- preserve return-value evaluation before awaiting aclose()
- distinguish nested-loop break from nested-loop return in HIR validation and codegen
- add direct and nested return pass/fail fixtures to the quick lane

## Review
- Opus review: reviews/phase32_async_for_closable_return.md
- REVIEW_STATUS: SATISFIED

## Validation
- cargo fmt --check
- cargo check -p sifr_hir -p sifr_codegen
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_closable_iterator_return_cleanup.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_for_closable_iterator_nested_return_cleanup.sifr
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- git diff --check
- scripts/run_all_tests.sh --profile quick (58 pass fixtures, report_signature=e57abc40499d8961, wall_time=96.25s)