### PR TITLE
Add async generator anext builtin surface

### DIFF
--- a/crates/sifr/tests/e2e/fail/anext_non_async_iterator_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/anext_non_async_iterator_rejected.sifr
@@ -1,0 +1,5 @@
+# expect-error[col=17]: SIFR-TYPE-0002
+
+async def main() -> None:
+    values: list[int] = [1, 2, 3]
+    await anext(values)

--- a/crates/sifr/tests/e2e/pass/async_generator_anext_result_option.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_anext_result_option.sifr
@@ -1,0 +1,16 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 4
+    yield 5
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    agen = numbers()
+
+    first: Result[Option[int], GeneratorCloseError] = await anext(agen)
+    second: Result[Option[int], GeneratorCloseError] = await anext(agen)
+    done: Result[Option[int], GeneratorCloseError] = await anext(agen)
+
+    assert str(first) == "Ok(Some(4))"
+    assert str(second) == "Ok(Some(5))"
+    assert str(done) == "Ok(None)"
+    return None

--- a/crates/sifr_codegen/src/hir_analysis/queries.rs
+++ b/crates/sifr_codegen/src/hir_analysis/queries.rs
@@ -24,6 +24,8 @@ pub(crate) const MUTATING_METHODS: &[&str] = &[
     "difference_update",
     "symmetric_difference_update",
     "discard",
+    "anext",
+    "aclose",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -366,6 +368,11 @@ pub(crate) fn collect_mutated_vars(
                     mutated.borrow_mut().insert(name.clone());
                 }
             }
+            if canonical_func == "anext" {
+                if let Some(HirExpr::Name { name, .. }) = args.first() {
+                    mutated.borrow_mut().insert(name.clone());
+                }
+            }
         }
         HirExpr::IteratorCall { op, args, .. } => {
             if *op == HirIteratorOp::Next {
@@ -675,6 +682,26 @@ mod tests {
 
         let mutated = collect_mutated_vars(&stmts, None);
         assert!(mutated.contains("it"));
+    }
+
+    #[test]
+    fn collect_mutated_vars_marks_anext_argument() {
+        let stmts = vec![HirStmt::Expr {
+            expr: HirExpr::Call {
+                func: "anext".to_string(),
+                args: vec![HirExpr::Name {
+                    name: "agen".to_string(),
+                    ty: Type::AsyncGenerator(Box::new(Type::Int), Box::new(Type::Never)),
+                }],
+                ty: Type::Awaitable(Box::new(Type::Result(
+                    Box::new(Type::Union(vec![Type::Int, Type::None])),
+                    Box::new(Type::Never),
+                ))),
+            },
+        }];
+
+        let mutated = collect_mutated_vars(&stmts, None);
+        assert!(mutated.contains("agen"));
     }
 
     #[test]

--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -568,6 +568,16 @@ fn try_lower_simple_call_expr(func: &str, args: &[HirExpr]) -> Option<RustExpr> 
             args: vec![try_lower_leaf_or_name_expr(worker)?],
         });
     }
+    if func == "anext" {
+        let [iterator] = args else {
+            return None;
+        };
+        return Some(RustExpr::MethodCall {
+            receiver: Box::new(try_lower_leaf_or_name_expr(iterator)?),
+            method: "anext".to_string(),
+            args: vec![],
+        });
+    }
     if func == "hash" {
         return try_lower_simple_hash_call_expr(args);
     }

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -2153,6 +2153,16 @@ impl RustEmitter {
                     args: vec![],
                 }));
             }
+            if func == "anext" && args.len() == 1 {
+                let Some(lowered_iterator) = self.lower_stmt_expr_for_ir(&args[0])? else {
+                    return Ok(None);
+                };
+                return Ok(Some(crate::RustExpr::MethodCall {
+                    receiver: Box::new(lowered_iterator),
+                    method: "anext".to_string(),
+                    args: vec![],
+                }));
+            }
             if func == "str" && args.is_empty() {
                 return Ok(Some(crate::RustExpr::FnCall {
                     func: Box::new(crate::RustExpr::Path(vec![
@@ -4935,6 +4945,16 @@ impl RustEmitter {
                 return Ok(Some(crate::RustExpr::MethodCall {
                     receiver: Box::new(lowered_iterator),
                     method: "next".to_string(),
+                    args: vec![],
+                }));
+            }
+            if func == "anext" && args.len() == 1 {
+                let Some(lowered_iterator) = self.lower_stmt_expr_for_ir(&args[0])? else {
+                    return Ok(None);
+                };
+                return Ok(Some(crate::RustExpr::MethodCall {
+                    receiver: Box::new(lowered_iterator),
+                    method: "anext".to_string(),
                     args: vec![],
                 }));
             }

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -52,7 +52,7 @@ fn option_value_type(ty: &Type) -> Option<Type> {
     }
 }
 
-fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {
+pub(super) fn async_iterator_parts(ty: &Type) -> Option<(Type, Type)> {
     match ty.resolve_alias() {
         Type::AsyncIterator(item_ty, err_ty) | Type::AsyncGenerator(item_ty, err_ty) => {
             Some((item_ty.as_ref().clone(), err_ty.as_ref().clone()))

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -1,4 +1,5 @@
 use super::async_await::{coroutine_result_type, lower_await};
+use super::async_for::async_iterator_parts;
 use super::builtin_calls::{
     callable_builtin_element_type, lower_bytes_constructor_call, lower_bytes_type_factory_call,
     lower_chr_call, lower_defaultdict_constructor_call, lower_dict_constructor_call,
@@ -514,6 +515,49 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
                 op: HirIteratorOp::Next,
                 args: vec![iterator],
                 ty: Type::Union(vec![elem_ty, Type::None]),
+            });
+        }
+
+        // anext(async_iterator) -> Awaitable[Result[Option[T], E]]
+        if func_name == "anext" {
+            if !call.arguments.keywords.is_empty() {
+                expression_diagnostics::call_unexpected_keyword(
+                    ctx,
+                    "anext() does not accept keyword arguments".to_string(),
+                    first_call_keyword_range(call),
+                );
+                return None;
+            }
+            if call.arguments.args.len() != 1 {
+                expression_diagnostics::call_wrong_positional_count(
+                    ctx,
+                    format!(
+                        "anext() takes exactly 1 argument, got {}",
+                        call.arguments.args.len()
+                    ),
+                    call_arity_range(call),
+                );
+                return None;
+            }
+            let iterator = lower_expr(&call.arguments.args[0], ctx)?;
+            let Some((item_ty, err_ty)) = async_iterator_parts(iterator.ty()) else {
+                expression_diagnostics::type_mismatch(
+                    ctx,
+                    format!(
+                        "anext() argument must be an async iterator, got '{}'",
+                        iterator.ty().display_name()
+                    ),
+                    call.arguments.args[0].range(),
+                );
+                return None;
+            };
+            return Some(HirExpr::Call {
+                func: "anext".to_string(),
+                args: vec![iterator],
+                ty: Type::Awaitable(Box::new(Type::Result(
+                    Box::new(Type::Union(vec![item_ty, Type::None])),
+                    Box::new(err_ty),
+                ))),
             });
         }
 

--- a/verification/validation_lanes/quick_e2e_manifest.json
+++ b/verification/validation_lanes/quick_e2e_manifest.json
@@ -42,6 +42,7 @@
     "async_for_closable_iterator_return_cleanup",
     "async_for_closable_iterator_nested_return_cleanup",
     "async_generator_basic",
+    "async_generator_anext_result_option",
     "lock_basic",
     "rwlock_readers",
     "channel_basic",


### PR DESCRIPTION
## Summary
- add  built-in lowering for async iterators and async generators
- lower  to 
- mark  receivers as mutated so repeated advances generate mutable bindings
- add pass/fail fixtures and quick-lane coverage

## Validation
- cargo fmt --check
- cargo check -p sifr_hir -p sifr_codegen
- cargo test -p sifr_codegen hir_analysis::queries::tests::collect_mutated_vars_marks_anext_argument
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_anext_result_option.sifr
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/async_generator_anext_result_option.sifr | rg -n "let mut agen|agen\.anext\(\)\.await|fn anext|fn numbers|async fn numbers"
- git diff --check
- scripts/run_all_tests.sh --profile quick (PASS, 61 pass fixtures, report_signature=b25900b84372f1a5, wall_time=153.41s)

## Review
- Opus review: reviews/phase32_async_generator_anext.md
- REVIEW_STATUS: SATISFIED