### PR TITLE
hir: reject inconsistent async generator yields

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_inconsistent_yield_types_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_inconsistent_yield_types_rejected.sifr
@@ -1,0 +1,5 @@
+# expect-error: SIFR-TYPE-0002
+
+async def mixed() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield "two"

--- a/crates/sifr_hir/src/lower/function_flow.rs
+++ b/crates/sifr_hir/src/lower/function_flow.rs
@@ -118,6 +118,14 @@ pub(super) fn infer_function_return_type(
     if !yielded_types.is_empty() {
         let yielded_type = normalize_generator_yield_type(collapse_types(yielded_types, Type::Any));
         if is_async {
+            if let Type::Union(members) = yielded_type.resolve_alias() {
+                if members.len() > 1 {
+                    report_error(format!(
+                        "async generator '{function_name}' has inconsistent yield types '{}'; yielded values must converge to one async generator element type",
+                        yielded_type.display_name()
+                    ));
+                }
+            }
             let inferred_generator =
                 Type::AsyncGenerator(Box::new(yielded_type.clone()), Box::new(Type::Never));
             if has_explicit_return_annotation {


### PR DESCRIPTION
## Summary

- Reject async generator bodies whose yielded values infer to multiple non-None element types.
- Preserve sync generator union-yield behavior by applying the convergence check only to async generators.
- Add a fail fixture for mixed async generator yield types.

## Validation

- `cargo fmt --check && cargo check -p sifr_hir && cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature: `b6baaa9a0d3afebf`
  - pass fixtures: 62
  - wall_time: 101.71s
  - max_rss: 636.6MiB

## Review

- Opus reviewer: `SATISFIED` (`reviews/phase32_async_generator_yield_convergence.md`, not committed)
