### PR TITLE
[codex] refine Phase 33 preview release plan

### DIFF
--- a/internal_docs/phases/33_preview_distribution_and_release_automation.md
+++ b/internal_docs/phases/33_preview_distribution_and_release_automation.md
@@ -1,35 +1,278 @@
 # Phase 33: Preview Distribution and Release Automation (`alpha`/`beta`)
 
-## Objective
-Ship preview channels early for adoption while keeping stable GA promotion gated for later phases.
+status: refining
 
-## Depends on
-- Phase 32
+## Objective
+
+Ship preview release channels early for adoption while keeping stable GA promotion gated for Phase 39.
+
+Phase 33 is not a compiler-feature phase. It establishes the first canonical distribution path for preview binaries:
+
+- a public installer entrypoint at `https://sifr.sh/install`,
+- channel metadata for `alpha`, `beta`, and gated `stable`,
+- reproducible multi-platform preview artifacts,
+- checksum and signature verification before install,
+- release automation for repeatable `alpha`/`beta` publication.
+
+The phase is complete when a user can install an `alpha` or `beta` preview from the public installer and the project can cut another preview release through the documented automation without enabling stable GA promotion.
+
+## Distribution Source Of Truth
+
+This file is the authoritative contract for Phase 33 until implementation creates supporting docs. It records the channel protocol, artifact layout, milestone order, validation goals, deferrals, and phase exit gate. Implementation PRs may add a dedicated `internal_docs/distribution_pipeline.md`, but they must not introduce behavior that conflicts with this phase file unless a review PR updates this file first.
+
+The Sifr site repository is part of this phase:
+
+- Site repo: `/Users/yaseralnajjar/work/sifr/sifr-blog-website/`
+- Public installer source: `apps/sifr-site/public/install`
+- Public manifest roots: `apps/sifr-site/public/releases/channels/` and `apps/sifr-site/public/releases/versions/`
+- Deployment target: the existing `sifr.sh` site deployment
+
+The compiler repository owns release automation, artifact building, verification scripts, and the `/create-new-version` workflow.
+
+## Depends On
+
+- Phase 32 is completed. Current closure evidence: Phase 32 is marked `status: completed` in `internal_docs/phases/32_async_ecosystem.md`, with corrective follow-up completed on 2026-05-12.
+- Phase 27 runtime-safety and diagnostics contracts remain green.
+- The `sifr.sh` site repository can deploy static files from `apps/sifr-site/public/`.
+
+## Non-Goals And Deferrals
+
+The following are not Phase 33 exit criteria:
+
+- Stable GA promotion.
+- Package-manager distribution (`brew`, `apt`, `npm`, `pip`, `cargo install`, Windows package managers).
+- Automatic runtime telemetry or update checks from installed binaries.
+- Rollback and incident governance beyond preview manifest rollback mechanics; Phase 39 owns GA rollback governance.
+- Windows installer support for `curl | bash`; Windows artifacts may be added later behind a separate installer contract.
+- Long-term signing authority rotation policy; Phase 33 only locks the preview verification mechanism.
+
+## Locked Preview Distribution Decisions
+
+1. `alpha` and `beta` are the only installable moving channels in Phase 33.
+2. `stable` channel metadata is allowed to exist, but it must be explicitly gated with `enabled: false` and no installer path may install from it before Phase 39.
+3. Explicit `--version` pinning accepts only preview versions published in the version manifest tree, for example `0.1.0-alpha.1` or `0.1.0-beta.1`. Stable-looking versions without preview prerelease labels are rejected until Phase 39.
+4. Channel resolution order is deterministic: `--version` wins over `--channel`; otherwise `--channel`; otherwise `SIFR_CHANNEL`; otherwise `beta`.
+5. Invalid combinations are hard errors. `--version` with a conflicting `--channel` is rejected instead of silently choosing one.
+6. The installer never compiles Sifr from source and never falls back to an alternate artifact if the resolved artifact is missing or invalid.
+7. The installer validates checksum and signature before replacing or creating the installed binary.
+8. The preview target set is initially:
+   - `aarch64-apple-darwin`
+   - `x86_64-apple-darwin`
+   - `x86_64-unknown-linux-gnu`
+   - `aarch64-unknown-linux-gnu`
+9. Artifacts are published as GitHub Release assets in `sifr-lang/sifr`; the website hosts only installer and manifest files.
+10. Checksums use SHA-256. Signatures use the selected repository-supported signing mechanism documented by the implementation PR before first real release; unsigned artifacts are never accepted by the installer.
+11. Channel manifests point to immutable version manifests. Version manifests point to immutable artifact URLs and verification metadata.
+12. Preview release automation must support dry-run and real-run modes with identical planning logic. Real-run is the dry-run plan plus authorized mutations.
+
+## Manifest Contract
+
+Channel manifests live at:
+
+- `https://sifr.sh/releases/channels/alpha.json`
+- `https://sifr.sh/releases/channels/beta.json`
+- `https://sifr.sh/releases/channels/stable.json`
+
+Each channel manifest contains:
+
+- `schema_version`
+- `channel`
+- `enabled`
+- `version`
+- `version_manifest_url`
+- `updated_at`
+
+Version manifests live at `https://sifr.sh/releases/versions/<version>.json` and contain:
+
+- `schema_version`
+- `version`
+- `channel`
+- `git_sha`
+- `created_at`
+- `artifacts[]`
+
+Each artifact entry contains:
+
+- `target`
+- `asset_url`
+- `sha256`
+- `signature_url`
+- `archive_format`
+- `binary_path`
+
+The installer must reject unknown schema versions, disabled channels, missing fields, target mismatches, checksum mismatches, signature failures, unavailable manifests, and unavailable assets.
+
+## `/create-new-version` Workflow Contract
+
+The preview release command is implemented as `.cursor/commands/create-new-version.md` in the compiler repository.
+
+Inputs:
+
+- `--channel alpha|beta`
+- `--version <semver-prerelease>`
+- `--dry-run`
+- `--real-run`
+- optional `--base-ref <sha-or-branch>`
+
+Dry-run behavior:
+
+- Validate channel/version compatibility.
+- Resolve the base commit.
+- Compute artifact names and manifest changes for every target.
+- Verify release notes source and checklist links.
+- Verify that `stable` will not be changed.
+- Print the exact GitHub Release, manifest, and site-deployment mutations that a real run would perform.
+- Exit non-zero if any precondition fails.
+
+Real-run behavior:
+
+- Re-run the dry-run planner and require the same plan.
+- Build and validate all target artifacts.
+- Create or update the preview GitHub Release for the exact version.
+- Upload artifacts, checksum files, and signatures.
+- Update the immutable version manifest and the selected channel manifest.
+- Open PRs for repository changes that must be reviewed before deployment.
+- Trigger or document the `sifr.sh` deployment step for manifest publication.
+
+Failure behavior:
+
+- Any failed artifact, checksum, signature, or manifest validation aborts the release.
+- A failed real run must leave a written recovery note with completed and incomplete mutations.
+- The command must not update `stable` manifests or stable release metadata in Phase 33.
+
+## Milestone Sequencing
+
+Implementation must execute the milestones in order unless a later reviewed PR updates this file with rationale.
+
+```mermaid
+flowchart TD
+    m33_1["m33.1 Installer + Channel Resolution"]
+    m33_2["m33.2 Artifact + Manifest Pipeline"]
+    m33_3["m33.3 Agentic Preview Release Command"]
+
+    m33_1 --> m33_2
+    m33_2 --> m33_3
+```
 
 ## Milestones
 
 ### milestone_33_1: Installer and Channel Resolution
-- Scope:
-  - Implement install entrypoint (`curl -fsSL https://sifr.sh/install | bash`).
-  - Support `SIFR_CHANNEL`/`--channel` and explicit `--version` pinning.
-- Definition of done:
-  - Installer resolves `alpha`/`beta`/`stable` channel metadata correctly.
+
+**Goal:** Publish the installer entrypoint and lock deterministic channel/version resolution without requiring real release artifacts yet.
+
+**Scope:**
+
+- Add the `https://sifr.sh/install` static installer entrypoint in the site repo.
+- Implement installer argument parsing for `--channel` and `--version`.
+- Support `SIFR_CHANNEL`.
+- Resolve channel metadata from the public manifest roots.
+- Reject stable channel installs while preserving explicit stable metadata for Phase 39.
+- Reject invalid channel names, conflicting channel/version inputs, unavailable manifests, unsupported platforms, and malformed manifests.
+
+**Definition of done:**
+
+- Installer resolution is deterministic for `alpha`, `beta`, gated `stable`, and explicit preview version pins.
+- Installer does not install anything until a valid enabled preview manifest and supported target are resolved.
+- The site repo deployment path for `/install` and preview manifests is documented in the PR.
+
+**Positive validation:**
+
+- `verification/distribution/install_default_beta_channel.sh`
+- `verification/distribution/install_alpha_channel.sh`
+- `verification/distribution/install_version_pin_preview.sh`
+- `verification/distribution/install_stable_channel_gated.sh`
+
+**Negative validation:**
+
+- `verification/distribution/install_invalid_channel_rejected.sh`
+- `verification/distribution/install_conflicting_channel_and_version_rejected.sh`
+- `verification/distribution/install_stable_version_pin_rejected.sh`
+- `verification/distribution/install_manifest_unavailable_rejected.sh`
+- `verification/distribution/install_malformed_manifest_rejected.sh`
+
+**Demo:** none yet; installer resolution uses mocked manifests until real artifacts exist.
 
 ### milestone_33_2: Artifact and Manifest Pipeline
-- Scope:
-  - Publish multi-platform artifacts with checksums/signatures.
-  - Maintain channel manifest pointers.
-- Definition of done:
-  - Installer validates checksums and installs matching artifacts.
+
+**Goal:** Publish verifiable preview artifacts and wire installer installation to immutable version manifests.
+
+**Depends on:** `milestone_33_1`
+
+**Scope:**
+
+- Add release artifact build automation for the preview target set.
+- Publish GitHub Release assets for each target.
+- Generate SHA-256 checksums and signatures.
+- Generate immutable version manifests.
+- Update channel manifests to point at the selected version manifest.
+- Extend the installer to download, verify, extract, and install the matching artifact.
+- Ensure failed verification never replaces an existing installed binary.
+
+**Definition of done:**
+
+- Installer validates checksum and signature before installation.
+- Installer installs the artifact matching the local OS/architecture target.
+- Channel manifests point to immutable version manifests.
+- Stable manifest remains disabled and unmodified by preview publication.
+
+**Positive validation:**
+
+- `verification/distribution/artifact_manifest_all_preview_targets.sh`
+- `verification/distribution/artifact_sha256_validated.sh`
+- `verification/distribution/artifact_signature_validated.sh`
+- `verification/distribution/install_matching_target_artifact.sh`
+- `verification/distribution/channel_manifest_points_to_version_manifest.sh`
+
+**Negative validation:**
+
+- `verification/distribution/artifact_missing_target_rejected.sh`
+- `verification/distribution/artifact_checksum_mismatch_rejected.sh`
+- `verification/distribution/artifact_signature_failure_rejected.sh`
+- `verification/distribution/artifact_target_mismatch_rejected.sh`
+- `verification/distribution/stable_manifest_unchanged_by_preview_release.sh`
+
+**Demo:** `demos/preview_distribution_demo/README.md` records a local mocked-manifest install walkthrough and the commands used to verify checksum/signature handling.
 
 ### milestone_33_3: Agentic Preview Release Command
-- Scope:
-  - Add `/create-new-version` workflow for preview release automation.
-  - Support dry-run and real-run paths.
-- Definition of done:
-  - Preview release flow is repeatable end-to-end for `alpha`/`beta`.
+
+**Goal:** Add repeatable preview release automation that can plan and execute `alpha`/`beta` releases without enabling stable GA.
+
+**Depends on:** `milestone_33_2`
+
+**Scope:**
+
+- Add `.cursor/commands/create-new-version.md`.
+- Implement the dry-run planner for `alpha` and `beta`.
+- Implement the authorized real-run workflow for preview releases.
+- Validate version/channel compatibility and reject stable releases.
+- Produce a release checklist with artifact, manifest, installer, site deployment, and validation evidence.
+- Record recovery information when a real run partially completes.
+
+**Definition of done:**
+
+- `/create-new-version --channel alpha --version <preview> --dry-run` produces the exact mutation plan without side effects.
+- `/create-new-version --channel beta --version <preview> --real-run` can publish a validated preview release end to end after review.
+- Stable release attempts fail before artifact or manifest mutation.
+- The generated checklist maps every validation artifact to the phase exit gate.
+
+**Positive validation:**
+
+- `verification/distribution/create_new_version_alpha_dry_run.sh`
+- `verification/distribution/create_new_version_beta_dry_run.sh`
+- `verification/distribution/create_new_version_real_run_plan_reuse.sh`
+- `verification/distribution/create_new_version_release_checklist.sh`
+
+**Negative validation:**
+
+- `verification/distribution/create_new_version_stable_rejected.sh`
+- `verification/distribution/create_new_version_bad_semver_rejected.sh`
+- `verification/distribution/create_new_version_missing_artifact_rejected.sh`
+- `verification/distribution/create_new_version_site_manifest_drift_rejected.sh`
+
+**Demo:** `demos/preview_release_lifecycle/README.md` captures a dry-run transcript and a mocked real-run transcript showing release planning, artifact verification, manifest publication, and stable gating.
 
 ## Quality Contract
+
 - Entry criteria: Phase 32 is completed and async/runtime ecosystem primitives are stable.
 - Phase 27 non-regression baseline is required at phase start and must remain green through completion.
 - Phase 27 non-regression invariants that must hold in this phase include: no user-triggerable panic paths; no data-dependent emitted `.unwrap()` / `.expect()` / `panic!` in user runtime paths; stable diagnostic contract (codes, severity, spans, URLs, suggestions, schema); canonical/lossless `json` diagnostics with `human` and `compact` as renderer views only; enforced recovery limits with deterministic ordering; and enforced exit-code and CLI stability contracts (`0/1/2/3`, and unknown `--diagnostic-format` exits `2` before semantic work).
@@ -38,16 +281,23 @@ Ship preview channels early for adoption while keeping stable GA promotion gated
 - Milestone quality checks:
   - No fallback, migration, or legacy compatibility code is allowed; implement the canonical architecture directly with clean code only.
   - No lazy or partial fixes are allowed; each milestone must resolve root causes completely, even when that requires significant rework.
-  - All implementations must be production-grade compiler code: strict typing, deterministic behavior, explicit invariants, and unforgiving correctness standards, with architecture cleaned up toward the target design.
+  - All implementations must be production-grade release automation: deterministic behavior, explicit invariants, auditable mutations, and hard failure on ambiguity.
   - Every milestone in this phase must satisfy the scope and definition-of-done already documented in this file.
   - Validation evidence must be recorded in the phase execution checklist issue before merge.
   - Validation evidence for every milestone must include at least one positive-path case and one negative-path case mapped to the milestone validation planning goals.
 - Validation planning goals:
-  - `milestone_33_1` (Installer and Channel Resolution): validation goals cover: Implement install entrypoint (`curl -fsSL https://sifr.sh/install | bash`); Support `SIFR_CHANNEL`/`--channel` and explicit `--version` pinning. Include negative-path goals that catch regressions against these guarantees.
-  - `milestone_33_2` (Artifact and Manifest Pipeline): validation goals cover: Publish multi-platform artifacts with checksums/signatures; Maintain channel manifest pointers. Include negative-path goals that catch regressions against these guarantees.
-  - `milestone_33_3` (Agentic Preview Release Command): validation goals cover: Add `/create-new-version` workflow for preview release automation; Support dry-run and real-run paths. Include negative-path goals that catch regressions against these guarantees.
-  - Exit-gate evidence explicitly demonstrates: Preview release lifecycle works reliably without enabling stable GA promotion.
+  - `milestone_33_1` (Installer and Channel Resolution): validation goals cover installer entrypoint publication, channel/default/version resolution, stable gating, invalid input rejection, malformed manifest rejection, and unsupported target rejection.
+  - `milestone_33_2` (Artifact and Manifest Pipeline): validation goals cover multi-platform artifact publication, immutable version manifests, channel manifest pointers, checksum validation, signature validation, target matching, and no stable manifest mutation.
+  - `milestone_33_3` (Agentic Preview Release Command): validation goals cover dry-run planning, real-run plan reuse, release checklist generation, stable release rejection, malformed version rejection, missing artifact rejection, and site manifest drift rejection.
+  - Exit-gate evidence explicitly demonstrates an end-to-end preview release lifecycle for `alpha` or `beta` and separately demonstrates that stable GA promotion remains impossible.
 
 ## Exit Gate
-- Preview release lifecycle works reliably without enabling stable GA promotion.
+
+- `https://sifr.sh/install` resolves and installs a validated `alpha` or `beta` preview artifact on supported platforms.
+- Explicit preview version pinning installs the exact requested version.
+- All artifact downloads are checksum- and signature-validated before installation.
+- Channel manifests point to immutable version manifests.
+- `/create-new-version` dry-run and real-run flows are repeatable for preview releases.
+- `stable` channel and stable-looking version pins are rejected before any artifact or manifest mutation.
+- The site deployment path for installer and manifests has been exercised.
 - Phase 27 non-regression contract remains green: panic-free user paths, no emitted data-dependent unwrap/expect/panic, and stable diagnostics/renderer/exit-code behavior.

--- a/reviews/phase-33-preview-distribution-readiness-review-pass-1.md
+++ b/reviews/phase-33-preview-distribution-readiness-review-pass-1.md
@@ -1,0 +1,161 @@
+
+
+Based on my review of the Phase 33 document alongside Phase 32 (completed), Phase 39 (GA promotion), Phase 34 (depends on 33), Phase 38 (docs), and the broader roadmap, here is my assessment:
+
+---
+
+## Verdict: NOT READY
+
+---
+
+## Blocking Issues (ordered by severity)
+
+### 1. Critical: No Installer/Artifact Architecture Document
+Phase 33 references `https://sifr.sh/install | bash`, multi-platform artifacts, checksums, signatures, and channel manifests — but none of this infrastructure is defined anywhere in the codebase or documented. Before implementation, the following must be documented:
+
+- Where does the installer script live? (own repo? embedded in docs? CI-generated?)
+- What is the channel manifest schema? (JSON? TOML? hosted where?)
+- How does version pinning work at the protocol level?
+- What is the multi-platform target list? (aarch64-apple-darwin, x86_64-unknown-linux-gnu, etc.)
+- What checksum algorithm? (SHA256? SHA512?)
+- What signature mechanism? (GPG? Sigstore? cosign?)
+- Where are artifacts published? (GitHub Releases? S3? A package registry?)
+- How does `SIFR_CHANNEL` / `--channel` resolve to a specific version?
+
+**Fix**: Add a reference to a new architecture document (e.g., `internal_docs/distribution_pipeline.md`) that defines the installer contract, channel resolution protocol, and artifact pipeline before any implementation begins.
+
+### 2. Critical: "/create-new-version" Workflow Is Underspecified
+The third milestone references a `/create-new-version` workflow with no description of:
+- What it actually does (creates a Linear issue? creates GitHub Release? updates a manifest?)
+- Which Linear entities it manages (version, release, milestone?)
+- What the dry-run path validates vs. what the real path does
+- What triggers it (manual? CI on tag push? commit message convention?)
+- What rollback looks like if it fails
+
+Without this, milestone_33_3 is not executable as written.
+
+**Fix**: Add a dedicated section defining the `/create-new-version` workflow contract, inputs, outputs, dry-run semantics, and failure modes.
+
+### 3. Critical: No Sequencing or Dependency Between Milestones
+The phase lists three milestones but does not define:
+- Whether they have ordering dependencies (e.g., does milestone_33_2 need milestone_33_1's installer to validate?)
+- Whether they can run in parallel
+- What the canonical implementation order is
+
+**Fix**: Add a milestone ordering section and/or mermaid diagram (as Phase 32 does) showing explicit dependencies.
+
+### 4. High: No Validation Fixtures Defined
+Every completed phase in this repo specifies named fixtures (positive and negative paths) that constitute validation evidence. Phase 33 specifies validation *goals* but provides no fixture names, making it impossible to:
+- Know what "passing" looks like
+- Create regression tests
+- Verify milestone completion
+
+Phase 32's thorough fixture naming (e.g., `async_basic.sifr`, `await_outside_async.sifr`) sets the expected standard.
+
+**Fix**: Add explicit fixture names for each milestone's positive and negative validation paths. Example for milestone_33_1: `install_alpha_channel.sifr`, `install_beta_channel.sifr`, `install_version_pin.sifr`, `install_invalid_channel_rejected.sifr`, `install_checksum_mismatch_rejected.sifr`.
+
+### 5. High: No Stable GA Promotion Gate Mechanism Defined
+The exit gate says "without enabling stable GA promotion" but the phase provides no mechanism for how stable promotion is *prevented*. Is it:
+- A code path that doesn't exist yet?
+- A feature flag that is explicitly set to `false`?
+- A separate release workflow that isn't wired up?
+- An environment variable not shipped?
+
+Without defining the gate mechanism, "without enabling" is an aspiration, not a verified property.
+
+**Fix**: Document how the stable promotion gate is enforced (e.g., the installer rejects `SIFR_CHANNEL=stable` until a future flag is set, or stable resolution points to a not-yet-populated endpoint).
+
+### 6. Medium: Missing Cross-Repo/Docs Dependency
+The installer entrypoint `https://sifr.sh/install` implies the docs website already exists. Phase 33 doesn't reference a docs dependency, but Phase 38 (Docs and Documentation) doesn't appear to be referenced in the phase ordering either. The installer URL being live suggests docs infrastructure is a prerequisite for Phase 33 to have a working end-to-end path.
+
+**Fix**: Clarify whether `https://sifr.sh` infrastructure exists as a Phase 33 prerequisite or if the installer points to a placeholder URL that gets wired up in Phase 38.
+
+### 7. Medium: No Milestone-Level Demo Requirements
+Phase 32 specifies demos (e.g., `demos/async_syntax_demo/main.sifr`) for each milestone. Phase 33 has no demo requirements, which makes it harder to verify the installer works end-to-end.
+
+**Fix**: Add a demo section per milestone, or at minimum a final phase demo that exercises the full preview release lifecycle.
+
+### 8. Medium: Roadmap Phase 32 Status May Be Stale
+The roadmap table shows "Phase 32: completed" but there's no date stamp in the phase document header (only a `status: completed` line and a corrective follow-up note). Phase 33's entry criteria states "Phase 32 is completed and async/runtime ecosystem primitives are stable" — this is a blocking condition that needs an explicit Phase 32 closure date or checkpoint reference.
+
+**Fix**: Add a Phase 32 closure date to the phase document header and confirm Phase 33 entry criteria are met.
+
+---
+
+## Concrete Recommended Edits to Phase MD
+
+```markdown
+## Semantic Source of Truth
+`internal_docs/distribution_pipeline.md` is the authoritative contract for this phase.
+This file records milestone order, implementation responsibilities, validation goals, deferrals, and phase exit gate.
+If a detail conflicts with the distribution_pipeline doc, the distribution_pipeline doc wins and this phase file must be updated before implementation continues.
+
+## Installer and Artifact Architecture (Pre-requisite)
+Before any implementation begins, `internal_docs/distribution_pipeline.md` must be authored and reviewed, defining:
+- Installer script location and hosting
+- Channel manifest schema (JSON/TOML hosted endpoint)
+- Multi-platform target list and artifact naming convention
+- Checksum algorithm (SHA256) and signature mechanism
+- `SIFR_CHANNEL`/`--channel` resolution protocol
+- `--version` pinning semantics
+- Stable promotion gate: how stable is prevented from resolving until Phase 39 gates pass
+```
+
+Then add after the Quality Contract section:
+
+```markdown
+## Milestone Sequencing
+
+```mermaid
+flowchart TD
+    m33_1["m33.1 Installer + Channel Resolution"]
+    m33_2["m33.2 Artifact + Manifest Pipeline"]
+    m33_3["m33.3 Agentic Release Command"]
+
+    m33_1 --> m33_2
+    m33_2 --> m33_3
+```
+
+Implementation order: milestone_33_1 first (installer entrypoint, channel resolution), then milestone_33_2 (artifact publishing, checksum/signature validation), then milestone_33_3 (release automation workflow).
+
+## /create-new-version Workflow Contract
+[New section defining: trigger, inputs, dry-run behavior, real-run behavior, Linear entities managed, failure modes, rollback]
+```
+
+And update each milestone to add:
+
+```markdown
+### milestone_33_1: Installer and Channel Resolution
+[existing scope]
+
+**Positive validation:**
+- `install_alpha_channel.sifr`
+- `install_beta_channel.sifr`
+- `install_version_pin.sifr`
+- `install_stable_blocked.sifr`
+
+**Negative validation:**
+- `install_invalid_channel_rejected.sifr`
+- `install_checksum_mismatch_rejected.sifr`
+- `install_manifest_unavailable_rejected.sifr`
+
+**Demo:** `demos/install_demo/` [or similar]
+
+[Similar additions for milestone_33_2 and milestone_33_3]
+```
+
+---
+
+## Compact Checklist for Next Review
+
+To make me satisfied in the next review, the phase MD must have all of:
+
+- [ ] A reference to `internal_docs/distribution_pipeline.md` (or equivalent architecture doc) as the semantic source of truth, authored before implementation begins
+- [ ] The `/create-new-version` workflow fully described: trigger, dry-run vs. real-run, Linear entities, failure modes
+- [ ] Milestone sequencing diagram showing 33_1 → 33_2 → 33_3 order
+- [ ] Named validation fixtures for each milestone (positive AND negative paths, fixture names listed explicitly)
+- [ ] Stable promotion gate mechanism documented (how is stable prevented from resolving?)
+- [ ] Phase 32 closure date/evidence confirming entry criteria are met
+- [ ] Docs/website infrastructure dependency clarified (does `https://sifr.sh` exist as a prerequisite?)
+- [ ] At least one end-to-end demo or integration test covering the full preview release lifecycle
+- [ ] Exit gate evidence checklist that explicitly maps to "Preview release lifecycle works reliably without enabling stable GA promotion"

--- a/reviews/phase-33-preview-distribution-readiness-review-pass-2.md
+++ b/reviews/phase-33-preview-distribution-readiness-review-pass-2.md
@@ -1,0 +1,43 @@
+
+
+Let me review the revised phase document against the pass 1 blockers.
+
+## Review Against Pass 1 Compact Checklist
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| Architecture/source-of-truth doc | ✅ | "Distribution Source Of Truth" section names the site repo, installer path (`apps/sifr-site/public/install`), manifest roots, and deployment target. Explicitly states this file is authoritative until implementation creates supporting docs. |
+| `/create-new-version` workflow | ✅ | Full section with inputs, dry-run behavior, real-run behavior, and failure behavior. No gaps. |
+| Milestone sequencing diagram | ✅ | Mermaid flowchart shows `33_1 → 33_2 → 33_3`. Explicit ordering note: "Implementation must execute the milestones in order." |
+| Named validation fixtures | ✅ | Each milestone lists explicit fixture names for positive and negative paths. |
+| Stable promotion gate mechanism | ✅ | Locked decision #2: `enabled: false` gated, no installer path. Locked #5: invalid combinations hard errors. Negative validation fixture `install_stable_channel_gated.sh` explicitly tests the gate. |
+| Phase 32 closure date/evidence | ✅ | "Current closure evidence: Phase 32 is marked `status: completed` ... with corrective follow-up completed on 2026-05-12." |
+| Docs/website infrastructure dependency | ✅ | "The Sifr site repository is part of this phase" with explicit repo path and deployment target. |
+| End-to-end demo or integration test | ✅ | `demos/preview_distribution_demo/README.md` (m33_2) and `demos/preview_release_lifecycle/README.md` (m33_3) are specified. |
+| Exit gate mapped to stable blocking | ✅ | Exit gate explicitly maps to "without enabling stable GA promotion" via stable rejection fixtures and the `stable_manifest_unchanged_by_preview_release.sh` negative validation. |
+
+## Cross-Check: No New Gaps Introduced
+
+- **Deferrals are explicit and bounded**: stable promotion, package managers, Windows, rollback governance all declared non-goals with phase 39 ownership noted.
+- **Non-regression contract**: Phase 27 baseline locked in Quality Contract with explicit invariant list (panic-free, no data-dependent unwrap, diagnostics stability, exit codes 0/1/2/3).
+- **Locked decisions are precise**: All 12 are specific enough to be non-ambiguous in implementation. "The selected repository-supported signing mechanism documented by the implementation PR" is correctly scoped — Phase 33 ships the signing infrastructure, implementation PR documents the mechanism.
+- **Command location**: `.cursor/commands/create-new-version.md` is specified in compiler repo. Appropriate ownership split confirmed.
+- **GitHub Release ownership**: Artifacts published in `sifr-lang/sifr` per locked decision #9. Website hosts only installer and manifests.
+
+---
+
+## Verdict: READY
+
+The phase document now satisfies every pass 1 blocker. The three critical blockers (architecture, `/create-new-version` workflow, sequencing) are resolved. The three high-severity blockers (fixtures, stable gate, Phase 32 evidence) are resolved. The medium-severity items (docs dependency, demos, Phase 32 date) are resolved.
+
+## Acceptance Rationale
+
+Phase 33 is ready for implementation because:
+
+1. **Executable scope**: Each milestone has unambiguous scope, depends-on relationships, and definition-of-done that maps to testable artifacts.
+2. **Non-ambiguous protocol**: The manifest contract, locked distribution decisions, and `/create-new-version` workflow are specific enough that two independent implementers would produce compatible output.
+3. **Validated gate mechanism**: The stable blocking is concrete — `enabled: false` in manifests, `--version` rejects stable-looking semver without prerelease labels, negative validation fixtures explicitly exercise the rejection path.
+4. **Positive/negative coverage**: Every milestone has named positive and negative validation fixtures. Exit gate maps to a checklist of verifiable outcomes.
+5. **Infrastructure ownership is resolved**: The site repo is explicitly part of the phase with paths named, the compiler owns release automation and the command workflow.
+
+Implementation can proceed once the site repo is confirmed to exist at the specified path. No further phase document edits are required before implementation begins.


### PR DESCRIPTION
## Summary

Refines the Phase 33 preview distribution and release automation plan before implementation begins.

- expands the phase into a concrete preview distribution contract
- defines cross-repo ownership for the site installer and manifests
- locks channel resolution, stable gating, manifest shape, target matrix, artifact verification, and /create-new-version semantics
- adds named positive and negative validation artifacts for every milestone
- records two Claude Opus readiness review passes, ending with a READY verdict

## Validation

- scripts/run_all_tests.sh --profile quick passed locally
- Note: the quick lane reported a warm wall-time advisory (budget_ok=no) but exited successfully with all tests passing

## Review Evidence

- reviews/phase-33-preview-distribution-readiness-review-pass-1.md: NOT READY with blockers
- reviews/phase-33-preview-distribution-readiness-review-pass-2.md: READY with acceptance rationale