### PR TITLE
tests: cover async generator borrowed yields

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_generator_borrow_yield.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_borrow_yield.sifr
@@ -1,0 +1,18 @@
+async def lengths(items: list[int]) -> AsyncGenerator[int, GeneratorCloseError]:
+    yield len(items)
+    yield len(items) + 1
+
+
+async def main() -> Result[None, GeneratorCloseError]:
+    items: list[int] = [10, 20, 30]
+    agen = lengths(items)
+
+    first: Result[Option[int], GeneratorCloseError] = await anext(agen)
+    second: Result[Option[int], GeneratorCloseError] = await anext(agen)
+    done: Result[Option[int], GeneratorCloseError] = await anext(agen)
+
+    assert str(first) == "Ok(Some(3))"
+    assert str(second) == "Ok(Some(4))"
+    assert str(done) == "Ok(None)"
+    assert len(items) == 3
+    return None


### PR DESCRIPTION
## Summary
- add the Phase 32 async_generator_borrow_yield positive e2e fixture
- cover immutable borrowed list use across async-generator yields
- assert anext exhaustion and caller list usability after generator consumption

## Validation
- cargo fmt --check && cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_borrow_yield.sifr
- scripts/run_all_tests.sh --profile quick (passed functionally; report_signature=b6baaa9a0d3afebf; 62 quick pass tests; wall_time=343.34s; budget_ok=no due warm wall-time advisory)

## Review
- Opus review: SATISFIED (reviews/phase32_async_generator_borrow_yield_positive.md, not committed)