### PR TITLE
hir: reject reentrant async generator anext

### DIFF
--- a/crates/sifr/tests/e2e/fail/async_generator_reentrant_anext_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/async_generator_reentrant_anext_rejected.sifr
@@ -1,0 +1,14 @@
+# expect-error[col=20]: SIFR-OWN-0002
+
+async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:
+    yield 1
+    yield 2
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    agen = numbers()
+    first = anext(agen)
+    second = anext(agen)
+    observed: Result[Option[int], GeneratorCloseError] = await first
+    other: Result[Option[int], GeneratorCloseError] = await second
+    return None

--- a/crates/sifr_hir/src/lower/async_await.rs
+++ b/crates/sifr_hir/src/lower/async_await.rs
@@ -1,3 +1,4 @@
+use super::async_generator_advances::finish_async_generator_advance_for_expr;
 use super::expression_diagnostics;
 use super::expressions::lower_expr;
 use super::ownership_diagnostics;
@@ -47,6 +48,7 @@ pub(super) fn lower_await(await_expr: &ExprAwait, ctx: &mut LowerCtx) -> Option<
             ctx.scope.mark_moved(name);
         }
     }
+    finish_async_generator_advance_for_expr(ctx, &value);
 
     Some(HirExpr::Await {
         value: Box::new(value),

--- a/crates/sifr_hir/src/lower/async_generator_advances.rs
+++ b/crates/sifr_hir/src/lower/async_generator_advances.rs
@@ -1,0 +1,138 @@
+use super::async_for::async_iterator_parts;
+use super::call_argument_ranges::{call_arity_range, first_call_keyword_range};
+use super::expression_diagnostics;
+use super::expressions::lower_expr;
+use super::LowerCtx;
+use crate::hir_nodes::HirExpr;
+use ruff_text_size::{Ranged, TextRange};
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::ExprCall;
+use sifr_type_system::Type;
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub(super) struct AsyncGeneratorAdvanceTracker {
+    pending_generators: HashMap<String, TextRange>,
+    pending_bindings: HashMap<String, String>,
+}
+
+pub(super) fn lower_anext_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr> {
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "anext() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return None;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            format!(
+                "anext() takes exactly 1 argument, got {}",
+                call.arguments.args.len()
+            ),
+            call_arity_range(call),
+        );
+        return None;
+    }
+    let iterator = lower_expr(&call.arguments.args[0], ctx)?;
+    let Some((item_ty, err_ty)) = async_iterator_parts(iterator.ty()) else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "anext() argument must be an async iterator, got '{}'",
+                iterator.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return None;
+    };
+    if matches!(iterator.ty().resolve_alias(), Type::AsyncGenerator(_, _)) {
+        if let HirExpr::Name { name, .. } = &iterator {
+            begin_async_generator_advance(ctx, name, call.arguments.args[0].range());
+        }
+    }
+    Some(HirExpr::Call {
+        func: "anext".to_string(),
+        args: vec![iterator],
+        ty: Type::Awaitable(Box::new(Type::Result(
+            Box::new(Type::Union(vec![item_ty, Type::None])),
+            Box::new(err_ty),
+        ))),
+    })
+}
+
+pub(super) fn record_async_generator_advance_binding(
+    ctx: &mut LowerCtx,
+    binding_name: &str,
+    value: &HirExpr,
+) {
+    clear_async_generator_advance_binding(ctx, binding_name);
+    if let Some(generator_name) = async_generator_anext_source(value) {
+        ctx.async_generator_advances
+            .pending_bindings
+            .insert(binding_name.to_string(), generator_name);
+    }
+}
+
+pub(super) fn finish_async_generator_advance_for_expr(ctx: &mut LowerCtx, value: &HirExpr) {
+    if let Some(generator_name) = async_generator_anext_source(value) {
+        ctx.async_generator_advances
+            .pending_generators
+            .remove(&generator_name);
+        return;
+    }
+    if let HirExpr::Name { name, .. } = value {
+        clear_async_generator_advance_binding(ctx, name);
+    }
+}
+
+fn begin_async_generator_advance(ctx: &mut LowerCtx, generator_name: &str, range: TextRange) {
+    if ctx
+        .async_generator_advances
+        .pending_generators
+        .contains_key(generator_name)
+    {
+        ctx.error_with_code_at(
+            DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW,
+            format!(
+                "async generator `{generator_name}` already has a pending anext() advance; await it before starting another advance"
+            ),
+            range,
+        );
+        return;
+    }
+    ctx.async_generator_advances
+        .pending_generators
+        .insert(generator_name.to_string(), range);
+}
+
+fn clear_async_generator_advance_binding(ctx: &mut LowerCtx, binding_name: &str) {
+    if let Some(generator_name) = ctx
+        .async_generator_advances
+        .pending_bindings
+        .remove(binding_name)
+    {
+        ctx.async_generator_advances
+            .pending_generators
+            .remove(&generator_name);
+    }
+}
+
+fn async_generator_anext_source(value: &HirExpr) -> Option<String> {
+    let HirExpr::Call { func, args, .. } = value else {
+        return None;
+    };
+    if func != "anext" || args.len() != 1 {
+        return None;
+    }
+    let HirExpr::Name { name, ty } = &args[0] else {
+        return None;
+    };
+    if matches!(ty.resolve_alias(), Type::AsyncGenerator(_, _)) {
+        Some(name.clone())
+    } else {
+        None
+    }
+}

--- a/crates/sifr_hir/src/lower/call_argument_ranges.rs
+++ b/crates/sifr_hir/src/lower/call_argument_ranges.rs
@@ -45,3 +45,18 @@ pub(super) fn type_param_argument_range(
     }
     None
 }
+
+pub(super) fn first_call_keyword_range(call: &ExprCall) -> TextRange {
+    call.arguments
+        .keywords
+        .first()
+        .map_or_else(|| call.range(), Ranged::range)
+}
+
+pub(super) fn call_arity_range(call: &ExprCall) -> TextRange {
+    if call.arguments.args.is_empty() {
+        call.range()
+    } else {
+        call.arguments.range()
+    }
+}

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -1,5 +1,5 @@
 use super::async_await::{coroutine_result_type, lower_await};
-use super::async_for::async_iterator_parts;
+use super::async_generator_advances::lower_anext_call;
 use super::builtin_calls::{
     callable_builtin_element_type, lower_bytes_constructor_call, lower_bytes_type_factory_call,
     lower_chr_call, lower_defaultdict_constructor_call, lower_dict_constructor_call,
@@ -534,45 +534,7 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
 
         // anext(async_iterator) -> Awaitable[Result[Option[T], E]]
         if func_name == "anext" {
-            if !call.arguments.keywords.is_empty() {
-                expression_diagnostics::call_unexpected_keyword(
-                    ctx,
-                    "anext() does not accept keyword arguments".to_string(),
-                    first_call_keyword_range(call),
-                );
-                return None;
-            }
-            if call.arguments.args.len() != 1 {
-                expression_diagnostics::call_wrong_positional_count(
-                    ctx,
-                    format!(
-                        "anext() takes exactly 1 argument, got {}",
-                        call.arguments.args.len()
-                    ),
-                    call_arity_range(call),
-                );
-                return None;
-            }
-            let iterator = lower_expr(&call.arguments.args[0], ctx)?;
-            let Some((item_ty, err_ty)) = async_iterator_parts(iterator.ty()) else {
-                expression_diagnostics::type_mismatch(
-                    ctx,
-                    format!(
-                        "anext() argument must be an async iterator, got '{}'",
-                        iterator.ty().display_name()
-                    ),
-                    call.arguments.args[0].range(),
-                );
-                return None;
-            };
-            return Some(HirExpr::Call {
-                func: "anext".to_string(),
-                args: vec![iterator],
-                ty: Type::Awaitable(Box::new(Type::Result(
-                    Box::new(Type::Union(vec![item_ty, Type::None])),
-                    Box::new(err_ty),
-                ))),
-            });
+            return lower_anext_call(call, ctx);
         }
 
         // Special handling for isinstance() built-in

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -1770,6 +1770,30 @@ fn test_mutable_borrow_parameter_across_async_generator_yield_rejected() {
 }
 
 #[test]
+fn test_async_generator_pending_anext_rejects_reentrant_advance() {
+    let source = "async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:\n    yield 1\n    yield 2\n\nasync def main() -> Result[None, GeneratorCloseError]:\n    agen = numbers()\n    first = anext(agen)\n    second = anext(agen)\n    observed: Result[Option[int], GeneratorCloseError] = await first\n    other: Result[Option[int], GeneratorCloseError] = await second\n    return None\n";
+    let result = lower_source(source);
+    assert!(result.is_err());
+    let errors = result.unwrap_err();
+    assert!(errors.iter().any(|e| {
+        e.message
+            .contains("async generator `agen` already has a pending anext() advance")
+            && e.code == Some(DiagnosticCode::OWN_DOUBLE_MUTABLE_BORROW)
+            && e.primary_range == Some(range_for_after(source, "second = anext(", "agen"))
+    }));
+}
+
+#[test]
+fn test_async_generator_anext_pending_state_clears_after_await() {
+    let source = "async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:\n    yield 1\n    yield 2\n\nasync def main() -> Result[None, GeneratorCloseError]:\n    agen = numbers()\n    first = anext(agen)\n    observed: Result[Option[int], GeneratorCloseError] = await first\n    second = anext(agen)\n    other: Result[Option[int], GeneratorCloseError] = await second\n    return None\n";
+    let result = lower_source(source);
+    assert!(
+        result.is_ok(),
+        "awaited anext handle should release the async generator advance state: {result:?}"
+    );
+}
+
+#[test]
 fn test_await_after_completed_mutable_borrow_lowers() {
     let source = "def mutate_local(mut items: list[int]) -> None:\n    items.append(2)\n    return None\n\nasync def main() -> None:\n    items: list[int] = [1]\n    mutate_local(items)\n    await task.sleep(0.0)\n    return None\n";
     let result = lower_source(source);

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -11,6 +11,7 @@ mod async_await;
 mod async_comprehension_diagnostics;
 mod async_comprehensions;
 mod async_for;
+mod async_generator_advances;
 mod async_generator_methods;
 mod async_with;
 mod attribute_access;
@@ -219,6 +220,7 @@ pub(super) struct LowerCtx {
     numeric_sentinel_vars: HashMap<String, numeric_sentinels::NumericSentinelFact>,
     pending_numeric_sentinel_patches: HashMap<String, numeric_sentinels::NumericSentinelPatch>,
     pending_container_specialization_patches: HashMap<String, Type>,
+    async_generator_advances: async_generator_advances::AsyncGeneratorAdvanceTracker,
     sequence_shapes: Vec<sequence_shapes::SequenceShapeFact>,
     proven_nonzero_integer_bindings: std::collections::HashSet<String>,
     function_scopes: Vec<function_scopes::FunctionScopeState>,
@@ -227,6 +229,7 @@ pub(super) struct LowerCtx {
     empty_dict_specializations: HashMap<String, Type>,
     const_integer_values: HashMap<String, num_bigint::BigInt>,
 }
+
 impl LowerCtx {
     fn new() -> Self {
         Self {
@@ -272,6 +275,7 @@ impl LowerCtx {
             numeric_sentinel_vars: HashMap::new(),
             pending_numeric_sentinel_patches: HashMap::new(),
             pending_container_specialization_patches: HashMap::new(),
+            async_generator_advances: Default::default(),
             sequence_shapes: Vec::new(),
             proven_nonzero_integer_bindings: std::collections::HashSet::new(),
             function_scopes: Vec::new(),
@@ -285,6 +289,7 @@ impl LowerCtx {
     fn is_stdlib_lowering(&self) -> bool {
         self.allow_intrinsic_imports
     }
+
     fn warn_arithmetic_overflow_risk(&mut self, operation: &'static str, range: TextRange) {
         self.warnings
             .push(LoweringWarningDiagnostic::ArithmeticOverflowRisk {

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -1,5 +1,8 @@
 use super::assignment_widening::reconcile_optional_reassignment;
 use super::async_for::lower_async_for;
+use super::async_generator_advances::{
+    finish_async_generator_advance_for_expr, record_async_generator_advance_binding,
+};
 use super::async_with::lower_async_with;
 use super::aug_assign_lowering::lower_aug_assign as lower_aug_assign_impl;
 use super::binding_mutability::ensure_mutable_parameter_binding;
@@ -248,6 +251,7 @@ pub(super) fn lower_stmt(
                     expr_stmt.value.range(),
                 );
             }
+            finish_async_generator_advance_for_expr(ctx, &expr);
             Some(HirStmt::Expr { expr })
         }
         Stmt::If(if_stmt) => lower_if(if_stmt, func_type, ctx),
@@ -1184,6 +1188,7 @@ pub(super) fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Optio
     let initializer = ann.value.as_ref()?;
     record_len_alias_fact(ctx, &name, initializer);
     record_sequence_pointer_fact(ctx, &name, initializer);
+    record_async_generator_advance_binding(ctx, &name, &value);
     Some(HirStmt::Let {
         name,
         ty: declared_type,
@@ -1529,6 +1534,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
     if name == "_" {
         let value = lower_expr(&assign.value, ctx)?;
         let value_ty = value.ty().clone();
+        finish_async_generator_advance_for_expr(ctx, &value);
         return Some(HirStmt::Let {
             name: "_".to_string(),
             ty: value_ty,
@@ -1600,6 +1606,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
         // Reset moved state on reassignment
         ctx.scope.reset_moved(&name);
         ctx.task_handle_group_owners.remove(&name);
+        record_async_generator_advance_binding(ctx, &name, &value);
         invalidate_rebound_binding_facts(ctx, &name);
         if ctx.numeric_sentinel_fact(&name).is_some() {
             if let Some(domain) = numeric_domain_for_type(&value_ty) {
@@ -1627,6 +1634,7 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
             .cloned()
             .unwrap_or_else(|| value_ty.clone());
         ctx.scope.define(name.clone(), binding_ty.clone());
+        record_async_generator_advance_binding(ctx, &name, &value);
         if let Some(group_name) = task_group_spawn_owner(&value) {
             ctx.task_handle_group_owners
                 .insert(name.clone(), group_name);


### PR DESCRIPTION
## Summary
- add focused HIR tracking for pending async generator anext advances
- reject a second pending anext on the same async generator with SIFR-OWN-0002
- add unit coverage for rejection and post-await clearing, plus the e2e fail fixture requested by Phase 32

## Validation
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- cargo test -p sifr_hir async_generator_anext_pending
- cargo test -p sifr -- test_e2e_fail -- --nocapture
- scripts/run_all_tests.sh --profile quick
  - report_signature=b6baaa9a0d3afebf
  - 62 pass tests, 0 failures
  - wall_time=181.91s, budget_ok=yes

## Review
- Opus review: SATISFIED (reviews/phase32_async_generator_reentrant_anext.md, not committed)
