### PR TITLE
docs: track async list comprehensions

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -802,6 +802,7 @@ Implementation notes:
 - PR [#2056](https://github.com/sifr-lang/sifr/pull/2056) async-generator borrow-yield validation slice: async generator functions now reject mutable borrowed move-type parameters at yield suspension points, extending the existing ownership suspension diagnostic to the `yield` boundary; `async_generator_mut_borrow_across_yield_rejected.sifr` covers the negative path.
 - PR [#2058](https://github.com/sifr-lang/sifr/pull/2058) async-generator deferred return validation slice: `return None` and bare `return` inside async generators are now covered by e2e fail fixtures, keeping those paths fail-closed until async-generator state-machine return lowering lands.
 - PR [#2060](https://github.com/sifr-lang/sifr/pull/2060) async-generator yield-type positive validation slice: `async_generator_yield_types.sifr` now covers converged async-generator yield typing through computed values consumed by `async for`, complementing the literal-yield smoke test without claiming lazy state-machine lowering.
+- PR [#2062](https://github.com/sifr-lang/sifr/pull/2062) async list-comprehension lowering slice: single-clause async list comprehensions over `AsyncIterator`/`AsyncGenerator` now lower to an `anext().await` loop with compatible error propagation and `None` exhaustion, while nested async comprehensions, awaited filters, and async set/dict comprehensions remain deferred.
 
 **Goal:** Complete general user-defined async control-flow protocols without dragging in broad ecosystem APIs.
 


### PR DESCRIPTION
## Summary
- record merged PR #2062 in the Phase 32 async ecosystem tracker
- document async list-comprehension lowering while keeping set/dict, nested async comprehensions, and awaited filters deferred

## Validation
- `scripts/run_all_tests.sh --profile quick`
- report signature: `b6baaa9a0d3afebf`
- 62 pass fixtures, wall time 213.94s
- Opus review: `SATISFIED` (`reviews/phase32_async_comprehension_list_tracker.md`, untracked)
