### PR TITLE
tests: cover async generator deferred returns

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_bare_return_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_bare_return_deferred.sifr
@@ -1,0 +1,5 @@
+# expect-error[col=5]: SIFR-TYPE-0002
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    return

--- a/crates/sifr/tests/e2e/fail/async_generator_return_none_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_return_none_deferred.sifr
@@ -1,0 +1,5 @@
+# expect-error[col=12]: SIFR-TYPE-0002
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    return None


### PR DESCRIPTION
## Summary
- add e2e fail coverage for bare `return` inside async generators
- add e2e fail coverage for `return None` inside async generators
- keep deferred async-generator return paths fail-closed until state-machine return lowering lands

## Validation
- `cargo fmt --check && cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick`
- Opus review: `SATISFIED` (`reviews/phase32_async_generator_return_deferred_fixtures.md`, untracked)
