### PR TITLE
Reject async generator return values

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_return_value_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_return_value_rejected.sifr
@@ -1,0 +1,5 @@
+# expect-error[col=12]: SIFR-TYPE-0002
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    return 2

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -176,6 +176,8 @@ pub(super) struct LowerCtx {
     in_try_block: bool,
     /// Whether the currently lowered function body is async.
     current_function_is_async: bool,
+    /// Whether the currently lowered function body is an `async def` containing `yield`.
+    current_function_is_async_generator: bool,
     /// Error types collected from Result-returning calls during try body lowering.
     /// Each entry is the name of an error class encountered via auto-unwrap in the current try block.
     try_block_error_types: std::collections::HashSet<String>,
@@ -242,6 +244,7 @@ impl LowerCtx {
             current_parent_class: None,
             in_try_block: false,
             current_function_is_async: false,
+            current_function_is_async_generator: false,
             try_block_error_types: std::collections::HashSet::new(),
             error_types: std::collections::HashSet::new(),
             error_hierarchy: HashMap::new(),

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1663,6 +1663,41 @@ pub(super) fn lower_return(
     func_type: &FunctionType,
     ctx: &mut LowerCtx,
 ) -> HirStmt {
+    if ctx.current_function_is_async_generator {
+        if let Some(val) = &ret.value {
+            let Some(expr) = lower_expr(val, ctx) else {
+                return HirStmt::Return {
+                    value: Some(HirExpr::NoneLiteral),
+                };
+            };
+            let expr_ty = expr.ty().clone();
+            if matches!(expr_ty.resolve_alias(), Type::None) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    "return with a value inside async generator bodies requires async generator state-machine lowering and is not supported yet"
+                        .to_string(),
+                    val.range(),
+                );
+            } else {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    "non-None async generator return values are rejected in v1; async generators expose yielded items through AsyncGenerator[T, E]"
+                        .to_string(),
+                    val.range(),
+                );
+            }
+            return HirStmt::Return { value: Some(expr) };
+        }
+
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "return inside async generator bodies requires async generator state-machine lowering and is not supported yet"
+                .to_string(),
+            ret.range(),
+        );
+        return HirStmt::Return { value: None };
+    }
+
     let value = if let Some(val) = &ret.value {
         let Some(expr) = lower_expr(val, ctx) else {
             // Keep control-flow shape intact after expression diagnostics so

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -1122,8 +1122,9 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
             ctx.borrowed_params.insert(param.name.clone());
         }
     }
+    let is_async_generator = func.is_async && function_body_contains_yield(&func.body);
     if func.is_async {
-        if function_body_contains_yield(&func.body) {
+        if is_async_generator {
             if let Some(await_range) = first_await_range_in_stmts(&func.body) {
                 ctx.error_with_code_at(
                     DiagnosticCode::TYPE_MISMATCH,
@@ -1151,9 +1152,12 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
     // Lower body
     let previous_owner = ctx.current_owner.replace(func.name.to_string());
     let previous_async = ctx.current_function_is_async;
+    let previous_async_generator = ctx.current_function_is_async_generator;
     ctx.current_function_is_async = func.is_async;
+    ctx.current_function_is_async_generator = is_async_generator;
     let body = lower_stmts(&func.body, &ft, ctx);
     ctx.current_function_is_async = previous_async;
+    ctx.current_function_is_async_generator = previous_async_generator;
     ctx.current_owner = previous_owner;
 
     ctx.borrowed_params.clear();


### PR DESCRIPTION
## Summary
- track async-generator body context during HIR lowering
- reject non-`None` async-generator `return <expr>` with a targeted `SIFR-TYPE-0002` diagnostic
- fail closed for `return None` / bare `return` until async-generator state-machine return lowering exists
- add `async_generator_return_value_rejected.sifr`

## Validation
- `cargo fmt --check` PASS
- `cargo check -p sifr_hir` PASS
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/async_generator_return_value_rejected.sifr` produced the intended async-generator-specific type error
- `cargo test -p sifr -- test_e2e_fail -- --nocapture` PASS
- `scripts/run_all_tests.sh --profile quick` PASS
  - `report_signature=b25900b84372f1a5`
  - 61 pass fixtures
  - wall time 148.68s

## Review
- Opus implementation review: `reviews/phase32_async_generator_return_value.md`
- `REVIEW_STATUS: SATISFIED`
