### PR TITLE
close phase 32 async ecosystem

### DIFF
--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -2590,6 +2590,18 @@ impl RustEmitter {
             self.lowering_stats.stmt_candidate_structured += 1;
             return Ok(true);
         }
+        if let HirStmt::TryFinally { body, finalbody } = stmt {
+            let Some(lowered_stmts) = self.try_lower_try_finally_stmt_for_ir(body, finalbody)?
+            else {
+                return Ok(false);
+            };
+            for lowered_stmt in lowered_stmts {
+                self.push_captured_stmt(&lowered_stmt);
+            }
+            self.lowering_stats.stmt_structured += 1;
+            self.lowering_stats.stmt_candidate_structured += 1;
+            return Ok(true);
+        }
         if self.try_lower_structured_assert_stmt(stmt)? {
             self.lowering_stats.stmt_structured += 1;
             self.lowering_stats.stmt_candidate_structured += 1;

--- a/crates/sifr_codegen/src/lib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests.rs
@@ -4252,6 +4252,40 @@ fn test_try_finally_runs_cleanup_before_timeout_propagates() {
 }
 
 #[test]
+fn test_try_finally_cleanup_try_except_lowers_question_mark_calls() {
+    let result = generate_rust_with_metadata(
+        &lower_module(
+            parse_module(
+                r#"def fallible() -> Result[str, Error]:
+    return "ok"
+
+def main() -> Result[None, Error]:
+    try:
+        body_out: str = fallible()
+    except Error as e:
+        body_out = str(e.message)
+    finally:
+        try:
+            cleanup_out: str = fallible()
+        except Error as e:
+            cleanup_out = str(e.message)
+    return None
+"#,
+            )
+            .expect("parse failed")
+            .suite(),
+        )
+        .expect("lowering failed")
+        .module,
+    );
+
+    assert!(!result.rust_source.contains("compile_error!"));
+    assert!(result.rust_source.contains("let __sifr_try_finally_res"));
+    assert!(result.rust_source.contains("let __sifr_try_res"));
+    assert!(result.rust_source.contains("fallible()?"));
+}
+
+#[test]
 fn test_async_generated_errors_convert_to_error_return_type() {
     let result = generate_rust_with_metadata(
         &lower_module(

--- a/crates/sifr_codegen/src/stmt_support_emitter.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter.rs
@@ -32,6 +32,61 @@ fn select_try_error_type(handlers: &[HirExceptHandler]) -> String {
         .unwrap_or_else(|| "Error".to_string())
 }
 
+fn first_try_error_type_in_stmts(stmts: &[HirStmt]) -> Option<String> {
+    for stmt in stmts {
+        if let Some(error_type) = first_try_error_type_in_stmt(stmt) {
+            return Some(error_type);
+        }
+    }
+    None
+}
+
+fn first_try_error_type_in_stmt(stmt: &HirStmt) -> Option<String> {
+    match stmt {
+        HirStmt::TryExcept {
+            body,
+            handlers,
+            body_error_types,
+        } => body_error_types.first().cloned().or_else(|| {
+            first_try_error_type_in_stmts(body).or_else(|| {
+                handlers
+                    .iter()
+                    .find_map(|handler| first_try_error_type_in_stmts(&handler.body))
+            })
+        }),
+        HirStmt::TryFinally { body, finalbody } => {
+            first_try_error_type_in_stmts(body).or_else(|| first_try_error_type_in_stmts(finalbody))
+        }
+        HirStmt::If {
+            then_body,
+            elif_clauses,
+            else_body,
+            ..
+        } => first_try_error_type_in_stmts(then_body)
+            .or_else(|| {
+                elif_clauses
+                    .iter()
+                    .find_map(|(_, body)| first_try_error_type_in_stmts(body))
+            })
+            .or_else(|| else_body.as_deref().and_then(first_try_error_type_in_stmts)),
+        HirStmt::While {
+            body, else_body, ..
+        }
+        | HirStmt::For {
+            body, else_body, ..
+        } => first_try_error_type_in_stmts(body)
+            .or_else(|| else_body.as_deref().and_then(first_try_error_type_in_stmts)),
+        HirStmt::With { body, .. }
+        | HirStmt::AsyncWith { body, .. }
+        | HirStmt::AsyncFor { body, .. } => first_try_error_type_in_stmts(body),
+        HirStmt::NestedFunction { func } => first_try_error_type_in_stmts(&func.body),
+        HirStmt::Match { arms, .. } => arms
+            .iter()
+            .find_map(|arm| first_try_error_type_in_stmts(&arm.body)),
+        _ => None,
+    }
+}
+
 fn can_construct_error_from_message_for_ir(ty_name: &str) -> bool {
     matches!(
         ty_name,
@@ -6179,8 +6234,13 @@ impl RustEmitter {
                 let lowered_value = if let Some(clone_expr) = lowered_value {
                     clone_expr
                 } else {
-                    let Some(lowered) = self.lower_rendered_expr_for_ir(value)? else {
-                        return Ok(None);
+                    let lowered = if let Some(lowered) = self.lower_rendered_expr_for_ir(value)? {
+                        lowered
+                    } else {
+                        let Some(lowered) = self.lower_stmt_expr_for_ir(value)? else {
+                            return Ok(None);
+                        };
+                        lowered
                     };
                     self.coerce_local_value_for_target_type_for_ir(&effective_ty, value, lowered)?
                 };
@@ -6213,8 +6273,13 @@ impl RustEmitter {
                     true,
                 )
             } else if let HirStmt::Assign { name, value } = stmt {
-                let Some(lowered_value) = self.lower_rendered_expr_for_ir(value)? else {
-                    return Ok(None);
+                let lowered_value = if let Some(lowered) = self.lower_rendered_expr_for_ir(value)? {
+                    lowered
+                } else {
+                    let Some(lowered) = self.lower_stmt_expr_for_ir(value)? else {
+                        return Ok(None);
+                    };
+                    lowered
                 };
                 let lowered_value = if let Some(target_ty) =
                     self.local_binding_types.get(name).cloned()
@@ -6534,9 +6599,17 @@ impl RustEmitter {
                     true,
                 )
             } else if let HirStmt::Expr { expr } = stmt {
-                let Some(lowered_expr) = self.lower_rendered_expr_for_ir(expr)? else {
-                    return Ok(None);
-                };
+                let lowered_expr =
+                    if let Some(lowered) = self.try_lower_stmt_expr_statement_only(expr)? {
+                        lowered
+                    } else if let Some(lowered) = self.lower_rendered_expr_for_ir(expr)? {
+                        lowered
+                    } else {
+                        let Some(lowered) = self.lower_stmt_expr_for_ir(expr)? else {
+                            return Ok(None);
+                        };
+                        lowered
+                    };
                 (vec![RustStmt::Expr(lowered_expr)], true)
             } else if let HirStmt::Return { value } = stmt {
                 let return_ty_snapshot = self.current_return_type.clone();
@@ -9376,12 +9449,40 @@ impl RustEmitter {
             .unwrap_or_else(|| "Error".to_string())
     }
 
-    fn try_lower_try_finally_stmt_for_ir(
+    fn try_finally_error_type_name_for_ir(
+        &self,
+        body: &[HirStmt],
+        finalbody: &[HirStmt],
+    ) -> String {
+        self.try_closure_error_type
+            .last()
+            .cloned()
+            .or_else(|| {
+                let Type::Result(_, err_ty) = self.current_return_type.as_ref()? else {
+                    return None;
+                };
+                Some(crate::render_type(&crate::sifr_type_to_rust_type(err_ty)))
+            })
+            .or_else(|| {
+                first_try_error_type_in_stmts(body)
+                    .or_else(|| first_try_error_type_in_stmts(finalbody))
+            })
+            .unwrap_or_else(|| "Error".to_string())
+    }
+
+    pub(crate) fn try_lower_try_finally_stmt_for_ir(
         &mut self,
         body: &[HirStmt],
         finalbody: &[HirStmt],
     ) -> Result<Option<Vec<RustStmt>>, crate::CodegenError> {
-        let err_ty = self.current_result_error_type_name_for_ir();
+        let err_ty = self.try_finally_error_type_name_for_ir(body, finalbody);
+        let can_return_error = self.try_closure_depth > 0
+            || self.current_return_type.as_ref().is_some_and(|return_ty| {
+                matches!(
+                    crate::resolve_alias_type_for_plain_call(return_ty),
+                    Type::Result(_, _)
+                )
+            });
         let capture_returns =
             queries::body_contains_return(body) && self.current_return_type.is_some();
         let direct_return_capture =
@@ -9498,14 +9599,23 @@ impl RustEmitter {
                 pattern: "Err(__sifr_finally_err)".to_string(),
                 bindings: vec!["__sifr_finally_err".to_string()],
                 guard: None,
-                body: vec![RustStmt::Return(Some(RustExpr::FnCall {
-                    func: Box::new(RustExpr::Ident("Err".to_string())),
-                    args: vec![RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
-                        method: "into".to_string(),
+                body: if can_return_error {
+                    vec![RustStmt::Return(Some(RustExpr::FnCall {
+                        func: Box::new(RustExpr::Ident("Err".to_string())),
+                        args: vec![RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
+                            method: "into".to_string(),
+                            args: vec![],
+                        }],
+                    }))]
+                } else {
+                    vec![RustStmt::Expr(RustExpr::FormatMacro {
+                        name: "unreachable".to_string(),
+                        format_str: "sifr try/finally error propagation in non-Result function"
+                            .to_string(),
                         args: vec![],
-                    }],
-                }))],
+                    })]
+                },
             });
             lowered.push(RustStmt::Match {
                 expr: RustExpr::Ident("__sifr_try_finally_res".to_string()),
@@ -9515,14 +9625,23 @@ impl RustEmitter {
             lowered.push(RustStmt::IfLet {
                 pattern: "Err(__sifr_finally_err)".to_string(),
                 expr: RustExpr::Ident("__sifr_try_finally_res".to_string()),
-                then_body: vec![RustStmt::Return(Some(RustExpr::FnCall {
-                    func: Box::new(RustExpr::Ident("Err".to_string())),
-                    args: vec![RustExpr::MethodCall {
-                        receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
-                        method: "into".to_string(),
+                then_body: if can_return_error {
+                    vec![RustStmt::Return(Some(RustExpr::FnCall {
+                        func: Box::new(RustExpr::Ident("Err".to_string())),
+                        args: vec![RustExpr::MethodCall {
+                            receiver: Box::new(RustExpr::Ident("__sifr_finally_err".to_string())),
+                            method: "into".to_string(),
+                            args: vec![],
+                        }],
+                    }))]
+                } else {
+                    vec![RustStmt::Expr(RustExpr::FormatMacro {
+                        name: "unreachable".to_string(),
+                        format_str: "sifr try/finally error propagation in non-Result function"
+                            .to_string(),
                         args: vec![],
-                    }],
-                }))],
+                    })]
+                },
                 else_body: None,
             });
         }

--- a/internal_docs/phases/32_async_ecosystem.md
+++ b/internal_docs/phases/32_async_ecosystem.md
@@ -1,6 +1,6 @@
 # Phase 32: Async and Concurrency Model
 
-status: in_progress
+status: completed
 
 ## Objective
 
@@ -781,7 +781,7 @@ status: completed
 
 ### milestone_async_7a: Async Context Managers, Async Iteration, and Resource Cleanup
 
-status: proposed
+status: completed
 
 Implementation notes:
 
@@ -904,7 +904,7 @@ Implementation notes:
 
 ### milestone_async_7b: Async Generators and Async Comprehensions
 
-status: in progress
+status: completed
 
 **Goal:** Make user-defined async streams and async collection-building part of the first async model.
 
@@ -1010,7 +1010,7 @@ status: in progress
 
 ### milestone_async_8: Compatibility Veneers and Phase Closure
 
-status: in progress
+status: completed
 
 Implementation notes:
 
@@ -1021,6 +1021,7 @@ Implementation notes:
 - PR [#2086](https://github.com/sifr-lang/sifr/pull/2086) `sifr.asyncio.run` veneer slice: imported `run(coro)` now lowers to a coroutine await while treating sync `main()` as the canonical async entrypoint bootstrap, so compatibility code does not construct a public event loop or nested runtime; `asyncio_run_subset.sifr` covers the supported subset, and `asyncio_run_requires_coroutine.sifr` records the coroutine-only diagnostic while `Future` and unsupported-event-loop diagnostics remain follow-up slices.
 - PR [#2088](https://github.com/sifr-lang/sifr/pull/2088) `sifr.concurrent.Future` veneer slice: `Future[T, E]` is now importable as a compatibility annotation name that resolves to the canonical affine `BlockingTask[T, E]` handle returned by `ThreadPoolExecutor.submit`, preserving existing `join()`/await observation semantics and avoiding a second future runtime; `concurrent_future_subset.sifr` covers the supported annotation path, and `concurrent_future_result_type_rejected.sifr` records result-type mismatch rejection while unsupported-event-loop diagnostics remain follow-up slices.
 - PR [#2090](https://github.com/sifr-lang/sifr/pull/2090) deferred compatibility diagnostics slice: raw event-loop policy imports, transport/protocol callback APIs, public selectors, contextvars, and `ProcessPoolExecutor` now fail with explicit structured deferred-surface diagnostics instead of generic missing-module/member messages; `asyncio_loop_policy_not_supported.sifr`, `asyncio_transport_protocol_not_supported.sifr`, `selectors_public_api_deferred.sifr`, `contextvars_deferred.sifr`, and `process_pool_not_available.sifr` cover the unsupported compatibility surface.
+- Phase closure slice: all Phase 32 milestones are marked completed after the compatibility veneer, deferred-surface diagnostics, local validation, and final implementation review gates.
 
 **Goal:** Expose limited compatibility surfaces only after the canonical model is proven.
 

--- a/internal_docs/roadmap.md
+++ b/internal_docs/roadmap.md
@@ -60,7 +60,7 @@ This roadmap is the authoritative execution plan for the current hardening and e
 
 | # | Phase | Status | Phase File | Unlocks |
 |---|---|---|---|---|
-| 32 | Async and Ecosystem Foundation | in_progress | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives; milestone_async_6 blocking/thread offload is complete with workload annotations, explicit `BlockingTask` offload, `ThreadPoolExecutor`, `sifr.threading`, cancellation validation, and `demos/m32_blocking_offload_demo.sifr` |
+| 32 | Async and Ecosystem Foundation | completed | [32_async_ecosystem.md](./phases/32_async_ecosystem.md) | Async runtime and ecosystem primitives completed on 2026-05-11: typed async/await, structured task scopes, cancellation/timeout semantics, synchronization/channels, explicit blocking offload, async context/iteration/generator/comprehension support, and limited runtime-neutral compatibility veneers are implemented with deferred APIs documented by negative fixtures. |
 | 33 | Preview Distribution and Release Automation (`alpha`/`beta`) | planned | [33_preview_distribution_and_release_automation.md](./phases/33_preview_distribution_and_release_automation.md) | Early adopter channels and release automation |
 | 34 | Generated Code Quality and Production Readiness | planned | [34_generated_code_quality_and_production_readiness.md](./phases/34_generated_code_quality_and_production_readiness.md) | Deterministic, lint-clean, production-safe generated Rust |
 | 35 | Performance Benchmarking and Shared Analysis Query Architecture | planned | [35_performance_benchmarking_and_budgets.md](./phases/35_performance_benchmarking_and_budgets.md) | Performance budgets plus a canonical reusable analysis/query foundation |


### PR DESCRIPTION
## Summary
- close Phase 32 and mark remaining async ecosystem milestones completed in the phase tracker and roadmap
- route top-level try/finally through structured codegen and harden nested cleanup try/except lowering uncovered by the full validation gate
- add regression coverage for try/finally cleanup try/except with Result/? calls

## Validation
- cargo fmt --check
- cargo test -p sifr_codegen test_try_finally_cleanup_try_except_lowers_question_mark_calls -- --nocapture
- scripts/run_e2e_pass.sh --fixture-manifest pathlib_glob_semantics (report_signature=bf70caf116fd3e47)
- scripts/run_all_tests.sh (profile=pr, wall_time=308.63s, budget_ok=yes, e2e=73/73, report_signature=6cd36071cf629b47, hardening variants=28 failures=0)

## Review
- Opus final implementation review: SATISFIED (reviews/phase32_phase_closure.md locally)