### PR TITLE
docs: track asyncio context veneers

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -1014,7 +1014,8 @@ status: in progress
 
 Implementation notes:
 
-- PR [#2078](https://github.com/sifr-lang/sifr/pull/2078) basic `sifr.asyncio` veneer slice: imported `sleep`, `wait_for`, and `gather` now lower through the canonical `task.sleep`, `task.timeout`, and `task.gather` HIR paths, with `lib/sifr/asyncio.sifr` kept as declaration stubs so no second runtime model or event-loop surface is introduced; `asyncio_sleep_subset.sifr`, `asyncio_wait_for_subset.sifr`, and `asyncio_gather_subset.sifr` cover the supported subset while `run`, `create_task`, `TaskGroup`, `timeout`, `Queue`, and unsupported-event-loop diagnostics remain follow-up slices.
+- PR [#2078](https://github.com/sifr-lang/sifr/pull/2078) basic `sifr.asyncio` veneer slice: imported `sleep`, `wait_for`, and `gather` now lower through the canonical `task.sleep`, `task.timeout`, and `task.gather` HIR paths, with `lib/sifr/asyncio.sifr` kept as declaration stubs so no second runtime model or event-loop surface is introduced; `asyncio_sleep_subset.sifr`, `asyncio_wait_for_subset.sifr`, and `asyncio_gather_subset.sifr` cover that initial supported subset while `run`, `create_task`, `TaskGroup`, `timeout`, `Queue`, and unsupported-event-loop diagnostics remained follow-up slices.
+- PR [#2080](https://github.com/sifr-lang/sifr/pull/2080) `sifr.asyncio` context-manager veneer slice: imported `timeout` and `TaskGroup` now lower through the canonical `task.timeout(duration)` and `task.TaskGroup()` async-with paths, with no second runtime behavior; `asyncio_timeout_subset.sifr` and `asyncio_task_group_subset.sifr` cover the supported context-manager subset while `run`, `create_task`, `Queue`, `Future`, and unsupported-event-loop diagnostics remain follow-up slices.
 
 **Goal:** Expose limited compatibility surfaces only after the canonical model is proven.
 
@@ -1069,6 +1070,7 @@ Implementation notes:
 
 - `asyncio_sleep_subset.sifr`
 - `asyncio_gather_subset.sifr`
+- `asyncio_timeout_subset.sifr`
 - `asyncio_run_subset.sifr`
 - `asyncio_create_task_subset.sifr`
 - `asyncio_task_group_subset.sifr`


### PR DESCRIPTION
## Summary
- record merged PR #2080 in milestone_async_8 tracker notes
- add `asyncio_timeout_subset.sifr` to positive validation
- keep remaining compatibility surfaces scoped as follow-up work

## Validation
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=681.34s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus tracker review: SATISFIED (`reviews/phase32_asyncio_context_veneers_tracker.md`)
