### PR TITLE
Simplify installer PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,8 @@ curl -fsSL https://sifr.sh/install | sh
 ```
 
 The installer downloads a prebuilt preview binary for your platform, verifies
-its SHA-256 checksum, and installs it to `~/.sifr/bin/sifr`.
-
-Add Sifr to your shell path:
-
-```bash
-export PATH="$HOME/.sifr/bin:$PATH"
-```
+its SHA-256 checksum, installs it to `~/.sifr/bin/sifr`, and updates your shell
+profile so new shells can find `sifr`.
 
 Install the alpha preview instead:
 
@@ -108,6 +103,14 @@ Install to a custom directory:
 
 ```bash
 curl -fsSL https://sifr.sh/install | SIFR_INSTALL_DIR="$HOME/bin" sh
+```
+
+Disable shell profile changes:
+
+```bash
+curl -fsSL https://sifr.sh/install | SIFR_NO_MODIFY_PATH=1 sh
+# or
+curl -fsSL https://sifr.sh/install | sh -s -- --no-modify-path
 ```
 
 Supported preview targets:

--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -129,9 +129,11 @@ The generated installer embeds:
 - the default GitHub Release asset base URL,
 - platform detection for the Phase 33 targets,
 - checksum validation before extraction or replacement,
-- atomic replacement of the installed `sifr` binary after validation.
+- atomic replacement of the installed `sifr` binary after validation,
+- shell profile wiring through `~/.sifr/env`, unless `SIFR_NO_MODIFY_PATH=1`
+  or `--no-modify-path` is used.
 
-The generated installer honors `SIFR_ARTIFACT_BASE_URL`, `SIFR_TARGET`, and `SIFR_INSTALL_DIR` for local validation.
+The generated installer honors `SIFR_ARTIFACT_BASE_URL`, `SIFR_TARGET`, `SIFR_INSTALL_DIR`, and `SIFR_NO_MODIFY_PATH` for local validation.
 
 ## Phase 33.2 Validation
 

--- a/internal_docs/phases/33_preview_distribution_and_release_automation.md
+++ b/internal_docs/phases/33_preview_distribution_and_release_automation.md
@@ -55,6 +55,8 @@ The following are not Phase 33 exit criteria:
 
 Phase 33 starts from a generated-installer model rather than a bespoke hand-written artifact resolver. The baseline is the same shape used by Astral's uv installer at `https://astral.sh/uv/install.sh`: a shell installer generated from release metadata that embeds the app version, release asset URLs, target-to-archive mapping, SHA-256 checksums, platform detection, download, verification, extraction, and install-path handling.
 
+The generated installer should also follow uv's default PATH ergonomics: after installing the binary, it updates shell profiles through an env script so users do not need a separate persistent `PATH` setup step. Users can opt out with `SIFR_NO_MODIFY_PATH=1` or `--no-modify-path`.
+
 Implementation should prefer `cargo-dist` or an equivalent generator so Sifr owns release metadata and generated output, not a manually maintained 2,000-line installer fork.
 
 If any code is copied or adapted from the Astral uv installer or the `astral-sh/uv` repository, the implementation PR must:

--- a/scripts/distribution/generate_version_installer.sh
+++ b/scripts/distribution/generate_version_installer.sh
@@ -119,11 +119,43 @@ set -eu
 APP_NAME="sifr"
 APP_VERSION="${VERSION}"
 ARTIFACT_BASE_URL="${ARTIFACT_BASE_URL}"
+NO_MODIFY_PATH="\${SIFR_NO_MODIFY_PATH:-0}"
 
 fail() {
   echo "sifr installer: \$*" >&2
   exit 2
 }
+
+usage() {
+  cat <<'EOFUSAGE'
+Usage: sifr-installer.sh [options]
+
+Options:
+  --no-modify-path    Do not update shell profiles to add Sifr to PATH
+  --help              Show this help
+
+Environment:
+  SIFR_INSTALL_DIR        Install directory (default: \$HOME/.sifr/bin)
+  SIFR_NO_MODIFY_PATH=1   Do not update shell profiles
+  SIFR_TARGET             Override target triple for validation
+EOFUSAGE
+}
+
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --no-modify-path)
+      NO_MODIFY_PATH=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: \$1"
+      ;;
+  esac
+done
 
 download() {
   if command -v curl >/dev/null 2>&1; then
@@ -168,8 +200,118 @@ detect_target() {
       ;;
     *)
       fail "unsupported platform: \${os}/\${arch}"
+    ;;
+  esac
+}
+
+profile_path_expr() {
+  path="\$1"
+  if [ -n "\${HOME:-}" ]; then
+    case "\${path}" in
+      "\${HOME}/"*)
+        suffix="\${path#"\${HOME}/"}"
+        printf '\${HOME}/%s\n' "\${suffix}"
+        return 0
+        ;;
+    esac
+  fi
+  printf '%s\n' "\${path}"
+}
+
+write_env_script_sh() {
+  install_dir_expr="\$1"
+  env_script_path="\$2"
+  {
+    printf '%s\n' '#!/usr/bin/env sh'
+    printf '%s\n' '# Adds Sifr binaries to PATH if needed.'
+    printf '%s\n' 'case ":\${PATH}:" in'
+    printf '  *:"%s":*)\n' "\${install_dir_expr}"
+    printf '%s\n' '    ;;'
+    printf '%s\n' '  *)'
+    printf '    export PATH="%s:\${PATH}"\n' "\${install_dir_expr}"
+    printf '%s\n' '    ;;'
+    printf '%s\n' 'esac'
+  } >"\${env_script_path}"
+}
+
+write_env_script_fish() {
+  install_dir_expr="\$1"
+  fish_env_script_path="\$2"
+  {
+    printf 'if not contains "%s" \$PATH\n' "\${install_dir_expr}"
+    printf '    set -x PATH "%s" \$PATH\n' "\${install_dir_expr}"
+    printf '%s\n' 'end'
+  } >"\${fish_env_script_path}"
+}
+
+append_source_line() {
+  profile_path="\$1"
+  source_line="\$2"
+  if [ -f "\${profile_path}" ] && grep -F "\${source_line}" "\${profile_path}" >/dev/null 2>&1; then
+    return 0
+  fi
+  {
+    [ ! -f "\${profile_path}" ] || printf '\n'
+    printf '%s\n' "\${source_line}"
+  } >>"\${profile_path}"
+  return 1
+}
+
+configure_path() {
+  [ "\${NO_MODIFY_PATH}" = "1" ] && return 0
+  [ -n "\${HOME:-}" ] || return 0
+
+  case ":\${PATH}:" in
+    *:"\${install_dir}":*)
+      return 0
       ;;
   esac
+
+  sifr_home="\${HOME}/.sifr"
+  env_script_path="\${sifr_home}/env"
+  fish_config_dir="\${HOME}/.config/fish/conf.d"
+  fish_env_script_path="\${fish_config_dir}/sifr.env.fish"
+  install_dir_expr="\$(profile_path_expr "\${install_dir}")"
+  env_script_expr="\$(profile_path_expr "\${env_script_path}")"
+  fish_env_script_expr="\$(profile_path_expr "\${fish_env_script_path}")"
+  source_line=". \"\${env_script_expr}\""
+  shell_name="\${SHELL##*/}"
+  changed=0
+
+  mkdir -p "\${sifr_home}"
+  write_env_script_sh "\${install_dir_expr}" "\${env_script_path}"
+
+  if append_source_line "\${HOME}/.profile" "\${source_line}"; then
+    :
+  else
+    changed=1
+  fi
+
+  if [ -f "\${HOME}/.bashrc" ] || [ "\${shell_name}" = "bash" ]; then
+    if append_source_line "\${HOME}/.bashrc" "\${source_line}"; then :; else changed=1; fi
+  fi
+  if [ -f "\${HOME}/.bash_profile" ]; then
+    if append_source_line "\${HOME}/.bash_profile" "\${source_line}"; then :; else changed=1; fi
+  fi
+
+  zsh_home="\${ZDOTDIR:-\${HOME}}"
+  if [ -f "\${zsh_home}/.zshrc" ] || [ "\${shell_name}" = "zsh" ]; then
+    if append_source_line "\${zsh_home}/.zshrc" "\${source_line}"; then :; else changed=1; fi
+  fi
+
+  if [ -d "\${HOME}/.config/fish" ] || [ "\${shell_name}" = "fish" ]; then
+    mkdir -p "\${fish_config_dir}"
+    write_env_script_fish "\${install_dir_expr}" "\${fish_env_script_path}"
+    changed=1
+  fi
+
+  if [ "\${changed}" = "1" ]; then
+    echo "configured Sifr PATH via \${env_script_path}"
+    echo "restart your shell or run: . \"\${env_script_path}\""
+    if [ -f "\${fish_env_script_path}" ]; then
+      echo "fish users can also run: source \"\${fish_env_script_expr}\""
+    fi
+  fi
 }
 
 target="\$(detect_target)"
@@ -184,7 +326,11 @@ esac
 
 base_url="\${SIFR_ARTIFACT_BASE_URL:-\${ARTIFACT_BASE_URL}}"
 artifact_url="\${base_url%/}/\${archive_name}"
-install_dir="\${SIFR_INSTALL_DIR:-\${HOME}/.sifr/bin}"
+install_dir="\${SIFR_INSTALL_DIR:-}"
+if [ -z "\${install_dir}" ]; then
+  [ -n "\${HOME:-}" ] || fail "HOME or SIFR_INSTALL_DIR is required"
+  install_dir="\${HOME}/.sifr/bin"
+fi
 
 if [ "\${SIFR_INSTALLER_TRACE:-0}" = "1" ]; then
   echo "sifr installer version=\${APP_VERSION} target=\${target} archive=\${archive_name}"
@@ -218,6 +364,7 @@ chmod 755 "\${tmp_binary}"
 mv "\${tmp_binary}" "\${install_dir}/sifr"
 
 echo "installed sifr \${APP_VERSION} to \${install_dir}/sifr"
+configure_path
 EOF
 
 chmod 755 "${OUT}"

--- a/verification/distribution/artifact_configures_path.sh
+++ b/verification/distribution/artifact_configures_path.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-artifact-path.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+version="0.1.0-beta.10"
+binary="${tmp_dir}/sifr"
+artifact_dir="${tmp_dir}/artifacts"
+installer="${tmp_dir}/installer.sh"
+home_dir="${tmp_dir}/home"
+target="x86_64-unknown-linux-gnu"
+
+make_mock_binary "${binary}" "path fixture"
+"${REPO_ROOT}/scripts/distribution/build_preview_artifacts.sh" \
+  --version "${version}" \
+  --output-dir "${artifact_dir}" \
+  --binary "${binary}" >/dev/null
+"${REPO_ROOT}/scripts/distribution/generate_version_installer.sh" \
+  --version "${version}" \
+  --artifact-dir "${artifact_dir}" \
+  --out "${installer}" \
+  --artifact-base-url "file://${artifact_dir}" >/dev/null
+
+mkdir -p "${home_dir}"
+output="$(
+  HOME="${home_dir}" \
+    SHELL=/bin/zsh \
+    PATH="/usr/bin:/bin" \
+    SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    sh "${installer}"
+)"
+
+if [[ "${output}" != *"configured Sifr PATH via ${home_dir}/.sifr/env"* ]]; then
+  echo "installer did not report PATH configuration" >&2
+  echo "--- output ---" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+grep -F '. "${HOME}/.sifr/env"' "${home_dir}/.profile" >/dev/null
+grep -F '. "${HOME}/.sifr/env"' "${home_dir}/.zshrc" >/dev/null
+
+resolved="$(
+  HOME="${home_dir}" PATH="/usr/bin:/bin" sh -c '. "${HOME}/.sifr/env"; command -v sifr'
+)"
+if [[ "${resolved}" != "${home_dir}/.sifr/bin/sifr" ]]; then
+  echo "env script did not put installed sifr on PATH: ${resolved}" >&2
+  exit 1
+fi
+
+output="$(
+  HOME="${home_dir}" PATH="/usr/bin:/bin" sh -c '. "${HOME}/.sifr/env"; sifr'
+)"
+if [[ "${output}" != "path fixture" ]]; then
+  echo "installed sifr was not runnable through configured PATH: ${output}" >&2
+  exit 1
+fi

--- a/verification/distribution/artifact_no_modify_path_respected.sh
+++ b/verification/distribution/artifact_no_modify_path_respected.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-artifact-no-path.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+version="0.1.0-beta.11"
+binary="${tmp_dir}/sifr"
+artifact_dir="${tmp_dir}/artifacts"
+installer="${tmp_dir}/installer.sh"
+home_dir="${tmp_dir}/home"
+target="x86_64-unknown-linux-gnu"
+
+make_mock_binary "${binary}" "no path fixture"
+"${REPO_ROOT}/scripts/distribution/build_preview_artifacts.sh" \
+  --version "${version}" \
+  --output-dir "${artifact_dir}" \
+  --binary "${binary}" >/dev/null
+"${REPO_ROOT}/scripts/distribution/generate_version_installer.sh" \
+  --version "${version}" \
+  --artifact-dir "${artifact_dir}" \
+  --out "${installer}" \
+  --artifact-base-url "file://${artifact_dir}" >/dev/null
+
+mkdir -p "${home_dir}"
+output="$(
+  HOME="${home_dir}" \
+    SHELL=/bin/zsh \
+    PATH="/usr/bin:/bin" \
+    SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path
+)"
+
+if [[ "${output}" == *"configured Sifr PATH"* ]]; then
+  echo "installer configured PATH despite opt-out" >&2
+  echo "--- output ---" >&2
+  echo "${output}" >&2
+  exit 1
+fi
+
+if [[ -e "${home_dir}/.sifr/env" || -e "${home_dir}/.profile" || -e "${home_dir}/.zshrc" ]]; then
+  echo "installer wrote shell profile files despite opt-out" >&2
+  find "${home_dir}" -maxdepth 2 -type f -print >&2
+  exit 1
+fi
+
+if [[ "$("${home_dir}/.sifr/bin/sifr")" != "no path fixture" ]]; then
+  echo "installer did not install binary when PATH modification was disabled" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Update generated preview installers to configure shell profiles via `~/.sifr/env` by default
- Add `SIFR_NO_MODIFY_PATH=1` and `--no-modify-path` opt-outs
- Add distribution validation for default PATH setup and opt-out behavior
- Update README and Phase 33 distribution docs

## Validation
- `scripts/run_distribution_validation.sh`
- `scripts/run_all_tests.sh --profile quick` (pass; advisory: e2e group skew is high)
- Reviewer rounds: `reviews/installer-path-setup-review-1.md`, `reviews/installer-path-setup-review-2.md` (satisfied)