### PR TITLE
Improve map callable codegen for NeetCode Trees audit

### DIFF
--- a/crates/sifr_codegen/src/lower_expr.rs
+++ b/crates/sifr_codegen/src/lower_expr.rs
@@ -2,7 +2,7 @@
 
 use crate::{CodegenError, RustExpr, RustLiteral, RustParam, RustStmt, RustType};
 use sifr_hir::{HirExpr, HirFStringPart, HirIteratorOp, HirParam};
-use sifr_type_system::Type;
+use sifr_type_system::{ParamConvention, Type};
 use std::cell::RefCell;
 
 thread_local! {
@@ -929,7 +929,7 @@ fn try_lower_simple_map_call_expr(args: &[HirExpr]) -> Option<RustExpr> {
     let [callable, iter] = args else {
         return None;
     };
-    let lowered_callable = try_lower_simple_callable_expr(callable)?;
+    let lowered_callable = lower_simple_map_callable_expr(callable, iter)?;
     let iter_source = try_lower_simple_iter_source_expr(iter)?;
     let mapped_iter = RustExpr::MethodCall {
         receiver: Box::new(iter_source),
@@ -940,6 +940,96 @@ fn try_lower_simple_map_call_expr(args: &[HirExpr]) -> Option<RustExpr> {
         func: Box::new(RustExpr::Path(vec!["Box".to_string(), "new".to_string()])),
         args: vec![mapped_iter],
     })
+}
+
+fn lower_simple_map_callable_expr(callable: &HirExpr, iter: &HirExpr) -> Option<RustExpr> {
+    let lowered_callable = try_lower_simple_callable_expr(callable)?;
+    let Some((param_types, conventions)) = simple_callable_param_info(callable) else {
+        return Some(lowered_callable);
+    };
+    if param_types.len() != 1 || conventions.len() != 1 {
+        return Some(lowered_callable);
+    }
+    let iter_elem_ty =
+        resolve_alias_type(unwrap_simple_iter_source_expr(iter).ty()).iterable_element_type()?;
+    let adapted_arg = adapt_simple_map_callable_arg(
+        RustExpr::Ident("__sifr_map_item".to_string()),
+        &iter_elem_ty,
+        &param_types[0],
+        conventions[0],
+    );
+    Some(RustExpr::Closure {
+        params: vec![RustParam::Named {
+            name: "__sifr_map_item".to_string(),
+            ty: RustType::Named("_".to_string()),
+        }],
+        body: Box::new(RustExpr::FnCall {
+            func: Box::new(lowered_callable),
+            args: vec![adapted_arg],
+        }),
+        is_move: false,
+    })
+}
+
+fn simple_callable_param_info(callable: &HirExpr) -> Option<(Vec<Type>, Vec<ParamConvention>)> {
+    match resolve_alias_type(callable.ty()) {
+        Type::Function(ft) | Type::AsyncFunction(ft) => Some((
+            ft.params
+                .iter()
+                .map(|(_, ty, _)| ty.clone())
+                .collect::<Vec<_>>(),
+            ft.params
+                .iter()
+                .map(|(_, _, convention)| *convention)
+                .collect::<Vec<_>>(),
+        )),
+        Type::Callable(param_types, conventions, _) => {
+            Some((param_types.clone(), conventions.clone()))
+        }
+        _ => None,
+    }
+}
+
+fn adapt_simple_map_callable_arg(
+    mut lowered_arg: RustExpr,
+    arg_ty: &Type,
+    param_ty: &Type,
+    convention: ParamConvention,
+) -> RustExpr {
+    let resolved_param = resolve_alias_type(param_ty);
+    let arg_is_option = is_option_like_simple(arg_ty);
+    if is_option_like_simple(resolved_param) && !arg_is_option {
+        lowered_arg = RustExpr::FnCall {
+            func: Box::new(RustExpr::Path(vec!["Some".to_string()])),
+            args: vec![lowered_arg],
+        };
+    }
+
+    let expects_shared_ref_type =
+        param_ty.rust_type().starts_with('&') && !param_ty.rust_type().starts_with("&mut ");
+    let expects_mut_ref_type = param_ty.rust_type().starts_with("&mut ");
+    let requires_shared_borrow = expects_shared_ref_type
+        || (convention.is_shared_borrow()
+            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                || matches!(resolved_param, Type::TypeVar(_) | Type::Any)));
+    let requires_mut_borrow = expects_mut_ref_type
+        || (convention.is_mut_borrow()
+            && (param_ty.ownership() != sifr_type_system::OwnershipKind::Copy
+                || matches!(resolved_param, Type::TypeVar(_) | Type::Any)));
+
+    if requires_shared_borrow {
+        RustExpr::Ref {
+            mutable: false,
+            expr: Box::new(lowered_arg),
+        }
+    } else if requires_mut_borrow {
+        RustExpr::Ref {
+            mutable: true,
+            expr: Box::new(lowered_arg),
+        }
+    } else {
+        lowered_arg
+    }
 }
 
 fn try_lower_simple_filter_call_expr(args: &[HirExpr]) -> Option<RustExpr> {
@@ -3795,6 +3885,68 @@ mod tests {
             ty: Type::Iterator(Box::new(Type::Int)),
         };
         assert!(try_lower_leaf_expr(&expr).is_some());
+    }
+
+    #[test]
+    fn lowers_map_named_callable_with_optional_widening_closure() {
+        let node_ty = Type::Class {
+            name: "TreeNode".to_string(),
+            fields: vec![],
+            methods: vec![],
+            parent_class: None,
+        };
+        let optional_node_ty = Type::Union(vec![node_ty.clone(), Type::None]);
+        let expr = HirExpr::Call {
+            func: "map".to_string(),
+            args: vec![
+                HirExpr::Name {
+                    name: "treeToString".to_string(),
+                    ty: Type::Function(sifr_type_system::FunctionType {
+                        params: vec![(
+                            "node".to_string(),
+                            optional_node_ty,
+                            sifr_type_system::ParamConvention::borrow(),
+                        )],
+                        return_type: Box::new(Type::Str),
+                    }),
+                },
+                HirExpr::Name {
+                    name: "nodes".to_string(),
+                    ty: Type::List(Box::new(node_ty)),
+                },
+            ],
+            ty: Type::Iterator(Box::new(Type::Str)),
+        };
+
+        let lowered = try_lower_leaf_expr(&expr).expect("map lowered");
+        assert!(matches!(
+            lowered,
+            RustExpr::FnCall { args, .. }
+                if matches!(
+                    args.first(),
+                    Some(RustExpr::MethodCall { method, args: map_args, .. })
+                        if method == "map"
+                            && matches!(
+                                map_args.first(),
+                                Some(RustExpr::Closure { body, .. })
+                                    if matches!(
+                                        body.as_ref(),
+                                        RustExpr::FnCall { func, args }
+                                            if matches!(func.as_ref(), RustExpr::Ident(name) if name == "treeToString")
+                                                && matches!(
+                                                    args.first(),
+                                                    Some(RustExpr::Ref { mutable: false, expr })
+                                                        if matches!(
+                                                            expr.as_ref(),
+                                                            RustExpr::FnCall { func, args }
+                                                                if matches!(func.as_ref(), RustExpr::Path(path) if path == &vec!["Some".to_string()])
+                                                                    && matches!(args.first(), Some(RustExpr::Ident(name)) if name == "__sifr_map_item")
+                                                        )
+                                                )
+                                    )
+                            )
+                )
+        ));
     }
 
     #[test]

--- a/internal_docs/generated_code_quality.md
+++ b/internal_docs/generated_code_quality.md
@@ -150,3 +150,46 @@ Result:
   gates. The 29 fixtures that previously emitted boolean literal comparisons
   were rechecked after the optimizer cleanup and now pass with zero remaining
   `== true`, `== false`, `!= true`, or `!= false` occurrences.
+
+## NeetCode Group Audit Wave
+
+The NeetCode-oriented audit reviewed fixtures by README problem group, then
+reran the full demo and LeetCode emitted-code corpora. One generated Rust
+blocker was found in the Trees group and fixed in compiler codegen:
+
+- `map(treeToString, nodes)` now emits a closure that applies optional widening
+  and borrowing for typed callable arguments instead of a direct function
+  pointer call when the iterable element is `T` and the callable parameter is
+  `T | None`.
+- The fixed Trees fixture now emits
+  `.map(|__sifr_map_item| treeToString(&Some(__sifr_map_item)))`.
+
+Evidence:
+
+- Trees post-fix group rerun:
+  `target/neetcode_group_quality/trees-post-map-1778787311/report.jsonl`.
+- Final demos full scan:
+  `target/full_emitted_quality/demos-neetcode-final-1778787559/report.jsonl`.
+- Final LeetCode full scan:
+  `target/full_emitted_quality/leetcode-neetcode-final-1778788537/report.jsonl`.
+- Claude review artifacts:
+  `reviews/phase34-neetcode-group-01-arrays-hashing-review.md`,
+  `reviews/phase34-neetcode-group-02-two-pointers-review.md`,
+  `reviews/phase34-neetcode-groups-03-through-18-review.md`, and
+  `reviews/phase34-neetcode-trees-map-fix-review.md`.
+- Final closing review:
+  `reviews/phase34-neetcode-final-review.md`.
+
+Result:
+
+- Trees group: 32/32 mapped fixtures reach generated Rust and pass build,
+  forbidden scan, `cargo fmt`, `cargo fmt --check`, generated clippy, and
+  fixed-pattern regression scans.
+- Demos: 261 entries pass the emitted-code gate; 49 fail before emitted Rust
+  quality due to expected negative diagnostics or frontend/type/demo-contract
+  gaps.
+- LeetCode: 378 fixtures pass the emitted-code gate; 33 remain pre-emission
+  frontend/type/lowering failures.
+- Final fixed-pattern scans report zero boolean literal comparisons, zero
+  identity `map_or_else`, zero `while true`, zero `.skip(0)`, and zero
+  `println!("")`.

--- a/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
+++ b/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
@@ -335,3 +335,58 @@ Wave 3 result:
 
 - Demos: 261 entries reach generated Rust and pass build, forbidden scan, `cargo fmt`, `cargo fmt --check`, and generated clippy; 49 entries remain pre-emitted-code expected negative diagnostics or frontend/type/demo-contract failures.
 - LeetCode: 377 entries reach generated Rust and pass the same emitted-code gates; 34 entries remain pre-emitted-code frontend/type/lowering compatibility failures. The 29 fixtures that previously emitted boolean literal comparisons were rechecked and now have zero remaining boolean-literal comparison occurrences.
+
+### Audit Wave 4: NeetCode Group Review (2026-05-14)
+
+Fourth-round emitted-code review followed the NeetCode README problem groups one
+group at a time, then reran full demo and LeetCode emitted-code scans.
+
+Group-by-group review:
+
+- Arrays & Hashing and Two Pointers were reviewed individually with Claude.
+- Groups 3 through 18 were audited sequentially in NeetCode README order.
+- The JavaScript README group has no mapped Sifr fixtures and was recorded as
+  not applicable for emitted Rust quality.
+- The Trees group exposed one real generated Rust blocker in
+  `0894_all_possible_full_binary_trees.sifr`: `map(treeToString, nodes)`
+  emitted a direct `.map(treeToString)` even though `treeToString` accepts
+  `TreeNode | None` and lowers to `&Option<TreeNode>`.
+
+Compiler improvement:
+
+- Simple `map` lowering now adapts typed single-argument callables with an
+  explicit closure when the callable parameter requires optional widening or
+  borrowing. The Trees fixture now emits
+  `.map(|__sifr_map_item| treeToString(&Some(__sifr_map_item)))`.
+- Regression coverage was added for named callable map optional widening.
+
+Wave 4 evidence:
+
+- Arrays & Hashing review:
+  `reviews/phase34-neetcode-group-01-arrays-hashing-review.md`.
+- Two Pointers review:
+  `reviews/phase34-neetcode-group-02-two-pointers-review.md`.
+- Groups 3 through 18 review:
+  `reviews/phase34-neetcode-groups-03-through-18-review.md`.
+- Trees fix review:
+  `reviews/phase34-neetcode-trees-map-fix-review.md`.
+- Final closing review:
+  `reviews/phase34-neetcode-final-review.md`.
+- Trees post-fix group rerun:
+  `target/neetcode_group_quality/trees-post-map-1778787311/report.jsonl`.
+- Final demos full scan:
+  `target/full_emitted_quality/demos-neetcode-final-1778787559/report.jsonl`.
+- Final LeetCode full scan:
+  `target/full_emitted_quality/leetcode-neetcode-final-1778788537/report.jsonl`.
+
+Wave 4 result:
+
+- Trees group: 32 fixtures reach generated Rust and pass build, forbidden scan,
+  `cargo fmt`, `cargo fmt --check`, generated clippy, and fixed-pattern
+  regression scans.
+- Demos: 261 entries reach generated Rust and pass the full emitted-code gate;
+  49 entries remain pre-emission build/type/negative-demo failures.
+- LeetCode: 378 fixtures reach generated Rust and pass the full emitted-code
+  gate; 33 fixtures remain pre-emission frontend/type/lowering failures.
+- Final fixed-pattern scans are zero for boolean literal comparisons,
+  identity `map_or_else`, `while true`, `.skip(0)`, and `println!("")`.

--- a/reviews/phase34-neetcode-final-review.md
+++ b/reviews/phase34-neetcode-final-review.md
@@ -1,0 +1,61 @@
+# Phase 34 Final NeetCode Group Audit Review
+
+## Summary
+
+Group-by-group emitted-code review is complete. One compiler improvement was made to
+fix a Trees group blocker. The group-by-group review loop and final whole-corpus scans
+have been satisfied.
+
+---
+
+## 1. Findings
+
+### Correctness
+
+**No blockers.** The diff touches three focused areas:
+
+1. **`crates/sifr_codegen/src/lower_expr.rs` (+156 lines)**: Adds `lower_simple_map_callable_expr`, `simple_callable_param_info`, and `adapt_simple_map_callable_arg`. These adapt typed callables in `map` calls with an explicit closure when optional widening or borrowing is needed. The implementation is opt-in with early-return fallbacks to existing behavior for non-single-param callables, non-resolvable signatures, or when no adaptation is required.
+
+2. **`internal_docs/generated_code_quality.md` (+41 lines)**: Documents the NeetCode group audit wave and its evidence artifacts.
+
+3. **`internal_docs/phases/34_generated_code_quality_and_production_readiness.md` (+53 lines)**: Documents Wave 4 with per-group review artifacts and final corpus scan results.
+
+**Pre-existing clippy failures in `sifr_hir`**: 8 lint errors in `crates/sifr_hir/src/lower/mod.rs` were confirmed via `git stash` to exist on `HEAD` before this branch. They are unrelated to this diff and represent pre-existing debt in the HIR crate (large enum variants, `Option<Option<T>>`, excessive bools in struct, `Default::default()` style). They do not block this PR.
+
+### Regression
+
+**Low risk.** The map callable adaptation is gated by `simple_callable_param_info` returning type info — all other paths preserve existing behavior exactly. The new unit test `lowers_map_named_callable_with_optional_widening_closure` directly covers the Trees fixture case.
+
+### Generated-Code Quality
+
+**Clean.** Final corpus scans report zero occurrences of the five fixed patterns:
+- `bool_lit_cmp`: 0
+- `map_or_else_identity`: 0
+- `while_true`: 0
+- `skip_zero`: 0
+- `println_empty`: 0
+
+`cargo fmt` and `cargo fmt --check` pass.
+
+### Documentation
+
+**Complete.** Both the quality log and the phase doc are updated with Wave 4 evidence, review artifact paths, and numeric results per corpus.
+
+---
+
+## 2. Scope Satisfaction
+
+| Requested | Delivered |
+|-----------|-----------|
+| Review by NeetCode group, one at a time | Arrays & Hashing, Two Pointers reviewed individually; Groups 3–18 audited sequentially; Trees reviewed post-fix |
+| Consult Claude for reviews | 4 Claude review artifacts: `reviews/phase34-neetcode-group-01-arrays-hashing-review.md`, `phase34-neetcode-group-02-two-pointers-review.md`, `phase34-neetcode-groups-03-through-18-review.md`, `phase34-neetcode-trees-map-fix-review.md` |
+| Improve generated code quality group-by-group | Trees blocker fixed in `lower_expr.rs`; zero fixed-pattern regressions in all groups |
+| Finish with full scans of demos and LeetCode | Final demos: 261/310 pass; Final LeetCode: 378/411 pass; fixed patterns at zero across both |
+
+---
+
+## 3. Recommendation
+
+**Satisfactory — ready to proceed.** The requested group-by-group review loop and final whole-corpus scan are complete. One root-cause fix was identified and implemented. No additional implementation or review rounds are required.
+
+The 49 demo and 33 LeetCode failures are pre-emission type/HIR/lowering gaps (documented in prior review artifacts), not generated Rust quality issues. These should be triaged separately as part of future compiler type-system work.

--- a/reviews/phase34-neetcode-group-01-arrays-hashing-review.md
+++ b/reviews/phase34-neetcode-group-01-arrays-hashing-review.md
@@ -1,0 +1,82 @@
+# Phase 34 NeetCode Group Review — Group 1: Arrays & Hashing
+
+## Summary
+
+58 of 66 fixtures pass generated-code quality gates. 8 fail before Rust emission due to
+pre-emission type errors. No emitted Rust quality issues were found.
+
+---
+
+## Q1: Blocker or generated-code quality issue?
+
+**No.** All 58 passing fixtures clear the full gate sequence:
+- `cargo build` — compiles
+- Forbidden construct scan — clean (no `.unwrap()`, `.expect()`, `panic!`, `todo!`,
+  `unimplemented!`, `unsafe`, `#[allow(...)]`)
+- `cargo fmt` + `cargo fmt -- --check` — passes
+- Clippy with generated-code profile — passes
+
+The 8 build failures are pre-emission type errors, not emitted Rust quality issues.
+
+---
+
+## Q2: Is any pattern debt a safe, clearly scoped compiler improvement worth doing now?
+
+**No — hold as documented style debt for broader follow-up.**
+
+Pattern debt in this group:
+
+| Pattern              | Count | Clippy currently |
+|----------------------|------:|-------------------|
+| `unnecessary_cast`   |   400 | `-A clippy::unnecessary_cast` (allowed) |
+| `to_string_literal`  |   284 | `-A clippy::to_string_in_format_args`, `-A clippy::useless_conversion` (allowed) |
+| `double_parens`      |   148 | `-A clippy::double_parens` (allowed) |
+| `clone`              |    67 | `-A clippy::clone_on_copy` (allowed) |
+| `needless_return`    |    59 | `-A clippy::needless_return` (allowed) |
+| `return_unit`        |     2 | `-A clippy::unused_unit` (allowed) |
+
+All are intentionally allowed by the generated-code clippy profile in
+`verification/generated_code_quality/generated_code_quality.py`. The profile's purpose is to
+verify the compiler produces *syntactically valid, panic-free, formattable* Rust — not to
+enforce style polish.
+
+Fixing any of these individually (e.g., suppressing `as_i64` when the target type is already
+`i64`) requires cross-cutting codegen changes with non-obvious scope. They belong in a
+coordinated style-debt pass after the compiler matures past type-system gaps, not in a
+NeetCode group review.
+
+---
+
+## Q3: Are the 8 failures correctly classified as pre-emission issues?
+
+**Yes — all 8 are pre-emission type/lowering errors, not generated Rust quality issues.**
+
+| Fixture | Error summary | Root cause |
+|---------|---------------|------------|
+| `0049_group_anagrams` | `Any + int` | Dict indexing returns `Any`; `+` not defined on `Any` |
+| `0068_text_justification` | `Result[int, DivisionError]` arithmetic, `Never` type ops | Division operator produces `Result[int, DivisionError]` which can't be used in arithmetic or comparison |
+| `0118_pascals_triangle` | Index `Any \| None` with `int` | `_nz_int` helper extracts value but type narrowing doesn't propagate to indexed type |
+| `0523_continuous_subarray_sum` | `%` on `Result[int, DivisionError]`; hashmap key type mismatch | Same `Result[int, DivisionError]` from `%` operator |
+| `1189_maximum_number_of_balloons` | `min(int, Result[int, DivisionError])` | `//` operator returns `Result[int, DivisionError]` |
+| `1396_design_underground_system` | Exact int-to-float conversion contract | `total / count` where `total` is `int`, division produces `float` with overflow/precision-loss contract |
+| `1461_check_if_a_string_contains_all_binary_codes_of_size_k` | Integer division/modulo/exponentiation | `2**k` triggers the same integer arithmetic safety check |
+| `2348_number_of_zero_filled_subarrays` | Exact int-to-float conversion contract | `len() * (len() - 1) / 2` involves int-to-float promotion |
+
+**Thematic classification:**
+- 4 failures: `Result[int, DivisionError]` propagating from `/` or `%` operators into subsequent
+  operations that don't handle the error branch (`+`, comparison, `min`, `in`).
+- 2 failures: Exact integer to float conversion contract (division producing float without
+  explicit error handling).
+- 1 failure: Dict indexing returning `Any` type.
+- 1 failure: `2**k` exponentiation triggering integer safety check.
+
+These are HIR/frontend type system gaps (Result propagation, Any type narrowing, integer
+literal handling, int-to-float conversion contracts). Not codegen quality issues.
+
+---
+
+## Recommendation
+
+**Clear to proceed to Group 2 (Two Pointers).** The 8 failures are pre-emission type errors
+that should be tracked and triaged separately from generated-code quality. All 58 passing
+fixtures produce clean Rust by every metric in the gate sequence.

--- a/reviews/phase34-neetcode-group-02-two-pointers-review.md
+++ b/reviews/phase34-neetcode-group-02-two-pointers-review.md
@@ -1,0 +1,26 @@
+
+
+## Group 2 Review: Two Pointers
+
+### Q1: Blocker or generated-code quality issue?
+
+**No.** 17 of 19 fixtures pass the full gate sequence (build, forbidden construct scan, fmt, clippy). The 2 failures are pre-emission type errors. No emitted Rust quality issues.
+
+### Q2: Is any pattern debt worth fixing now?
+
+**No — hold as broader style debt.** Same patterns as Group 1, comparable counts (146 unnecessary_cast, 42 to_string_literal, etc.). All are intentionally allowed in the generated-code clippy profile. These require cross-cutting codegen changes and belong in a coordinated style-debt pass after the compiler matures.
+
+### Q3: Are the 2 failures correctly classified as pre-emission issues?
+
+**Yes.**
+
+| Fixture | Root Cause |
+|---------|------------|
+| `0189_rotate_array` | `len(nums) % rot` in the `while rot > 0` guard produces `Result[int, DivisionError]`; comparison with `>` fails because `Result` doesn't implement `PartialOrd` with `int`. Line 7: `while rot > 0` — `rot` is `Result[int, DivisionError]` after `k % len(nums)`. |
+| `1498_number_of_subsequences...` | `res % mod` on line 20 produces `Result[int, DivisionError]` but return type is `int`. Same `Result[int, DivisionError]` propagation theme as Group 1. |
+
+Both are HIR-level type system gaps (integer division/modulo returning `Result` that doesn't propagate through subsequent operations). Not codegen quality issues.
+
+---
+
+**Recommendation: Clear to proceed to the next group.** File the 2 failures under the same HIR/frontend tracking bucket as Group 1's `Result[int, DivisionError]` theme (already tracked in Group 1's review).

--- a/reviews/phase34-neetcode-groups-03-through-18-review.md
+++ b/reviews/phase34-neetcode-groups-03-through-18-review.md
@@ -1,0 +1,36 @@
+
+
+No forbidden construct violations or clippy failures across any group.
+
+## Findings
+
+### Q1: Any generated-code quality blocker before the final scan?
+
+**No.** The 18 build failures are all pre-emission type errors. The 330 passing fixtures across groups 3-18 each cleared the full per-fixture gate sequence:
+- `cargo build` — compiles cleanly
+- Forbidden construct scan — zero violations (no `.unwrap()`, `.expect()`, `panic!`, `todo!`, `unimplemented!`, `unsafe`, `#[allow(...)]`)
+- `cargo fmt` + `cargo fmt -- --check` — passes
+- Clippy with generated-code profile — passes
+
+Zero regressions of the five targeted fixed patterns (`== true`/`== false`, `map_or_else(..., |x| x)`, `while true`, `.skip(0)`, `println!("")`).
+
+### Q2: Are the 18 build_failed counts properly classified as pre-emission issues?
+
+**Yes.** All 18 are HIR/frontend type errors with no generated Rust to scan:
+
+| Theme | Count | Example |
+|-------|------:|---------|
+| `Result[int, DivisionError]` propagating into ops that don't handle `Result` (comparison, `min`, arithmetic, `in`, dict indexing, assignment) | 12 | `cannot compare 'Result[int, DivisionError]' and 'int' with !=` |
+| Exact integer-to-float conversion contract | 4 | `exact integer to float conversion requires handling possible overflow or precision loss` |
+| `Any \| None` type narrowing (dict `.get()` returning `Any`) | 2 | `cannot index type 'Any \| None' with 'int'` |
+| Rust codegen type mismatch (post-emission) | 1 | `0084_all_possible_full_binary_trees` — function signature mismatch in `.map()` |
+
+The `all_possible_full_binary_trees` failure is the one post-emission Rust error — a function signature mismatch in generated code. It's a codegen issue but a narrow, isolated one (not a forbidden construct). All others are pre-emission HIR gaps.
+
+### Q3: Is it acceptable to proceed to the final whole-repo demo + LeetCode emitted-code scans?
+
+**Yes.** Groups 1-18 (all 16 NeetCode groups) are now audited sequentially. Every passing fixture across all groups produced clean Rust by every gate. The 26 total build failures (8 + 2 + 18) are all pre-emission type system gaps dominated by two themes (`Result[int, DivisionError]` propagation, int-to-float conversion contracts) that belong in a coordinated HIR follow-up pass.
+
+---
+
+**Recommendation: Proceed to the final full scan.**

--- a/reviews/phase34-neetcode-trees-map-fix-review.md
+++ b/reviews/phase34-neetcode-trees-map-fix-review.md
@@ -1,0 +1,57 @@
+Looking at the fix for the Trees group blocker.
+
+## Findings
+
+### 1. Correctness of Root-Cause Fix
+
+**Yes, this is correct.** The fix addresses the exact mismatch:
+
+- `nodes: List<TreeNode>` iterates to `TreeNode` items
+- `treeToString` expects `&Option<TreeNode>` (the `T | None` union)
+- Without fix: direct call `treeToString(item)` — type error
+- With fix: closure `|__sifr_map_item| treeToString(&Some(__sifr_map_item))` — correct
+
+The adaptation chain is sound:
+1. `Some` wrapping when param is `T | None` but arg is `T`
+2. Shared borrow `&` added per `ParamConvention::borrow()` and non-Copy param
+3. Result: `&Some(__sifr_map_item)` matching the expected `&Option<TreeNode>`
+
+### 2. Regression Risks
+
+**Low risk.** The fix is opt-in via early returns:
+
+```rust
+fn lower_simple_map_callable_expr(callable: &HirExpr, iter: &HirExpr) -> Option<RustExpr> {
+    let lowered_callable = try_lower_simple_callable_expr(callable)?;
+    let Some((param_types, conventions)) = simple_callable_param_info(callable) else {
+        return Some(lowered_callable);  // ← existing behavior preserved
+    };
+    if param_types.len() != 1 || conventions.len() != 1 {
+        return Some(lowered_callable);  // ← existing behavior preserved
+    }
+    // ... adaptation logic only reached for single-param callables with known sig
+}
+```
+
+Existing paths are preserved for:
+- Non-closure callables
+- Multi-arg callables
+- Callables without resolvable param info
+- Any case where adaptation isn't needed
+
+**Minor observation**: `is_option_like_simple` and `resolve_alias_type` are used in `adapt_simple_map_callable_arg`. If `resolve_alias_type(param_ty)` returns a type that doesn't unwrap cleanly, the `Some` wrapping won't trigger — but this would only happen for malformed types, and the fallback path would emit the old (incorrect) code. Given the test coverage and Trees group passing, this case isn't occurring.
+
+### 3. Test Coverage
+
+The unit test is focused and correctly asserts the closure structure with `Some` wrapping and shared borrow. The pattern matched is exactly the emitted code shown in verification:
+```rust
+map(|__sifr_map_item| treeToString(&Some(__sifr_map_item)))
+```
+
+No additional test rounds needed for this fix.
+
+---
+
+## Recommendation
+
+**This fix is satisfactory to proceed.** The implementation is correct, the fix is narrow and safe, and it has passed all verification gates (unit test, build, Trees group full pass).


### PR DESCRIPTION
## Summary
- Reviewed emitted code by NeetCode problem group with Claude review artifacts committed under `reviews/`.
- Fixed the Trees group generated Rust blocker for `map(treeToString, nodes)` by adapting typed single-argument map callables with optional widening and borrowing.
- Documented Wave 4 evidence in the Phase 34 and generated-code quality docs.

## Key Fix
`map(treeToString, nodes)` now emits a closure equivalent to:

```rust
.map(|__sifr_map_item| treeToString(&Some(__sifr_map_item)))
```

instead of passing the function pointer directly when the iterable element is `T` and the callable parameter is `T | None`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sifr_codegen lowers_map`
- `cargo run -q -p sifr -- build audits/leetcode/src/0894_all_possible_full_binary_trees.sifr -o target/phase34-neetcode-fixes/0894_all_possible_full_binary_trees`
- Trees post-fix group rerun: 32 passed, zero fixed-pattern regressions
- Final demos scan: 261 passed emitted-code gates, 49 pre-emission failures, zero fixed-pattern regressions
- Final LeetCode scan: 378 passed emitted-code gates, 33 pre-emission failures, zero fixed-pattern regressions
- `scripts/run_all_tests.sh --profile quick` passed with exit code 0; it reported a warm wall-time advisory but no test failure

## Review
Claude review artifacts:
- `reviews/phase34-neetcode-group-01-arrays-hashing-review.md`
- `reviews/phase34-neetcode-group-02-two-pointers-review.md`
- `reviews/phase34-neetcode-groups-03-through-18-review.md`
- `reviews/phase34-neetcode-trees-map-fix-review.md`
- `reviews/phase34-neetcode-final-review.md`
