### PR TITLE
stdlib: add asyncio queue veneer

### DIFF
--- a/crates/sifr/tests/e2e/pass/asyncio_queue_via_channel.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_queue_via_channel.sifr
@@ -1,0 +1,12 @@
+from sifr.asyncio import Queue
+from sifr.sync import ClosedError
+
+
+async def main() -> Result[None, ClosedError]:
+    queue: Queue[int] = Queue(2)
+    sent: Result[None, ClosedError] = await queue.put(41)
+    received: Result[int, ClosedError] = await queue.get()
+    assert str(sent) == "Ok(())"
+    assert str(received) == "Ok(41)"
+    queue.close()
+    return None

--- a/lib/sifr/asyncio.sifr
+++ b/lib/sifr/asyncio.sifr
@@ -1,5 +1,8 @@
 # sifr.asyncio — compatibility veneer over the canonical task model
 
+from sifr.sync import ClosedError
+
+
 def sleep(delay: float) -> None:
     return None
 
@@ -18,3 +21,33 @@ class TaskGroup:
 
 def timeout(delay: float) -> None:
     return None
+
+
+class Queue[T]:
+    _buffer: list[T]
+    _closed: bool
+    _capacity: int
+
+    def __init__(self, maxsize: int):
+        self._buffer = []
+        self._closed = False
+        self._capacity = maxsize
+
+    def __str__(self) -> str:
+        return "Queue"
+
+    async def put(self, own value: T) -> Result[None, ClosedError]:
+        if self._closed:
+            raise ClosedError()
+        self._buffer.append(value)
+        return None
+
+    async def get(self) -> Result[T, ClosedError]:
+        if len(self._buffer) == 0:
+            raise ClosedError()
+        value: T = self._buffer[0]
+        self._buffer.pop(0)
+        return value
+
+    def close(self) -> None:
+        self._closed = True


### PR DESCRIPTION
## Summary
- add `sifr.asyncio.Queue[T]` with `put`, `get`, and `close` for the v1 compatibility subset
- use `sifr.sync.ClosedError` for typed queue closure/exhaustion results
- add a focused FIFO queue fixture for the supported subset

## Notes
- The queue veneer mirrors the existing channel buffer/closed semantics internally rather than storing `Channel` fields, because bare `from sifr.asyncio import Queue` does not currently materialize transitive stdlib `Channel` dependencies cleanly in single-file output.
- No `task_done`/`join` accounting, event-loop behavior, or second runtime model is introduced.

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_queue_via_channel.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=477.13s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_queue_veneer.md`)
