### PR TITLE
docs: track basic asyncio veneers

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -1010,7 +1010,11 @@ status: in progress
 
 ### milestone_async_8: Compatibility Veneers and Phase Closure
 
-status: proposed
+status: in progress
+
+Implementation notes:
+
+- PR [#2078](https://github.com/sifr-lang/sifr/pull/2078) basic `sifr.asyncio` veneer slice: imported `sleep`, `wait_for`, and `gather` now lower through the canonical `task.sleep`, `task.timeout`, and `task.gather` HIR paths, with `lib/sifr/asyncio.sifr` kept as declaration stubs so no second runtime model or event-loop surface is introduced; `asyncio_sleep_subset.sifr`, `asyncio_wait_for_subset.sifr`, and `asyncio_gather_subset.sifr` cover the supported subset while `run`, `create_task`, `TaskGroup`, `timeout`, `Queue`, and unsupported-event-loop diagnostics remain follow-up slices.
 
 **Goal:** Expose limited compatibility surfaces only after the canonical model is proven.
 
@@ -1063,6 +1067,8 @@ status: proposed
 
 **Positive validation:**
 
+- `asyncio_sleep_subset.sifr`
+- `asyncio_gather_subset.sifr`
 - `asyncio_run_subset.sifr`
 - `asyncio_create_task_subset.sifr`
 - `asyncio_task_group_subset.sifr`


### PR DESCRIPTION
## Summary
- record merged PR #2078 in milestone_async_8 tracker notes
- mark milestone_async_8 in progress
- add asyncio sleep/gather subset fixtures to positive validation while keeping remaining compatibility surfaces deferred

## Validation
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=381.95s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus tracker review: SATISFIED (`reviews/phase32_asyncio_basic_veneer_tracker.md`)
