### PR TITLE
hir: add concurrent Future veneer

### DIFF
--- a/crates/sifr/tests/e2e/fail/concurrent_future_result_type_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/concurrent_future_result_type_rejected.sifr
@@ -1,0 +1,15 @@
+from sifr.concurrent import Future, ThreadPoolExecutor
+
+
+def compute_value() -> int:
+    return 42
+
+
+async def main() -> Result[None, ScopeFailure]:
+    executor: ThreadPoolExecutor = ThreadPoolExecutor()
+    future: Future[str, Never] = executor.submit(compute_value)
+    result = await future.join()
+    return None
+
+
+# EXPECT_ERROR: [type] type mismatch: expected 'BlockingTask[str, Never]', got 'BlockingTask[int, Never]'

--- a/crates/sifr/tests/e2e/pass/concurrent_future_subset.sifr
+++ b/crates/sifr/tests/e2e/pass/concurrent_future_subset.sifr
@@ -1,0 +1,12 @@
+from sifr.concurrent import Future, ThreadPoolExecutor
+
+
+def compute_value() -> int:
+    return 42
+
+
+async def main() -> Result[None, ScopeFailure]:
+    executor: ThreadPoolExecutor = ThreadPoolExecutor()
+    future: Future[int, Never] = executor.submit(compute_value)
+    result = await future.join()
+    return None

--- a/crates/sifr_hir/src/lower/typing_and_functions.rs
+++ b/crates/sifr_hir/src/lower/typing_and_functions.rs
@@ -862,7 +862,7 @@ pub(super) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
                     let err_ty = resolve_annotation_expr(&sub.slice, ctx);
                     Type::Failure(Box::new(err_ty))
                 }
-                "Coroutine" | "Task" | "TaskResult" | "Select2" | "BlockingTask"
+                "Coroutine" | "Task" | "TaskResult" | "Select2" | "BlockingTask" | "Future"
                 | "AsyncIterator" | "AsyncGenerator" => {
                     let Expr::Tuple(tuple) = sub.slice.as_ref() else {
                         invalid_type_annotation(
@@ -889,7 +889,9 @@ pub(super) fn resolve_annotation_expr(expr: &Expr, ctx: &mut LowerCtx) -> Type {
                         "Task" => Type::Task(Box::new(ok_ty), Box::new(err_ty)),
                         "TaskResult" => Type::TaskResult(Box::new(ok_ty), Box::new(err_ty)),
                         "Select2" => Type::Select2(Box::new(ok_ty), Box::new(err_ty)),
-                        "BlockingTask" => Type::BlockingTask(Box::new(ok_ty), Box::new(err_ty)),
+                        "BlockingTask" | "Future" => {
+                            Type::BlockingTask(Box::new(ok_ty), Box::new(err_ty))
+                        }
                         "AsyncIterator" => Type::AsyncIterator(Box::new(ok_ty), Box::new(err_ty)),
                         "AsyncGenerator" => Type::AsyncGenerator(Box::new(ok_ty), Box::new(err_ty)),
                         _ => Type::Any,

--- a/lib/sifr/concurrent.sifr
+++ b/lib/sifr/concurrent.sifr
@@ -2,3 +2,8 @@
 
 class ThreadPoolExecutor:
     pass
+
+
+class Future[T, E]:
+    _value: T
+    _error: E


### PR DESCRIPTION
## Summary
- add importable `sifr.concurrent.Future[T, E]` compatibility symbol
- resolve `Future[T, E]` annotations to canonical `BlockingTask[T, E]` handles
- cover valid `ThreadPoolExecutor.submit` annotation and result-type rejection fixtures

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/concurrent_future_subset.sifr`
- negative check for `concurrent_future_result_type_rejected.sifr`
- `scripts/run_all_tests.sh --profile quick` (passed, report_signature=b6baaa9a0d3afebf, wall_time=576.65s; warm budget advisory only)

## Review
- Opus reviewer: SATISFIED (`reviews/phase32_concurrent_future_veneer.md`)