### PR TITLE
tests: cover async generator close before start

### DIFF
--- a/crates/sifr/tests/e2e/pass/async_generator_aclose_before_start.sifr
+++ b/crates/sifr/tests/e2e/pass/async_generator_aclose_before_start.sifr
@@ -1,0 +1,32 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_async_generator_aclose_before_start_" + str(getpid()) + ".txt"
+
+
+async def numbers(path: str) -> AsyncGenerator[int, IOError]:
+    try:
+        _written: None = write_text(path, "started")
+    except IOError as e:
+        _write_error: str = str(e.message)
+    yield 1
+
+
+async def main() -> Result[None, IOError]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _existing_cleanup_error: str = str(e.message)
+
+    agen = numbers(path)
+    closed: Result[None, GeneratorCloseError] = await agen.aclose()
+    done: Result[Option[int], IOError] = await anext(agen)
+
+    assert str(closed) == "Ok(())"
+    assert str(done) == "Ok(None)"
+    assert not exists(path)
+    return None


### PR DESCRIPTION
## Summary
- add a focused async-generator lifecycle fixture for `aclose()` before the first `anext()`
- prove the lazy generator body is not started when closed before first advance
- verify later `anext()` observes `Ok(None)` after close

## Validation
- `cargo fmt --check`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/async_generator_aclose_before_start.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=361.08s
  - budget_ok=no; advisory warm wall-time/cache/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_async_generator_aclose_before_start.md`)
