### PR TITLE
hir: fail-close async comprehension deferred surfaces

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_comprehension_await_filter_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/async_comprehension_await_filter_deferred.sifr
@@ -1,0 +1,10 @@
+# expect-error: SIFR-TYPE-0012
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def keep(value: int) -> bool:
+    return value > 0
+
+async def main() -> None:
+    values = [x async for x in numbers() if await keep(x)]

--- a/crates/sifr/tests/e2e/fail/async_comprehension_list_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/async_comprehension_list_deferred.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-TYPE-0012
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def main() -> None:
+    values = [x async for x in numbers()]

--- a/crates/sifr/tests/e2e/fail/async_generator_expr_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_expr_deferred.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-TYPE-0012
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+
+async def main() -> None:
+    values = (x async for x in numbers())

--- a/crates/sifr/tests/e2e/fail/nested_async_comprehension_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/nested_async_comprehension_deferred.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-TYPE-0012
+
+async def rows() -> AsyncGenerator[list[int], GeneratorCloseError]:
+    yield [1]
+
+async def main() -> None:
+    values = [item async for row in rows() for item in row]

--- a/crates/sifr_hir/src/lower/async_comprehension_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/async_comprehension_diagnostics.rs
@@ -1,0 +1,105 @@
+use super::LowerCtx;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Comprehension, Expr};
+
+fn reject_unsupported_expression_form(ctx: &mut LowerCtx, message: &str, range: TextRange) {
+    ctx.error_with_code_at(
+        DiagnosticCode::TYPE_UNSUPPORTED_EXPRESSION_FORM,
+        message.to_string(),
+        range,
+    );
+}
+
+fn first_await_range_in_expr(expr: &Expr) -> Option<TextRange> {
+    match expr {
+        Expr::Await(await_expr) => Some(await_expr.range()),
+        Expr::Call(call) => first_await_range_in_expr(call.func.as_ref()).or_else(|| {
+            call.arguments
+                .args
+                .iter()
+                .find_map(first_await_range_in_expr)
+                .or_else(|| {
+                    call.arguments
+                        .keywords
+                        .iter()
+                        .find_map(|keyword| first_await_range_in_expr(&keyword.value))
+                })
+        }),
+        Expr::Attribute(attr) => first_await_range_in_expr(attr.value.as_ref()),
+        Expr::Subscript(sub) => first_await_range_in_expr(sub.value.as_ref())
+            .or_else(|| first_await_range_in_expr(sub.slice.as_ref())),
+        Expr::BinOp(bin) => first_await_range_in_expr(bin.left.as_ref())
+            .or_else(|| first_await_range_in_expr(bin.right.as_ref())),
+        Expr::BoolOp(bool_op) => bool_op.values.iter().find_map(first_await_range_in_expr),
+        Expr::UnaryOp(unary) => first_await_range_in_expr(unary.operand.as_ref()),
+        Expr::Compare(compare) => first_await_range_in_expr(compare.left.as_ref()).or_else(|| {
+            compare
+                .comparators
+                .iter()
+                .find_map(first_await_range_in_expr)
+        }),
+        Expr::If(if_expr) => first_await_range_in_expr(if_expr.test.as_ref())
+            .or_else(|| first_await_range_in_expr(if_expr.body.as_ref()))
+            .or_else(|| first_await_range_in_expr(if_expr.orelse.as_ref())),
+        Expr::List(list) => list.elts.iter().find_map(first_await_range_in_expr),
+        Expr::Tuple(tuple) => tuple.elts.iter().find_map(first_await_range_in_expr),
+        Expr::Set(set) => set.elts.iter().find_map(first_await_range_in_expr),
+        Expr::Dict(dict) => dict.items.iter().find_map(|item| {
+            item.key
+                .as_ref()
+                .and_then(first_await_range_in_expr)
+                .or_else(|| first_await_range_in_expr(&item.value))
+        }),
+        _ => None,
+    }
+}
+
+pub(super) fn reject_deferred_async_comprehension_shape(
+    ctx: &mut LowerCtx,
+    comprehension_kind: &str,
+    generators: &[Comprehension],
+    fallback_range: TextRange,
+) -> bool {
+    if !generators.iter().any(|generator| generator.is_async) {
+        return false;
+    }
+
+    if generators.len() != 1 {
+        reject_unsupported_expression_form(
+            ctx,
+            "nested async comprehensions are deferred in v1; use a single async for clause",
+            generators
+                .iter()
+                .find(|generator| generator.is_async)
+                .map_or(fallback_range, Ranged::range),
+        );
+        return true;
+    }
+
+    if let Some(await_range) = generators[0].ifs.iter().find_map(first_await_range_in_expr) {
+        reject_unsupported_expression_form(
+            ctx,
+            "await inside async comprehension filters is deferred in v1; compute the awaited value before the comprehension",
+            await_range,
+        );
+        return true;
+    }
+
+    reject_unsupported_expression_form(
+        ctx,
+        &format!(
+            "async {comprehension_kind} comprehensions require async-comprehension lowering and are not supported yet"
+        ),
+        fallback_range,
+    );
+    true
+}
+
+pub(super) fn reject_async_generator_expression(ctx: &mut LowerCtx, range: TextRange) {
+    reject_unsupported_expression_form(
+        ctx,
+        "async generator expressions are deferred in v1; use an async def with yield or an eager async comprehension",
+        range,
+    );
+}

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -3427,6 +3427,15 @@ pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option
         return None;
     }
 
+    if super::async_comprehension_diagnostics::reject_deferred_async_comprehension_shape(
+        ctx,
+        "list",
+        &comp.generators,
+        comp.range(),
+    ) {
+        return None;
+    }
+
     let mut generators = Vec::new();
     let mut pushed_scopes = 0;
     let result = (|| {
@@ -3531,6 +3540,15 @@ pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option
 }
 
 pub(super) fn lower_set_comp(comp: &ExprSetComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if super::async_comprehension_diagnostics::reject_deferred_async_comprehension_shape(
+        ctx,
+        "set",
+        &comp.generators,
+        comp.range(),
+    ) {
+        return None;
+    }
+
     let mut generators = Vec::new();
     let mut pushed_scopes = 0;
     let result = (|| {
@@ -3576,6 +3594,15 @@ pub(super) fn lower_set_comp(comp: &ExprSetComp, ctx: &mut LowerCtx) -> Option<H
 }
 
 pub(super) fn lower_dict_comp(comp: &ExprDictComp, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if super::async_comprehension_diagnostics::reject_deferred_async_comprehension_shape(
+        ctx,
+        "dict",
+        &comp.generators,
+        comp.range(),
+    ) {
+        return None;
+    }
+
     let mut generators = Vec::new();
     let mut pushed_scopes = 0;
     let result = (|| {
@@ -3661,6 +3688,11 @@ pub(super) fn lower_dict_comp(comp: &ExprDictComp, ctx: &mut LowerCtx) -> Option
 }
 
 pub(super) fn lower_generator_expr(gen: &ExprGenerator, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if gen.generators.iter().any(|generator| generator.is_async) {
+        super::async_comprehension_diagnostics::reject_async_generator_expression(ctx, gen.range());
+        return None;
+    }
+
     // Only support single generator: (expr for var in iter) or (expr for var in iter if cond)
     if gen.generators.len() != 1 {
         reject_unsupported_expression_form(

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -8,6 +8,7 @@ mod append_growth_shapes;
 mod arithmetic_warnings;
 mod assignment_widening;
 mod async_await;
+mod async_comprehension_diagnostics;
 mod async_for;
 mod async_generator_methods;
 mod async_with;


### PR DESCRIPTION
## Summary
- Add a focused async-comprehension diagnostic helper module.
- Fail-close async list/set/dict comprehensions until positive async-comprehension lowering lands, preventing accidental sync lowering.
- Add targeted deferred diagnostics for nested async comprehensions, awaited async-comprehension filters, and async generator expressions.
- Add fail fixtures covering the deferred surfaces.

## Validation
- `cargo fmt --check`
- `cargo check -p sifr_hir`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 pass fixtures
  - wall_time=162.86s
- Opus review: `reviews/phase32_async_comprehension_deferred_diagnostics.md` final status `SATISFIED`
