### PR TITLE
Tighten emitted boolean and decimal codegen

### DIFF
--- a/crates/sifr_codegen/src/ir_optimize.rs
+++ b/crates/sifr_codegen/src/ir_optimize.rs
@@ -1,4 +1,4 @@
-use crate::{RustExpr, RustItem, RustLiteral, RustStmt, RustType};
+use crate::{RustExpr, RustItem, RustLiteral, RustParam, RustStmt, RustType};
 
 const MUTATING_METHODS: &[&str] = &[
     "append",
@@ -674,6 +674,12 @@ fn optimize_expr(expr: &mut RustExpr) -> usize {
                     *std::mem::replace(receiver, Box::new(RustExpr::Literal(RustLiteral::Unit)));
                 *expr = replacement;
                 removed += 1;
+            } else if method == "map_or_else" && args.len() == 2 && is_identity_closure(&args[1]) {
+                if is_known_std_fallible_receiver(receiver.as_ref()) {
+                    *method = "unwrap_or_else".to_string();
+                    args.pop();
+                    removed += 1;
+                }
             }
             removed
         }
@@ -704,7 +710,14 @@ fn optimize_expr(expr: &mut RustExpr) -> usize {
             }
             removed
         }
-        RustExpr::BinOp { left, right, .. } => optimize_expr(left) + optimize_expr(right),
+        RustExpr::BinOp { left, op, right } => {
+            let mut removed = optimize_expr(left) + optimize_expr(right);
+            if let Some(replacement) = simplified_bool_comparison(left, op, right) {
+                *expr = replacement;
+                removed += 1;
+            }
+            removed
+        }
         RustExpr::UnaryOp { operand, .. }
         | RustExpr::Deref(operand)
         | RustExpr::Try(operand)
@@ -777,6 +790,69 @@ fn is_zero_usize_expr(expr: &RustExpr) -> bool {
         }
         RustExpr::Paren(inner) => is_zero_usize_expr(inner),
         _ => false,
+    }
+}
+
+fn is_identity_closure(expr: &RustExpr) -> bool {
+    let RustExpr::Closure { params, body, .. } = expr else {
+        return false;
+    };
+    let [RustParam::Named { name, .. }] = params.as_slice() else {
+        return false;
+    };
+    match body.as_ref() {
+        RustExpr::Ident(body_name) => body_name == name,
+        RustExpr::Paren(inner) => {
+            matches!(inner.as_ref(), RustExpr::Ident(body_name) if body_name == name)
+        }
+        _ => false,
+    }
+}
+
+fn is_known_std_fallible_receiver(expr: &RustExpr) -> bool {
+    matches!(
+        expr,
+        RustExpr::FnCall { func, .. }
+            if matches!(
+                func.as_ref(),
+                RustExpr::Path(parts)
+                    if matches!(
+                        parts.as_slice(),
+                        [type_name, method] if type_name == "Decimal" && method == "checked_div"
+                    )
+            )
+    )
+}
+
+fn simplified_bool_comparison(left: &RustExpr, op: &str, right: &RustExpr) -> Option<RustExpr> {
+    if !matches!(op, "==" | "!=") {
+        return None;
+    }
+    if let RustExpr::Literal(RustLiteral::Bool(value)) = right {
+        return Some(if (*value && op == "==") || (!*value && op == "!=") {
+            left.clone()
+        } else {
+            not_expr(left.clone())
+        });
+    }
+    if let RustExpr::Literal(RustLiteral::Bool(value)) = left {
+        return Some(if (*value && op == "==") || (!*value && op == "!=") {
+            right.clone()
+        } else {
+            not_expr(right.clone())
+        });
+    }
+    None
+}
+
+fn not_expr(expr: RustExpr) -> RustExpr {
+    match expr {
+        RustExpr::Literal(RustLiteral::Bool(value)) => RustExpr::Literal(RustLiteral::Bool(!value)),
+        RustExpr::UnaryOp { op, operand } if op == "!" => *operand,
+        other => RustExpr::UnaryOp {
+            op: "!".to_string(),
+            operand: Box::new(other),
+        },
     }
 }
 
@@ -996,5 +1072,140 @@ mod tests {
         };
         assert_eq!(method, "take");
         assert!(matches!(receiver.as_ref(), RustExpr::Ident(name) if name == "items"));
+    }
+
+    #[test]
+    fn rewrites_identity_map_or_else_to_unwrap_or_else() {
+        let mut items = vec![RustItem::Fn {
+            name: "demo".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![],
+            ret: None,
+            body: vec![RustStmt::Expr(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::FnCall {
+                    func: Box::new(RustExpr::Path(vec![
+                        "Decimal".to_string(),
+                        "checked_div".to_string(),
+                    ])),
+                    args: vec![
+                        RustExpr::Ident("left".to_string()),
+                        RustExpr::Ident("right".to_string()),
+                    ],
+                }),
+                method: "map_or_else".to_string(),
+                args: vec![
+                    RustExpr::Closure {
+                        params: vec![],
+                        body: Box::new(RustExpr::Ident("fallback".to_string())),
+                        is_move: false,
+                    },
+                    RustExpr::Closure {
+                        params: vec![RustParam::Named {
+                            name: "value".to_string(),
+                            ty: RustType::Named("_".to_string()),
+                        }],
+                        body: Box::new(RustExpr::Ident("value".to_string())),
+                        is_move: false,
+                    },
+                ],
+            })],
+            is_async: false,
+        }];
+
+        let removed = remove_trivial_clones_in_items(&mut items);
+        assert_eq!(removed, 1);
+
+        let RustItem::Fn { body, .. } = &items[0] else {
+            panic!("expected fn item");
+        };
+        let Some(RustStmt::Expr(RustExpr::MethodCall { method, args, .. })) = body.first() else {
+            panic!("expected method call");
+        };
+        assert_eq!(method, "unwrap_or_else");
+        assert_eq!(args.len(), 1);
+    }
+
+    #[test]
+    fn keeps_identity_map_or_else_on_unknown_receivers() {
+        let mut items = vec![RustItem::Fn {
+            name: "demo".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![],
+            ret: None,
+            body: vec![RustStmt::Expr(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("maybe_value".to_string())),
+                method: "map_or_else".to_string(),
+                args: vec![
+                    RustExpr::Closure {
+                        params: vec![],
+                        body: Box::new(RustExpr::Ident("fallback".to_string())),
+                        is_move: false,
+                    },
+                    RustExpr::Closure {
+                        params: vec![RustParam::Named {
+                            name: "value".to_string(),
+                            ty: RustType::Named("_".to_string()),
+                        }],
+                        body: Box::new(RustExpr::Ident("value".to_string())),
+                        is_move: false,
+                    },
+                ],
+            })],
+            is_async: false,
+        }];
+
+        let removed = remove_trivial_clones_in_items(&mut items);
+        assert_eq!(removed, 0);
+
+        let RustItem::Fn { body, .. } = &items[0] else {
+            panic!("expected fn item");
+        };
+        let Some(RustStmt::Expr(RustExpr::MethodCall { method, args, .. })) = body.first() else {
+            panic!("expected method call");
+        };
+        assert_eq!(method, "map_or_else");
+        assert_eq!(args.len(), 2);
+    }
+
+    #[test]
+    fn simplifies_bool_literal_comparisons() {
+        let mut items = vec![RustItem::Fn {
+            name: "demo".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![],
+            ret: None,
+            body: vec![
+                RustStmt::Expr(RustExpr::BinOp {
+                    left: Box::new(RustExpr::Ident("flag".to_string())),
+                    op: "==".to_string(),
+                    right: Box::new(RustExpr::Literal(RustLiteral::Bool(false))),
+                }),
+                RustStmt::Expr(RustExpr::BinOp {
+                    left: Box::new(RustExpr::Literal(RustLiteral::Bool(false))),
+                    op: "!=".to_string(),
+                    right: Box::new(RustExpr::Ident("other".to_string())),
+                }),
+            ],
+            is_async: false,
+        }];
+
+        let removed = remove_trivial_clones_in_items(&mut items);
+        assert_eq!(removed, 2);
+
+        let RustItem::Fn { body, .. } = &items[0] else {
+            panic!("expected fn item");
+        };
+        assert!(matches!(
+            body.first(),
+            Some(RustStmt::Expr(RustExpr::UnaryOp { op, operand }))
+                if op == "!" && matches!(operand.as_ref(), RustExpr::Ident(name) if name == "flag")
+        ));
+        assert!(matches!(
+            body.get(1),
+            Some(RustStmt::Expr(RustExpr::Ident(name))) if name == "other"
+        ));
     }
 }

--- a/internal_docs/generated_code_quality.md
+++ b/internal_docs/generated_code_quality.md
@@ -113,3 +113,40 @@ Result:
 - LeetCode: 377 entries reach generated Rust and pass the emitted-code quality
   gates. The remaining 34 fail before emitted-code quality due to
   frontend/type/lowering compatibility gaps.
+
+## Post-Closure Audit Wave 3 (2026-05-14)
+
+The third emitted-code audit wave expanded the demo sweep to every
+`demos/**/main.sifr` entry, including negative demo cases, and rechecked all
+top-level LeetCode fixtures. It removed two additional generated Rust artifacts:
+
+- Known `Decimal::checked_div(...).map_or_else(default, |value| value)` calls
+  now optimize to `unwrap_or_else(default)`, removing a generated clippy failure
+  in the decimal division negative demo without rewriting unknown receivers.
+- Boolean literal comparisons now simplify during IR optimization, for example
+  `flag == false` becomes `!flag` and `flag != false` becomes `flag`.
+- The generated clippy profile no longer allows `clippy::bool_comparison`.
+
+Evidence:
+
+- All-demo pre-patch sweep:
+  `target/full_emitted_quality/demos-wave3-all-1778776830/report.jsonl`.
+- Demo failed-subset recheck after optimizer cleanup:
+  `target/full_emitted_quality/demos-wave3-failed-subset-post-bool-map-1778779394/report.jsonl`.
+- LeetCode full sweep:
+  `target/full_emitted_quality/leetcode-wave3-all-1778778208/report.jsonl`.
+- LeetCode boolean-comparison subset recheck:
+  `target/full_emitted_quality/leetcode-wave3-bool-subset-post-bool-map-1778779466/report.jsonl`.
+- Reduced-allowlist generated clippy gate:
+  `target/sifr_generated_code_quality/evidence/clippy-1778780702-5147.json`.
+
+Result:
+
+- Demos: 261 entries reach generated Rust and pass build, forbidden scan,
+  `cargo fmt`, `cargo fmt --check`, and generated clippy. The remaining 49
+  entries fail before emitted-code quality due to expected negative demo
+  diagnostics or frontend/type/demo-contract gaps.
+- LeetCode: 377 entries reach generated Rust and pass the emitted-code quality
+  gates. The 29 fixtures that previously emitted boolean literal comparisons
+  were rechecked after the optimizer cleanup and now pass with zero remaining
+  `== true`, `== false`, `!= true`, or `!= false` occurrences.

--- a/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
+++ b/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
@@ -311,3 +311,27 @@ Wave 2 result:
 
 - Demos: 259 entries reach generated Rust and pass build, forbidden scan, `cargo fmt`, `cargo fmt --check`, and generated clippy; 13 entries remain pre-emitted-code frontend/type/demo-contract failures.
 - LeetCode: 377 entries reach generated Rust and pass the same emitted-code gates; 34 entries remain pre-emitted-code frontend/type/lowering compatibility failures.
+
+### Audit Wave 3 (2026-05-14)
+
+Third-round emitted-code review expanded the demo audit to every
+`demos/**/main.sifr` entry and removed two more generated Rust artifacts:
+
+- Known `Decimal::checked_div(...).map_or_else(default, |value| value)` calls
+  now optimize to `unwrap_or_else(default)` without rewriting unknown receivers.
+- Boolean literal comparisons now simplify during IR optimization.
+- The generated-code clippy allowlist no longer includes
+  `clippy::bool_comparison`.
+
+Wave 3 evidence:
+
+- All-demo pre-patch sweep: `target/full_emitted_quality/demos-wave3-all-1778776830/report.jsonl`.
+- Demo failed-subset recheck after optimizer cleanup: `target/full_emitted_quality/demos-wave3-failed-subset-post-bool-map-1778779394/report.jsonl`.
+- LeetCode full sweep: `target/full_emitted_quality/leetcode-wave3-all-1778778208/report.jsonl`.
+- LeetCode boolean-comparison subset recheck: `target/full_emitted_quality/leetcode-wave3-bool-subset-post-bool-map-1778779466/report.jsonl`.
+- Reduced-allowlist clippy gate: `target/sifr_generated_code_quality/evidence/clippy-1778780702-5147.json`.
+
+Wave 3 result:
+
+- Demos: 261 entries reach generated Rust and pass build, forbidden scan, `cargo fmt`, `cargo fmt --check`, and generated clippy; 49 entries remain pre-emitted-code expected negative diagnostics or frontend/type/demo-contract failures.
+- LeetCode: 377 entries reach generated Rust and pass the same emitted-code gates; 34 entries remain pre-emitted-code frontend/type/lowering compatibility failures. The 29 fixtures that previously emitted boolean literal comparisons were rechecked and now have zero remaining boolean-literal comparison occurrences.

--- a/reviews/phase34-demo-leetcode-emitted-audit-wave3-review-1.md
+++ b/reviews/phase34-demo-leetcode-emitted-audit-wave3-review-1.md
@@ -1,0 +1,93 @@
+
+
+## Phase 34 Wave 3 Review — Round 1
+
+**Recommendation: Approve. No blockers.**
+
+---
+
+### Semantic Soundness of the Two Rewrites
+
+**1. `map_or_else(default, |value| value)` → `unwrap_or_else(default)`**
+
+Sound. The preconditions `method == "map_or_else"`, `args.len() == 2`, and `is_identity_closure(&args[1])` ensure the second closure is `|v| v` where `v` is the single parameter. This is precisely the `Option::map_or_else` optimization that Rust's `unnecessary_option_map_or_else` lint flags. The optimizer correctly:
+- Renames method to `unwrap_or_else`
+- Removes the identity closure (the second argument)
+- Leaves the default (first argument) intact
+
+The test `rewrites_identity_map_or_else_to_unwrap_or_else` verifies the transformation end-to-end. The `is_identity_closure` helper checks both bare identifier and parenthesized identifier bodies, covering the full range of Sifr's closure lowering.
+
+**2. Boolean literal comparison simplification**
+
+Sound. The `simplified_bool_comparison` function recognizes four patterns:
+
+| Pattern | Rewrite |
+|---|---|
+| `x == true` | `x` |
+| `x == false` | `!x` |
+| `x != true` | `!x` |
+| `x != false` | `x` |
+
+And symmetrically when the literal is on the left. This is algebraically correct for boolean types. The `not_expr` helper handles double-negation (`!` on `!x` collapses to `x`) and does not generate tautological code for `true == true` (the `true` case returns the operand unchanged rather than wrapping in an identity negation).
+
+The test `simplifies_bool_literal_comparisons` covers `flag == false` → `!flag` and `false != other` → `other`, exercising both rewrite branches.
+
+Both rewrites are conservative: they only fire on exact structural matches inside the existing `optimize_expr` traversal, which is already conservative by design.
+
+---
+
+### `clippy::bool_comparison` Removal Adequacy
+
+**Evidence is conclusive:**
+
+1. **Before optimizer cleanup**: The all-demo sweep (`demos-wave3-all-1778776830`) recorded 1 `clippy_failed` — the decimal division-by-zero negative demo — specifically from `Option::map_or_else(..., |__q| __q)` triggering `clippy::unnecessary_option_map_or_else`. That is the primary trigger being addressed.
+
+2. **Pattern scan found 29 LeetCode fixtures with boolean literal comparisons** across 75 occurrences. This is the scope of what `clippy::bool_comparison` would flag.
+
+3. **After optimizer cleanup**: The boolean-comparison subset recheck (`leetcode-wave3-bool-subset-post-bool-map-1778779466`) passed 29/29, and post-check verified zero remaining `== true`, `== false`, `!= true`, or `!= false` occurrences in those generated crates.
+
+4. **Full LeetCode sweep**: 377 passed, 34 build_failed, 0 clippy_failed — the only remaining failures are pre-emission (frontend/type/lowering), not clippy-related.
+
+5. **Reduced-allowlist clippy gate**: 71 manifest entries, 71 passed, with `clippy::bool_comparison` removed from the allowlist.
+
+The removal is fully validated. No residual boolean literal comparisons remain in any passing generated crate.
+
+---
+
+### Generated Code Quality Issues Found by This Wave
+
+**No additional issues require fixing before merge.**
+
+The remaining failures are correctly classified as pre-emitted-code issues:
+- Demos: 49 build failures are either expected-negative demo diagnostics or frontend/type/demo-contract gaps. Not generated Rust quality problems.
+- LeetCode: 34 build failures are frontend/type/lowering compatibility gaps. Not generated Rust quality problems.
+
+The phase file and generated-code docs accurately reflect the current state. The review artifact `reviews/phase34-demo-leetcode-emitted-audit-wave3-review-1.md` exists but is empty — it should be populated before merge with the review narrative to match the pattern of wave-2 review files. This is a documentation gap, not a code quality blocker.
+
+---
+
+### Minor Observations (Non-blocking)
+
+1. **`not_expr` double-negation optimization is safe**: `not_expr(!x)` returns `*operand` (drops the outer `!`), which is correct. However, if the operand is itself a `!`-wrapped expression (e.g., `!(a && b)`), the optimizer produces `!(a && b)` rather than `!(a && b)` — identical, no issue.
+
+2. **The `is_identity_closure` test does not cover move closures**: `is_move: false` in the test closure means the pattern won't fire for `|value| value` with `is_move: true`. This is correct — `is_move` closures are not identity-preserving in the same way and should not be rewritten.
+
+3. **`clippy::bool_comparison` and `clippy::needless_bool` interaction**: These two lints are closely related. The generator currently removes `bool_comparison`, but if `needless_bool` fires on other generated patterns (like `if x == true` → `if x`), those would need to be handled by the optimizer or left in the allowlist. Current evidence shows no such residual.
+
+---
+
+### Summary
+
+| Check | Result |
+|---|---|
+| Optimizer rewrites semantically sound | ✅ Correct algebra, correct preconditions |
+| Unit tests pass | ✅ Both new tests green |
+| `cargo check -p sifr_codegen` | ✅ Passes |
+| `cargo fmt --check` | ✅ Passes |
+| `clippy::bool_comparison` removal validated | ✅ 377 LeetCode + 261 demos clean |
+| Residual clippy failures | ✅ None |
+| Remaining failures correctly classified | ✅ Pre-emission only |
+| Docs updated | ✅ Phase file + generated-code docs accurate |
+| Review artifact populated | ⚠️ Empty — should be written before merge |
+
+One action item: populate `reviews/phase34-demo-leetcode-emitted-audit-wave3-review-1.md` with the review narrative. Otherwise, **ready to merge**.

--- a/reviews/phase34-demo-leetcode-emitted-audit-wave3-review-2.md
+++ b/reviews/phase34-demo-leetcode-emitted-audit-wave3-review-2.md
@@ -1,0 +1,103 @@
+## Phase 34 Wave 3 Review — Round 2
+
+**Recommendation: Approve. No blockers.**
+
+---
+
+### Scope of This Round
+
+Review the final implementation after round-1 feedback narrowed two rewrites:
+1. `Decimal::checked_div(...).map_or_else(default, |value| value)` narrows to `unwrap_or_else(default)` — only known `Decimal::checked_div` receivers are rewritten.
+2. `clippy::bool_comparison` removed from `GENERATED_CLIPPY_ARGS`.
+
+---
+
+### `is_known_std_fallible_receiver` Guard — Semantic Soundness
+
+The narrowed guard at `ir_optimize.rs:812` matches only the exact call pattern:
+
+```rust
+RustExpr::FnCall { func, .. }
+    if matches!(
+        func.as_ref(),
+        RustExpr::Path(parts)
+            if matches!(
+                parts.as_slice(),
+                [type_name, method] if type_name == "Decimal" && method == "checked_div"
+            )
+    )
+```
+
+**Sound.** The pattern is:
+- `receiver` must be a `RustExpr::FnCall`
+- `func` must be a `RustExpr::Path` with exactly two segments
+- Segment 0 must be `"Decimal"` (the type name)
+- Segment 1 must be `"checked_div"` (the method name)
+
+This matches the exact receiver shape the Sifr-to-Rust codegen emits for `Decimal::checked_div(...)`. Any other receiver — `Decimal::try_from`, `Option::checked_div` (nonsense), bare identifiers, method chains — is left untouched.
+
+The test `keeps_identity_map_or_else_on_unknown_receivers` explicitly verifies that a bare `maybe_value.map_or_else(...)` with an identity closure is **not** rewritten, confirming the narrowing is active.
+
+**Semantic overreach risk is resolved.** The optimizer does not generalize this rewrite to all identity-closure `map_or_else` calls.
+
+---
+
+### Boolean Literal Comparison Simplification — Correctness
+
+The `simplified_bool_comparison` function at `ir_optimize.rs:827` and `not_expr` at `ir_optimize.rs:848` cover all four patterns and both literal positions:
+
+| Pattern | Rewrite |
+|---|---|
+| `x == true` | `x` |
+| `x == false` | `!x` |
+| `x != true` | `!x` |
+| `x != false` | `x` |
+| `true == x` | `x` |
+| `false == x` | `!x` |
+| `true != x` | `!x` |
+| `false != x` | `x` |
+
+**Correct.** The truth-table derivation:
+- `x == true` ↔ `x` (true when x is true) ✓
+- `x == false` ↔ `!x` (true when x is false) ✓
+- `x != true` ↔ `!x` (false when x is true) ✓
+- `x != false` ↔ `x` (true when x is false) ✓
+
+`not_expr` handles double-negation correctly: `not_expr(!x)` returns `*operand`, collapsing `!!x` to `x`. It also handles boolean literal negation: `not_expr(true)` → `false`.
+
+`clippy::bool_comparison` is no longer in the allowlist. The LeetCode boolean-comparison subset recheck passed 29/29 with zero remaining `== true`, `== false`, `!= true`, `!= false` occurrences.
+
+---
+
+### `clippy::bool_comparison` Removal — Adequacy
+
+Evidence from round 1 remains valid. The official generated clippy gate evidence:
+`target/sifr_generated_code_quality/evidence/clippy-1778780702-5147.json`
+
+All 71 manifest entries pass with `clippy::bool_comparison` absent from `GENERATED_CLIPPY_ARGS`.
+
+---
+
+### Documentation Accuracy
+
+- `internal_docs/phases/34_generated_code_quality_and_production_readiness.md`: Section "Audit Wave 3 (2026-05-14)" accurately describes the narrowed `Decimal::checked_div` rewrite, the boolean literal simplification, and the `clippy::bool_comparison` removal, with correct evidence file paths and results.
+- `internal_docs/generated_code_quality.md`: Section "Post-Closure Audit Wave 3 (2026-05-14)" mirrors the phase file accurately.
+
+---
+
+### Summary
+
+| Check | Result |
+|---|---|
+| `is_known_std_fallible_receiver` guard is sound | ✅ Only `Decimal::checked_div` |
+| Unknown receivers preserved | ✅ `keeps_identity_map_or_else_on_unknown_receivers` passes |
+| Boolean literal comparison algebra correct | ✅ All 8 patterns verified |
+| Double-negation handled | ✅ `!!x` → `x` |
+| `clippy::bool_comparison` removed | ✅ Not in `GENERATED_CLIPPY_ARGS` |
+| Generated clippy gate passes | ✅ 71/71 manifest entries |
+| `cargo fmt --check` | ✅ Passes |
+| `cargo check -p sifr_codegen` | ✅ Passes |
+| Unit tests | ✅ All 3 new tests green |
+| Docs accurate | ✅ Phase file + generated-code docs correct |
+
+**Ready to merge.**

--- a/verification/generated_code_quality/generated_code_quality.py
+++ b/verification/generated_code_quality/generated_code_quality.py
@@ -108,8 +108,6 @@ GENERATED_CLIPPY_ARGS = [
     "-A",
     "clippy::box_collection",
     "-A",
-    "clippy::bool_comparison",
-    "-A",
     "clippy::borrow_deref_ref",
     "-A",
     "clippy::cmp_owned",


### PR DESCRIPTION
## Summary

- simplify generated boolean literal comparisons in Rust IR (`x == false` -> `!x`, `x != false` -> `x`, plus symmetric forms)
- remove `clippy::bool_comparison` from the generated-code clippy allowlist
- rewrite known generated `Decimal::checked_div(...).map_or_else(default, |value| value)` to `unwrap_or_else(default)` while preserving unknown receivers
- record wave-3 demo/LeetCode emitted-code audit evidence and two Claude review rounds

## Evidence

- All-demo sweep before cleanup: `target/full_emitted_quality/demos-wave3-all-1778776830/report.jsonl`
  - 260 passed, 49 build_failed, 1 clippy_failed
- Demo failed-subset recheck after cleanup: `target/full_emitted_quality/demos-wave3-failed-subset-post-bool-map-1778779394/report.jsonl`
  - 1 passed, 49 build_failed; effective all-demo state is 261 generated-code-gate passes and 49 pre-emission failures
- Full LeetCode sweep: `target/full_emitted_quality/leetcode-wave3-all-1778778208/report.jsonl`
  - 377 passed, 34 build_failed
- LeetCode boolean-comparison subset after cleanup: `target/full_emitted_quality/leetcode-wave3-bool-subset-post-bool-map-1778779466/report.jsonl`
  - 29 passed, zero remaining boolean literal comparison occurrences in those generated crates
- Reduced-allowlist generated clippy: `target/sifr_generated_code_quality/evidence/clippy-1778780702-5147.json`
- Claude reviews: `reviews/phase34-demo-leetcode-emitted-audit-wave3-review-1.md`, `reviews/phase34-demo-leetcode-emitted-audit-wave3-review-2.md`

## Validation

- `cargo fmt --check`
- `cargo check -p sifr_codegen`
- `cargo test -p sifr_codegen rewrites_identity_map_or_else_to_unwrap_or_else -- --nocapture`
- `cargo test -p sifr_codegen keeps_identity_map_or_else_on_unknown_receivers -- --nocapture`
- `cargo test -p sifr_codegen simplifies_bool_literal_comparisons -- --nocapture`
- targeted generated crate fmt/check/clippy for decimal division negative demo and representative LeetCode boolean-comparison fixture
- `python3 verification/generated_code_quality/generated_code_quality.py clippy`
- `scripts/run_all_tests.sh --profile quick` (passed; warm wall-time advisory exceeded, report at `target/validation_lane_reports/quick.latest.json`)
