### PR TITLE
hir: add asyncio context manager veneers

### DIFF
--- a/crates/sifr/tests/e2e/pass/asyncio_task_group_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_task_group_subset.sifr
@@ -1,0 +1,13 @@
+from sifr.asyncio import TaskGroup
+
+
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with TaskGroup() as group:
+        handle = group.spawn(worker())
+        result = await handle.join()
+    return None

--- a/crates/sifr/tests/e2e/pass/asyncio_timeout_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_timeout_subset.sifr
@@ -1,0 +1,7 @@
+from sifr.asyncio import timeout
+
+
+async def main() -> Result[None, TimeoutError]:
+    async with timeout(1.0):
+        await task.sleep(0.0)
+    return None

--- a/crates/sifr_hir/src/lower/async_with.rs
+++ b/crates/sifr_hir/src/lower/async_with.rs
@@ -57,6 +57,24 @@ fn async_task_call_name(expr: &Expr) -> Option<(&str, &sifr_python_ast::ExprCall
     }
 }
 
+fn async_compat_call_name<'a>(
+    expr: &'a Expr,
+    ctx: &LowerCtx,
+) -> Option<(&'static str, &'a sifr_python_ast::ExprCall)> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    let Expr::Name(name) = call.func.as_ref() else {
+        return None;
+    };
+    let member = ctx.asyncio_compat_imports.get(name.id.as_str())?;
+    match member.as_str() {
+        "TaskGroup" => Some(("TaskGroup", call)),
+        "timeout" => Some(("timeout", call)),
+        _ => None,
+    }
+}
+
 fn timeout_error_type() -> Type {
     Type::Class {
         name: "TimeoutError".to_string(),
@@ -738,7 +756,9 @@ pub(super) fn lower_async_with(
     }
 
     let item = &with_stmt.items[0];
-    let Some((task_fn, call)) = async_task_call_name(&item.context_expr) else {
+    let task_call = async_task_call_name(&item.context_expr)
+        .or_else(|| async_compat_call_name(&item.context_expr, ctx));
+    let Some((task_fn, call)) = task_call else {
         return lower_user_async_with(with_stmt, item, func_type, ctx);
     };
 

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -46,7 +46,7 @@ pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ct
             if module_key == "sifr.asyncio" {
                 for name in &names {
                     match name.as_str() {
-                        "sleep" | "wait_for" | "gather" => {
+                        "sleep" | "wait_for" | "gather" | "timeout" | "TaskGroup" => {
                             ctx.asyncio_compat_imports
                                 .insert(local_name_for(name), name.clone());
                         }

--- a/lib/sifr/asyncio.sifr
+++ b/lib/sifr/asyncio.sifr
@@ -10,3 +10,11 @@ def wait_for(handle: Any, delay: float) -> None:
 
 def gather(handles: Any) -> None:
     return None
+
+
+class TaskGroup:
+    pass
+
+
+def timeout(delay: float) -> None:
+    return None


### PR DESCRIPTION
## Summary
- route imported `sifr.asyncio.timeout` async-with usage through canonical `task.timeout(duration)` lowering
- route imported `sifr.asyncio.TaskGroup` async-with usage through canonical `task.TaskGroup()` lowering
- add focused pass fixtures for the supported context-manager compatibility subset

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_timeout_subset.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_task_group_subset.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=509.78s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_context_veneers.md`)
