### PR TITLE
hir: lower async set and dict comprehensions

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_comprehension_dict.sifr
+++ b/crates/sifr/tests/e2e/pass/async_comprehension_dict.sifr
@@ -1,0 +1,13 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield 2
+    yield 3
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    offsets: dict[int, int] = {x: x + 10 async for x in numbers() if x > 1}
+
+    assert len(offsets) == 2
+    assert offsets[2] == 12
+    assert offsets[3] == 13
+    return None

--- a/crates/sifr/tests/e2e/pass/async_comprehension_set.sifr
+++ b/crates/sifr/tests/e2e/pass/async_comprehension_set.sifr
@@ -1,0 +1,13 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield 2
+    yield 3
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    values: set[int] = {x async for x in numbers() if x > 1}
+
+    assert len(values) == 2
+    assert 2 in values
+    assert 3 in values
+    return None

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -700,6 +700,222 @@ impl RustEmitter {
         }))
     }
 
+    fn try_lower_async_set_comp_for_ir(
+        &mut self,
+        value_expr: &HirExpr,
+        generators: &[(String, HirExpr, Option<HirExpr>)],
+    ) -> Result<Option<RustExpr>, crate::CodegenError> {
+        let Some((var, iter_expr, maybe_filter)) = generators.first() else {
+            return Ok(None);
+        };
+        if generators.len() != 1 || var.contains(',') {
+            return Ok(None);
+        }
+        let Some(iter_error_ty) = Self::async_iterator_error_type_for_ir(iter_expr) else {
+            return Ok(None);
+        };
+        let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
+            return Ok(None);
+        };
+        let Some(lowered_value) = self.lower_stmt_expr_for_ir(value_expr)? else {
+            return Ok(None);
+        };
+
+        let result_ident = "__sifr_async_set_comp".to_string();
+        let iter_ident = "__sifr_async_set_iter".to_string();
+        let next_ident = "__sifr_async_set_next".to_string();
+
+        let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(result_ident.clone())),
+            method: "insert".to_string(),
+            args: vec![lowered_value],
+        });
+        let value_body = if let Some(filter) = maybe_filter {
+            let Some(lowered_filter) = self.lower_stmt_expr_for_ir(filter)? else {
+                return Ok(None);
+            };
+            vec![RustStmt::If {
+                cond: lowered_filter,
+                then_body: vec![insert_stmt],
+                else_body: None,
+            }]
+        } else {
+            vec![insert_stmt]
+        };
+
+        let next_call = RustExpr::Await(Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(iter_ident.clone())),
+            method: "anext".to_string(),
+            args: vec![],
+        }));
+        let next_value = if matches!(iter_error_ty.resolve_alias(), Type::Never) {
+            next_call
+        } else {
+            RustExpr::Try(Box::new(next_call))
+        };
+
+        Ok(Some(RustExpr::Block {
+            stmts: vec![
+                RustStmt::Let {
+                    mutable: true,
+                    name: result_ident.clone(),
+                    ty: None,
+                    value: RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "HashSet".to_string(),
+                            "new".to_string(),
+                        ])),
+                        args: vec![],
+                    },
+                },
+                RustStmt::Let {
+                    mutable: true,
+                    name: iter_ident,
+                    ty: None,
+                    value: lowered_iter,
+                },
+                RustStmt::Loop {
+                    body: vec![
+                        RustStmt::Let {
+                            mutable: false,
+                            name: next_ident.clone(),
+                            ty: None,
+                            value: next_value,
+                        },
+                        RustStmt::Match {
+                            expr: RustExpr::Ident(next_ident),
+                            arms: vec![
+                                crate::RustMatchArm {
+                                    pattern: format!("Some({var})"),
+                                    bindings: vec![var.clone()],
+                                    guard: None,
+                                    body: value_body,
+                                },
+                                crate::RustMatchArm {
+                                    pattern: "None".to_string(),
+                                    bindings: vec![],
+                                    guard: None,
+                                    body: vec![RustStmt::Break],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            expr: Some(Box::new(RustExpr::Ident(result_ident))),
+        }))
+    }
+
+    fn try_lower_async_dict_comp_for_ir(
+        &mut self,
+        key_expr: &HirExpr,
+        val_expr: &HirExpr,
+        generators: &[(String, HirExpr, Option<HirExpr>)],
+    ) -> Result<Option<RustExpr>, crate::CodegenError> {
+        let Some((var, iter_expr, maybe_filter)) = generators.first() else {
+            return Ok(None);
+        };
+        if generators.len() != 1 || var.contains(',') {
+            return Ok(None);
+        }
+        let Some(iter_error_ty) = Self::async_iterator_error_type_for_ir(iter_expr) else {
+            return Ok(None);
+        };
+        let Some(lowered_iter) = self.lower_stmt_expr_for_ir(iter_expr)? else {
+            return Ok(None);
+        };
+        let Some(lowered_key) = self.lower_stmt_expr_for_ir(key_expr)? else {
+            return Ok(None);
+        };
+        let Some(lowered_value) = self.lower_stmt_expr_for_ir(val_expr)? else {
+            return Ok(None);
+        };
+
+        let result_ident = "__sifr_async_dict_comp".to_string();
+        let iter_ident = "__sifr_async_dict_iter".to_string();
+        let next_ident = "__sifr_async_dict_next".to_string();
+
+        let insert_stmt = RustStmt::Expr(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(result_ident.clone())),
+            method: "insert".to_string(),
+            args: vec![lowered_key, lowered_value],
+        });
+        let value_body = if let Some(filter) = maybe_filter {
+            let Some(lowered_filter) = self.lower_stmt_expr_for_ir(filter)? else {
+                return Ok(None);
+            };
+            vec![RustStmt::If {
+                cond: lowered_filter,
+                then_body: vec![insert_stmt],
+                else_body: None,
+            }]
+        } else {
+            vec![insert_stmt]
+        };
+
+        let next_call = RustExpr::Await(Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident(iter_ident.clone())),
+            method: "anext".to_string(),
+            args: vec![],
+        }));
+        let next_value = if matches!(iter_error_ty.resolve_alias(), Type::Never) {
+            next_call
+        } else {
+            RustExpr::Try(Box::new(next_call))
+        };
+
+        Ok(Some(RustExpr::Block {
+            stmts: vec![
+                RustStmt::Let {
+                    mutable: true,
+                    name: result_ident.clone(),
+                    ty: None,
+                    value: RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "HashMap".to_string(),
+                            "new".to_string(),
+                        ])),
+                        args: vec![],
+                    },
+                },
+                RustStmt::Let {
+                    mutable: true,
+                    name: iter_ident,
+                    ty: None,
+                    value: lowered_iter,
+                },
+                RustStmt::Loop {
+                    body: vec![
+                        RustStmt::Let {
+                            mutable: false,
+                            name: next_ident.clone(),
+                            ty: None,
+                            value: next_value,
+                        },
+                        RustStmt::Match {
+                            expr: RustExpr::Ident(next_ident),
+                            arms: vec![
+                                crate::RustMatchArm {
+                                    pattern: format!("Some({var})"),
+                                    bindings: vec![var.clone()],
+                                    guard: None,
+                                    body: value_body,
+                                },
+                                crate::RustMatchArm {
+                                    pattern: "None".to_string(),
+                                    bindings: vec![],
+                                    guard: None,
+                                    body: vec![RustStmt::Break],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            expr: Some(Box::new(RustExpr::Ident(result_ident))),
+        }))
+    }
+
     fn try_lower_comprehension_expr_for_ir(
         &mut self,
         expr: &HirExpr,
@@ -786,6 +1002,9 @@ impl RustEmitter {
                 if var.contains(',') {
                     return Ok(None);
                 }
+                if Self::async_iterator_error_type_for_ir(iter_expr).is_some() {
+                    return self.try_lower_async_dict_comp_for_ir(key_expr, val_expr, generators);
+                }
                 let Some(iter) = self.lower_comprehension_iter_for_ir(iter_expr)? else {
                     return Ok(None);
                 };
@@ -854,6 +1073,9 @@ impl RustEmitter {
                 };
                 if var.contains(',') {
                     return Ok(None);
+                }
+                if Self::async_iterator_error_type_for_ir(iter_expr).is_some() {
+                    return self.try_lower_async_set_comp_for_ir(expr, generators);
                 }
                 let Some(iter) = self.lower_comprehension_iter_for_ir(iter_expr)? else {
                     return Ok(None);

--- a/crates/sifr_hir/src/lower/async_comprehensions.rs
+++ b/crates/sifr_hir/src/lower/async_comprehensions.rs
@@ -3,7 +3,7 @@ use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
 use ruff_text_size::Ranged;
 use sifr_diagnostics::DiagnosticCode;
-use sifr_python_ast::{Expr, ExprListComp};
+use sifr_python_ast::{Expr, ExprDictComp, ExprListComp, ExprSetComp};
 use sifr_type_system::Type;
 
 pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option<Option<HirExpr>> {
@@ -96,4 +96,147 @@ pub(super) fn lower_list_comp(comp: &ExprListComp, ctx: &mut LowerCtx) -> Option
     })();
     ctx.scope.pop();
     Some(result)
+}
+
+pub(super) fn lower_set_comp(comp: &ExprSetComp, ctx: &mut LowerCtx) -> Option<Option<HirExpr>> {
+    if !comp.generators.iter().any(|generator| generator.is_async) {
+        return None;
+    }
+    let Some((var_name, iter_source_expr, filter)) =
+        lower_single_async_generator(&comp.generators, comp.range(), ctx)
+    else {
+        return Some(None);
+    };
+
+    ctx.scope.push();
+    let elem_ty = super::async_for::async_iterator_parts(iter_source_expr.ty())
+        .map(|(elem_ty, _)| elem_ty)
+        .unwrap_or(Type::Any);
+    ctx.scope.define(var_name.clone(), elem_ty);
+    let result = (|| {
+        let expr = lower_expr(&comp.elt, ctx)?;
+        let expr_ty = expr.ty().clone();
+        Some(HirExpr::SetComp {
+            expr: Box::new(expr),
+            generators: vec![(var_name, iter_source_expr, filter)],
+            ty: Type::Set(Box::new(expr_ty)),
+        })
+    })();
+    ctx.scope.pop();
+    Some(result)
+}
+
+pub(super) fn lower_dict_comp(comp: &ExprDictComp, ctx: &mut LowerCtx) -> Option<Option<HirExpr>> {
+    if !comp.generators.iter().any(|generator| generator.is_async) {
+        return None;
+    }
+    let Some((var_name, iter_source_expr, filter)) =
+        lower_single_async_generator(&comp.generators, comp.range(), ctx)
+    else {
+        return Some(None);
+    };
+
+    ctx.scope.push();
+    let elem_ty = super::async_for::async_iterator_parts(iter_source_expr.ty())
+        .map(|(elem_ty, _)| elem_ty)
+        .unwrap_or(Type::Any);
+    ctx.scope.define(var_name.clone(), elem_ty);
+    let result = (|| {
+        let key_expr = lower_expr(&comp.key, ctx)?;
+        let val_expr = lower_expr(&comp.value, ctx)?;
+        let key_ty = key_expr.ty().clone();
+        let val_ty = val_expr.ty().clone();
+        Some(HirExpr::DictComp {
+            key_expr: Box::new(key_expr),
+            val_expr: Box::new(val_expr),
+            generators: vec![(var_name, iter_source_expr, filter)],
+            ty: Type::Dict(Box::new(key_ty), Box::new(val_ty)),
+        })
+    })();
+    ctx.scope.pop();
+    Some(result)
+}
+
+fn lower_single_async_generator(
+    generators: &[sifr_python_ast::Comprehension],
+    fallback_range: ruff_text_size::TextRange,
+    ctx: &mut LowerCtx,
+) -> Option<(String, HirExpr, Option<HirExpr>)> {
+    if super::async_comprehension_diagnostics::reject_unsupported_basic_async_comprehension_shape(
+        ctx,
+        generators,
+        fallback_range,
+    ) {
+        return None;
+    }
+    if !ctx.current_function_is_async {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "async comprehensions are only valid inside async functions".to_string(),
+            fallback_range,
+        );
+        return None;
+    }
+
+    let generator = &generators[0];
+    let var_name = if let Expr::Name(name) = &generator.target {
+        name.id.to_string()
+    } else {
+        ctx.error_with_code_at(
+            DiagnosticCode::FLOW_INVALID_ITERATION,
+            "async comprehension target must be a simple name".to_string(),
+            generator.target.range(),
+        );
+        return None;
+    };
+    let iter_source_expr = lower_expr(&generator.iter, ctx)?;
+    let iter_ty = iter_source_expr.ty().clone();
+    let Some((elem_ty, iter_error_ty)) = super::async_for::async_iterator_parts(&iter_ty) else {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            format!(
+                "async comprehension requires AsyncIterator[T, E] with anext() -> Result[Option[T], E], got '{}'",
+                iter_ty.display_name()
+            ),
+            generator.iter.range(),
+        );
+        return None;
+    };
+    let return_type = ctx
+        .current_function_return_type
+        .clone()
+        .unwrap_or(Type::None);
+    if !super::async_for::return_type_accepts_error(&return_type, &iter_error_ty) {
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "fallible async comprehension requires the enclosing function to return a compatible Result error type".to_string(),
+            generator.iter.range(),
+        );
+        return None;
+    }
+
+    ctx.scope.push();
+    ctx.scope.define(var_name.clone(), elem_ty);
+    let filter = if generator.ifs.is_empty() {
+        None
+    } else {
+        let first = lower_expr(&generator.ifs[0], ctx)?;
+        if generator.ifs.len() == 1 {
+            Some(first)
+        } else {
+            let mut combined = first;
+            for cond in &generator.ifs[1..] {
+                let next = lower_expr(cond, ctx)?;
+                combined = HirExpr::BoolOp {
+                    op: "and".to_string(),
+                    values: vec![combined, next],
+                    ty: Type::Bool,
+                };
+            }
+            Some(combined)
+        }
+    };
+    ctx.scope.pop();
+
+    Some((var_name, iter_source_expr, filter))
 }

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -112,8 +112,10 @@ pub(super) fn lower_expr(expr: &Expr, ctx: &mut LowerCtx) -> Option<HirExpr> {
         Expr::Named(named) => lower_named_expr(named, ctx),
         Expr::Lambda(lambda) => lower_lambda(lambda, ctx),
         Expr::ListComp(comp) => lower_list_comp(comp, ctx),
-        Expr::SetComp(comp) => lower_set_comp(comp, ctx),
-        Expr::DictComp(comp) => lower_dict_comp(comp, ctx),
+        Expr::SetComp(comp) => super::async_comprehensions::lower_set_comp(comp, ctx)
+            .unwrap_or_else(|| lower_set_comp(comp, ctx)),
+        Expr::DictComp(comp) => super::async_comprehensions::lower_dict_comp(comp, ctx)
+            .unwrap_or_else(|| lower_dict_comp(comp, ctx)),
         Expr::Generator(gen) => lower_generator_expr(gen, ctx),
         Expr::YieldFrom(yield_from) if ctx.current_function_is_async_generator => {
             expression_diagnostics::unsupported_form(


### PR DESCRIPTION
## Summary
- lower single-clause async set and dict comprehensions through the async comprehension path
- emit HashSet/HashMap builders using `anext().await`, `None` exhaustion, and compatible error propagation
- add pass fixtures for async set and dict comprehensions

## Validation
- `cargo fmt --check`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_comprehension_set.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_comprehension_dict.sifr`
- `cargo test -p sifr -- test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile quick` (report_signature=b6baaa9a0d3afebf, 62 pass tests)