### PR TITLE
docs: track asyncio create_task veneer

### DIFF
--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -1017,6 +1017,7 @@ Implementation notes:
 - PR [#2078](https://github.com/sifr-lang/sifr/pull/2078) basic `sifr.asyncio` veneer slice: imported `sleep`, `wait_for`, and `gather` now lower through the canonical `task.sleep`, `task.timeout`, and `task.gather` HIR paths, with `lib/sifr/asyncio.sifr` kept as declaration stubs so no second runtime model or event-loop surface is introduced; `asyncio_sleep_subset.sifr`, `asyncio_wait_for_subset.sifr`, and `asyncio_gather_subset.sifr` cover that initial supported subset while `run`, `create_task`, `TaskGroup`, `timeout`, `Queue`, and unsupported-event-loop diagnostics remained follow-up slices.
 - PR [#2080](https://github.com/sifr-lang/sifr/pull/2080) `sifr.asyncio` context-manager veneer slice: imported `timeout` and `TaskGroup` now lower through the canonical `task.timeout(duration)` and `task.TaskGroup()` async-with paths, with no second runtime behavior; `asyncio_timeout_subset.sifr` and `asyncio_task_group_subset.sifr` cover the supported context-manager subset while `run`, `create_task`, `Queue`, `Future`, and unsupported-event-loop diagnostics remain follow-up slices.
 - PR [#2082](https://github.com/sifr-lang/sifr/pull/2082) `sifr.asyncio.Queue` veneer slice: `Queue[T]` now provides the v1 `put`, `get`, and `close` subset with FIFO behavior and `sifr.sync.ClosedError` typing, intentionally omitting `task_done`/`join` accounting and event-loop behavior; `asyncio_queue_via_channel.sifr` covers the supported subset while `run`, `create_task`, `Future`, and unsupported-event-loop diagnostics remain follow-up slices.
+- PR [#2084](https://github.com/sifr-lang/sifr/pull/2084) `sifr.asyncio.create_task` veneer slice: imported `create_task(coro)` now lowers through the canonical scope-owned `spawn` path when exactly one active `task.scope()` or `task.TaskGroup()` binding is in scope, preserving the no-orphan-task model and existing spawn validation; `asyncio_create_task_subset.sifr` covers the supported subset, and `asyncio_create_task_outside_scope_rejected.sifr` records the explicit-scope requirement while `run`, `Future`, and unsupported-event-loop diagnostics remain follow-up slices.
 
 **Goal:** Expose limited compatibility surfaces only after the canonical model is proven.
 
@@ -1083,6 +1084,7 @@ Implementation notes:
 
 - `asyncio_loop_policy_not_supported.sifr`
 - `asyncio_transport_protocol_not_supported.sifr`
+- `asyncio_create_task_outside_scope_rejected.sifr`
 - `selectors_public_api_deferred.sifr`
 - `contextvars_deferred.sifr`
 - `process_pool_not_available.sifr`


### PR DESCRIPTION
## Summary
- record merged PR #2084 in the Phase 32 milestone_async_8 implementation notes
- document the `asyncio.create_task` explicit-scope behavior and remaining follow-up slices
- add `asyncio_create_task_outside_scope_rejected.sifr` to the milestone negative validation list

## Validation
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=560.11s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_create_task_tracker.md`)
