### PR TITLE
hir: add asyncio create_task veneer

### DIFF
--- a/crates/sifr/tests/e2e/fail/asyncio_create_task_outside_scope_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/asyncio_create_task_outside_scope_rejected.sifr
@@ -1,0 +1,12 @@
+from sifr.asyncio import create_task
+
+
+async def worker() -> int:
+    return 41
+
+
+async def main() -> None:
+    handle = create_task(worker())
+    return None
+
+# EXPECT_ERROR: [type] asyncio.create_task() requires exactly one active task scope; use it inside async with task.scope() or task.TaskGroup()

--- a/crates/sifr/tests/e2e/pass/asyncio_create_task_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_create_task_subset.sifr
@@ -1,0 +1,13 @@
+from sifr.asyncio import create_task
+
+
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 41
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        handle = create_task(worker())
+        result = await handle
+    return None

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -46,7 +46,8 @@ pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ct
             if module_key == "sifr.asyncio" {
                 for name in &names {
                     match name.as_str() {
-                        "sleep" | "wait_for" | "gather" | "timeout" | "TaskGroup" => {
+                        "sleep" | "wait_for" | "gather" | "timeout" | "TaskGroup"
+                        | "create_task" => {
                             ctx.asyncio_compat_imports
                                 .insert(local_name_for(name), name.clone());
                         }

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -1,7 +1,9 @@
 use super::expression_diagnostics;
 use super::expressions::lower_expr;
-use super::task_scope_calls::mark_task_handle_observed;
 use super::task_scope_calls::non_send_reason;
+use super::task_scope_calls::{
+    is_task_scope_type, lower_task_scope_spawn_from_object, mark_task_handle_observed,
+};
 use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
 use ruff_text_size::{Ranged, TextRange};
@@ -27,8 +29,32 @@ pub(super) fn lower_asyncio_compat_call(
         "sleep" => lower_task_sleep_call(call, ctx),
         "wait_for" => lower_task_timeout_call(call, ctx),
         "gather" => lower_task_gather_call(call, ctx),
+        "create_task" => lower_asyncio_create_task_call(call, ctx),
         _ => TaskCallLowering::NoMatch,
     }
+}
+
+fn lower_asyncio_create_task_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {
+    let active_scopes: Vec<(String, Type)> = ctx
+        .scope
+        .active_bindings()
+        .into_iter()
+        .filter(|(_, ty)| is_task_scope_type(ty))
+        .collect();
+    let [(scope_name, scope_ty)] = active_scopes.as_slice() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "asyncio.create_task() requires exactly one active task scope; use it inside async with task.scope() or task.TaskGroup()".to_string(),
+            call.range(),
+        );
+        return TaskCallLowering::Rejected;
+    };
+    let scope_object = HirExpr::Name {
+        name: scope_name.clone(),
+        ty: scope_ty.clone(),
+    };
+    lower_task_scope_spawn_from_object(scope_object, call, ctx)
+        .map_or(TaskCallLowering::Rejected, TaskCallLowering::Lowered)
 }
 
 pub(super) fn lower_task_module_call(

--- a/crates/sifr_hir/src/lower/task_scope_calls.rs
+++ b/crates/sifr_hir/src/lower/task_scope_calls.rs
@@ -22,6 +22,14 @@ pub(super) fn lower_task_scope_spawn_call(
     call: &ExprCall,
     ctx: &mut LowerCtx,
 ) -> Option<HirExpr> {
+    lower_task_scope_spawn_from_object(object, call, ctx)
+}
+
+pub(super) fn lower_task_scope_spawn_from_object(
+    object: HirExpr,
+    call: &ExprCall,
+    ctx: &mut LowerCtx,
+) -> Option<HirExpr> {
     if !ctx.current_function_is_async {
         expression_diagnostics::type_mismatch(
             ctx,

--- a/lib/sifr/asyncio.sifr
+++ b/lib/sifr/asyncio.sifr
@@ -15,6 +15,10 @@ def gather(handles: Any) -> None:
     return None
 
 
+def create_task(coroutine: Any) -> None:
+    return None
+
+
 class TaskGroup:
     pass
 


### PR DESCRIPTION
## Summary
- route imported `sifr.asyncio.create_task(coro)` through canonical task-scope spawn lowering when exactly one active scope/group is in scope
- reject `create_task` outside an explicit active task scope, preserving the no-orphan-task model
- add focused positive and negative fixtures for the supported subset

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_create_task_subset.sifr`
- direct negative diagnostic check for `asyncio_create_task_outside_scope_rejected.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=484.84s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_create_task_veneer.md`)
