### PR TITLE
hir: add asyncio run veneer

### DIFF
--- a/crates/sifr/tests/e2e/fail/asyncio_run_requires_coroutine.sifr
+++ b/crates/sifr/tests/e2e/fail/asyncio_run_requires_coroutine.sifr
@@ -1,0 +1,9 @@
+from sifr.asyncio import run
+
+
+def main() -> None:
+    value = run(42)
+    return None
+
+
+# EXPECT_ERROR: [type] asyncio.run() requires a coroutine returned by an async function

--- a/crates/sifr/tests/e2e/pass/asyncio_run_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/asyncio_run_subset.sifr
@@ -1,0 +1,11 @@
+from sifr.asyncio import run
+
+
+async def worker() -> int:
+    await task.sleep(0.0)
+    return 42
+
+
+def main() -> None:
+    value = run(worker())
+    assert value == 42

--- a/crates/sifr_hir/src/lower/asyncio_run_entrypoint.rs
+++ b/crates/sifr_hir/src/lower/asyncio_run_entrypoint.rs
@@ -1,0 +1,130 @@
+use ruff_text_size::{Ranged, TextRange};
+use sifr_python_ast::{Expr, Stmt, StmtFunctionDef};
+
+use super::LowerCtx;
+
+pub(super) fn function_uses_asyncio_run_entrypoint(func: &StmtFunctionDef, ctx: &LowerCtx) -> bool {
+    !func.is_async
+        && func.name.as_str() == "main"
+        && first_asyncio_run_range_in_stmts(&func.body, ctx).is_some()
+}
+
+fn first_asyncio_run_range_in_stmts(stmts: &[Stmt], ctx: &LowerCtx) -> Option<TextRange> {
+    stmts
+        .iter()
+        .find_map(|stmt| first_asyncio_run_range_in_stmt(stmt, ctx))
+}
+
+fn first_asyncio_run_range_in_stmt(stmt: &Stmt, ctx: &LowerCtx) -> Option<TextRange> {
+    match stmt {
+        Stmt::Expr(expr_stmt) => first_asyncio_run_range_in_expr(expr_stmt.value.as_ref(), ctx),
+        Stmt::Return(ret) => ret
+            .value
+            .as_ref()
+            .and_then(|expr| first_asyncio_run_range_in_expr(expr.as_ref(), ctx)),
+        Stmt::AnnAssign(ann) => ann
+            .value
+            .as_ref()
+            .and_then(|expr| first_asyncio_run_range_in_expr(expr.as_ref(), ctx)),
+        Stmt::Assign(assign) => first_asyncio_run_range_in_expr(assign.value.as_ref(), ctx),
+        Stmt::AugAssign(aug) => first_asyncio_run_range_in_expr(aug.value.as_ref(), ctx),
+        Stmt::If(if_stmt) => first_asyncio_run_range_in_expr(if_stmt.test.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_stmts(&if_stmt.body, ctx))
+            .or_else(|| {
+                if_stmt.elif_else_clauses.iter().find_map(|clause| {
+                    clause
+                        .test
+                        .as_ref()
+                        .and_then(|expr| first_asyncio_run_range_in_expr(expr, ctx))
+                        .or_else(|| first_asyncio_run_range_in_stmts(&clause.body, ctx))
+                })
+            }),
+        Stmt::While(while_stmt) => first_asyncio_run_range_in_expr(while_stmt.test.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_stmts(&while_stmt.body, ctx))
+            .or_else(|| first_asyncio_run_range_in_stmts(&while_stmt.orelse, ctx)),
+        Stmt::For(for_stmt) => first_asyncio_run_range_in_expr(for_stmt.iter.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_stmts(&for_stmt.body, ctx))
+            .or_else(|| first_asyncio_run_range_in_stmts(&for_stmt.orelse, ctx)),
+        Stmt::With(with_stmt) => with_stmt
+            .items
+            .iter()
+            .find_map(|item| first_asyncio_run_range_in_expr(&item.context_expr, ctx))
+            .or_else(|| first_asyncio_run_range_in_stmts(&with_stmt.body, ctx)),
+        Stmt::Try(try_stmt) => first_asyncio_run_range_in_stmts(&try_stmt.body, ctx)
+            .or_else(|| {
+                try_stmt.handlers.iter().find_map(|handler| {
+                    let sifr_python_ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    first_asyncio_run_range_in_stmts(&handler.body, ctx)
+                })
+            })
+            .or_else(|| first_asyncio_run_range_in_stmts(&try_stmt.orelse, ctx))
+            .or_else(|| first_asyncio_run_range_in_stmts(&try_stmt.finalbody, ctx)),
+        _ => None,
+    }
+}
+
+fn first_asyncio_run_range_in_expr(expr: &Expr, ctx: &LowerCtx) -> Option<TextRange> {
+    match expr {
+        Expr::Call(call) => {
+            if let Expr::Name(name) = call.func.as_ref() {
+                if ctx
+                    .asyncio_compat_imports
+                    .get(name.id.as_str())
+                    .is_some_and(|member| member == "run")
+                {
+                    return Some(call.range());
+                }
+            }
+            first_asyncio_run_range_in_expr(call.func.as_ref(), ctx).or_else(|| {
+                call.arguments
+                    .args
+                    .iter()
+                    .find_map(|arg| first_asyncio_run_range_in_expr(arg, ctx))
+                    .or_else(|| {
+                        call.arguments.keywords.iter().find_map(|keyword| {
+                            first_asyncio_run_range_in_expr(&keyword.value, ctx)
+                        })
+                    })
+            })
+        }
+        Expr::Attribute(attr) => first_asyncio_run_range_in_expr(attr.value.as_ref(), ctx),
+        Expr::Subscript(sub) => first_asyncio_run_range_in_expr(sub.value.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_expr(sub.slice.as_ref(), ctx)),
+        Expr::BinOp(bin) => first_asyncio_run_range_in_expr(bin.left.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_expr(bin.right.as_ref(), ctx)),
+        Expr::BoolOp(bool_op) => bool_op
+            .values
+            .iter()
+            .find_map(|value| first_asyncio_run_range_in_expr(value, ctx)),
+        Expr::UnaryOp(unary) => first_asyncio_run_range_in_expr(unary.operand.as_ref(), ctx),
+        Expr::Compare(compare) => first_asyncio_run_range_in_expr(compare.left.as_ref(), ctx)
+            .or_else(|| {
+                compare
+                    .comparators
+                    .iter()
+                    .find_map(|expr| first_asyncio_run_range_in_expr(expr, ctx))
+            }),
+        Expr::If(if_expr) => first_asyncio_run_range_in_expr(if_expr.test.as_ref(), ctx)
+            .or_else(|| first_asyncio_run_range_in_expr(if_expr.body.as_ref(), ctx))
+            .or_else(|| first_asyncio_run_range_in_expr(if_expr.orelse.as_ref(), ctx)),
+        Expr::List(list) => list
+            .elts
+            .iter()
+            .find_map(|expr| first_asyncio_run_range_in_expr(expr, ctx)),
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .find_map(|expr| first_asyncio_run_range_in_expr(expr, ctx)),
+        Expr::Set(set) => set
+            .elts
+            .iter()
+            .find_map(|expr| first_asyncio_run_range_in_expr(expr, ctx)),
+        Expr::Dict(dict) => dict.items.iter().find_map(|item| {
+            item.key
+                .as_ref()
+                .and_then(|expr| first_asyncio_run_range_in_expr(expr, ctx))
+                .or_else(|| first_asyncio_run_range_in_expr(&item.value, ctx))
+        }),
+        _ => None,
+    }
+}

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -47,7 +47,7 @@ pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ct
                 for name in &names {
                     match name.as_str() {
                         "sleep" | "wait_for" | "gather" | "timeout" | "TaskGroup"
-                        | "create_task" => {
+                        | "create_task" | "run" => {
                             ctx.asyncio_compat_imports
                                 .insert(local_name_for(name), name.clone());
                         }

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -14,6 +14,7 @@ mod async_for;
 mod async_generator_advances;
 mod async_generator_methods;
 mod async_with;
+mod asyncio_run_entrypoint;
 mod attribute_access;
 mod aug_assign_lowering;
 mod binding_mutability;
@@ -118,6 +119,7 @@ mod typevar_annotations;
 mod typevar_shape_compat;
 mod typing_and_functions;
 mod workload_annotations;
+use asyncio_run_entrypoint::function_uses_asyncio_run_entrypoint;
 use classes::{collect_class_type, lower_class};
 use default_args::collect_function_defaults;
 pub use diagnostic_types::{HirDiagnostic, LoweringWarningDiagnostic, RevealTypeDiagnostic};
@@ -605,7 +607,6 @@ fn lower_module_impl(
         }
     }
     resolve_type_aliases(&alias_decls, &mut ctx);
-
     // Refresh class definitions after alias resolution so class field/method annotations that
     // depend on aliases declared later in the module see the final alias shapes.
     for stmt in stmts {
@@ -613,7 +614,6 @@ fn lower_module_impl(
             collect_class_type(class_def, &mut ctx, true);
         }
     }
-
     let mut function_name_registry = module_function_registry::ModuleFunctionRegistry::default();
     for stmt in stmts {
         if let Stmt::FunctionDef(func) = stmt {
@@ -688,9 +688,11 @@ fn lower_module_impl(
             }
 
             collect_function_defaults(&mut ctx, &function_name, func);
-            if func.is_async && function_body_contains_yield(&func.body) {
+            let effective_is_async =
+                func.is_async || function_uses_asyncio_run_entrypoint(func, &ctx);
+            if effective_is_async && function_body_contains_yield(&func.body) {
                 ctx.async_generator_functions.insert(function_name.clone());
-            } else if func.is_async {
+            } else if effective_is_async {
                 ctx.async_functions.insert(function_name.clone());
             }
             if let Some(workload) =
@@ -1151,9 +1153,7 @@ fn lower_module_impl(
             }
         }
     }
-
     let constants = module_constants_lowering::collect_module_constants(stmts, &mut ctx);
-
     // Second pass: lower function bodies and class method bodies
     let mut functions = Vec::new();
     let mut classes = Vec::new();
@@ -1176,7 +1176,6 @@ fn lower_module_impl(
             _ => {}
         }
     }
-
     if ctx.errors.is_empty() {
         imports.extend(ctx.synthetic_imports.clone());
         Ok(LoweringResult {

--- a/crates/sifr_hir/src/lower/task_calls.rs
+++ b/crates/sifr_hir/src/lower/task_calls.rs
@@ -30,8 +30,60 @@ pub(super) fn lower_asyncio_compat_call(
         "wait_for" => lower_task_timeout_call(call, ctx),
         "gather" => lower_task_gather_call(call, ctx),
         "create_task" => lower_asyncio_create_task_call(call, ctx),
+        "run" => lower_asyncio_run_call(call, ctx),
         _ => TaskCallLowering::NoMatch,
     }
+}
+
+fn lower_asyncio_run_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {
+    if ctx.current_owner.as_deref() != Some("main") {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            "asyncio.run() is only supported as a main() entrypoint compatibility shim; call and await the coroutine directly inside async code".to_string(),
+            call.range(),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if !call.arguments.keywords.is_empty() {
+        expression_diagnostics::call_unexpected_keyword(
+            ctx,
+            "asyncio.run() does not accept keyword arguments".to_string(),
+            first_call_keyword_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+    if call.arguments.args.len() != 1 {
+        expression_diagnostics::call_wrong_positional_count(
+            ctx,
+            "asyncio.run() takes exactly one coroutine argument".to_string(),
+            call_arity_range(call),
+        );
+        return TaskCallLowering::Rejected;
+    }
+
+    let Some(coroutine) = lower_expr(&call.arguments.args[0], ctx) else {
+        return TaskCallLowering::Rejected;
+    };
+    let Type::Coroutine(ok_ty, err_ty) = coroutine.ty().resolve_alias() else {
+        expression_diagnostics::type_mismatch(
+            ctx,
+            format!(
+                "asyncio.run() requires a coroutine returned by an async function, got '{}'",
+                coroutine.ty().display_name()
+            ),
+            call.arguments.args[0].range(),
+        );
+        return TaskCallLowering::Rejected;
+    };
+    let ty = if matches!(err_ty.resolve_alias(), Type::Never) {
+        ok_ty.as_ref().clone()
+    } else {
+        Type::Result(ok_ty.clone(), err_ty.clone())
+    };
+    TaskCallLowering::Lowered(HirExpr::Await {
+        value: Box::new(coroutine),
+        ty,
+    })
 }
 
 fn lower_asyncio_create_task_call(call: &ExprCall, ctx: &mut LowerCtx) -> TaskCallLowering {

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -11,6 +11,7 @@ use sifr_type_system::{
 };
 use std::collections::HashMap;
 
+use super::asyncio_run_entrypoint::function_uses_asyncio_run_entrypoint;
 use super::diagnostics::{format_type_name, is_valid_error_type};
 use super::expressions::lower_expr;
 use super::function_flow::{collect_yield_types, infer_function_return_type};
@@ -1132,6 +1133,8 @@ pub(super) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
 
 pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Option<HirFunction> {
     let ft = ctx.functions.get::<str>(func.name.as_ref())?.clone();
+    let is_asyncio_run_entrypoint = function_uses_asyncio_run_entrypoint(func, ctx);
+    let effective_is_async = func.is_async || is_asyncio_run_entrypoint;
 
     ctx.enter_function_scope(collect_declared_nonlocals(&func.body));
 
@@ -1219,8 +1222,8 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
             ctx.borrowed_params.insert(param.name.clone());
         }
     }
-    let is_async_generator = func.is_async && function_body_contains_yield(&func.body);
-    if func.is_async {
+    let is_async_generator = effective_is_async && function_body_contains_yield(&func.body);
+    if effective_is_async {
         if is_async_generator {
             if let Some(yield_range) = first_yield_range_in_stmts(&func.body) {
                 for param in &params {
@@ -1267,7 +1270,7 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
     let previous_return_type = ctx
         .current_function_return_type
         .replace(ft.return_type.as_ref().clone());
-    ctx.current_function_is_async = func.is_async;
+    ctx.current_function_is_async = effective_is_async;
     ctx.current_function_is_async_generator = is_async_generator;
     let body = lower_stmts(&func.body, &ft, ctx);
     ctx.current_function_is_async = previous_async;
@@ -1315,7 +1318,7 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
         .map_or_else(|| func.name.range(), |returns| returns.range());
     let inferred_return_type = infer_function_return_type(
         func.name.as_ref(),
-        func.is_async,
+        effective_is_async,
         ft.return_type.as_ref(),
         func.returns.is_some(),
         &body,
@@ -1358,7 +1361,7 @@ pub(super) fn lower_function(func: &StmtFunctionDef, ctx: &mut LowerCtx) -> Opti
         params,
         return_type: inferred_return_type,
         body,
-        is_async: func.is_async,
+        is_async: effective_is_async,
         method_kind: MethodKind::Regular,
         decorators,
         type_params,

--- a/lib/sifr/asyncio.sifr
+++ b/lib/sifr/asyncio.sifr
@@ -19,6 +19,10 @@ def create_task(coroutine: Any) -> None:
     return None
 
 
+def run(coroutine: Any) -> None:
+    return None
+
+
 class TaskGroup:
     pass
 


### PR DESCRIPTION
## Summary
- mark imported `sifr.asyncio.run` as a compatibility import and lower `run(coro)` to an await of the coroutine
- treat sync `main()` containing imported `run(...)` as the canonical async entrypoint so codegen reuses the existing Tokio bootstrap
- reject non-coroutine `run(...)` inputs with a focused diagnostic and keep the scanner in a dedicated HIR lower module

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/asyncio_run_subset.sifr`
- direct negative diagnostic check for `asyncio_run_requires_coroutine.sifr`
- `scripts/run_all_tests.sh --profile quick`
  - report_signature=b6baaa9a0d3afebf
  - 62 quick pass tests
  - wall_time=534.13s
  - budget_ok=no; advisory warm wall-time/skew only

## Reviewer
- Opus review: SATISFIED (`reviews/phase32_asyncio_run_veneer_r2.md`)
- Note: first reviewer process produced only whitespace and was discarded (`reviews/phase32_asyncio_run_veneer.md`)
