### PR TITLE
Run async context cleanup before returns

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_with_raise_cleanup_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_with_raise_cleanup_rejected.sifr
@@ -1,0 +1,18 @@
+# expect-error[col=16]: SIFR-TYPE-0002
+
+class ResourceError(Error):
+    pass
+
+
+class MarkerResource:
+    async def __aenter__(self) -> Result[int, ResourceError]:
+        return 1
+
+    async def __aexit__(self, _cause: AsyncExitCause) -> Result[None, ResourceError]:
+        return None
+
+
+async def main() -> Result[None, ResourceError]:
+    async with MarkerResource() as value:
+        raise ResourceError()
+    return None

--- a/crates/sifr/tests/e2e/pass/async_with_return_cleanup.sifr
+++ b/crates/sifr/tests/e2e/pass/async_with_return_cleanup.sifr
@@ -1,0 +1,67 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path(name: str) -> str:
+    return "/tmp/sifr_async_with_return_cleanup_" + name + "_" + str(getpid()) + ".txt"
+
+
+class MarkerResource:
+    path: str
+    value: int
+
+    def __init__(self, path: str, value: int):
+        self.path = path
+        self.value = value
+
+    async def __aenter__(self) -> Result[int, IOError]:
+        return self.value
+
+    async def __aexit__(self, _cause: AsyncExitCause) -> Result[None, IOError]:
+        return write_text(self.path, "cleanup")
+
+
+async def direct_return(own path: str) -> Result[int, Error]:
+    async with MarkerResource(path, 7) as value:
+        return value
+    return 0
+
+
+async def nested_return(own path: str) -> Result[int, Error]:
+    async with MarkerResource(path, 11) as value:
+        while value == 11:
+            return value
+    return 0
+
+
+async def main() -> Result[None, Error]:
+    direct_path: str = marker_path("direct")
+    nested_path: str = marker_path("nested")
+    if exists(direct_path):
+        try:
+            _removed_direct_existing: None = remove_file(direct_path)
+        except IOError as e:
+            _direct_existing_cleanup_message: str = str(e.message)
+    if exists(nested_path):
+        try:
+            _removed_nested_existing: None = remove_file(nested_path)
+        except IOError as e:
+            _nested_existing_cleanup_message: str = str(e.message)
+
+    direct_result = await direct_return(marker_path("direct"))
+    nested_result = await nested_return(marker_path("nested"))
+
+    assert str(direct_result) == "Ok(7)"
+    assert str(nested_result) == "Ok(11)"
+    assert exists(direct_path)
+    assert exists(nested_path)
+
+    try:
+        _removed_direct: None = remove_file(direct_path)
+    except IOError as e:
+        _direct_cleanup_message: str = str(e.message)
+    try:
+        _removed_nested: None = remove_file(nested_path)
+    except IOError as e:
+        _nested_cleanup_message: str = str(e.message)
+    return None

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -7509,10 +7509,15 @@ impl RustEmitter {
         body: &[HirStmt],
     ) -> Result<Option<RustStmt>, crate::CodegenError> {
         if let sifr_hir::HirAsyncWithKind::UserDefined { context, .. } = kind {
+            let body_always_exits = queries::block_control_flow_effect(body).always_exits();
             let Some(mut lowered_body) = self.try_lower_stmt_block_for_ir(body)? else {
                 return Ok(None);
             };
             if let HirExpr::Name { name, .. } = context {
+                lowered_body = inject_async_with_return_cleanup(
+                    &lowered_body,
+                    &crate::RustExpr::Ident(name.clone()),
+                );
                 let enter_stmt = crate::RustStmt::Let {
                     mutable: false,
                     name: target.unwrap_or("_").to_string(),
@@ -7540,13 +7545,19 @@ impl RustEmitter {
                 let mut stmts = Vec::with_capacity(lowered_body.len() + 2);
                 stmts.push(enter_stmt);
                 stmts.append(&mut lowered_body);
-                stmts.push(exit_stmt);
+                if !body_always_exits {
+                    stmts.push(exit_stmt);
+                }
                 return Ok(Some(RustStmt::Block(stmts)));
             }
 
             let Some(lowered_context) = self.lower_stmt_expr_for_ir(context)? else {
                 return Ok(None);
             };
+            lowered_body = inject_async_with_return_cleanup(
+                &lowered_body,
+                &crate::RustExpr::Ident("__sifr_async_cm".to_string()),
+            );
             let enter_call = crate::RustExpr::Try(Box::new(crate::RustExpr::Await(Box::new(
                 crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Ident("__sifr_async_cm".to_string())),
@@ -7581,7 +7592,9 @@ impl RustEmitter {
             });
             stmts.push(enter_stmt);
             stmts.append(&mut lowered_body);
-            stmts.push(exit_stmt);
+            if !body_always_exits {
+                stmts.push(exit_stmt);
+            }
             return Ok(Some(RustStmt::Block(stmts)));
         }
 
@@ -9758,6 +9771,105 @@ fn result_int_to_sifr_int_rust_type(ty: &Type) -> crate::RustType {
         Box::new(crate::RustType::Named("SifrInt".to_string())),
         Box::new(crate::sifr_type_to_rust_type(err_ty)),
     )
+}
+
+fn inject_async_with_return_cleanup(stmts: &[RustStmt], receiver: &RustExpr) -> Vec<RustStmt> {
+    stmts
+        .iter()
+        .flat_map(|stmt| inject_async_with_return_cleanup_stmt(stmt, receiver))
+        .collect()
+}
+
+fn inject_async_with_return_cleanup_stmt(stmt: &RustStmt, receiver: &RustExpr) -> Vec<RustStmt> {
+    match stmt {
+        RustStmt::Return(Some(value)) => vec![RustStmt::Return(Some(RustExpr::Block {
+            stmts: vec![
+                RustStmt::Let {
+                    mutable: false,
+                    name: "__sifr_async_with_return".to_string(),
+                    ty: None,
+                    value: value.clone(),
+                },
+                RustStmt::Expr(async_with_exit_call(receiver.clone(), "Return")),
+            ],
+            expr: Some(Box::new(RustExpr::Ident(
+                "__sifr_async_with_return".to_string(),
+            ))),
+        }))],
+        RustStmt::Return(None) => vec![
+            RustStmt::Expr(async_with_exit_call(receiver.clone(), "Return")),
+            RustStmt::Return(None),
+        ],
+        RustStmt::If {
+            cond,
+            then_body,
+            else_body,
+        } => vec![RustStmt::If {
+            cond: cond.clone(),
+            then_body: inject_async_with_return_cleanup(then_body, receiver),
+            else_body: else_body
+                .as_ref()
+                .map(|body| inject_async_with_return_cleanup(body, receiver)),
+        }],
+        RustStmt::IfLet {
+            pattern,
+            expr,
+            then_body,
+            else_body,
+        } => vec![RustStmt::IfLet {
+            pattern: pattern.clone(),
+            expr: expr.clone(),
+            then_body: inject_async_with_return_cleanup(then_body, receiver),
+            else_body: else_body
+                .as_ref()
+                .map(|body| inject_async_with_return_cleanup(body, receiver)),
+        }],
+        RustStmt::Match { expr, arms } => vec![RustStmt::Match {
+            expr: expr.clone(),
+            arms: arms
+                .iter()
+                .map(|arm| crate::RustMatchArm {
+                    pattern: arm.pattern.clone(),
+                    bindings: arm.bindings.clone(),
+                    guard: arm.guard.clone(),
+                    body: inject_async_with_return_cleanup(&arm.body, receiver),
+                })
+                .collect(),
+        }],
+        RustStmt::With { items, body } => vec![RustStmt::With {
+            items: items.clone(),
+            body: inject_async_with_return_cleanup(body, receiver),
+        }],
+        RustStmt::Block(body) => {
+            vec![RustStmt::Block(inject_async_with_return_cleanup(
+                body, receiver,
+            ))]
+        }
+        RustStmt::For { var, iter, body } => vec![RustStmt::For {
+            var: var.clone(),
+            iter: iter.clone(),
+            body: inject_async_with_return_cleanup(body, receiver),
+        }],
+        RustStmt::While { cond, body } => vec![RustStmt::While {
+            cond: cond.clone(),
+            body: inject_async_with_return_cleanup(body, receiver),
+        }],
+        RustStmt::Loop { body } => vec![RustStmt::Loop {
+            body: inject_async_with_return_cleanup(body, receiver),
+        }],
+        _ => vec![stmt.clone()],
+    }
+}
+
+fn async_with_exit_call(receiver: RustExpr, cause_variant: &str) -> RustExpr {
+    RustExpr::Try(Box::new(RustExpr::Await(Box::new(RustExpr::MethodCall {
+        receiver: Box::new(receiver),
+        method: "__aexit__".to_string(),
+        args: vec![RustExpr::Ref {
+            mutable: false,
+            expr: Box::new(RustExpr::Ident(format!("AsyncExitCause::{cause_variant}"))),
+        }],
+    }))))
 }
 
 fn inject_async_for_early_exit_cleanup(

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -213,10 +213,10 @@ fn lower_user_async_with(
             ctx.scope.define(name.clone(), enter_value_ty.clone());
         }
         let body = lower_stmts(&with_stmt.body, func_type, ctx);
-        if body.iter().any(stmt_contains_scope_early_exit) {
+        if body.iter().any(stmt_contains_user_async_with_blocked_exit) {
             ctx.error_with_code_at(
                 DiagnosticCode::TYPE_MISMATCH,
-                "user-defined async context managers cannot use return, raise, or yield inside the body until abnormal-exit cleanup lowering is implemented".to_string(),
+                "user-defined async context managers cannot use raise or yield inside the body until abnormal-exit cleanup lowering is implemented".to_string(),
                 item.context_expr.range(),
             );
             return None;
@@ -640,22 +640,35 @@ fn stmt_contains_task_spawn(stmt: &HirStmt) -> bool {
     }
 }
 
+fn stmt_contains_user_async_with_blocked_exit(stmt: &HirStmt) -> bool {
+    stmt_contains_scope_exit(stmt, false)
+}
+
 fn stmt_contains_scope_early_exit(stmt: &HirStmt) -> bool {
+    stmt_contains_scope_exit(stmt, true)
+}
+
+fn stmt_contains_scope_exit(stmt: &HirStmt, include_return: bool) -> bool {
     match stmt {
-        HirStmt::Return { .. } | HirStmt::Raise { .. } | HirStmt::Yield { .. } => true,
+        HirStmt::Return { .. } => include_return,
+        HirStmt::Raise { .. } | HirStmt::Yield { .. } => true,
         HirStmt::If {
             then_body,
             elif_clauses,
             else_body,
             ..
         } => {
-            then_body.iter().any(stmt_contains_scope_early_exit)
-                || elif_clauses
-                    .iter()
-                    .any(|(_, body)| body.iter().any(stmt_contains_scope_early_exit))
-                || else_body
-                    .as_ref()
-                    .is_some_and(|body| body.iter().any(stmt_contains_scope_early_exit))
+            then_body
+                .iter()
+                .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                || elif_clauses.iter().any(|(_, body)| {
+                    body.iter()
+                        .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                })
+                || else_body.as_ref().is_some_and(|body| {
+                    body.iter()
+                        .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                })
         }
         HirStmt::While {
             body, else_body, ..
@@ -666,27 +679,38 @@ fn stmt_contains_scope_early_exit(stmt: &HirStmt) -> bool {
         | HirStmt::AsyncFor {
             body, else_body, ..
         } => {
-            body.iter().any(stmt_contains_scope_early_exit)
-                || else_body
-                    .as_ref()
-                    .is_some_and(|body| body.iter().any(stmt_contains_scope_early_exit))
+            body.iter()
+                .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                || else_body.as_ref().is_some_and(|body| {
+                    body.iter()
+                        .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                })
         }
-        HirStmt::AsyncWith { body, .. } | HirStmt::With { body, .. } => {
-            body.iter().any(stmt_contains_scope_early_exit)
-        }
+        HirStmt::AsyncWith { body, .. } | HirStmt::With { body, .. } => body
+            .iter()
+            .any(|stmt| stmt_contains_scope_exit(stmt, include_return)),
         HirStmt::TryExcept { body, handlers, .. } => {
-            body.iter().any(stmt_contains_scope_early_exit)
-                || handlers
-                    .iter()
-                    .any(|handler| handler.body.iter().any(stmt_contains_scope_early_exit))
+            body.iter()
+                .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                || handlers.iter().any(|handler| {
+                    handler
+                        .body
+                        .iter()
+                        .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                })
         }
         HirStmt::TryFinally { body, finalbody } => {
-            body.iter().any(stmt_contains_scope_early_exit)
-                || finalbody.iter().any(stmt_contains_scope_early_exit)
+            body.iter()
+                .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+                || finalbody
+                    .iter()
+                    .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
         }
-        HirStmt::Match { arms, .. } => arms
-            .iter()
-            .any(|arm| arm.body.iter().any(stmt_contains_scope_early_exit)),
+        HirStmt::Match { arms, .. } => arms.iter().any(|arm| {
+            arm.body
+                .iter()
+                .any(|stmt| stmt_contains_scope_exit(stmt, include_return))
+        }),
         _ => false,
     }
 }

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -35,6 +35,7 @@
     "threading_compat_basic",
     "async_with_basic",
     "async_with_nested_cleanup_order",
+    "async_with_return_cleanup",
     "async_for_stream_result",
     "async_for_channel",
     "async_for_closable_iterator_cleanup",


### PR DESCRIPTION
## Summary
- allow explicit return in user-defined async-with bodies while keeping raise/yield rejected
- inject __aexit__(AsyncExitCause::Return) before direct and nested-loop return paths
- preserve task-scope early-exit guard behavior for spawned children
- add async_with_return_cleanup to quick lane and keep raise rejection covered

## Review
- Opus review: reviews/phase32_async_with_return_cleanup.md
- REVIEW_STATUS: SATISFIED

## Validation
- cargo fmt --check
- cargo check -p sifr_hir -p sifr_codegen
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_with_return_cleanup.sifr
- emitted Rust inspected for AsyncExitCause::Return and AsyncExitCause::Normal paths
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- git diff --check
- scripts/run_all_tests.sh --profile quick (59 pass fixtures, report_signature=f2e05c5e8a08f8e7, wall_time=98.14s)