### PR TITLE
Fix preview release submodule checkout

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.validate.outputs.base_ref }}
+          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Fetch recursive submodules in the Phase 33 preview release workflow before building target binaries.
- Fixes failed release dispatches where Cargo could not read `third_party/ruff/crates/ruff_text_size/Cargo.toml`.

## Validation
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`
- Claude reviewer verdict: SATISFIED for the corrective patch and safe to re-dispatch alpha/beta releases.