### PR TITLE
tests: cover async generator yield types

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_generator_yield_types.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_yield_types.sifr
@@ -1,0 +1,17 @@
+async def offsets(seed: int) -> AsyncGenerator[int, GeneratorCloseError]:
+    first: int = seed + 1
+    second: int = first + 2
+
+    yield first
+    yield second
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    agen = offsets(10)
+    total: int = 0
+
+    async for value in agen:
+        total = total + value
+
+    assert total == 24
+    return None


### PR DESCRIPTION
## Summary
- add the Phase 32 `async_generator_yield_types.sifr` positive fixture
- cover converged async-generator yield typing through computed `int` values and `async for` consumption

## Validation
- `cargo fmt --check && cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_yield_types.sifr`
- `scripts/run_all_tests.sh --profile quick`
- report signature: `b6baaa9a0d3afebf`
- 62 pass fixtures, wall time 77.38s
- Opus review: `SATISFIED` (`reviews/phase32_async_generator_yield_types_fixture.md`, untracked)
