### PR TITLE
Honor proven exact int true division

### DIFF
--- a/crates/sifr/tests/e2e/fail/exact_int_true_division_requires_handling.sifr
+++ b/crates/sifr/tests/e2e/fail/exact_int_true_division_requires_handling.sifr
@@ -1,6 +1,4 @@
 # expect-error: SIFR-INT-0006
 
-def main() -> None:
-    numerator: int = 10
-    denominator: int = 3
+def main(numerator: int, denominator: int) -> None:
     value: float = numerator / denominator

--- a/crates/sifr_hir/src/lower/aug_assign_lowering.rs
+++ b/crates/sifr_hir/src/lower/aug_assign_lowering.rs
@@ -308,6 +308,7 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
     let value = lower_expr(&aug.value, ctx)?;
     ctx.clear_sequence_pointer(&name);
     ctx.clear_len_alias(&name);
+    ctx.scope.clear_const_integer_value(&name);
     ctx.clear_proven_nonzero_integer_binding(&name);
 
     let op_str = op_to_augassign_string(aug.op, ctx, aug.target.range())?;

--- a/crates/sifr_hir/src/lower/expression_operators.rs
+++ b/crates/sifr_hir/src/lower/expression_operators.rs
@@ -9,6 +9,7 @@ use super::numeric_sentinels::{
 };
 use super::LowerCtx;
 use crate::hir_nodes::HirExpr;
+use num_bigint::BigInt;
 use ruff_text_size::Ranged;
 use sifr_python_ast::{CmpOp, ExprBinOp, ExprCompare, ExprUnaryOp, Operator, UnaryOp};
 use sifr_type_system::{type_check_binary_op, type_check_comparison, type_check_unary_op, Type};
@@ -64,6 +65,14 @@ pub(super) fn lower_binop(binop: &ExprBinOp, ctx: &mut LowerCtx) -> Option<HirEx
         return None;
     }
     if let Some(result_ty) = exact_int_floor_result_type(&left, op_str, &right, ctx) {
+        return Some(HirExpr::BinOp {
+            left: Box::new(left),
+            op: op_str.to_string(),
+            right: Box::new(right),
+            ty: result_ty,
+        });
+    }
+    if let Some(result_ty) = exact_int_true_division_result_type(&left, op_str, &right, ctx) {
         return Some(HirExpr::BinOp {
             left: Box::new(left),
             op: op_str.to_string(),
@@ -140,8 +149,52 @@ fn division_error_type(ctx: &LowerCtx) -> Type {
         })
 }
 
+fn exact_int_true_division_result_type(
+    left: &HirExpr,
+    op: &str,
+    right: &HirExpr,
+    ctx: &LowerCtx,
+) -> Option<Type> {
+    if ctx.is_stdlib_lowering() || op != "/" {
+        return None;
+    }
+    if !is_exact_int_like(left.ty()) || !is_exact_int_like(right.ty()) {
+        return None;
+    }
+    let left_value = proven_exact_integer_value(left, ctx)?;
+    let right_value = proven_exact_integer_value(right, ctx)?;
+    if right_value == BigInt::from(0) {
+        return None;
+    }
+    (is_exactly_representable_as_float(&left_value)
+        && is_exactly_representable_as_float(&right_value))
+    .then_some(Type::Float)
+}
+
 fn is_exact_int_like(ty: &Type) -> bool {
     matches!(ty, Type::Int | Type::LiteralInt(_))
+}
+
+fn proven_exact_integer_value(expr: &HirExpr, ctx: &LowerCtx) -> Option<BigInt> {
+    match expr {
+        HirExpr::IntLiteral(value) => Some(BigInt::from(*value)),
+        HirExpr::LargeIntLiteral(value) => value.parse::<BigInt>().ok(),
+        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
+            proven_exact_integer_value(operand, ctx).map(|value| -value)
+        }
+        HirExpr::Name { name, .. } => ctx
+            .scope
+            .const_integer_value(name)
+            .or_else(|| ctx.const_integer_values.get(name))
+            .cloned(),
+        _ => None,
+    }
+}
+
+fn is_exactly_representable_as_float(value: &BigInt) -> bool {
+    let max_exact = BigInt::from(9_007_199_254_740_992_i64);
+    let min_exact = -max_exact.clone();
+    value >= &min_exact && value <= &max_exact
 }
 
 fn is_proven_nonzero_integer_expr(expr: &HirExpr, ctx: &LowerCtx) -> bool {

--- a/crates/sifr_hir/src/lower/expressions_tests.rs
+++ b/crates/sifr_hir/src/lower/expressions_tests.rs
@@ -65,6 +65,48 @@ fn function_let_value<'a>(module: &'a HirModule, name: &str) -> &'a HirExpr {
         .expect("expected local binding")
 }
 
+fn let_value_in_stmts<'a>(stmts: &'a [HirStmt], name: &str) -> Option<&'a HirExpr> {
+    for stmt in stmts {
+        match stmt {
+            HirStmt::Let {
+                name: local_name,
+                value,
+                ..
+            } if local_name == name => return Some(value),
+            HirStmt::If {
+                then_body,
+                elif_clauses,
+                else_body,
+                ..
+            } => {
+                if let Some(value) = let_value_in_stmts(then_body, name) {
+                    return Some(value);
+                }
+                for (_, body) in elif_clauses {
+                    if let Some(value) = let_value_in_stmts(body, name) {
+                        return Some(value);
+                    }
+                }
+                if let Some(else_body) = else_body {
+                    if let Some(value) = let_value_in_stmts(else_body, name) {
+                        return Some(value);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn function_nested_let_value<'a>(module: &'a HirModule, name: &str) -> &'a HirExpr {
+    module
+        .functions
+        .iter()
+        .find_map(|function| let_value_in_stmts(&function.body, name))
+        .expect("expected nested local binding")
+}
+
 #[test]
 fn test_simple_function() {
     let module = lower_source("def add(a: int, b: int) -> int:\n    return a + b\n").unwrap();
@@ -384,9 +426,7 @@ def main() -> None:
 #[test]
 fn test_exact_int_true_division_has_int0006() {
     let source = "\
-def main() -> None:
-    numerator: int = 10
-    denominator: int = 3
+def main(numerator: int, denominator: int) -> None:
     value: float = numerator / denominator
 ";
     let errors = lower_source(source).expect_err("exact-int true division should fail closed");
@@ -397,6 +437,119 @@ def main() -> None:
                 == "exact integer to float conversion requires handling possible overflow or precision loss"
             && error.primary_range == Some(range_for(source, "numerator / denominator"))
     }));
+}
+
+#[test]
+fn test_proven_safe_exact_int_true_division_lowers_as_float() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    numerator: int = 10
+    denominator: int = 3
+    value: float = numerator / denominator
+",
+    )
+    .expect("small exact-int constants should prove safe for true division");
+
+    assert!(matches!(
+        function_let_value(&module, "value"),
+        HirExpr::BinOp {
+            ty: Type::Float,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_large_exact_int_true_division_still_requires_handling() {
+    let source = "\
+def main() -> None:
+    numerator: int = 9007199254740993
+    denominator: int = 3
+    value: float = numerator / denominator
+";
+    let errors = lower_source(source).expect_err("precision-losing exact-int division should fail");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_EXACT_TO_FLOAT_REQUIRES_HANDLING)
+            && error.primary_range == Some(range_for(source, "numerator / denominator"))
+    }));
+}
+
+#[test]
+fn test_exact_int_true_division_branch_reassignment_does_not_leak_const_proof() {
+    let source = "\
+def main(flag: bool) -> None:
+    numerator: int = 10
+    denominator: int = 3
+    if flag:
+        numerator = 9007199254740993
+    value: float = numerator / denominator
+";
+    let errors = lower_source(source).expect_err("branch-dependent int should fail closed");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_EXACT_TO_FLOAT_REQUIRES_HANDLING)
+            && error.primary_range == Some(range_for(source, "numerator / denominator"))
+    }));
+}
+
+#[test]
+fn test_exact_int_true_division_augassign_reassignment_does_not_leak_const_proof() {
+    let source = "\
+def main(delta: int) -> None:
+    numerator: int = 10
+    denominator: int = 3
+    numerator += delta
+    value: float = numerator / denominator
+";
+    let errors = lower_source(source).expect_err("augassigned int should fail closed");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_EXACT_TO_FLOAT_REQUIRES_HANDLING)
+            && error.primary_range == Some(range_for(source, "numerator / denominator"))
+    }));
+}
+
+#[test]
+fn test_exact_int_true_division_loop_reassignment_does_not_leak_const_proof() {
+    let source = "\
+def main(items: list[int]) -> None:
+    numerator: int = 10
+    denominator: int = 3
+    for item in items:
+        numerator = item
+    value: float = numerator / denominator
+";
+    let errors = lower_source(source).expect_err("loop-dependent int should fail closed");
+
+    assert!(errors.iter().any(|error| {
+        error.code == Some(DiagnosticCode::INT_EXACT_TO_FLOAT_REQUIRES_HANDLING)
+            && error.primary_range == Some(range_for(source, "numerator / denominator"))
+    }));
+}
+
+#[test]
+fn test_exact_int_true_division_optional_narrowed_consts_lower_as_float() {
+    let module = lower_source(
+        "\
+def main() -> None:
+    total: int | None = 9
+    count: int | None = 3
+    if total is not None:
+        if count is not None:
+            value: float = total / count
+",
+    )
+    .expect("narrowed optional exact-int constants should prove safe for true division");
+
+    assert!(matches!(
+        function_nested_let_value(&module, "value"),
+        HirExpr::BinOp {
+            ty: Type::Float,
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/sifr_hir/src/lower/integer_const_facts.rs
+++ b/crates/sifr_hir/src/lower/integer_const_facts.rs
@@ -1,0 +1,50 @@
+use crate::hir_nodes::HirExpr;
+use crate::scope::ConstIntegerSnapshot;
+use num_bigint::BigInt;
+
+use super::LowerCtx;
+
+fn const_integer_value_for_binding(value: &HirExpr) -> Option<BigInt> {
+    match value {
+        HirExpr::IntLiteral(value) => Some(BigInt::from(*value)),
+        HirExpr::LargeIntLiteral(value) => value.parse::<BigInt>().ok(),
+        HirExpr::UnaryOp { op, operand, .. } if op == "-" => {
+            const_integer_value_for_binding(operand).map(|value| -value)
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn record_const_integer_binding(ctx: &mut LowerCtx, name: &str, value: &HirExpr) {
+    if let Some(const_value) = const_integer_value_for_binding(value) {
+        ctx.scope.set_const_integer_value(name, const_value);
+    } else {
+        ctx.scope.clear_const_integer_value(name);
+    }
+}
+
+fn snapshot_const_value<'a>(
+    snapshot: &'a ConstIntegerSnapshot,
+    name: &str,
+) -> Option<&'a Option<BigInt>> {
+    snapshot
+        .iter()
+        .find_map(|(snapshot_name, value)| (snapshot_name == name).then_some(value))
+}
+
+pub(super) fn restore_const_integer_state_after_branches(
+    ctx: &mut LowerCtx,
+    saved: &ConstIntegerSnapshot,
+    branch_states: &[(ConstIntegerSnapshot, bool)],
+) {
+    ctx.scope.restore_const_integer_state(saved);
+    for (name, saved_value) in saved {
+        let changed_by_live_branch = branch_states
+            .iter()
+            .filter(|(_, branch_exits)| !*branch_exits)
+            .any(|(branch_state, _)| snapshot_const_value(branch_state, name) != Some(saved_value));
+        if changed_by_live_branch {
+            ctx.scope.clear_const_integer_value(name);
+        }
+    }
+}

--- a/crates/sifr_hir/src/lower/mod.rs
+++ b/crates/sifr_hir/src/lower/mod.rs
@@ -1,4 +1,3 @@
-//! AST to HIR lowering with type checking and name resolution.
 use crate::hir_nodes::{HirExpr, HirImport, HirModule};
 use crate::scope::{ErrorTaint, Scope};
 use sifr_python_ast::{Expr, Stmt};
@@ -63,6 +62,7 @@ mod if_expression;
 mod import_diagnostics;
 mod imported_defaults;
 mod imports;
+mod integer_const_facts;
 mod integer_failure_diagnostics;
 mod integer_literal_diagnostics;
 mod integer_literals;
@@ -95,6 +95,7 @@ mod protocol_diagnostics;
 mod result_diagnostics;
 #[cfg(test)]
 mod result_diagnostics_tests;
+mod return_lowering;
 mod scope_helpers;
 mod sequence_guard_detection;
 mod sequence_guard_updates;

--- a/crates/sifr_hir/src/lower/return_lowering.rs
+++ b/crates/sifr_hir/src/lower/return_lowering.rs
@@ -1,0 +1,121 @@
+use ruff_text_size::Ranged;
+use sifr_diagnostics::DiagnosticCode;
+use sifr_python_ast::StmtReturn;
+use sifr_type_system::{FunctionType, OwnershipKind, Type};
+
+use crate::hir_nodes::{HirExpr, HirStmt};
+
+use super::expressions::lower_expr;
+use super::ownership_diagnostics;
+use super::task_scope_calls::is_lock_guard_type;
+use super::LowerCtx;
+
+pub(super) fn lower_return(
+    ret: &StmtReturn,
+    func_type: &FunctionType,
+    ctx: &mut LowerCtx,
+) -> HirStmt {
+    if ctx.current_function_is_async_generator {
+        if let Some(val) = &ret.value {
+            let Some(expr) = lower_expr(val, ctx) else {
+                return HirStmt::Return {
+                    value: Some(HirExpr::NoneLiteral),
+                };
+            };
+            let expr_ty = expr.ty().clone();
+            if matches!(expr_ty.resolve_alias(), Type::None) {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    "return with a value inside async generator bodies requires async generator state-machine lowering and is not supported yet"
+                        .to_string(),
+                    val.range(),
+                );
+            } else {
+                ctx.error_with_code_at(
+                    DiagnosticCode::TYPE_MISMATCH,
+                    "non-None async generator return values are rejected in v1; async generators expose yielded items through AsyncGenerator[T, E]"
+                        .to_string(),
+                    val.range(),
+                );
+            }
+            return HirStmt::Return { value: Some(expr) };
+        }
+
+        ctx.error_with_code_at(
+            DiagnosticCode::TYPE_MISMATCH,
+            "return inside async generator bodies requires async generator state-machine lowering and is not supported yet"
+                .to_string(),
+            ret.range(),
+        );
+        return HirStmt::Return { value: None };
+    }
+
+    let value = if let Some(val) = &ret.value {
+        let Some(expr) = lower_expr(val, ctx) else {
+            // Keep control-flow shape intact after expression diagnostics so
+            // return-completeness analysis does not emit a cascade error.
+            return HirStmt::Return {
+                value: Some(HirExpr::NoneLiteral),
+            };
+        };
+        let expr_ty = expr.ty().clone();
+
+        if let HirExpr::Name { name, ty } = &expr {
+            if ctx.borrowed_params.contains(name.as_str()) && ty.ownership() == OwnershipKind::Move
+            {
+                ownership_diagnostics::borrowed_parameter_return_escape(ctx, name, val.range());
+            }
+        }
+        if !ctx.allow_intrinsic_imports && is_lock_guard_type(&expr_ty) {
+            ownership_diagnostics::lock_guard_return_escape(ctx, val.range());
+        }
+
+        if let Type::Result(ref ok_ty, _) = *func_type.return_type {
+            if expr_ty.is_assignable_to(ok_ty) && !matches!(expr_ty, Type::Result(_, _)) {
+                return HirStmt::Return {
+                    value: Some(HirExpr::OkWrap {
+                        ty: func_type.return_type.as_ref().clone(),
+                        value: Box::new(expr),
+                    }),
+                };
+            }
+        }
+
+        if !expr_ty.is_assignable_to(&func_type.return_type) {
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                format!(
+                    "return type mismatch: expected '{}', got '{}'",
+                    func_type.return_type.display_name(),
+                    expr_ty.display_name()
+                ),
+                val.range(),
+            );
+        }
+        Some(expr)
+    } else {
+        if *func_type.return_type != Type::None {
+            if let Type::Result(ref ok_ty, _) = *func_type.return_type {
+                if **ok_ty == Type::None {
+                    return HirStmt::Return {
+                        value: Some(HirExpr::OkWrap {
+                            ty: func_type.return_type.as_ref().clone(),
+                            value: Box::new(HirExpr::NoneLiteral),
+                        }),
+                    };
+                }
+            }
+            ctx.error_with_code_at(
+                DiagnosticCode::TYPE_MISMATCH,
+                format!(
+                    "type mismatch: expected '{}', got 'None'",
+                    func_type.return_type.display_name()
+                ),
+                ret.range(),
+            );
+        }
+        None
+    };
+
+    HirStmt::Return { value }
+}

--- a/crates/sifr_hir/src/lower/statements.rs
+++ b/crates/sifr_hir/src/lower/statements.rs
@@ -22,6 +22,9 @@ use super::function_flow::infer_function_return_type;
 use super::if_branch_bindings::{
     predeclare_exhaustive_if_assigned_names, seed_exhaustive_if_bindings,
 };
+use super::integer_const_facts::{
+    record_const_integer_binding, restore_const_integer_state_after_branches,
+};
 use super::integer_nonzero_guards::{
     detect_false_nonzero_integer_guards, detect_true_nonzero_integer_guards,
 };
@@ -39,6 +42,7 @@ use super::numeric_sentinels::{
 };
 use super::ownership_diagnostics;
 use super::protocol_diagnostics;
+use super::return_lowering::lower_return;
 use super::sequence_guard_detection::{
     detect_false_exit_sequence_guards, detect_range_sequence_guards, detect_true_sequence_guards,
     detect_while_sequence_guards,
@@ -49,7 +53,7 @@ use super::sequence_guard_updates::{
 use super::sequence_pointers::record_sequence_pointer_fact;
 use super::sequence_shapes::sequence_shape_fact;
 use super::statement_diagnostics;
-use super::task_scope_calls::{is_lock_guard_type, task_group_spawn_owner};
+use super::task_scope_calls::task_group_spawn_owner;
 use super::typing_and_functions::{
     ast_convention_to_param, register_local_function_signature, register_local_function_symbol,
     resolve_annotation_expr,
@@ -63,9 +67,9 @@ use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{
     ExceptHandler, Expr, Pattern, Singleton, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
-    StmtFor, StmtIf, StmtReturn, StmtWhile,
+    StmtFor, StmtIf, StmtWhile,
 };
-use sifr_type_system::{make_union, FunctionType, NarrowingCondition, OwnershipKind, Type};
+use sifr_type_system::{make_union, FunctionType, NarrowingCondition, Type};
 
 fn empty_collection_literal_kind(expr: &Expr) -> Option<&'static str> {
     match expr {
@@ -1031,6 +1035,7 @@ fn failed_initializer_taint(
 
 fn invalidate_rebound_binding_facts(ctx: &mut LowerCtx, name: &str) {
     ctx.scope.clear_narrowing(name);
+    ctx.scope.clear_const_integer_value(name);
     ctx.clear_sequence_guards_for_binding(name);
     ctx.clear_proven_nonzero_integer_binding(name);
 }
@@ -1164,6 +1169,11 @@ pub(super) fn lower_ann_assign(ann: &StmtAnnAssign, ctx: &mut LowerCtx) -> Optio
     ctx.pending_container_specialization_patches.remove(&name);
     ctx.scope
         .define_explicit_local(name.clone(), declared_type.clone());
+    if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
+        && value.ty().is_assignable_to(&declared_type)
+    {
+        record_const_integer_binding(ctx, &name, &value);
+    }
     if let Some(kind) = ann
         .value
         .as_ref()
@@ -1608,6 +1618,11 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
         ctx.task_handle_group_owners.remove(&name);
         record_async_generator_advance_binding(ctx, &name, &value);
         invalidate_rebound_binding_facts(ctx, &name);
+        if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
+            && value.ty().is_assignable_to(&info_ty)
+        {
+            record_const_integer_binding(ctx, &name, &value);
+        }
         if ctx.numeric_sentinel_fact(&name).is_some() {
             if let Some(domain) = numeric_domain_for_type(&value_ty) {
                 ctx.resolve_numeric_sentinel_domain(&name, domain);
@@ -1634,6 +1649,11 @@ pub(super) fn lower_assign(assign: &StmtAssign, ctx: &mut LowerCtx) -> Option<Hi
             .cloned()
             .unwrap_or_else(|| value_ty.clone());
         ctx.scope.define(name.clone(), binding_ty.clone());
+        if matches!(value.ty(), Type::Int | Type::LiteralInt(_))
+            && value.ty().is_assignable_to(&binding_ty)
+        {
+            record_const_integer_binding(ctx, &name, &value);
+        }
         record_async_generator_advance_binding(ctx, &name, &value);
         if let Some(group_name) = task_group_spawn_owner(&value) {
             ctx.task_handle_group_owners
@@ -1666,122 +1686,6 @@ pub(super) fn lower_aug_assign(aug: &StmtAugAssign, ctx: &mut LowerCtx) -> Optio
     lower_aug_assign_impl(aug, ctx)
 }
 
-pub(super) fn lower_return(
-    ret: &StmtReturn,
-    func_type: &FunctionType,
-    ctx: &mut LowerCtx,
-) -> HirStmt {
-    if ctx.current_function_is_async_generator {
-        if let Some(val) = &ret.value {
-            let Some(expr) = lower_expr(val, ctx) else {
-                return HirStmt::Return {
-                    value: Some(HirExpr::NoneLiteral),
-                };
-            };
-            let expr_ty = expr.ty().clone();
-            if matches!(expr_ty.resolve_alias(), Type::None) {
-                ctx.error_with_code_at(
-                    DiagnosticCode::TYPE_MISMATCH,
-                    "return with a value inside async generator bodies requires async generator state-machine lowering and is not supported yet"
-                        .to_string(),
-                    val.range(),
-                );
-            } else {
-                ctx.error_with_code_at(
-                    DiagnosticCode::TYPE_MISMATCH,
-                    "non-None async generator return values are rejected in v1; async generators expose yielded items through AsyncGenerator[T, E]"
-                        .to_string(),
-                    val.range(),
-                );
-            }
-            return HirStmt::Return { value: Some(expr) };
-        }
-
-        ctx.error_with_code_at(
-            DiagnosticCode::TYPE_MISMATCH,
-            "return inside async generator bodies requires async generator state-machine lowering and is not supported yet"
-                .to_string(),
-            ret.range(),
-        );
-        return HirStmt::Return { value: None };
-    }
-
-    let value = if let Some(val) = &ret.value {
-        let Some(expr) = lower_expr(val, ctx) else {
-            // Keep control-flow shape intact after expression diagnostics so
-            // return-completeness analysis does not emit a cascade error.
-            return HirStmt::Return {
-                value: Some(HirExpr::NoneLiteral),
-            };
-        };
-        let expr_ty = expr.ty().clone();
-
-        // Escape analysis: returning a borrowed parameter is a compile error.
-        // The programmer must add `own` at the signature boundary, or call `.clone()` explicitly.
-        if let HirExpr::Name { name, ty } = &expr {
-            if ctx.borrowed_params.contains(name.as_str()) && ty.ownership() == OwnershipKind::Move
-            {
-                let range = val.range();
-                ownership_diagnostics::borrowed_parameter_return_escape(ctx, name, range);
-            }
-        }
-        if !ctx.allow_intrinsic_imports && is_lock_guard_type(&expr_ty) {
-            ownership_diagnostics::lock_guard_return_escape(ctx, val.range());
-        }
-
-        // If the function returns Result[T, E] and the value is T (not Result), wrap in Ok()
-        if let Type::Result(ref ok_ty, _) = *func_type.return_type {
-            if expr_ty.is_assignable_to(ok_ty) && !matches!(expr_ty, Type::Result(_, _)) {
-                // Wrap in Ok()
-                return HirStmt::Return {
-                    value: Some(HirExpr::OkWrap {
-                        ty: func_type.return_type.as_ref().clone(),
-                        value: Box::new(expr),
-                    }),
-                };
-            }
-        }
-
-        if !expr_ty.is_assignable_to(&func_type.return_type) {
-            ctx.error_with_code_at(
-                DiagnosticCode::TYPE_MISMATCH,
-                format!(
-                    "return type mismatch: expected '{}', got '{}'",
-                    func_type.return_type.display_name(),
-                    expr_ty.display_name()
-                ),
-                val.range(),
-            );
-        }
-        Some(expr)
-    } else {
-        if *func_type.return_type != Type::None {
-            // If function returns Result[(), E], wrap in Ok(())
-            if let Type::Result(ref ok_ty, _) = *func_type.return_type {
-                if **ok_ty == Type::None {
-                    return HirStmt::Return {
-                        value: Some(HirExpr::OkWrap {
-                            ty: func_type.return_type.as_ref().clone(),
-                            value: Box::new(HirExpr::NoneLiteral),
-                        }),
-                    };
-                }
-            }
-            ctx.error_with_code_at(
-                DiagnosticCode::TYPE_MISMATCH,
-                format!(
-                    "type mismatch: expected '{}', got 'None'",
-                    func_type.return_type.display_name()
-                ),
-                ret.range(),
-            );
-        }
-        None
-    };
-
-    HirStmt::Return { value }
-}
-
 pub(super) fn lower_if(
     if_stmt: &StmtIf,
     func_type: &FunctionType,
@@ -1795,6 +1699,7 @@ pub(super) fn lower_if(
 
     let saved_state = ctx.scope.save_narrowing_state();
     let saved_moved = ctx.scope.save_moved_state();
+    let saved_const_integer_state = ctx.scope.save_const_integer_state();
     let saved_sequence_guards = ctx.save_sequence_guards();
     let saved_nonzero_integer_bindings = ctx.save_proven_nonzero_integer_bindings();
 
@@ -1813,10 +1718,13 @@ pub(super) fn lower_if(
     ctx.scope.pop();
 
     let then_moved = ctx.scope.save_moved_state();
+    let then_const_integer_state = ctx.scope.save_const_integer_state();
     let then_sequence_guards = ctx.save_sequence_guards();
 
     ctx.scope.restore_narrowing_state(&saved_state);
     ctx.scope.restore_moved_state(&saved_moved);
+    ctx.scope
+        .restore_const_integer_state(&saved_const_integer_state);
     ctx.restore_sequence_guards(&saved_sequence_guards);
     ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
 
@@ -1826,6 +1734,8 @@ pub(super) fn lower_if(
     }
 
     let mut branch_moved_states: Vec<_> = vec![then_moved];
+    let mut branch_const_integer_states =
+        vec![(then_const_integer_state, then_body_always_exits(&then_body))];
     let mut branch_sequence_states = vec![then_sequence_guards];
     let mut post_if_false_nonzero_guards = Vec::new();
     let mut all_previous_branches_exit = then_body_always_exits(&then_body);
@@ -1839,6 +1749,8 @@ pub(super) fn lower_if(
         if let Some(test) = &clause.test {
             ctx.scope.restore_narrowing_state(&saved_state);
             ctx.scope.restore_moved_state(&saved_moved);
+            ctx.scope
+                .restore_const_integer_state(&saved_const_integer_state);
             ctx.restore_sequence_guards(&saved_sequence_guards);
             ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
             for prev_cond in &all_conditions {
@@ -1871,10 +1783,14 @@ pub(super) fn lower_if(
             elif_clauses.push((cond, body));
 
             branch_moved_states.push(ctx.scope.save_moved_state());
+            branch_const_integer_states
+                .push((ctx.scope.save_const_integer_state(), elif_body_exits));
             branch_sequence_states.push(ctx.save_sequence_guards());
 
             ctx.scope.restore_narrowing_state(&elif_saved);
             ctx.scope.restore_moved_state(&saved_moved);
+            ctx.scope
+                .restore_const_integer_state(&saved_const_integer_state);
             ctx.restore_sequence_guards(&saved_sequence_guards);
             ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
 
@@ -1891,6 +1807,8 @@ pub(super) fn lower_if(
         .map(|clause| {
             ctx.scope.restore_narrowing_state(&saved_state);
             ctx.scope.restore_moved_state(&saved_moved);
+            ctx.scope
+                .restore_const_integer_state(&saved_const_integer_state);
             ctx.restore_sequence_guards(&saved_sequence_guards);
             ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
             for prev_cond in &all_conditions {
@@ -1900,12 +1818,21 @@ pub(super) fn lower_if(
             let body = lower_stmts(&clause.body, func_type, ctx);
             ctx.scope.pop();
             branch_moved_states.push(ctx.scope.save_moved_state());
+            branch_const_integer_states.push((
+                ctx.scope.save_const_integer_state(),
+                then_body_always_exits(&body),
+            ));
             branch_sequence_states.push(ctx.save_sequence_guards());
             body
         });
 
     ctx.scope.restore_narrowing_state(&saved_state);
     ctx.scope.restore_moved_state(&saved_moved);
+    restore_const_integer_state_after_branches(
+        ctx,
+        &saved_const_integer_state,
+        &branch_const_integer_states,
+    );
     ctx.restore_sequence_guards(&saved_sequence_guards);
     ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
 
@@ -1954,6 +1881,7 @@ pub(super) fn lower_while(
     let condition = lower_expr(&while_stmt.test, ctx)?;
     validate_control_flow_condition(&condition, "while", while_stmt.test.range(), ctx);
     let saved_narrowing_state = ctx.scope.save_narrowing_state();
+    let saved_const_integer_state = ctx.scope.save_const_integer_state();
     let saved_sequence_guards = ctx.save_sequence_guards();
     let saved_nonzero_integer_bindings = ctx.save_proven_nonzero_integer_bindings();
     if let Some(ref cond) = narrowing_cond {
@@ -1974,7 +1902,13 @@ pub(super) fn lower_while(
     let body = lower_stmts(&while_stmt.body, func_type, ctx);
     ctx.loop_depth -= 1;
     ctx.scope.pop();
+    let body_const_integer_state = ctx.scope.save_const_integer_state();
     ctx.scope.restore_narrowing_state(&saved_narrowing_state);
+    restore_const_integer_state_after_branches(
+        ctx,
+        &saved_const_integer_state,
+        &[(body_const_integer_state, false)],
+    );
     ctx.restore_sequence_guards(&saved_sequence_guards);
     ctx.restore_proven_nonzero_integer_bindings(&saved_nonzero_integer_bindings);
 
@@ -2098,6 +2032,7 @@ pub(super) fn lower_for(
 
     // Snapshot moved state before loop to detect moves inside the body
     let moved_before_loop = ctx.scope.save_moved_state();
+    let saved_const_integer_state = ctx.scope.save_const_integer_state();
 
     // Create a new scope for the loop body, define the loop variable(s)
     ctx.scope.push();
@@ -2145,6 +2080,12 @@ pub(super) fn lower_for(
     let body = lower_stmts(&for_stmt.body, func_type, ctx);
     ctx.loop_depth -= 1;
     ctx.scope.pop();
+    let body_const_integer_state = ctx.scope.save_const_integer_state();
+    restore_const_integer_state_after_branches(
+        ctx,
+        &saved_const_integer_state,
+        &[(body_const_integer_state, false)],
+    );
     ctx.restore_sequence_guards(&saved_sequence_guards);
     super::append_growth_shapes::record_append_growth_sequence_shape_fact(
         for_stmt,

--- a/crates/sifr_hir/src/scope.rs
+++ b/crates/sifr_hir/src/scope.rs
@@ -3,6 +3,7 @@
 //! Supports type narrowing: variables can have a `narrowed_type` that
 //! differs from their `declared_type` within control flow branches.
 
+use num_bigint::BigInt;
 use sifr_type_system::{OwnershipKind, Type};
 use std::collections::HashMap;
 
@@ -50,6 +51,8 @@ pub struct VarInfo {
     pub binding_kind: BindingKind,
     /// Whether the binding type was provided explicitly (annotation/parameter).
     pub type_source: BindingTypeSource,
+    /// Compile-time exact integer value known for this binding, if any.
+    pub const_integer_value: Option<BigInt>,
     /// Proof that this binding only exists to suppress cascades after an emitted error.
     error_taint: Option<ErrorTaint>,
 }
@@ -85,6 +88,9 @@ pub type NarrowingSnapshot = Vec<(String, Option<Type>)>;
 /// A snapshot of the moved state for all variables in scope.
 /// Used to save/restore moved state at branch points and loop boundaries.
 pub(crate) type MovedSnapshot = Vec<(String, bool)>;
+
+/// A snapshot of known compile-time integer values for all variables in scope.
+pub(crate) type ConstIntegerSnapshot = Vec<(String, Option<BigInt>)>;
 
 /// A scope for name resolution.
 #[derive(Debug, Clone)]
@@ -212,6 +218,7 @@ impl Scope {
                     mutability,
                     binding_kind,
                     type_source,
+                    const_integer_value: None,
                     error_taint,
                 },
             );
@@ -223,9 +230,47 @@ impl Scope {
         if let Some(info) = self.lookup_var_mut(name) {
             info.ty = ty;
             info.narrowed_type = None;
+            info.const_integer_value = None;
             return true;
         }
         false
+    }
+
+    pub(crate) fn set_const_integer_value(&mut self, name: &str, value: BigInt) -> bool {
+        if let Some(info) = self.lookup_var_mut(name) {
+            info.const_integer_value = Some(value);
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn clear_const_integer_value(&mut self, name: &str) {
+        if let Some(info) = self.lookup_var_mut(name) {
+            info.const_integer_value = None;
+        }
+    }
+
+    pub(crate) fn const_integer_value(&self, name: &str) -> Option<&BigInt> {
+        self.lookup_var(name)
+            .and_then(|info| info.const_integer_value.as_ref())
+    }
+
+    pub(crate) fn save_const_integer_state(&self) -> ConstIntegerSnapshot {
+        let mut snapshot = Vec::new();
+        for frame in &self.frames {
+            for (name, info) in frame {
+                snapshot.push((name.clone(), info.const_integer_value.clone()));
+            }
+        }
+        snapshot
+    }
+
+    pub(crate) fn restore_const_integer_state(&mut self, snapshot: &ConstIntegerSnapshot) {
+        for (name, const_integer_value) in snapshot {
+            if let Some(info) = self.lookup_var_mut(name) {
+                info.const_integer_value.clone_from(const_integer_value);
+            }
+        }
     }
 
     /// Look up a variable, searching from innermost to outermost scope.

--- a/demos/code_generation/main.sifr
+++ b/demos/code_generation/main.sifr
@@ -25,9 +25,9 @@ def main():
     print(f"Tuple index: {a}, {b}")
     assert str(f"Tuple index: {a}, {b}") == "Tuple index: 10, 20"
 
-    # Fix 2: float division
-    x: float = 10.0
-    y: float = 3.0
+    # Fix 2: int/int true division
+    x: int = 10
+    y: int = 3
     result: float = x / y
     print(f"Division 10/3: {result}")
     assert str(f"Division 10/3: {result}") == "Division 10/3: 3.3333333333333335"
@@ -53,8 +53,8 @@ def main():
     print(f"2**3 = {base}")
     assert str(f"2**3 = {base}") == "2**3 = 8"
 
-    # Fix 6: float arithmetic
-    i: float = 10.0
+    # Fix 6: Mixed int/float arithmetic
+    i: int = 10
     f: float = 3.5
     mixed: float = i + f
     print(f"10 + 3.5 = {mixed}")

--- a/demos/optional_arithmetic/main.sifr
+++ b/demos/optional_arithmetic/main.sifr
@@ -8,14 +8,17 @@ def safe_add_one(x: int | None) -> int:
         return 0
     return x + 1
 
-def safe_divide(total: float | None, count: float) -> float:
-    if total is None:
-        return 0.0
-    return total / count
-
 def main():
     print('m26_3 optional arithmetic soundness demo:')
     print(safe_add_one(5))
     print(safe_add_one(None))
-    print(safe_divide(9.0, 3.0))
-    print(safe_divide(None, 3.0))
+
+    total: int | None = 9
+    count: int | None = 3
+    if total is not None:
+        if count is not None:
+            print(total / count)
+
+    missing_total: int | None = None
+    if missing_total is None:
+        print(0)

--- a/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
+++ b/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
@@ -438,6 +438,8 @@ compile-time integer facts, the divisor is nonzero, and both integer operands
 are exactly representable as `float`. Runtime-dependent exact `int / int`
 continues to fail closed with `SIFR-INT-0006`.
 
+Follow-up PR: https://github.com/sifr-lang/sifr/pull/2121
+
 Integer-model hardening:
 
 - Local const-integer facts are tracked through HIR lowering and cleared or

--- a/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
+++ b/internal_docs/phases/34_generated_code_quality_and_production_readiness.md
@@ -428,5 +428,48 @@ Repair evidence:
 Positive-demo result:
 
 - All 272 non-negative `demos/**/main.sifr` entries now run successfully.
+
+### Integer Model Division Follow-Up (2026-05-15)
+
+Follow-up review corrected the demo repair that had converted some integer
+division examples to float operands. The compiler now accepts the safe subset
+of exact `int / int` true division only when both operands have reliable
+compile-time integer facts, the divisor is nonzero, and both integer operands
+are exactly representable as `float`. Runtime-dependent exact `int / int`
+continues to fail closed with `SIFR-INT-0006`.
+
+Integer-model hardening:
+
+- Local const-integer facts are tracked through HIR lowering and cleared or
+  conservatively merged across reassignment, augmented assignment, branches,
+  `while`, and `for` loops.
+- The generic type-system contract remains unchanged: unproven `int / int`
+  still requires explicit handling for possible overflow or precision loss.
+- `demos/code_generation/main.sifr` again demonstrates proven-safe integer
+  true division, and `demos/optional_arithmetic/main.sifr` demonstrates the
+  same contract through optional narrowing.
+
+Follow-up evidence:
+
+- Focused HIR regression coverage for proven-safe division, runtime-dependent
+  `SIFR-INT-0006`, large exact integers, branch/loop/augassign fact clearing,
+  and narrowed optional constants.
+- Targeted demo checks and runs pass for `demos/code_generation/main.sifr` and
+  `demos/optional_arithmetic/main.sifr`.
+- Reviewer handoff:
+  `reviews/phase34-integer-model-division-followup-review-2.md`.
+- Generated-code quality evidence:
+  `target/sifr_generated_code_quality/evidence/corpus-1778843374-68801.json`,
+  `target/sifr_generated_code_quality/evidence/panic-scan-1778843687-2237.json`,
+  `target/sifr_generated_code_quality/evidence/rustfmt-1778844934-23425.json`,
+  `target/sifr_generated_code_quality/evidence/clippy-1778849008-49051.json`,
+  `target/sifr_generated_code_quality/evidence/determinism-1778850320-82439.json`,
+  and `target/sifr_generated_code_quality/evidence/corpus-1778850957-90134.json`
+  from the required demo quality gate.
+- Local validation: `scripts/run_all_tests.sh --profile quick` passed, and
+  `scripts/run_all_tests.sh` passed with PR-profile report
+  `target/validation_lane_reports/pr.latest.json` on 2026-05-15. The full
+  run exceeded the warm-time target but had zero blocking failures and zero
+  hardening failures.
 - Remaining demo failures are expected negative demos, not positive
   pre-emission demo-contract failures.

--- a/reviews/phase34-integer-model-division-followup-review-2.md
+++ b/reviews/phase34-integer-model-division-followup-review-2.md
@@ -1,0 +1,56 @@
+
+
+## Review Findings: Integer Model Division Follow-up
+
+### SIFR-INT-0006 Fail-Closed for Runtime-Dependent Operands
+**SEV: OK**
+
+`exact_int_true_division_result_type` correctly returns `None` for runtime-dependent operands. `proven_exact_integer_value` returns `None` for:
+- `HirExpr::Name` bindings without `const_integer_value` in scope
+- Function parameters (default `const_integer_value: None`)
+
+The fallback path at `lower_binop` line 84 will hit `type_check_binary_op` which emits `SIFR-INT-0006` for unhandled `int / int`. Test `test_exact_int_true_division_has_int0006` covers this.
+
+### Float Lowering Requires Reliable Const Facts
+**SEV: OK**
+
+All three conditions are checked before lowering to `Type::Float`:
+1. Both operands have const integer facts (`proven_exact_integer_value`)
+2. Divisor is nonzero (`right_value == BigInt::from(0)`)
+3. Both operands fit exact float representation (`is_exactly_representable_as_float`)
+
+`is_exactly_representable_as_float` correctly uses `2^53` as the boundary. Tests verify both the positive case (10/3 → float) and the large-int negative case (9007199254740993/3 → INT-0006).
+
+### Const Fact Leak Prevention
+**SEV: OK**
+
+| Scenario | Clearing Mechanism |
+|---|---|
+| Reassignment | `invalidate_rebound_binding_facts` + `record_const_integer_binding` on new value |
+| Augassign | `clear_const_integer_value` at line 311 in `aug_assign_lowering.rs` |
+| Branches | `save_const_integer_state` / `restore_const_integer_state` + merge via `restore_const_integer_state_after_branches` |
+| Loops | Same branch-magic pattern in `lower_while` and `lower_for` |
+| Optional narrowing | Falls through to `record_const_integer_binding` when narrowed type is `int` |
+
+The merge logic in `restore_const_integer_state_after_branches` correctly clears a binding if any non-exiting branch changed its value — this is conservative and sound.
+
+### Generated Rust Safety
+**SEV: OK**
+
+The lowering produces `HirExpr::BinOp` with `Type::Float`, not `Result<...>`. Codegen will emit ordinary float division with no unwrap/expect/panic path.
+
+### Test Coverage
+**SEV: OK**
+
+All cases covered:
+- Runtime-dependent → INT-0006
+- Small literals → `Type::Float`
+- Large literals → INT-0006
+- Branch reassignment → INT-0006
+- Augassign → INT-0006
+- Loop reassignment → INT-0006
+- Optional narrowed consts → `Type::Float`
+
+---
+
+**No blockers.**


### PR DESCRIPTION
## Summary
- allow exact `int / int` to lower as `float` only when both operands have reliable const integer facts, the divisor is nonzero, and operands fit the exact float safety envelope
- clear and merge const integer facts across reassignment, augassign, branches, and loops so runtime-dependent division still fails closed
- restore integer-model-correct demo coverage and update Phase 34 evidence/review notes

## Validation
- `cargo fmt --check`
- `scripts/check_hir_maintainability_guardrails.py`
- `git diff --check`
- `cargo test -p sifr_hir exact_int_true_division -- --nocapture`
- `cargo test -p sifr_hir -- --skip test_e2e_pass`
- `cargo test -p sifr_type_system test_exact_integer_true_division_requires_float_handling`
- `cargo run -q -p sifr -- check demos/code_generation/main.sifr`
- `cargo run -q -p sifr -- run demos/code_generation/main.sifr`
- `cargo run -q -p sifr -- check demos/optional_arithmetic/main.sifr`
- `cargo run -q -p sifr -- run demos/optional_arithmetic/main.sifr`
- `scripts/run_all_tests.sh --profile quick`
- `verification/generated_code_quality/generated_code_quality_panic_scan.sh`
- `scripts/run_all_tests.sh` (passed; warm-time advisory only)
- Claude review: `reviews/phase34-integer-model-division-followup-review-2.md` (No blockers)
