### PR TITLE
codegen: lazy-start async generators

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_generator_lazy_start.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_lazy_start.sifr
@@ -1,0 +1,42 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_async_generator_lazy_start_" + str(getpid()) + ".txt"
+
+
+async def numbers(path: str) -> AsyncGenerator[int, IOError]:
+    try:
+        _written: None = write_text(path, "started")
+    except IOError as e:
+        _write_error: str = str(e.message)
+    yield 1
+    yield 2
+
+
+async def main() -> Result[None, IOError]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _existing_cleanup_error: str = str(e.message)
+
+    agen = numbers(path)
+    assert not exists(path)
+
+    first: Result[Option[int], IOError] = await anext(agen)
+    second: Result[Option[int], IOError] = await anext(agen)
+    done: Result[Option[int], IOError] = await anext(agen)
+
+    assert exists(path)
+    assert str(first) == "Ok(Some(1))"
+    assert str(second) == "Ok(Some(2))"
+    assert str(done) == "Ok(None)"
+
+    try:
+        _removed: None = remove_file(path)
+    except IOError as e:
+        _cleanup_error: str = str(e.message)
+    return None

--- a/crates/sifr_codegen/src/function_emitter.rs
+++ b/crates/sifr_codegen/src/function_emitter.rs
@@ -984,7 +984,8 @@ impl RustEmitter {
             self.mut_borrowed_params.remove(name);
         }
 
-        body.push(RustStmt::Let {
+        let mut materialize_body = Vec::new();
+        materialize_body.push(RustStmt::Let {
             mutable: true,
             name: "_yields".to_string(),
             ty: Some(RustType::Vec(Box::new(yield_ty))),
@@ -994,19 +995,27 @@ impl RustEmitter {
             },
         });
         for stmt in &func.body {
-            body.extend(self.lower_stmt_strict_for_function(
+            materialize_body.extend(self.lower_stmt_strict_for_function(
                 stmt,
-                "async generator materialization statement lowering",
+                "async generator lazy materialization statement lowering",
             ));
         }
         self.borrowed_params = saved_borrowed_params;
         self.mut_borrowed_params = saved_mut_borrowed_params;
+        materialize_body.push(RustStmt::Return(Some(RustExpr::Ident(
+            "_yields".to_string(),
+        ))));
         body.push(RustStmt::Return(Some(RustExpr::FnCall {
             func: Box::new(RustExpr::Path(vec![
                 "AsyncGenerator".to_string(),
-                "new".to_string(),
+                "new_lazy".to_string(),
             ])),
-            args: vec![RustExpr::Ident("_yields".to_string())],
+            args: vec![RustExpr::ClosureBlock {
+                params: vec![],
+                body: materialize_body,
+                is_move: true,
+                is_async: false,
+            }],
         })));
         body
     }

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -17,6 +17,17 @@ fn generate_rust_from_source(source: &str) -> String {
     generate_rust(&lowering.module)
 }
 
+#[test]
+fn test_async_generator_codegen_uses_lazy_materialization() {
+    let rust_code = generate_rust_from_source(
+        "async def numbers() -> AsyncGenerator[int, GeneratorCloseError]:\n    yield 1\n    yield 2\n",
+    );
+
+    assert!(rust_code.contains("AsyncGenerator::new_lazy"));
+    assert!(rust_code.contains("move ||"));
+    assert!(!rust_code.contains("AsyncGenerator::new(_yields)"));
+}
+
 fn empty_module() -> HirModule {
     HirModule {
         functions: vec![],

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -347,6 +347,12 @@ pub fn build_async_generator_type_items() -> Vec<RustItem> {
                     "items".to_string(),
                     RustType::Named("std::vec::IntoIter<T>".to_string()),
                 ),
+                (
+                    "factory".to_string(),
+                    RustType::Named(
+                        "Option<Box<dyn FnOnce() -> Vec<T> + Send + 'static>>".to_string(),
+                    ),
+                ),
                 ("closed".to_string(), RustType::Bool),
                 (
                     "_err".to_string(),
@@ -377,6 +383,63 @@ pub fn build_async_generator_type_items() -> Vec<RustItem> {
                                     receiver: Box::new(RustExpr::Ident("items".to_string())),
                                     method: "into_iter".to_string(),
                                     args: vec![],
+                                },
+                            ),
+                            ("factory".to_string(), RustExpr::Ident("None".to_string())),
+                            (
+                                "closed".to_string(),
+                                RustExpr::Literal(crate::RustLiteral::Bool(false)),
+                            ),
+                            (
+                                "_err".to_string(),
+                                RustExpr::Path(vec![
+                                    "std".to_string(),
+                                    "marker".to_string(),
+                                    "PhantomData".to_string(),
+                                ]),
+                            ),
+                        ],
+                    }))],
+                    is_async: false,
+                },
+                RustItem::Fn {
+                    name: "new_lazy".to_string(),
+                    visibility: Visibility::Private,
+                    type_params: vec![crate::RustTypeParam {
+                        name: "F".to_string(),
+                        bounds: vec![
+                            "FnOnce() -> Vec<T>".to_string(),
+                            "Send".to_string(),
+                            "'static".to_string(),
+                        ],
+                    }],
+                    params: vec![RustParam::Named {
+                        name: "factory".to_string(),
+                        ty: RustType::Named("F".to_string()),
+                    }],
+                    ret: Some(RustType::Named("Self".to_string())),
+                    body: vec![RustStmt::Return(Some(RustExpr::StructInit {
+                        name: "Self".to_string(),
+                        fields: vec![
+                            (
+                                "items".to_string(),
+                                RustExpr::MethodCall {
+                                    receiver: Box::new(RustExpr::Vec(vec![])),
+                                    method: "into_iter".to_string(),
+                                    args: vec![],
+                                },
+                            ),
+                            (
+                                "factory".to_string(),
+                                RustExpr::FnCall {
+                                    func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+                                    args: vec![RustExpr::FnCall {
+                                        func: Box::new(RustExpr::Path(vec![
+                                            "Box".to_string(),
+                                            "new".to_string(),
+                                        ])),
+                                        args: vec![RustExpr::Ident("factory".to_string())],
+                                    }],
                                 },
                             ),
                             (
@@ -414,6 +477,34 @@ pub fn build_async_generator_type_items() -> Vec<RustItem> {
                                 func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
                                 args: vec![RustExpr::Ident("None".to_string())],
                             }))],
+                            else_body: None,
+                        },
+                        RustStmt::IfLet {
+                            pattern: "Some(__sifr_async_generator_factory)".to_string(),
+                            expr: RustExpr::MethodCall {
+                                receiver: Box::new(RustExpr::Field {
+                                    expr: Box::new(RustExpr::Ident("self".to_string())),
+                                    field: "factory".to_string(),
+                                }),
+                                method: "take".to_string(),
+                                args: vec![],
+                            },
+                            then_body: vec![RustStmt::Assign {
+                                target: RustExpr::Field {
+                                    expr: Box::new(RustExpr::Ident("self".to_string())),
+                                    field: "items".to_string(),
+                                },
+                                value: RustExpr::MethodCall {
+                                    receiver: Box::new(RustExpr::FnCall {
+                                        func: Box::new(RustExpr::Ident(
+                                            "__sifr_async_generator_factory".to_string(),
+                                        )),
+                                        args: vec![],
+                                    }),
+                                    method: "into_iter".to_string(),
+                                    args: vec![],
+                                },
+                            }],
                             else_body: None,
                         },
                         RustStmt::Return(Some(RustExpr::FnCall {


### PR DESCRIPTION
## Summary
- store an optional one-shot materialization factory on AsyncGenerator
- lower async-generator functions through AsyncGenerator::new_lazy(move || ...), so body work starts on first anext rather than at generator construction
- add a marker-file e2e fixture and codegen unit coverage for lazy materialization

## Scope
- this advances lazy-start semantics for the existing materialized backend
- it does not implement per-yield state-machine suspension, await inside async generators, or cancellation/finally cleanup

## Validation
- cargo fmt --check
- cargo test -p sifr_codegen test_async_generator_codegen_uses_lazy_materialization
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_lazy_start.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_send_boundary.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_basic.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_aclose_result.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_comprehension_list.sifr
- scripts/run_all_tests.sh --profile quick (passed functionally; report_signature=b6baaa9a0d3afebf; 62 quick pass tests; wall_time=422.16s; budget_ok=no due warm wall-time advisory)

## Review
- Opus review: SATISFIED (reviews/phase32_async_generator_lazy_start.md, not committed)