### PR TITLE
hir: add basic asyncio task veneers

### DIFF
--- a/crates/sifr/tests/e2e/pass/asyncio_gather_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_gather_subset.sifr
@@ -1,0 +1,17 @@
+from sifr.asyncio import gather
+
+
+async def first() -> int:
+    await task.sleep(0.0)
+    return 1
+
+
+async def second() -> int:
+    await task.sleep(0.0)
+    return 2
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        result = await gather([scope.spawn(first()), scope.spawn(second())])
+    return None

--- a/crates/sifr/tests/e2e/pass/asyncio_sleep_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_sleep_subset.sifr
@@ -1,0 +1,6 @@
+from sifr.asyncio import sleep
+
+
+async def main() -> None:
+    await sleep(0.0)
+    return None

--- a/crates/sifr/tests/e2e/pass/asyncio_wait_for_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_wait_for_subset.sifr
@@ -1,0 +1,13 @@
+from sifr.asyncio import wait_for
+
+
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = scope.spawn(worker())
+        result = await wait_for(handle, 1.0)
+    return None

--- a/crates/sifr_driver/src/stdlib/registry.rs
+++ b/crates/sifr_driver/src/stdlib/registry.rs
@@ -37,6 +37,10 @@ pub(super) const STDLIB_FILES: &[(&str, &str)] = &[
         include_str!("../../../../lib/sifr/concurrent.sifr"),
     ),
     (
+        "sifr.asyncio",
+        include_str!("../../../../lib/sifr/asyncio.sifr"),
+    ),
+    (
         "sifr.string",
         include_str!("../../../../lib/sifr/string.sifr"),
     ),

--- a/crates/sifr_hir/src/lower/expressions.rs
+++ b/crates/sifr_hir/src/lower/expressions.rs
@@ -61,7 +61,7 @@ use super::sequence_guard_detection::{
     detect_false_exit_sequence_guards, detect_true_sequence_guards,
 };
 use super::subscript_type::resolve_subscript_result_type;
-use super::task_calls::{lower_task_module_call, TaskCallLowering};
+use super::task_calls::{lower_asyncio_compat_call, lower_task_module_call, TaskCallLowering};
 use super::task_handle_calls::{is_task_handle_type, lower_task_handle_method_call};
 use super::task_scope_calls as tsc;
 pub(super) use super::tuple_unpack::{lower_star_unpack_assign, lower_tuple_unpack_assign};
@@ -366,6 +366,11 @@ pub(super) fn lower_call(call: &ExprCall, ctx: &mut LowerCtx) -> Option<HirExpr>
         );
         return None;
     };
+    match lower_asyncio_compat_call(&func_name, call, ctx) {
+        TaskCallLowering::Lowered(expr) => return Some(expr),
+        TaskCallLowering::Rejected => return None,
+        TaskCallLowering::NoMatch => {}
+    }
     // Handle `cls(...)` in @classmethod as constructor call for the current class
     if func_name == "cls" {
         if let Some(ref class_name) = ctx.current_class {

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -43,6 +43,17 @@ pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ct
 
             // Only resolve from externals (stdlib and local modules)
             let module_key = module_name.clone();
+            if module_key == "sifr.asyncio" {
+                for name in &names {
+                    match name.as_str() {
+                        "sleep" | "wait_for" | "gather" => {
+                            ctx.asyncio_compat_imports
+                                .insert(local_name_for(name), name.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
             if let Some(module_classes) = externals.classes.get(&module_key) {
                 for name in &names {
                     let local = local_name_for(name);

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -206,12 +206,11 @@ pub(super) struct LowerCtx {
     /// Whether _sifr.* intrinsic imports are allowed (true for stdlib .sifr files)
     allow_intrinsic_imports: bool,
     /// Set of parameter names that are immutably borrowed (&T) in the current function.
-    /// Used for escape analysis: returning or storing a borrowed param is a compile error.
     borrowed_params: std::collections::HashSet<String>,
     /// Map of class names to their declared type parameters (from PEP 695 class C[T])
     class_declared_type_params: HashMap<String, Vec<String>>,
-    /// External definitions available to compatibility shims.
     externals: ExternalDefs,
+    asyncio_compat_imports: HashMap<String, String>,
     synthetic_imports: Vec<HirImport>,
     synthetic_import_aliases: HashMap<String, String>,
     sequence_guards: Vec<SequenceGuard>,
@@ -267,6 +266,7 @@ impl LowerCtx {
             borrowed_params: std::collections::HashSet::new(),
             class_declared_type_params: HashMap::new(),
             externals: ExternalDefs::default(),
+            asyncio_compat_imports: HashMap::new(),
             synthetic_imports: Vec::new(),
             synthetic_import_aliases: HashMap::new(),
             sequence_guards: Vec::new(),

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -15,6 +15,22 @@ pub(super) enum TaskCallLowering {
     NoMatch,
 }
 
+pub(super) fn lower_asyncio_compat_call(
+    func_name: &str,
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> TaskCallLowering {
+    let Some(member_name) = ctx.asyncio_compat_imports.get(func_name).cloned() else {
+        return TaskCallLowering::NoMatch;
+    };
+    match member_name.as_str() {
+        "sleep" => lower_task_sleep_call(call, ctx),
+        "wait_for" => lower_task_timeout_call(call, ctx),
+        "gather" => lower_task_gather_call(call, ctx),
+        _ => TaskCallLowering::NoMatch,
+    }
+}
+
 pub(super) fn lower_task_module_call(
     attr: &ExprAttribute,
     call: &ExprCall,

--- a/lib/sifr/asyncio.sifr
+++ b/lib/sifr/asyncio.sifr
@@ -1,0 +1,12 @@
+# sifr.asyncio — compatibility veneer over the canonical task model
+
+def sleep(delay: float) -> None:
+    return None
+
+
+def wait_for(handle: Any, delay: float) -> None:
+    return None
+
+
+def gather(handles: Any) -> None:
+    return None


### PR DESCRIPTION
## Summary
- register `sifr.asyncio` as a stdlib compatibility veneer module
- lower imported `sleep`, `wait_for`, and `gather` through the canonical `task.sleep`, `task.timeout`, and `task.gather` paths
- add focused e2e fixtures for the three supported subset calls

## Validation
- `cargo fmt --check`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_sleep_subset.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_wait_for_subset.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_gather_subset.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=669.21s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_basic_veneer.md`)
