### PR TITLE
tests: cover async generator send boundaries

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_non_send_boundary_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_non_send_boundary_rejected.sifr
@@ -1,0 +1,21 @@
+# expect-error[col=30]: SIFR-OWN-0010
+class LocalCell(NonSend):
+    pass
+
+
+async def cells() -> AsyncGenerator[LocalCell, GeneratorCloseError]:
+    yield LocalCell()
+
+
+async def consume(own mut agen: AsyncGenerator[LocalCell, GeneratorCloseError]) -> Result[int, GeneratorCloseError]:
+    count: int = 0
+    async for _ in agen:
+        count = count + 1
+    return count
+
+
+async def main() -> Result[None, ScopeFailure]:
+    agen = cells()
+    async with task.scope() as scope:
+        handle = scope.spawn(consume(agen))
+    return None

--- a/crates/sifr/tests/e2e/pass/async_generator_send_boundary.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_send_boundary.sifr
@@ -1,0 +1,19 @@
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 2
+    yield 3
+
+
+async def consume(own mut agen: AsyncGenerator[int, GeneratorCloseError]) -> Result[int, GeneratorCloseError]:
+    total: int = 0
+    async for value in agen:
+        total = total + value
+    return total
+
+
+async def main() -> Result[None, ScopeFailure]:
+    agen = numbers()
+    async with task.scope() as scope:
+        handle = scope.spawn(consume(agen))
+        result = await handle
+        assert str(result) == "Ok(5)"
+    return None


### PR DESCRIPTION
## Summary
- add a positive fixture proving a sendable async generator can move into a spawned worker and be consumed there
- add a negative fixture rejecting a non-send async generator at the scope.spawn boundary

## Validation
- cargo fmt --check
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_send_boundary.sifr
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- scripts/run_all_tests.sh --profile quick (report_signature=b6baaa9a0d3afebf, 62 pass tests, budget_ok=yes)
