### PR TITLE
hir: diagnose deferred compatibility imports

### DIFF
--- a/crates/sifr/tests/e2e/fail/asyncio_loop_policy_not_supported.sifr
+++ b/crates/sifr/tests/e2e/fail/asyncio_loop_policy_not_supported.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-NAME-0004
+from sifr.asyncio import get_event_loop_policy
+
+
+def main() -> None:
+    pass

--- a/crates/sifr/tests/e2e/fail/asyncio_transport_protocol_not_supported.sifr
+++ b/crates/sifr/tests/e2e/fail/asyncio_transport_protocol_not_supported.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-NAME-0004
+from sifr.asyncio import BaseTransport
+
+
+def main() -> None:
+    pass

--- a/crates/sifr/tests/e2e/fail/contextvars_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/contextvars_deferred.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-IMPORT-0002
+from sifr.contextvars import ContextVar
+
+
+def main() -> None:
+    pass

--- a/crates/sifr/tests/e2e/fail/process_pool_not_available.sifr
+++ b/crates/sifr/tests/e2e/fail/process_pool_not_available.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-NAME-0004
+from sifr.concurrent import ProcessPoolExecutor
+
+
+def main() -> None:
+    pass

--- a/crates/sifr/tests/e2e/fail/selectors_public_api_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/selectors_public_api_deferred.sifr
@@ -1,0 +1,6 @@
+# expect-error: SIFR-IMPORT-0002
+from sifr.selectors import DefaultSelector
+
+
+def main() -> None:
+    pass

--- a/crates/sifr_hir/src/lower/import_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/import_diagnostics.rs
@@ -19,6 +19,19 @@ pub(super) fn unknown_import_target(ctx: &mut LowerCtx, module: &str, range: Tex
     );
 }
 
+pub(super) fn deferred_compat_module(
+    ctx: &mut LowerCtx,
+    module: &str,
+    reason: &str,
+    range: TextRange,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::IMPORT_UNKNOWN_SOURCE_MODULE,
+        format!("module '{module}' is intentionally deferred: {reason}"),
+        range,
+    );
+}
+
 pub(super) fn unsupported_form(ctx: &mut LowerCtx, form: &str, range: TextRange) {
     ctx.error_with_code_at(
         DiagnosticCode::IMPORT_UNSUPPORTED_FORM,

--- a/crates/sifr_hir/src/lower/imports.rs
+++ b/crates/sifr_hir/src/lower/imports.rs
@@ -1,8 +1,55 @@
+use ruff_text_size::TextRange;
 use sifr_python_ast::Stmt;
 use sifr_type_system::{FunctionType, Type};
 
 use super::imported_defaults::import_callable_vararg;
-use super::{ExternalDefs, LowerCtx};
+use super::{import_diagnostics, name_diagnostics, ExternalDefs, LowerCtx};
+
+pub(super) fn report_missing_stdlib_member(
+    ctx: &mut LowerCtx,
+    module: &str,
+    member: &str,
+    range: TextRange,
+) {
+    if let Some(reason) = deferred_member_reason(module, member) {
+        name_diagnostics::deferred_compat_member(ctx, module, member, reason, range);
+    } else {
+        name_diagnostics::missing_member(ctx, module, member, range);
+    }
+}
+
+pub(super) fn report_unknown_stdlib_module(ctx: &mut LowerCtx, module: &str, range: TextRange) {
+    if let Some(reason) = deferred_module_reason(module) {
+        import_diagnostics::deferred_compat_module(ctx, module, reason, range);
+    } else {
+        import_diagnostics::unknown_import_target(ctx, module, range);
+    }
+}
+
+fn deferred_module_reason(module: &str) -> Option<&'static str> {
+    match module {
+        "sifr.selectors" => {
+            Some("public selectors APIs are deferred; compose tasks and channels instead")
+        }
+        "sifr.contextvars" => Some("context-local state is deferred; pass task state explicitly"),
+        _ => None,
+    }
+}
+
+fn deferred_member_reason(module: &str, member: &str) -> Option<&'static str> {
+    match (module, member) {
+        ("sifr.asyncio", "get_event_loop_policy" | "set_event_loop_policy") => {
+            Some("event loop policies are deferred; Sifr exposes structured task scopes instead")
+        }
+        ("sifr.asyncio", "BaseTransport" | "BaseProtocol" | "Protocol") => Some(
+            "transport/protocol callback APIs are deferred; compose async tasks and channels instead",
+        ),
+        ("sifr.concurrent", "ProcessPoolExecutor") => {
+            Some("process pools are blocked on the Phase 40 typed IPC and serialization contract")
+        }
+        _ => None,
+    }
+}
 
 pub(super) fn resolve_imports_early(stmts: &[Stmt], externals: &ExternalDefs, ctx: &mut LowerCtx) {
     for stmt in stmts {

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -973,7 +973,7 @@ fn lower_module_impl(
                             }
                         }
                         if !found {
-                            name_diagnostics::missing_member(
+                            imports::report_missing_stdlib_member(
                                 &mut ctx,
                                 &module_name,
                                 name,
@@ -988,8 +988,7 @@ fn lower_module_impl(
                     });
                     continue;
                 }
-                // Module doesn't exist in stdlib — emit clear error at the import site
-                import_diagnostics::unknown_import_target(&mut ctx, &module_name, import_range);
+                imports::report_unknown_stdlib_module(&mut ctx, &module_name, import_range);
                 continue;
             }
 

--- a/crates/sifr_hir/src/lower/name_diagnostics.rs
+++ b/crates/sifr_hir/src/lower/name_diagnostics.rs
@@ -27,6 +27,20 @@ pub(super) fn missing_member(ctx: &mut LowerCtx, container: &str, member: &str, 
     );
 }
 
+pub(super) fn deferred_compat_member(
+    ctx: &mut LowerCtx,
+    container: &str,
+    member: &str,
+    reason: &str,
+    range: TextRange,
+) {
+    ctx.error_with_code_at(
+        DiagnosticCode::NAME_MISSING_MODULE_MEMBER,
+        format!("'{container}.{member}' is intentionally deferred: {reason}"),
+        range,
+    );
+}
+
 pub(super) fn uninitialized_variable(ctx: &mut LowerCtx, name: &str, range: TextRange) {
     ctx.error_with_code_at(
         DiagnosticCode::NAME_UNINITIALIZED_VARIABLE,

--- a/crates/sifr_hir/src/lower/name_import_diagnostics_tests.rs
+++ b/crates/sifr_hir/src/lower/name_import_diagnostics_tests.rs
@@ -66,6 +66,39 @@ fn missing_stdlib_member_has_name_code() {
 }
 
 #[test]
+fn deferred_stdlib_member_has_name_code() {
+    let source = "from sifr.asyncio import get_event_loop_policy\n\ndef main():\n    pass\n";
+    let parsed = parse_module(source).expect("parse failed");
+    let mut externals = ExternalDefs::default();
+    externals
+        .functions
+        .insert("sifr.asyncio".to_string(), HashMap::new());
+    let errors = match lower_module_with_externals(parsed.suite(), &externals) {
+        Ok(_) => panic!("expected lowering error"),
+        Err(errors) => errors,
+    };
+
+    assert!(errors.iter().any(|error| {
+        error.message == "'sifr.asyncio.get_event_loop_policy' is intentionally deferred: event loop policies are deferred; Sifr exposes structured task scopes instead"
+            && error.code == Some(DiagnosticCode::NAME_MISSING_MODULE_MEMBER)
+            && error.primary_range == Some(range_for(source, "get_event_loop_policy"))
+    }));
+}
+
+#[test]
+fn deferred_stdlib_module_has_import_code() {
+    let source = "from sifr.contextvars import ContextVar\n\ndef main():\n    pass\n";
+    let errors = lower_errors(source);
+
+    assert!(errors.iter().any(|error| {
+        error.message
+            == "module 'sifr.contextvars' is intentionally deferred: context-local state is deferred; pass task state explicitly"
+            && error.code == Some(DiagnosticCode::IMPORT_UNKNOWN_SOURCE_MODULE)
+            && error.primary_range == Some(range_for(source, "from sifr.contextvars import ContextVar"))
+    }));
+}
+
+#[test]
 fn forbidden_intrinsic_import_has_import_code() {
     let source = "from _sifr.io import read_text\n\ndef main():\n    pass\n";
     let errors = lower_errors(source);


### PR DESCRIPTION
## Summary
- add explicit deferred compatibility diagnostics for raw asyncio policy/transport APIs, selectors, contextvars, and ProcessPoolExecutor
- route stdlib missing-member/unknown-module import failures through focused helpers while preserving existing diagnostic codes
- add unit coverage and five milestone_async_8 fail fixtures

## Validation
- `cargo fmt --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr_hir lower::name_import_diagnostics_tests::deferred_stdlib -- --nocapture`
- focused check loop over the five new fail fixtures
- `scripts/run_all_tests.sh --profile quick` (passed, report_signature=b6baaa9a0d3afebf, wall_time=445.49s; advisory budget/cache notes only)

## Review
- Opus reviewer: SATISFIED (`reviews/phase32_deferred_compat_diagnostics_r3.md`)
- Earlier reviewer attempts: first hit API usage limit, second hung with 0-byte output after 40 minutes and was killed before retry