### PR TITLE
hir: add async generator control diagnostics

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_aclose_wrong_arity.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_aclose_wrong_arity.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-CALL-0001
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def main() -> None:
+    agen: AsyncGenerator[int, GeneratorCloseError] = numbers()
+    await agen.aclose(1)

--- a/crates/sifr/tests/e2e/fail/async_generator_send_not_supported.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_send_not_supported.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-STDLIB-0001
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def main() -> None:
+    agen: AsyncGenerator[int, GeneratorCloseError] = numbers()
+    await agen.send(2)

--- a/crates/sifr/tests/e2e/fail/async_generator_throw_not_supported.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_throw_not_supported.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-STDLIB-0001
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def main() -> None:
+    agen: AsyncGenerator[int, GeneratorCloseError] = numbers()
+    await agen.throw(GeneratorCloseError("stop"))

--- a/crates/sifr/tests/e2e/fail/async_yield_from_not_supported.sifr
+++ b/crates/sifr/tests/e2e/fail/async_yield_from_not_supported.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-TYPE-0012
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def delegated() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield from numbers()

--- a/crates/sifr_hir/src/lower/async_generator_methods.rs
+++ b/crates/sifr_hir/src/lower/async_generator_methods.rs
@@ -24,6 +24,16 @@ pub(super) fn resolve_async_generator_method_type(
                 Box::new(generator_close_error_type(ctx)),
             ))))
         }
+        "send" | "throw" => {
+            ctx.error_with_code_at(
+                DiagnosticCode::STDLIB_UNSUPPORTED_SURFACE,
+                format!(
+                    "AsyncGenerator.{method}() is not supported in v1; consume async generators with async for, anext(), async comprehensions, or aclose()"
+                ),
+                method_range,
+            );
+            None
+        }
         _ => {
             ctx.error_with_code_at(
                 DiagnosticCode::STDLIB_UNSUPPORTED_SURFACE,

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -115,6 +115,14 @@ pub(super) fn lower_expr(expr: &Expr, ctx: &mut LowerCtx) -> Option<HirExpr> {
         Expr::SetComp(comp) => lower_set_comp(comp, ctx),
         Expr::DictComp(comp) => lower_dict_comp(comp, ctx),
         Expr::Generator(gen) => lower_generator_expr(gen, ctx),
+        Expr::YieldFrom(yield_from) if ctx.current_function_is_async_generator => {
+            expression_diagnostics::unsupported_form(
+                ctx,
+                "async yield from is not supported in v1; use async for over the source and yield values explicitly",
+                yield_from.range(),
+            );
+            None
+        }
         _ => {
             expression_diagnostics::unsupported_form(
                 ctx,


### PR DESCRIPTION
## Summary
- Add explicit unsupported diagnostics for `AsyncGenerator.send(...)` and `AsyncGenerator.throw(...)`.
- Add a targeted unsupported expression diagnostic for async-generator `yield from` delegation.
- Cover `send`, `throw`, async `yield from`, and `aclose` wrong arity with fail fixtures.

## Validation
- `cargo fmt --check`
- `cargo check -p sifr_hir`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 pass fixtures
  - wall_time=136.11s
- Opus review: `reviews/phase32_async_generator_control_diagnostics.md` final status `SATISFIED`
