### PR TITLE
docs: track async generator lazy start

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -808,6 +808,7 @@ Implementation notes:
 - PR [#2068](https://github.com/sifr-lang/sifr/pull/2068) async-generator/comprehension demo slice: `demos/m32_async_generator_comprehension_demo.sifr` now demonstrates supported async-generator consumption through `async for`, `anext()`, `aclose()`, and single-clause async list/set/dict comprehensions without claiming deferred state-machine, cancellation-cleanup, reentrant, `send()`, `throw()`, or `yield from` behavior.
 - PR [#2070](https://github.com/sifr-lang/sifr/pull/2070) async-generator reentrant advance validation slice: pending same-task `anext(agen)` advances are now tracked in HIR and a second pending advance on the same async-generator binding is rejected with `SIFR-OWN-0002`; `async_generator_reentrant_anext_rejected.sifr` covers the fail-closed boundary while full runtime `GeneratorBusyError` state-machine behavior remains deferred.
 - PR [#2072](https://github.com/sifr-lang/sifr/pull/2072) async-generator borrowed-yield positive validation slice: `async_generator_borrow_yield.sifr` now proves immutable borrowed move-type parameters can be read across supported async-generator yield points and consumed through `anext()`, with the caller's list still usable after exhaustion; lazy state-machine lowering and cancellation cleanup remain deferred.
+- PR [#2074](https://github.com/sifr-lang/sifr/pull/2074) async-generator lazy-start slice: generated async-generator functions now return a one-shot materialization factory through `AsyncGenerator::new_lazy`, so body side effects begin on first `anext()` consumption rather than function call; `async_generator_lazy_start.sifr` covers the supported materialized backend while per-yield state-machine suspension and cancellation cleanup remain deferred.
 
 **Goal:** Complete general user-defined async control-flow protocols without dragging in broad ecosystem APIs.
 
@@ -975,6 +976,7 @@ status: in progress
 - `async_generator_basic.sifr`
 - `async_generator_yield_types.sifr`
 - `async_generator_anext_result_option.sifr`
+- `async_generator_lazy_start.sifr`
 - `async_generator_cancel_cleanup.sifr`
 - `async_generator_borrow_yield.sifr`
 - `async_generator_send_boundary.sifr`


### PR DESCRIPTION
## Summary
- record merged PR #2074 in the Phase 32 implementation notes
- add async_generator_lazy_start.sifr to the milestone 7b positive validation list
- document that this is lazy-start for the materialized backend, with per-yield state-machine suspension and cleanup still deferred

## Validation
- scripts/run_all_tests.sh --profile quick (passed functionally; report_signature=b6baaa9a0d3afebf; 62 pass tests; wall_time=578.87s; budget_ok=no due warm wall-time/skew advisories)

## Review
- Opus review: SATISFIED (reviews/phase32_async_generator_lazy_start_tracker.md, not committed)