### PR TITLE
hir: lower async list comprehensions

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_comprehension_error_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_comprehension_error_type_rejected.sifr
@@ -1,7 +1,8 @@
-# expect-error: SIFR-TYPE-0012
+# expect-error: SIFR-TYPE-0002
 
 async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
     yield 1
+
 
 async def main() -> None:
     values = [x async for x in numbers()]

--- a/crates/sifr/tests/e2e/pass/async_comprehension_list.sifr
+++ b/crates/sifr/tests/e2e/pass/async_comprehension_list.sifr
@@ -1,0 +1,13 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield 2
+    yield 3
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    values: list[int] = [x async for x in numbers() if x > 1]
+
+    assert len(values) == 2
+    assert values[0] == 2
+    assert values[1] == 3
+    return None

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -591,6 +591,115 @@ impl RustEmitter {
         self.lower_structural_iter_source_expr_for_ir(iter_expr, None)
     }
 
+    fn async_iterator_error_type_for_ir(iter_expr: &HirExpr) -> Option<Type> {
+        match Self::resolve_alias_type_for_loop_iter(iter_expr.ty()) {
+            Type::AsyncIterator(_, err_ty) | Type::AsyncGenerator(_, err_ty) => {
+                Some(err_ty.as_ref().clone())
+            }
+            _ => None,
+        }
+    }
+
+    fn try_lower_async_list_comp_for_ir(
+        &mut self,
+        value_expr: &HirExpr,
+        generators: &[(String, HirExpr, Option<HirExpr>)],
+    ) -> Result<Option<RustExpr>, crate::CodegenError> {
+        let Some((var, iter_expr, maybe_filter)) = generators.first() else {
+            return Ok(None);
+        };
+        if generators.len() != 1 || var.contains(',') {
+            return Ok(None);
+        }
+        let Some(iter_error_ty) = Self::async_iterator_error_type_for_ir(iter_expr) else {
+            return Ok(None);
+        };
+        let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
+            return Ok(None);
+        };
+        let Some(lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
+            return Ok(None);
+        };
+
+        let result_ident = "__sifr_async_list_comp".to_string();
+        let iter_ident = "__sifr_async_list_iter".to_string();
+        let next_ident = "__sifr_async_list_next".to_string();
+
+        let push_stmt = RustStmt::Expr(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(result_ident.clone())),
+            method: "push".to_string(),
+            args: vec![lowered_value],
+        });
+        let value_body = if let Some(filter) = maybe_filter {
+            let Some(lowered_filter) = self.lower_stmt_expr_for_ir(filter)? else {
+                return Ok(None);
+            };
+            vec![RustStmt::If {
+                cond: lowered_filter,
+                then_body: vec![push_stmt],
+                else_body: None,
+            }]
+        } else {
+            vec![push_stmt]
+        };
+
+        let next_call = RustExpr::Await(Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(iter_ident.clone())),
+            method: "anext".to_string(),
+            args: vec![],
+        }));
+        let next_value = if matches!(iter_error_ty.resolve_alias(), Type::Never) {
+            next_call
+        } else {
+            RustExpr::Try(Box::new(next_call))
+        };
+
+        Ok(Some(RustExpr::Block {
+            stmts: vec![
+                RustStmt::Let {
+                    mutable: true,
+                    name: result_ident.clone(),
+                    ty: None,
+                    value: RustExpr::Vec(vec![]),
+                },
+                RustStmt::Let {
+                    mutable: true,
+                    name: iter_ident,
+                    ty: None,
+                    value: lowered_iter,
+                },
+                RustStmt::Loop {
+                    body: vec![
+                        RustStmt::Let {
+                            mutable: false,
+                            name: next_ident.clone(),
+                            ty: None,
+                            value: next_value,
+                        },
+                        RustStmt::Match {
+                            expr: RustExpr::Ident(next_ident),
+                            arms: vec![
+                                crate::RustMatchArm {
+                                    pattern: format!("Some({var})"),
+                                    bindings: vec![var.clone()],
+                                    guard: None,
+                                    body: value_body,
+                                },
+                                crate::RustMatchArm {
+                                    pattern: "None".to_string(),
+                                    bindings: vec![],
+                                    guard: None,
+                                    body: vec![RustStmt::Break],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            expr: Some(Box::new(RustExpr::Ident(result_ident))),
+        }))
+    }
+
     fn try_lower_comprehension_expr_for_ir(
         &mut self,
         expr: &HirExpr,
@@ -607,6 +716,11 @@ impl RustEmitter {
             {
                 if generators.is_empty() || generators.iter().any(|(var, _, _)| var.contains(',')) {
                     return Ok(None);
+                }
+                if generators.iter().any(|(_, iter_expr, _)| {
+                    Self::async_iterator_error_type_for_ir(iter_expr).is_some()
+                }) {
+                    return self.try_lower_async_list_comp_for_ir(expr, generators);
                 }
 
                 let result_ident = "__sifr_list_comp".to_string();

--- a/crates/sifr_hir/src/lower/async_comprehension_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/async_comprehension_diagnostics.rs
@@ -96,6 +96,39 @@ pub(super) fn reject_deferred_async_comprehension_shape(
     true
 }
 
+pub(super) fn reject_unsupported_basic_async_comprehension_shape(
+    ctx: &mut LowerCtx,
+    generators: &[Comprehension],
+    fallback_range: TextRange,
+) -> bool {
+    if !generators.iter().any(|generator| generator.is_async) {
+        return false;
+    }
+
+    if generators.len() != 1 {
+        reject_unsupported_expression_form(
+            ctx,
+            "nested async comprehensions are deferred in v1; use a single async for clause",
+            generators
+                .iter()
+                .find(|generator| generator.is_async)
+                .map_or(fallback_range, Ranged::range),
+        );
+        return true;
+    }
+
+    if let Some(await_range) = generators[0].ifs.iter().find_map(first_await_range_in_expr) {
+        reject_unsupported_expression_form(
+            ctx,
+            "await inside async comprehension filters is deferred in v1; compute the awaited value before the comprehension",
+            await_range,
+        );
+        return true;
+    }
+
+    false
+}
+
 pub(super) fn reject_async_generator_expression(ctx: &mut LowerCtx, range: TextRange) {
     reject_unsupported_expression_form(
         ctx,

--- a/crates/sifr_hir/src/lower/async_comprehensions.rs
+++ b/crates/sifr_hir/src/lower/async_comprehensions.rs
@@ -1,0 +1,99 @@
+use super::expressions::lower_expr;
+use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::Ranged;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::{Expr, ExprListComp};
+use sifr_type_system::Type;
+
+pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option<Option<HirExpr>> {
+    if !comp.generators.iter().any(|generator| generator.is_async) {
+        return None;
+    }
+
+    if super::async_comprehension_diagnostics::reject_unsupported_basic_async_comprehension_shape(
+        ctx,
+        &comp.generators,
+        comp.range(),
+    ) {
+        return Some(None);
+    }
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "async list comprehensions are only valid inside async functions".to_string(),
+            comp.range(),
+        );
+        return Some(None);
+    }
+
+    let generator = &comp.generators[0];
+    let var_name = if let Expr::Name(name) = &generator.target {
+        name.id.to_string()
+    } else {
+        ctx.error_with_code_at(
+            DiagnosticCode::FLOW_INVALID_ITERATION,
+            "async list comprehension target must be a simple name".to_string(),
+            generator.target.range(),
+        );
+        return Some(None);
+    };
+    let iter_source_expr = lower_expr(&generator.iter, ctx)?;
+    let iter_ty = iter_source_expr.ty().clone();
+    let Some((elem_ty, iter_error_ty)) = super::async_for::async_iterator_parts(&iter_ty) else {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            format!(
+                "async list comprehension requires AsyncIterator[T, E] with anext() -> Result[Option[T], E], got '{}'",
+                iter_ty.display_name()
+            ),
+            generator.iter.range(),
+        );
+        return Some(None);
+    };
+    let return_type = ctx
+        .current_function_return_type
+        .clone()
+        .unwrap_or(Type::None);
+    if !super::async_for::return_type_accepts_error(&return_type, &iter_error_ty) {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "fallible async list comprehension requires the enclosing function to return a compatible Result error type".to_string(),
+            generator.iter.range(),
+        );
+        return Some(None);
+    }
+
+    ctx.scope.push();
+    ctx.scope.define(var_name.clone(), elem_ty);
+    let result = (|| {
+        let filter = if generator.ifs.is_empty() {
+            None
+        } else {
+            let first = lower_expr(&generator.ifs[0], ctx)?;
+            if generator.ifs.len() == 1 {
+                Some(first)
+            } else {
+                let mut combined = first;
+                for cond in &generator.ifs[1..] {
+                    let next = lower_expr(cond, ctx)?;
+                    combined = HirExpr::BoolOp {
+                        op: "and".to_string(),
+                        values: vec![combined, next],
+                        ty: Type::Bool,
+                    };
+                }
+                Some(combined)
+            }
+        };
+        let expr = lower_expr(&comp.elt, ctx)?;
+        let expr_ty = expr.ty().clone();
+        Some(HirExpr::ListComp {
+            expr: Box::new(expr),
+            generators: vec![(var_name, iter_source_expr, filter)],
+            ty: Type::List(Box::new(expr_ty)),
+        })
+    })();
+    ctx.scope.pop();
+    Some(result)
+}

--- a/crates/sifr_hir/src/lower/async_for.rs
+++ b/crates/sifr_hir/src/lower/async_for.rs
@@ -86,7 +86,7 @@ fn async_closable_error_type(ty: &Type) -> Option<Type> {
     }
 }
 
-fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
+pub(super) fn return_type_accepts_error(return_type: &Type, error_ty: &Type) -> bool {
     if matches!(error_ty.resolve_alias(), Type::Never) {
         return true;
     }

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -3427,6 +3427,10 @@ pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option
         return None;
     }
 
+    if let Some(result) = super::async_comprehensions::lower_list_comp(comp, ctx) {
+        return result;
+    }
+
     if super::async_comprehension_diagnostics::reject_deferred_async_comprehension_shape(
         ctx,
         "list",

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -9,6 +9,7 @@ mod arithmetic_warnings;
 mod assignment_widening;
 mod async_await;
 mod async_comprehension_diagnostics;
+mod async_comprehensions;
 mod async_for;
 mod async_generator_methods;
 mod async_with;
@@ -181,6 +182,8 @@ pub(super) struct LowerCtx {
     current_function_is_async: bool,
     /// Whether the currently lowered function body is an `async def` containing `yield`.
     current_function_is_async_generator: bool,
+    /// Return type of the currently lowered function body.
+    current_function_return_type: Option<Type>,
     /// Error types collected from Result-returning calls during try body lowering.
     /// Each entry is the name of an error class encountered via auto-unwrap in the current try block.
     try_block_error_types: std::collections::HashSet<String>,
@@ -248,6 +251,7 @@ impl LowerCtx {
             in_try_block: false,
             current_function_is_async: false,
             current_function_is_async_generator: false,
+            current_function_return_type: None,
             try_block_error_types: std::collections::HashSet::new(),
             error_types: std::collections::HashSet::new(),
             error_hierarchy: HashMap::new(),

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -1264,11 +1264,15 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
     let previous_owner = ctx.current_owner.replace(func.name.to_string());
     let previous_async = ctx.current_function_is_async;
     let previous_async_generator = ctx.current_function_is_async_generator;
+    let previous_return_type = ctx
+        .current_function_return_type
+        .replace(ft.return_type.as_ref().clone());
     ctx.current_function_is_async = func.is_async;
     ctx.current_function_is_async_generator = is_async_generator;
     let body = lower_stmts(&func.body, &ft, ctx);
     ctx.current_function_is_async = previous_async;
     ctx.current_function_is_async_generator = previous_async_generator;
+    ctx.current_function_return_type = previous_return_type;
     ctx.current_owner = previous_owner;
 
     ctx.borrowed_params.clear();


### PR DESCRIPTION
## Summary
- lower single-clause async list comprehensions over `AsyncIterator`/`AsyncGenerator` values
- emit an async `anext().await` loop with fallible iterator error propagation and `None` exhaustion
- keep nested async comprehensions, awaited filters, and async set/dict comprehensions deferred
- replace the old list-deferred fail fixture with positive list coverage plus incompatible-error negative coverage

## Validation
- `cargo fmt --check && cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_comprehension_list.sifr && cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick`
- report signature: `b6baaa9a0d3afebf`
- 62 pass fixtures, wall time 117.32s
- Opus review: `SATISFIED` (`reviews/phase32_async_comprehension_list.md`, untracked)
