### PR TITLE
Add preview release publication workflow

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,194 @@
+name: preview-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Preview channel to publish
+        required: true
+        type: choice
+        options:
+          - alpha
+          - beta
+      version:
+        description: Semver prerelease version, for example 0.1.0-beta.1
+        required: true
+        type: string
+      base_ref:
+        description: Ref to build
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: validate preview inputs
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+      channel: ${{ steps.validate.outputs.channel }}
+      base_ref: ${{ steps.validate.outputs.base_ref }}
+    steps:
+      - name: Validate channel and version
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="${{ inputs.channel }}"
+          version="${{ inputs.version }}"
+          base_ref="${{ inputs.base_ref }}"
+
+          case "${channel}" in
+            alpha|beta) ;;
+            *) echo "::error::channel must be alpha or beta"; exit 2 ;;
+          esac
+
+          if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::stable-looking versions are disabled until Phase 39: ${version}"
+            exit 2
+          fi
+
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
+            echo "::error::version must be a semver prerelease using -alpha.N, -beta.N, or -rc.N"
+            exit 2
+          fi
+
+          version_channel="${BASH_REMATCH[1]}"
+          if [[ "${version_channel}" != "${channel}" ]]; then
+            echo "::error::version ${version} belongs to ${version_channel}, not ${channel}"
+            exit 2
+          fi
+
+          echo "version=${version}" >>"${GITHUB_OUTPUT}"
+          echo "channel=${channel}" >>"${GITHUB_OUTPUT}"
+          echo "base_ref=${base_ref:-main}" >>"${GITHUB_OUTPUT}"
+
+  build-artifacts:
+    name: build ${{ matrix.target }}
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-15
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.base_ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build target binary
+        run: cargo build --release -p sifr --target "${{ matrix.target }}"
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.validate.outputs.version }}"
+          target="${{ matrix.target }}"
+          archive="sifr-${version}-${target}.tar.gz"
+          mkdir -p dist package-root
+          cp "target/${target}/release/sifr" "package-root/sifr"
+          chmod 755 "package-root/sifr"
+          tar -C package-root -czf "dist/${archive}" sifr
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "dist/${archive}" | awk '{print $1}' >"dist/${archive}.sha256"
+          else
+            shasum -a 256 "dist/${archive}" | awk '{print $1}' >"dist/${archive}.sha256"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sifr-${{ needs.validate.outputs.version }}-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish-release:
+    name: publish preview release
+    needs:
+      - validate
+      - build-artifacts
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.validate.outputs.version }}
+      CHANNEL: ${{ needs.validate.outputs.channel }}
+      BASE_REF: ${{ needs.validate.outputs.base_ref }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify complete asset set
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_targets=(
+            aarch64-apple-darwin
+            x86_64-apple-darwin
+            x86_64-unknown-linux-gnu
+            aarch64-unknown-linux-gnu
+          )
+          for target in "${expected_targets[@]}"; do
+            archive="release-assets/sifr-${VERSION}-${target}.tar.gz"
+            checksum="${archive}.sha256"
+            test -f "${archive}" || { echo "::error::missing ${archive}"; exit 2; }
+            test -f "${checksum}" || { echo "::error::missing ${checksum}"; exit 2; }
+            expected="$(tr -d '[:space:]' <"${checksum}")"
+            actual="$(sha256sum "${archive}" | awk '{print $1}')"
+            if [[ "${expected}" != "${actual}" ]]; then
+              echo "::error::checksum mismatch for ${archive}"
+              exit 2
+            fi
+          done
+
+      - name: Publish GitHub prerelease
+        shell: bash
+        run: |
+          set -euo pipefail
+          notes_file="$(mktemp)"
+          {
+            echo "# Sifr ${VERSION}"
+            echo
+            echo "Preview channel: ${CHANNEL}"
+            echo "Base ref: ${BASE_REF}"
+            echo
+            echo "This is a Phase 33 public preview release. Stable GA promotion remains disabled until Phase 39."
+            echo
+            echo "Assets are .tar.gz archives plus SHA-256 checksum files for the Phase 33 target set."
+          } >"${notes_file}"
+
+          if gh release view "${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release edit "${VERSION}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --prerelease \
+              --latest=false \
+              --title "Sifr ${VERSION}" \
+              --notes-file "${notes_file}"
+          else
+            gh release create "${VERSION}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --prerelease \
+              --latest=false \
+              --title "Sifr ${VERSION}" \
+              --notes-file "${notes_file}"
+          fi
+
+          gh release upload "${VERSION}" release-assets/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber


### PR DESCRIPTION
## Summary\n- add manual preview-release workflow to build all Phase 33 target artifacts on native GitHub-hosted runners\n- publish public prerelease assets with .tar.gz archives and .sha256 files\n- reject stable-looking versions and channel/version mismatches before build or release mutation\n\n## Validation\n- git diff --check\n- inspected current GitHub-hosted runner labels from official GitHub docs\n\nThis corrects the Phase 33 publication gap: no GitHub Release was actually created by the prior merged automation.