### PR TITLE
Add basic async generator value surface

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_await_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_await_rejected.sifr
@@ -1,0 +1,5 @@
+# expect-error[col=5]: SIFR-TYPE-0002
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    await task.sleep(0.0)
+    yield 1

--- a/crates/sifr/tests/e2e/fail/async_generator_return_annotation_mismatch.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_return_annotation_mismatch.sifr
@@ -1,0 +1,4 @@
+# expect-error[col=24]: SIFR-TYPE-0002
+
+async def numbers() -> Iterator[int]:
+    yield 1

--- a/crates/sifr/tests/e2e/pass/async_generator_basic.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_basic.sifr
@@ -1,0 +1,18 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield 2
+    yield 3
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    total: int = 0
+    count: int = 0
+    agen = numbers()
+
+    async for value in agen:
+        total = total + value
+        count = count + 1
+
+    assert total == 6
+    assert count == 3
+    return None

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -935,6 +935,82 @@ impl RustEmitter {
         body
     }
 
+    fn lower_async_generator_function_body(
+        &mut self,
+        func: &HirFunction,
+        mutable_param_shadows: &[(String, RustExpr)],
+    ) -> Vec<RustStmt> {
+        let yield_ty = if let Type::AsyncGenerator(elem, _) = func.return_type.resolve_alias() {
+            self.rust_ir_type_with_generics(elem)
+        } else {
+            RustType::I64
+        };
+
+        let mut body = Self::emit_mutable_param_shadow_stmts(mutable_param_shadows);
+        for param in &func.params {
+            if mutable_param_shadows
+                .iter()
+                .any(|(name, _)| name == &param.name)
+                || !param.convention.is_borrowed()
+                || param.ty.ownership() == OwnershipKind::Copy
+            {
+                continue;
+            }
+            body.push(RustStmt::Let {
+                mutable: false,
+                name: param.name.clone(),
+                ty: None,
+                value: RustExpr::Clone(Box::new(RustExpr::Ident(param.name.clone()))),
+            });
+        }
+
+        let cloned_borrowed_param_names: Vec<String> = func
+            .params
+            .iter()
+            .filter(|param| {
+                !mutable_param_shadows
+                    .iter()
+                    .any(|(name, _)| name == &param.name)
+                    && param.convention.is_borrowed()
+                    && param.ty.ownership() != OwnershipKind::Copy
+            })
+            .map(|param| param.name.clone())
+            .collect();
+
+        let saved_borrowed_params = self.borrowed_params.clone();
+        let saved_mut_borrowed_params = self.mut_borrowed_params.clone();
+        for name in &cloned_borrowed_param_names {
+            self.borrowed_params.remove(name);
+            self.mut_borrowed_params.remove(name);
+        }
+
+        body.push(RustStmt::Let {
+            mutable: true,
+            name: "_yields".to_string(),
+            ty: Some(RustType::Vec(Box::new(yield_ty))),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec!["Vec".to_string(), "new".to_string()])),
+                args: vec![],
+            },
+        });
+        for stmt in &func.body {
+            body.extend(self.lower_stmt_strict_for_function(
+                stmt,
+                "async generator materialization statement lowering",
+            ));
+        }
+        self.borrowed_params = saved_borrowed_params;
+        self.mut_borrowed_params = saved_mut_borrowed_params;
+        body.push(RustStmt::Return(Some(RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec![
+                "AsyncGenerator".to_string(),
+                "new".to_string(),
+            ])),
+            args: vec![RustExpr::Ident("_yields".to_string())],
+        })));
+        body
+    }
+
     pub(super) fn emit_function(
         &mut self,
         func: &HirFunction,
@@ -992,6 +1068,8 @@ impl RustEmitter {
             Visibility::Private
         };
         let is_generator = body_contains_yield(&func.body);
+        let is_async_generator =
+            is_generator && matches!(func.return_type.resolve_alias(), Type::AsyncGenerator(_, _));
         if is_generator {
             self.generator_functions.insert(func.name.clone());
         }
@@ -1021,7 +1099,9 @@ impl RustEmitter {
             })
             .collect::<Vec<_>>();
 
-        let mut lowered_body = if is_generator {
+        let mut lowered_body = if is_async_generator {
+            self.lower_async_generator_function_body(func, &mutable_param_shadows)
+        } else if is_generator {
             self.lower_generator_function_body(func, &mutable_param_shadows)
         } else {
             let mut lowered = Self::emit_mutable_param_shadow_stmts(&mutable_param_shadows);
@@ -1074,7 +1154,7 @@ impl RustEmitter {
             params,
             ret: self.lower_function_return_type(func, is_generator),
             body: lowered_body,
-            is_async: func.is_async,
+            is_async: func.is_async && !is_async_generator,
         });
 
         self.current_return_type = saved_return_type;

--- a/crates/sifr_codegen/src/generic_bounds_helpers.rs
+++ b/crates/sifr_codegen/src/generic_bounds_helpers.rs
@@ -107,6 +107,11 @@ impl RustEmitter {
             Type::TimeoutResult(err) => {
                 format!("__SifrTimeoutResult<{}>", self.rust_type_with_generics(err))
             }
+            Type::AsyncGenerator(item, err) => format!(
+                "AsyncGenerator<{}, {}>",
+                self.rust_type_with_generics(item),
+                self.rust_generator_error_type_with_generics(err)
+            ),
             Type::TypeVar(name) => name.clone(),
             Type::Callable(params, conventions, ret) => {
                 let param_types = params
@@ -168,6 +173,14 @@ impl RustEmitter {
 
     pub(super) fn rust_ir_type_with_generics(&self, ty: &Type) -> crate::RustType {
         crate::RustType::Named(self.rust_type_with_generics(ty))
+    }
+
+    fn rust_generator_error_type_with_generics(&self, ty: &Type) -> String {
+        if matches!(ty.resolve_alias(), Type::Never) {
+            "std::convert::Infallible".to_string()
+        } else {
+            self.rust_type_with_generics(ty)
+        }
     }
 
     pub(super) fn type_contains_generic_class(&self, ty: &Type) -> bool {

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -169,6 +169,7 @@ const BUILTIN_ERROR_CLASSES: &[&str] = &[
     "ScopeFailure",
     "TaskCancelled",
     "SecondaryError",
+    "GeneratorCloseError",
 ];
 
 const IO_ERROR_SUBCLASSES: &[&str] = &[
@@ -495,6 +496,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     let uses_cancellation_error_type = module_uses_cancellation_error_type(module);
     let uses_async_exit_cause_type = module_uses_async_exit_cause_type(module);
     let uses_timeout_result_type = module_uses_timeout_result_type(module);
+    let uses_async_generator_type = module_uses_async_generator_type(module);
     let mut referenced_error_classes = collect_referenced_builtin_error_classes(
         module,
         &stdlib_preamble,
@@ -504,6 +506,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     );
     if uses_task_scope || uses_failure_type {
         referenced_error_classes.insert("SecondaryError".to_string());
+    }
+    if uses_async_generator_type {
+        referenced_error_classes.insert("GeneratorCloseError".to_string());
     }
     let user_defined_error_classes: HashSet<String> = module
         .classes
@@ -619,6 +624,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     }
     if uses_timeout_result_type && !uses_task_scope {
         preamble_items.extend(build_timeout_result_type_items());
+    }
+    if uses_async_generator_type {
+        preamble_items.extend(build_async_generator_type_items());
     }
 
     // Emit file handle global state if open() built-in or any file handle intrinsic is used.
@@ -1258,6 +1266,12 @@ fn type_contains_timeout_result(ty: &Type) -> bool {
     type_contains_by(ty, |candidate| matches!(candidate, Type::TimeoutResult(_)))
 }
 
+fn type_contains_async_generator(ty: &Type) -> bool {
+    type_contains_by(ty, |candidate| {
+        matches!(candidate, Type::AsyncGenerator(_, _))
+    })
+}
+
 fn type_contains_cancellation_error(ty: &Type) -> bool {
     type_contains_by(
         ty,
@@ -1347,6 +1361,24 @@ fn module_uses_timeout_result_type(module: &HirModule) -> bool {
             .any(|(_, ty, _)| type_contains_timeout_result(ty))
 }
 
+fn module_uses_async_generator_type(module: &HirModule) -> bool {
+    module
+        .functions
+        .iter()
+        .any(function_uses_async_generator_type)
+        || module.classes.iter().any(|class| {
+            class
+                .fields
+                .iter()
+                .any(|(_, field_ty)| type_contains_async_generator(field_ty))
+                || class.methods.iter().any(function_uses_async_generator_type)
+        })
+        || module
+            .constants
+            .iter()
+            .any(|(_, ty, _)| type_contains_async_generator(ty))
+}
+
 fn function_uses_cancellation_error_type(func: &HirFunction) -> bool {
     func.params
         .iter()
@@ -1373,6 +1405,13 @@ fn function_uses_timeout_result_type(func: &HirFunction) -> bool {
         .iter()
         .any(|param| type_contains_timeout_result(&param.ty))
         || type_contains_timeout_result(&func.return_type)
+}
+
+fn function_uses_async_generator_type(func: &HirFunction) -> bool {
+    func.params
+        .iter()
+        .any(|param| type_contains_async_generator(&param.ty))
+        || type_contains_async_generator(&func.return_type)
 }
 
 fn body_contains_await(body: &[HirStmt]) -> bool {

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -57,6 +57,13 @@ pub fn sifr_type_to_rust_type(ty: &Type) -> RustType {
                 sifr_type_to_rust_type(second),
             ],
         },
+        Type::AsyncGenerator(item, err) => RustType::Generic {
+            base: "AsyncGenerator".to_string(),
+            params: vec![
+                sifr_type_to_rust_type(item),
+                task_error_type_to_rust_type(err),
+            ],
+        },
         Type::Union(members) => {
             let non_none: Vec<&Type> = members
                 .iter()
@@ -316,6 +323,140 @@ pub fn build_timeout_result_type_items() -> Vec<RustItem> {
             },
         ],
     }]
+}
+
+pub fn build_async_generator_type_items() -> Vec<RustItem> {
+    let type_params = vec![
+        crate::RustTypeParam {
+            name: "T".to_string(),
+            bounds: vec![],
+        },
+        crate::RustTypeParam {
+            name: "E".to_string(),
+            bounds: vec![],
+        },
+    ];
+
+    vec![
+        RustItem::Struct {
+            name: "AsyncGenerator<T, E>".to_string(),
+            visibility: Visibility::Private,
+            derives: vec![],
+            fields: vec![
+                (
+                    "items".to_string(),
+                    RustType::Named("std::vec::IntoIter<T>".to_string()),
+                ),
+                ("closed".to_string(), RustType::Bool),
+                (
+                    "_err".to_string(),
+                    RustType::Named("std::marker::PhantomData<E>".to_string()),
+                ),
+            ],
+        },
+        RustItem::Impl {
+            target: "AsyncGenerator<T, E>".to_string(),
+            type_params,
+            trait_: None,
+            items: vec![
+                RustItem::Fn {
+                    name: "new".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::Named {
+                        name: "items".to_string(),
+                        ty: RustType::Vec(Box::new(RustType::Named("T".to_string()))),
+                    }],
+                    ret: Some(RustType::Named("Self".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "Self".to_string(),
+                        fields: vec![
+                            (
+                                "items".to_string(),
+                                RustExpr::MethodCall {
+                                    receiver: Box::new(RustExpr::Ident("items".to_string())),
+                                    method: "into_iter".to_string(),
+                                    args: vec![],
+                                },
+                            ),
+                            (
+                                "closed".to_string(),
+                                RustExpr::Literal(crate::RustLiteral::Bool(false)),
+                            ),
+                            (
+                                "_err".to_string(),
+                                RustExpr::Path(vec![
+                                    "std".to_string(),
+                                    "marker".to_string(),
+                                    "PhantomData".to_string(),
+                                ]),
+                            ),
+                        ],
+                    }))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "anext".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfParam { mutable: true }],
+                    ret: Some(RustType::Result(
+                        Box::new(RustType::Option(Box::new(RustType::Named("T".to_string())))),
+                        Box::new(RustType::Named("E".to_string())),
+                    )),
+                    body: vec![
+                        RustStmt::If {
+                            cond: RustExpr::Field {
+                                expr: Box::new(RustExpr::Ident("self".to_string())),
+                                field: "closed".to_string(),
+                            },
+                            then_body: vec![RustStmt::Return(Some(RustExpr::FnCall {
+                                func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+                                args: vec![RustExpr::Ident("None".to_string())],
+                            }))],
+                            else_body: None,
+                        },
+                        RustStmt::Return(Some(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+                            args: vec![RustExpr::MethodCall {
+                                receiver: Box::new(RustExpr::Field {
+                                    expr: Box::new(RustExpr::Ident("self".to_string())),
+                                    field: "items".to_string(),
+                                }),
+                                method: "next".to_string(),
+                                args: vec![],
+                            }],
+                        })),
+                    ],
+                    is_async: true,
+                },
+                RustItem::Fn {
+                    name: "aclose".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![],
+                    params: vec![RustParam::SelfParam { mutable: true }],
+                    ret: Some(RustType::Result(
+                        Box::new(RustType::Unit),
+                        Box::new(RustType::Named("GeneratorCloseError".to_string())),
+                    )),
+                    body: vec![
+                        RustStmt::Assign {
+                            target: RustExpr::Field {
+                                expr: Box::new(RustExpr::Ident("self".to_string())),
+                                field: "closed".to_string(),
+                            },
+                            value: RustExpr::Literal(crate::RustLiteral::Bool(true)),
+                        },
+                        RustStmt::Return(Some(RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
+                            args: vec![RustExpr::Literal(crate::RustLiteral::Unit)],
+                        })),
+                    ],
+                    is_async: true,
+                },
+            ],
+        },
+    ]
 }
 
 pub fn build_cancellation_error_type_items() -> Vec<RustItem> {

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -249,7 +249,9 @@ pub(super) fn lower_name(name: &ExprName, ctx: &mut LowerCtx) -> Option<HirExpr>
     }
     if let Some(ft) = ctx.functions.get(&var_name) {
         let ft = ft.clone();
-        let ty = if ctx.async_functions.contains(&var_name) {
+        let ty = if ctx.async_functions.contains(&var_name)
+            && !ctx.async_generator_functions.contains(&var_name)
+        {
             Type::AsyncFunction(ft)
         } else {
             Type::Function(ft)
@@ -1300,6 +1302,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
         None
     })?;
     let is_async_function = ctx.async_functions.contains(&func_name);
+    let is_async_generator_function = ctx.async_generator_functions.contains(&func_name);
     if is_async_function && !ctx.current_function_is_async {
         expression_diagnostics::type_mismatch(
             ctx,
@@ -1601,7 +1604,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
 
     let return_type = refine_constructor_return_type_from_args(&ft, &args, &return_type);
     tsc::validate_shared_constructor(&func_name, &args, &arg_ranges, call, ctx);
-    let call_type = if is_async_function {
+    let call_type = if is_async_function && !is_async_generator_function {
         coroutine_result_type(&return_type)
     } else {
         return_type

--- a/crates/sifr_hir/src/lower/function_flow.rs
+++ b/crates/sifr_hir/src/lower/function_flow.rs
@@ -108,6 +108,7 @@ pub(super) fn collapse_types(types: Vec<Type>, empty_type: Type) -> Type {
 
 pub(super) fn infer_function_return_type(
     function_name: &str,
+    is_async: bool,
     declared_return_type: &Type,
     has_explicit_return_annotation: bool,
     body: &[HirStmt],
@@ -116,31 +117,61 @@ pub(super) fn infer_function_return_type(
     let yielded_types = collect_yield_types(body);
     if !yielded_types.is_empty() {
         let yielded_type = normalize_generator_yield_type(collapse_types(yielded_types, Type::Any));
-        let inferred_iterator = Type::Iterator(Box::new(yielded_type.clone()));
-        if has_explicit_return_annotation {
-            match declared_return_type.resolve_alias() {
-                Type::Iterator(elem_ty) => {
-                    if !yielded_type.is_assignable_to(elem_ty.as_ref()) {
+        if is_async {
+            let inferred_generator =
+                Type::AsyncGenerator(Box::new(yielded_type.clone()), Box::new(Type::Never));
+            if has_explicit_return_annotation {
+                match declared_return_type.resolve_alias() {
+                    Type::AsyncGenerator(elem_ty, err_ty) => {
+                        if !yielded_type.is_assignable_to(elem_ty.as_ref()) {
+                            report_error(format!(
+                                "async generator '{}' yields '{}', which is not assignable to declared async generator element type '{}'",
+                                function_name,
+                                yielded_type.display_name(),
+                                elem_ty.display_name()
+                            ));
+                        }
+                        Type::AsyncGenerator(elem_ty.clone(), err_ty.clone())
+                    }
+                    declared => {
                         report_error(format!(
+                            "async generator function '{}' must declare return type 'AsyncGenerator[T, E]', got '{}'",
+                            function_name,
+                            declared.display_name()
+                        ));
+                        inferred_generator
+                    }
+                }
+            } else {
+                inferred_generator
+            }
+        } else {
+            let inferred_iterator = Type::Iterator(Box::new(yielded_type.clone()));
+            if has_explicit_return_annotation {
+                match declared_return_type.resolve_alias() {
+                    Type::Iterator(elem_ty) => {
+                        if !yielded_type.is_assignable_to(elem_ty.as_ref()) {
+                            report_error(format!(
                             "generator '{}' yields '{}', which is not assignable to declared iterator element type '{}'",
                             function_name,
                             yielded_type.display_name(),
                             elem_ty.display_name()
                         ));
+                        }
+                        Type::Iterator(elem_ty.clone())
                     }
-                    Type::Iterator(elem_ty.clone())
-                }
-                declared => {
-                    report_error(format!(
+                    declared => {
+                        report_error(format!(
                         "generator function '{}' must declare return type 'Iterator[T]', got '{}'",
                         function_name,
                         declared.display_name()
                     ));
-                    inferred_iterator
+                        inferred_iterator
+                    }
                 }
+            } else {
+                inferred_iterator
             }
-        } else {
-            inferred_iterator
         }
     } else if *declared_return_type == Type::Any && !has_explicit_return_annotation {
         let return_types = collect_return_types(body);

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -130,7 +130,9 @@ pub(super) use typevar_annotations::{
     decode_typevar_constraint, encode_typevar_constraint, parse_typevar_bound_expr,
     parse_typevar_declaration_specs,
 };
-use typing_and_functions::{extract_function_type, lower_function, register_builtins};
+use typing_and_functions::{
+    extract_function_type, function_body_contains_yield, lower_function, register_builtins,
+};
 use workload_annotations::WorkloadKind;
 /// The lowering context that tracks state during AST->HIR conversion.
 pub(super) struct LowerCtx {
@@ -138,6 +140,8 @@ pub(super) struct LowerCtx {
     functions: HashMap<String, FunctionType>,
     /// Names of functions declared with `async def`.
     async_functions: std::collections::HashSet<String>,
+    /// Names of `async def` functions whose body contains `yield`.
+    async_generator_functions: std::collections::HashSet<String>,
     /// Workload classification decorators for user-defined functions.
     function_workload_annotations: HashMap<String, WorkloadKind>,
     /// Default parameter values for functions (name -> vec of (`param_index`, `default_expr`))
@@ -220,6 +224,7 @@ impl LowerCtx {
         Self {
             functions: HashMap::new(),
             async_functions: std::collections::HashSet::new(),
+            async_generator_functions: std::collections::HashSet::new(),
             function_workload_annotations: HashMap::new(),
             function_defaults: HashMap::new(),
             class_types: HashMap::new(),
@@ -668,7 +673,9 @@ fn lower_module_impl(
             }
 
             collect_function_defaults(&mut ctx, &function_name, func);
-            if func.is_async {
+            if func.is_async && function_body_contains_yield(&func.body) {
+                ctx.async_generator_functions.insert(function_name.clone());
+            } else if func.is_async {
                 ctx.async_functions.insert(function_name.clone());
             }
             if let Some(workload) =

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -697,6 +697,7 @@ pub(super) fn lower_stmt(
                 .map_or_else(|| func.name.range(), |returns| returns.range());
             let inferred_return_type = infer_function_return_type(
                 func.name.as_ref(),
+                func.is_async,
                 ft.return_type.as_ref(),
                 func.returns.is_some(),
                 &body,

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -96,6 +96,7 @@ pub(super) fn register_builtins(ctx: &mut LowerCtx) {
         "ScopeFailure",
         "TaskCancelled",
         "SecondaryError",
+        "GeneratorCloseError",
     ];
     for &error_name in &other_mid_level_errors {
         let fields = vec![("message".to_string(), Type::Str)];
@@ -364,6 +365,14 @@ fn collect_function_defaults(
 
 fn first_await_range_in_stmts(stmts: &[Stmt]) -> Option<TextRange> {
     stmts.iter().find_map(first_await_range_in_stmt)
+}
+
+pub(super) fn function_body_contains_yield(stmts: &[Stmt]) -> bool {
+    let mut visitor = sifr_python_ast::helpers::ReturnStatementVisitor::default();
+    for stmt in stmts {
+        sifr_python_ast::visitor::Visitor::visit_stmt(&mut visitor, stmt);
+    }
+    visitor.is_generator
 }
 
 fn first_await_range_in_stmt(stmt: &Stmt) -> Option<TextRange> {
@@ -1114,6 +1123,15 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
         }
     }
     if func.is_async {
+        if function_body_contains_yield(&func.body) {
+            if let Some(await_range) = first_await_range_in_stmts(&func.body) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    "await inside async generator bodies requires async generator state-machine lowering and is not supported yet".to_string(),
+                    await_range,
+                );
+            }
+        }
         if let Some(await_range) = first_await_range_in_stmts(&func.body) {
             for param in &params {
                 if param.convention.is_mut_borrow()
@@ -1178,6 +1196,7 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
         .map_or_else(|| func.name.range(), |returns| returns.range());
     let inferred_return_type = infer_function_return_type(
         func.name.as_ref(),
+        func.is_async,
         ft.return_type.as_ref(),
         func.returns.is_some(),
         &body,

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -41,6 +41,7 @@
     "async_for_closable_iterator_cleanup",
     "async_for_closable_iterator_return_cleanup",
     "async_for_closable_iterator_nested_return_cleanup",
+    "async_generator_basic",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- classify async functions with yield as async generators instead of coroutine functions
- type calls as direct AsyncGenerator values and emit non-async Rust generator constructors
- add the initial AsyncGenerator runtime helper plus GeneratorCloseError builtin wiring
- add pass/fail fixtures for basic async-for consumption and rejected unsupported forms

## Validation
- cargo fmt --check
- cargo check -p sifr_hir -p sifr_codegen
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_basic.sifr
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/async_generator_basic.sifr | rg -n "struct AsyncGenerator|fn numbers|async fn numbers|fn anext|fn aclose|async fn anext|AsyncGenerator::new|_yields|tokio::main"
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- git diff --check
- scripts/run_all_tests.sh --profile quick (PASS, 60 pass fixtures, report_signature=827a6a7de4a4e667, wall_time=126.93s)

## Review
- Opus review: reviews/phase32_async_generator_basic.md
- REVIEW_STATUS: SATISFIED