### PR TITLE
Phase 35 m35.2 performance budget policy

### DIFF
--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -1,0 +1,77 @@
+# Performance Budgets
+
+Phase 35 performance policy is local-first and versioned under `verification/performance/`.
+
+## Files
+
+- `manifest.json` defines the benchmark corpus and stable budget ids.
+- `baselines.json` records the approved m35.1 baseline run for every manifest case.
+- `budgets.json` records thresholds derived from the checked-in baselines.
+- `waivers.json` records active temporary performance waivers.
+- `run_benchmarks.py` executes benchmarks and emits evidence under `target/performance/evidence/`.
+- `check_budgets.py` compares benchmark results against budgets and validates waivers.
+
+## Commands
+
+Run the schema and negative-seed checks:
+
+```bash
+python3 verification/performance/run_benchmarks.py --validate-only
+python3 verification/performance/run_benchmarks.py --self-test
+python3 verification/performance/check_budgets.py --self-test
+```
+
+Run a fast representative benchmark smoke:
+
+```bash
+python3 verification/performance/run_benchmarks.py --sample-scale smoke
+```
+
+Run the budget gate against checked-in baselines:
+
+```bash
+python3 verification/performance/check_budgets.py
+```
+
+Refresh baselines intentionally after review:
+
+```bash
+python3 verification/performance/run_benchmarks.py --capture-baseline
+python3 verification/performance/check_budgets.py
+```
+
+## Threshold Rules
+
+Command benchmarks use:
+
+- median latency: `max(baseline_median * 1.10, baseline_median + 25ms)`
+- p95 latency: `max(baseline_p95 * 1.15, baseline_p95 + 50ms)`
+- peak RSS: `max(baseline_peak_rss * 1.10, baseline_peak_rss + 32MiB)`
+
+Frontend-query and local edit-loop benchmarks use stricter latency thresholds:
+
+- median latency: `max(baseline_median * 1.05, baseline_median + 2ms)`
+- p95 latency: `max(baseline_p95 * 1.10, baseline_p95 + 5ms)`
+- peak RSS uses the same 10% / 32MiB rule as command benchmarks.
+- cases with baseline cache hits must keep at least the baseline hit count.
+
+Timeouts are hard failures. Missing results, unknown ids, malformed metric payloads, and cache-miss regressions are hard failures.
+
+## Waivers
+
+Waivers are allowed only for temporary performance threshold regressions. They must include:
+
+- `id`
+- `owner`
+- `issue`
+- `created`
+- `expires`
+- `benchmark_ids`
+- `budget_ids`
+- `override`
+- `rationale`
+- `removal_criteria`
+
+Waivers may override `median_ms`, `p95_ms`, `peak_rss_bytes`, or `cache_hits`. They may not suppress timeouts, missing or malformed results, unknown ids, stale-cache/correctness failures, diagnostic drift, split-brain semantics, or panic-safety failures.
+
+Expired waivers, ownerless waivers, issue-less waivers, unknown benchmark/budget references, and non-performance overrides fail `check_budgets.py`.

--- a/issues/phase35-performance-benchmarking-execution.md
+++ b/issues/phase35-performance-benchmarking-execution.md
@@ -10,7 +10,7 @@ status: in_progress
 - [x] m35.4a split-brain guardrail added with seeded negative self-test.
 - [x] m35.4a Ruff fork fixture revalidation contract added.
 - [x] m35.1 baseline benchmark suite.
-- [ ] m35.2 budget and waiver policy.
+- [x] m35.2 budget and waiver policy.
 - [ ] m35.3 enforcement integration for performance budgets.
 - [ ] m35.4b full CLI adoption and query regression lock.
 
@@ -26,7 +26,7 @@ status: in_progress
 - `python3 verification/performance/check_frontend_cache_contract.py` -> PASS.
 - `reviews/phase35-m35-4a-review-pass-1.md` -> NOT SATISFIED; blockers B1/B2 fixed.
 - `reviews/phase35-m35-4a-review-pass-2.md` -> SATISFIED for m35.4a.
-- `scripts/run_all_tests.sh --profile quick` -> PASS for m35.1; wall-time advisory recorded in `target/validation_lane_reports/quick.latest.json` (`wall_time=944.94s`, report signature `f808284595f17a99`).
+- `scripts/run_all_tests.sh --profile quick` -> PASS for m35.1 (`wall_time=944.94s`) and m35.2 (`wall_time=748.90s`); wall-time advisories recorded in `target/validation_lane_reports/quick.latest.json`, report signature `f808284595f17a99`.
 - `verification/performance/manifest.json` -> 45 benchmark cases across the required Phase 35 groups.
 - `verification/performance/baselines.json` -> captured with all 45 manifest cases; maximum coefficient of variation `0.091581`.
 - `python3 verification/performance/run_benchmarks.py --validate-only` -> PASS.
@@ -37,6 +37,13 @@ status: in_progress
 - `cargo clippy -p sifr_frontend -- -D warnings` -> PASS.
 - `cargo test -p sifr_frontend` -> PASS.
 - `reviews/phase35-m35-1-review-pass-1.md` -> SATISFIED for m35.1.
+- `verification/performance/budgets.json` -> derived from all 45 m35.1 baseline results.
+- `verification/performance/waivers.json` -> active waiver registry initialized empty.
+- `internal_docs/performance_budgets.md` -> budget derivation, waiver policy, and local commands documented.
+- `python3 verification/performance/check_budgets.py` -> PASS against checked-in baselines.
+- `python3 verification/performance/check_budgets.py --self-test` -> PASS; seeded median, p95, RSS, timeout, missing-result, unknown-id, malformed-result, expired-waiver, malformed-waiver, and correctness-waiver failures are rejected.
+- `python3 -m py_compile verification/performance/check_budgets.py verification/performance/run_benchmarks.py` -> PASS.
+- `reviews/phase35-m35-2-review-pass-1.md` -> SATISFIED for m35.2.
 
 ## Open Migration Targets
 

--- a/reviews/phase35-m35-2-review-pass-1.md
+++ b/reviews/phase35-m35-2-review-pass-1.md
@@ -1,0 +1,80 @@
+
+
+I have completed my thorough review. Here is my assessment:
+
+---
+
+## **SATISFIED** for m35.2.
+
+---
+
+### Blockers: None.
+
+### Detailed Review Findings
+
+**1. Budget Derivation Rules — ENCODED**
+
+`verification/performance/budgets.json` contains a `derivation` section that documents both rule sets:
+
+- **Command default** (median: `max(baseline * 1.10, baseline + 25ms)`, p95: `max(baseline * 1.15, baseline + 50ms)`, RSS: `max(baseline * 1.10, baseline + 32MiB)`) is explicitly defined and applied to all command-group cases (e.g., `check-single-file-001-arithmetic`: baseline median 1212.854ms → threshold 1334.139ms = `max(1334.1394, 1237.854)`).
+- **Frontend-query/edit-loop stricter rule** (median: `max(baseline * 1.05, baseline + 2ms)`, p95: `max(baseline * 1.10, baseline + 5ms)`, same RSS floor) is documented and applied to `incremental-*` and `interactive-tooling-*` cases (e.g., `perf.interactive.warm_diagnostics_query`: baseline median 0.16ms → threshold 2.16ms = `max(0.168, 2.16)` — correctly using the +2ms floor, not the +25ms command floor).
+
+The `policy` field in each budget entry correctly tags cases as `command-default` or `frontend-query-edit-loop`. The derivation is sound for both groups.
+
+**2. Default Rules Encoded — CONFIRMED**
+
+All 45 manifest cases have corresponding budget entries. Three cases (`perf.incremental.unchanged_file_update`, `perf.interactive.warm_diagnostics_query`, `perf.interactive.unchanged_file_update`) carry `cache.min_hits: 2300` enforcing the edit-loop cache-hit floor from the policy doc. The `budget_median_regression_result.json` and `budget_p95_regression_result.json` seeds each inject one regression while leaving all other entries at clean baseline values, correctly testing regression detection without cross-contamination.
+
+**3. `check_budgets` Rejection Coverage — COMPLETE**
+
+| Failure type | How rejected | Actionable diagnostic |
+|---|---|---|
+| Median regression | `compare_result` → `format_failure` with `median_ms regression` | ✓ |
+| p95 regression | `compare_result` → `format_failure` with `p95_ms regression` | ✓ |
+| RSS regression | `compare_result` → `format_failure` with `peak_rss_bytes regression` | ✓ |
+| Timeout | `compare_result` returns immediately with `timed_out: true` | ✓ |
+| Missing result | `check_budgets` loop detects `result is None` → `"missing result"` | ✓ |
+| Unknown benchmark id | `validate_results_shape` checks `result_id in cases` → `"unknown benchmark id"` | ✓ |
+| Malformed metric | `validate_results_shape` loops required fields → `"missing metric"` | ✓ |
+| Expired waiver | `validate_waivers` compares `expires < today` → `"expired"` | ✓ |
+| Malformed waiver (empty owner) | `validate_waivers` calls `require_string` → `"owner"` | ✓ |
+| Correctness waiver (non-performance override) | `validate_waivers` checks `override.keys ⊆ ALLOWED_WAIVER_OVERRIDE_KEYS` → `"non-performance"` | ✓ |
+
+The self-test (`--self-test`) covers all 9 negative seeds plus the positive active-waiver suppressing median regression. The `format_failure` output includes case id, budget id, metric name, measured value, threshold, and `waiver_status` — fully actionable.
+
+**4. Waiver Non-Suppression Enforcement — CORRECT**
+
+`ALLOWED_WAIVER_OVERRIDE_KEYS = {"median_ms", "p95_ms", "peak_rss_bytes", "cache_hits"}` — explicitly excludes `timeout`, `cache_misses`, and any correctness/non-performance fields. The `correctness_waiver.json` seed uses `override: {"timeout": true}` which the `validate_waivers` logic rejects at schema-validation time (before any budget comparison runs), so correctness failures are blocked at the door, not at the comparison step.
+
+In `compare_result`:
+- `timed_out` failures pass `waiverable=False` → `format_failure` produces `not_waiverable` status.
+- `cache_misses` violations pass `waiverable=False` → same.
+- Median/p95/RSS and `cache_hits` violations pass `waiverable=True` (default) → `has_waiver()` is consulted.
+
+The split-brain protection is at two levels: schema validation rejects non-performance override keys, and runtime `compare_result` never consults waivers for timeouts or cache-miss violations.
+
+**5. Positive Path — PASSES**
+
+`check_budgets` against `baselines.json` (all 45 clean entries) passes without errors. The `run_self_test` internal call to `check_budgets(manifest, budgets, active_waiver, median_regression)` proves that a valid waiver does suppress a seeded median regression — the full waiver lifecycle is exercised.
+
+**6. Documentation — COMPLETE**
+
+`internal_docs/performance_budgets.md` covers:
+- File inventory (manifest, baselines, budgets, waivers, runners, checker).
+- Threshold derivation formulas for both command and frontend-query/edit-loop groups.
+- Explicit statement that timeouts, missing/malformed results, unknown ids, and cache-miss regressions are hard failures.
+- Waiver override field enumeration with the same exclusion set as `ALLOWED_WAIVER_OVERRIDE_KEYS`.
+
+---
+
+### Non-Blocking Follow-Ups (not required for m35.2 completion)
+
+1. **Corpus floor**: The phase contract requires "at least 3 negative budget/waiver seeds". Current count is 9 (`budget_*` × 7 + `*waiver*` × 4 = 11, with overlap). More than sufficient, but no action needed.
+
+2. **Cache miss waiverability**: The phase doc says "cache-miss regressions are hard failures" and the code correctly implements `waiverable=False`. The `ALLOWED_WAIVER_OVERRIDE_KEYS` includes `cache_hits` (for the minimum-hit floor) but not `cache_misses`. This is the correct design but worth noting: the 3 cache-hit-floor budgets enforce a minimum, and cache-miss violations are unconditional hard failures — the two cache dimensions are asymmetrically waiverable.
+
+3. **M35.3 dependency**: `scripts/run_all_tests.sh` integration is still pending (m35.3 scope). The `check_budgets.py` standalone gate is complete; the CI lane integration is a separate milestone.
+
+---
+
+**Verdict**: `m35.2` is fully implemented against the contract. `check_budgets.py` accepts clean baselines, rejects all seeded failure classes with actionable diagnostics, validates waiver lifecycle end-to-end, and correctly prevents waivers from suppressing timeout/correctness/cache-staleness failures.

--- a/verification/performance/budgets.json
+++ b/verification/performance/budgets.json
@@ -1,0 +1,920 @@
+{
+  "budgets": [
+    {
+      "baseline": {
+        "coefficient_variation": 0.066129,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-project-001-additional-modules",
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {},
+      "group": "build-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 12207.525,
+        "p95_ms": 14452.433,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.007308,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-project-002-branch-paths",
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {},
+      "group": "build-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1551.902,
+        "p95_ms": 1631.888,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.012344,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-project-003-cargo-manifest",
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {},
+      "group": "build-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1574.471,
+        "p95_ms": 1696.298,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.006416,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-project-004-dependency-manifest",
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {},
+      "group": "build-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 4558.282,
+        "p95_ms": 4796.265,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.008012,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-project-005-project-graph",
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {},
+      "group": "build-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1564.741,
+        "p95_ms": 1641.705,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.0135,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-001-break-continue",
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1571.075,
+        "p95_ms": 1653.637,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.006483,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-002-builtin-any-all",
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1578.583,
+        "p95_ms": 1659.639,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.007754,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-003-builtin-enumerate-zip",
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1610.264,
+        "p95_ms": 1712.573,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.007815,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-004-bytes-constructors",
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1719.179,
+        "p95_ms": 1805.897,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.01841,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-005-class-methods",
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1558.593,
+        "p95_ms": 1703.623,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.005662,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-006-collection-len",
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1560.37,
+        "p95_ms": 1636.153,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.032879,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-007-comp-set",
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1637.018,
+        "p95_ms": 1842.629,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.041827,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-008-decimal-conversions",
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 8353.681,
+        "p95_ms": 9518.096,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.003674,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-009-dict-get-option",
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1632.046,
+        "p95_ms": 1714.72,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.011826,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "build-single-file-010-generic-identity",
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {},
+      "group": "build-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1569.687,
+        "p95_ms": 1678.367,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 120000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.012505,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-project-001-imports",
+      "budget_id": "perf.check.project.imports",
+      "cache": {},
+      "group": "check-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1351.541,
+        "p95_ms": 1449.718,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.015039,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-project-002-mode-consistency",
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {},
+      "group": "check-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1359.803,
+        "p95_ms": 1452.812,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.007054,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-project-003-project-build",
+      "budget_id": "perf.check.project.project_build",
+      "cache": {},
+      "group": "check-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1344.999,
+        "p95_ms": 1421.192,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.004881,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-project-004-project-graph",
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {},
+      "group": "check-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1357.524,
+        "p95_ms": 1428.693,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.021288,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-project-005-rooted-entrypoint",
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {},
+      "group": "check-project",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1358.935,
+        "p95_ms": 1485.894,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.007604,
+        "median_ms": 1212.854,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-001-arithmetic",
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1334.139,
+        "p95_ms": 1419.542,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.00501,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-002-break-continue",
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1352.58,
+        "p95_ms": 1427.896,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.041338,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-003-builtin-any-all",
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1354.436,
+        "p95_ms": 1549.524,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.014622,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-004-builtin-enumerate-zip",
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1335.239,
+        "p95_ms": 1445.251,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.008711,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-005-bytes-constructors",
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1338.998,
+        "p95_ms": 1419.156,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.042849,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-006-class-methods",
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1334.839,
+        "p95_ms": 1551.13,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.017598,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-007-collection-len",
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1345.37,
+        "p95_ms": 1467.53,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.008055,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-008-comp-set",
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1350.209,
+        "p95_ms": 1425.217,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.010145,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-009-decimal-conversions",
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1345.176,
+        "p95_ms": 1421.773,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.008175,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "check-single-file-010-dict-get-option",
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {},
+      "group": "check-single-file",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1342.024,
+        "p95_ms": 1424.086,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.02192,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "incremental-local-loop-001-unchanged-file-update",
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "min_hits": 2300
+      },
+      "group": "incremental-local-loop",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.113,
+        "p95_ms": 5.117,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.026896,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "incremental-local-loop-002-leaf-module-change",
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {},
+      "group": "incremental-local-loop",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.111,
+        "p95_ms": 5.116,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.009029,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "incremental-local-loop-003-imported-module-change",
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {},
+      "group": "incremental-local-loop",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.44,
+        "p95_ms": 5.447,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.011271,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "incremental-local-loop-004-public-api-change",
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {},
+      "group": "incremental-local-loop",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.456,
+        "p95_ms": 5.462,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.018871,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "incremental-local-loop-005-failure-recovery",
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {},
+      "group": "incremental-local-loop",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.285,
+        "p95_ms": 5.291,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.024,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "interactive-tooling-foundation-001-cold-context-load",
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {},
+      "group": "interactive-tooling-foundation",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.049,
+        "p95_ms": 5.052,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.091581,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "min_hits": 2300
+      },
+      "group": "interactive-tooling-foundation",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.16,
+        "p95_ms": 5.204,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.033337,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "min_hits": 2300
+      },
+      "group": "interactive-tooling-foundation",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.066,
+        "p95_ms": 5.07,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.014983,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {},
+      "group": "interactive-tooling-foundation",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.265,
+        "p95_ms": 5.27,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.025814,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "interactive-tooling-foundation-005-source-map-lookup",
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {},
+      "group": "interactive-tooling-foundation",
+      "policy": "frontend-query-edit-loop",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 2.03,
+        "p95_ms": 5.031,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 30000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.005931,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "phase27-non-regression-001-human-success-exit",
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {},
+      "group": "phase27-non-regression",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1350.441,
+        "p95_ms": 1424.574,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.026421,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "phase27-non-regression-002-json-diagnostic-schema",
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {},
+      "group": "phase27-non-regression",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1335.954,
+        "p95_ms": 1487.2,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.015743,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {},
+      "group": "phase27-non-regression",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1350.151,
+        "p95_ms": 1463.592,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.015609,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "phase27-non-regression-004-recovery-limit",
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {},
+      "group": "phase27-non-regression",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1354.67,
+        "p95_ms": 1448.913,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    },
+    {
+      "baseline": {
+        "coefficient_variation": 0.002534,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "benchmark_id": "phase27-non-regression-005-project-error-exit",
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {},
+      "group": "phase27-non-regression",
+      "policy": "command-default",
+      "rationale": "Derived from Phase 35 m35.1 checked-in baseline using the default command or frontend-query budget rule.",
+      "thresholds": {
+        "median_ms": 1339.056,
+        "p95_ms": 1404.585,
+        "peak_rss_bytes": 342556672,
+        "timeout_ms": 60000
+      }
+    }
+  ],
+  "derivation": {
+    "cache_hits": "frontend-query cases with baseline hits require at least the baseline hit count",
+    "command_median_ms": "max(baseline_median * 1.10, baseline_median + 25ms)",
+    "command_p95_ms": "max(baseline_p95 * 1.15, baseline_p95 + 50ms)",
+    "frontend_query_median_ms": "max(baseline_median * 1.05, baseline_median + 2ms)",
+    "frontend_query_p95_ms": "max(baseline_p95 * 1.10, baseline_p95 + 5ms)",
+    "peak_rss_bytes": "max(baseline_peak_rss * 1.10, baseline_peak_rss + 32MiB)"
+  },
+  "description": "Phase 35 performance budgets derived from verification/performance/baselines.json.",
+  "version": 1
+}

--- a/verification/performance/check_budgets.py
+++ b/verification/performance/check_budgets.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Phase 35 performance budget and waiver gate."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PERF_ROOT = REPO_ROOT / "verification" / "performance"
+DEFAULT_MANIFEST = PERF_ROOT / "manifest.json"
+DEFAULT_BASELINES = PERF_ROOT / "baselines.json"
+DEFAULT_BUDGETS = PERF_ROOT / "budgets.json"
+DEFAULT_WAIVERS = PERF_ROOT / "waivers.json"
+NEGATIVE_ROOT = PERF_ROOT / "negative_seeds"
+RUNNER_VERSION = 1
+ALLOWED_WAIVER_OVERRIDE_KEYS = {"median_ms", "p95_ms", "peak_rss_bytes", "cache_hits"}
+
+
+class BudgetError(Exception):
+    pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--results", default=str(DEFAULT_BASELINES))
+    parser.add_argument("--budgets", default=str(DEFAULT_BUDGETS))
+    parser.add_argument("--waivers", default=str(DEFAULT_WAIVERS))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            run_self_test()
+            print("performance budget checker self-test passed")
+            return 0
+
+        manifest = load_json(Path(args.manifest))
+        budgets = load_json(Path(args.budgets))
+        waivers = load_json(Path(args.waivers))
+        results = load_json(Path(args.results))
+        check_budgets(manifest, budgets, waivers, results)
+        print("performance budget check passed")
+        return 0
+    except BudgetError as error:
+        print(f"performance budget error: {error}", file=sys.stderr)
+        return 1
+
+
+def check_budgets(
+    manifest: dict[str, Any],
+    budgets: dict[str, Any],
+    waivers: dict[str, Any],
+    results: dict[str, Any],
+) -> None:
+    cases = validate_manifest(manifest)
+    budget_entries = validate_budgets(budgets, cases)
+    waiver_entries = validate_waivers(waivers, cases, budget_entries)
+    validate_results_shape(results, cases)
+
+    results_by_id = {result["id"]: result for result in results["results"]}
+    failures: list[str] = []
+    for case_id, budget in budget_entries.items():
+        result = results_by_id.get(case_id)
+        if result is None:
+            failures.append(f"{case_id}: missing result for budget {budget['budget_id']}")
+            continue
+        failures.extend(compare_result(result, budget, waiver_entries))
+
+    if failures:
+        raise BudgetError("budget check failed:\n" + "\n".join(failures))
+
+
+def validate_manifest(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if manifest.get("version") != 1:
+        raise BudgetError("benchmark manifest version must be 1")
+    cases_raw = manifest.get("cases")
+    if not isinstance(cases_raw, list):
+        raise BudgetError("benchmark manifest cases must be a list")
+    cases: dict[str, dict[str, Any]] = {}
+    budget_ids: set[str] = set()
+    for raw in cases_raw:
+        if not isinstance(raw, dict):
+            raise BudgetError("benchmark manifest case entries must be objects")
+        case_id = require_string(raw, "id", "manifest case")
+        budget_id = require_string(raw, "budget_id", f"manifest case {case_id}")
+        if case_id in cases:
+            raise BudgetError(f"duplicate benchmark case id {case_id}")
+        if budget_id in budget_ids:
+            raise BudgetError(f"duplicate benchmark budget id {budget_id}")
+        cases[case_id] = raw
+        budget_ids.add(budget_id)
+    return cases
+
+
+def validate_budgets(
+    budgets: dict[str, Any],
+    cases: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    if budgets.get("version") != 1:
+        raise BudgetError("budgets version must be 1")
+    entries = budgets.get("budgets")
+    if not isinstance(entries, list):
+        raise BudgetError("budgets must contain a budgets list")
+    by_case: dict[str, dict[str, Any]] = {}
+    by_budget_id: set[str] = set()
+    for raw in entries:
+        if not isinstance(raw, dict):
+            raise BudgetError("budget entries must be objects")
+        case_id = require_string(raw, "benchmark_id", "budget entry")
+        budget_id = require_string(raw, "budget_id", f"budget entry {case_id}")
+        if case_id not in cases:
+            raise BudgetError(f"budget {budget_id} references unknown benchmark id {case_id}")
+        if budget_id != cases[case_id]["budget_id"]:
+            raise BudgetError(
+                f"budget {budget_id} does not match manifest budget id {cases[case_id]['budget_id']} for {case_id}"
+            )
+        if case_id in by_case:
+            raise BudgetError(f"duplicate budget for benchmark id {case_id}")
+        if budget_id in by_budget_id:
+            raise BudgetError(f"duplicate budget id {budget_id}")
+        thresholds = raw.get("thresholds")
+        if not isinstance(thresholds, dict):
+            raise BudgetError(f"budget {budget_id} is missing thresholds")
+        for field in ["median_ms", "p95_ms", "timeout_ms"]:
+            require_number(thresholds, field, f"budget {budget_id} thresholds")
+        if "peak_rss_bytes" in thresholds and thresholds["peak_rss_bytes"] is not None:
+            require_number(thresholds, "peak_rss_bytes", f"budget {budget_id} thresholds")
+        cache = raw.get("cache", {})
+        if not isinstance(cache, dict):
+            raise BudgetError(f"budget {budget_id} cache policy must be an object")
+        for field in ["min_hits", "max_misses"]:
+            if field in cache and (not isinstance(cache[field], int) or cache[field] < 0):
+                raise BudgetError(f"budget {budget_id} cache.{field} must be a non-negative integer")
+        by_case[case_id] = raw
+        by_budget_id.add(budget_id)
+
+    missing = sorted(set(cases) - set(by_case))
+    if missing:
+        raise BudgetError(f"budgets are missing benchmark ids: {missing}")
+    return by_case
+
+
+def validate_waivers(
+    waivers: dict[str, Any],
+    cases: dict[str, dict[str, Any]],
+    budgets: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if waivers.get("version") != 1:
+        raise BudgetError("waivers version must be 1")
+    entries = waivers.get("waivers")
+    if not isinstance(entries, list):
+        raise BudgetError("waivers must contain a waivers list")
+    budget_ids = {budget["budget_id"] for budget in budgets.values()}
+    today = date.today()
+    seen: set[str] = set()
+    validated = []
+    for raw in entries:
+        if not isinstance(raw, dict):
+            raise BudgetError("waiver entries must be objects")
+        waiver_id = require_string(raw, "id", "waiver")
+        if waiver_id in seen:
+            raise BudgetError(f"duplicate waiver id {waiver_id}")
+        seen.add(waiver_id)
+        owner = require_string(raw, "owner", f"waiver {waiver_id}")
+        issue = require_string(raw, "issue", f"waiver {waiver_id}")
+        if not owner:
+            raise BudgetError(f"waiver {waiver_id} owner must not be empty")
+        if not (issue.startswith("https://github.com/") or "#" in issue):
+            raise BudgetError(f"waiver {waiver_id} must link to a GitHub issue")
+        expires = parse_date(require_string(raw, "expires", f"waiver {waiver_id}"), waiver_id, "expires")
+        parse_date(require_string(raw, "created", f"waiver {waiver_id}"), waiver_id, "created")
+        if expires < today:
+            raise BudgetError(f"waiver {waiver_id} expired on {expires.isoformat()}")
+        benchmark_ids = require_string_list(raw, "benchmark_ids", f"waiver {waiver_id}")
+        waiver_budget_ids = require_string_list(raw, "budget_ids", f"waiver {waiver_id}")
+        unknown_benchmarks = sorted(set(benchmark_ids) - set(cases))
+        unknown_budgets = sorted(set(waiver_budget_ids) - budget_ids)
+        if unknown_benchmarks:
+            raise BudgetError(f"waiver {waiver_id} references unknown benchmark ids: {unknown_benchmarks}")
+        if unknown_budgets:
+            raise BudgetError(f"waiver {waiver_id} references unknown budget ids: {unknown_budgets}")
+        override = raw.get("override")
+        if not isinstance(override, dict) or not override:
+            raise BudgetError(f"waiver {waiver_id} override must be a non-empty object")
+        unknown_override_keys = sorted(set(override) - ALLOWED_WAIVER_OVERRIDE_KEYS)
+        if unknown_override_keys:
+            raise BudgetError(
+                f"waiver {waiver_id} attempts to waive non-performance or unsupported fields: {unknown_override_keys}"
+            )
+        require_string(raw, "rationale", f"waiver {waiver_id}")
+        require_string(raw, "removal_criteria", f"waiver {waiver_id}")
+        validated.append(raw)
+    return validated
+
+
+def validate_results_shape(results: dict[str, Any], cases: dict[str, dict[str, Any]]) -> None:
+    if results.get("schema_version") != 1:
+        raise BudgetError("benchmark results schema_version must be 1")
+    if results.get("runner_version") != RUNNER_VERSION:
+        raise BudgetError(f"benchmark results runner_version must be {RUNNER_VERSION}")
+    entries = results.get("results")
+    if not isinstance(entries, list):
+        raise BudgetError("benchmark results must contain a results list")
+    seen: set[str] = set()
+    for raw in entries:
+        if not isinstance(raw, dict):
+            raise BudgetError("benchmark result entries must be objects")
+        result_id = require_string(raw, "id", "benchmark result")
+        if result_id not in cases:
+            raise BudgetError(f"benchmark result references unknown benchmark id {result_id}")
+        if result_id in seen:
+            raise BudgetError(f"duplicate benchmark result id {result_id}")
+        seen.add(result_id)
+        require_string(raw, "budget_id", f"benchmark result {result_id}")
+        metrics = raw.get("metrics")
+        if not isinstance(metrics, dict):
+            raise BudgetError(f"benchmark result {result_id} is missing metrics")
+        for field in ["median_ms", "p95_ms", "mad_ms", "coefficient_variation", "peak_rss_bytes"]:
+            if field not in metrics:
+                raise BudgetError(f"benchmark result {result_id} is missing metric {field}")
+        require_number(metrics, "median_ms", f"benchmark result {result_id} metrics")
+        require_number(metrics, "p95_ms", f"benchmark result {result_id} metrics")
+        if metrics["peak_rss_bytes"] is not None:
+            require_number(metrics, "peak_rss_bytes", f"benchmark result {result_id} metrics")
+        cache = raw.get("cache")
+        if not isinstance(cache, dict) or not isinstance(cache.get("hits"), int) or not isinstance(cache.get("misses"), int):
+            raise BudgetError(f"benchmark result {result_id} is missing cache hit/miss metrics")
+
+    missing = sorted(set(cases) - seen)
+    if missing:
+        raise BudgetError(f"benchmark results are missing benchmark ids: {missing}")
+
+
+def compare_result(
+    result: dict[str, Any],
+    budget: dict[str, Any],
+    waivers: list[dict[str, Any]],
+) -> list[str]:
+    case_id = result["id"]
+    budget_id = budget["budget_id"]
+    failures: list[str] = []
+    if result.get("timed_out"):
+        failures.append(format_failure(case_id, budget_id, "timeout", "true", "false", waivers, waiverable=False))
+        return failures
+    metrics = result["metrics"]
+    thresholds = budget["thresholds"]
+    checks = [
+        ("median_ms", metrics["median_ms"], thresholds["median_ms"]),
+        ("p95_ms", metrics["p95_ms"], thresholds["p95_ms"]),
+    ]
+    if thresholds.get("peak_rss_bytes") is not None and metrics.get("peak_rss_bytes") is not None:
+        checks.append(("peak_rss_bytes", metrics["peak_rss_bytes"], thresholds["peak_rss_bytes"]))
+    for metric, measured, threshold in checks:
+        if float(measured) > float(threshold) and not has_waiver(case_id, budget_id, metric, waivers):
+            failures.append(format_failure(case_id, budget_id, metric, measured, threshold, waivers))
+
+    cache_policy = budget.get("cache", {})
+    cache = result["cache"]
+    if "min_hits" in cache_policy and int(cache["hits"]) < int(cache_policy["min_hits"]):
+        metric = "cache_hits"
+        if not has_waiver(case_id, budget_id, metric, waivers):
+            failures.append(format_failure(case_id, budget_id, metric, cache["hits"], cache_policy["min_hits"], waivers))
+    if "max_misses" in cache_policy and int(cache["misses"]) > int(cache_policy["max_misses"]):
+        failures.append(
+            format_failure(
+                case_id,
+                budget_id,
+                "cache_misses",
+                cache["misses"],
+                cache_policy["max_misses"],
+                waivers,
+                waiverable=False,
+            )
+        )
+    return failures
+
+
+def has_waiver(case_id: str, budget_id: str, metric: str, waivers: list[dict[str, Any]]) -> bool:
+    for waiver in waivers:
+        if case_id in waiver["benchmark_ids"] and budget_id in waiver["budget_ids"] and metric in waiver["override"]:
+            return True
+    return False
+
+
+def format_failure(
+    case_id: str,
+    budget_id: str,
+    metric: str,
+    measured: Any,
+    threshold: Any,
+    waivers: list[dict[str, Any]],
+    *,
+    waiverable: bool = True,
+) -> str:
+    status = "waiver_available_but_not_matching" if waiverable and waivers else "no_waiver"
+    if not waiverable:
+        status = "not_waiverable"
+    return (
+        f"{case_id} ({budget_id}) {metric} regression: "
+        f"measured={measured} threshold={threshold} waiver_status={status}"
+    )
+
+
+def run_self_test() -> None:
+    manifest = load_json(DEFAULT_MANIFEST)
+    budgets = load_json(DEFAULT_BUDGETS)
+    waivers = load_json(DEFAULT_WAIVERS)
+    baselines = load_json(DEFAULT_BASELINES)
+    check_budgets(manifest, budgets, waivers, baselines)
+
+    assert_budget_fails("budget_median_regression_result.json", "median_ms regression")
+    assert_budget_fails("budget_p95_regression_result.json", "p95_ms regression")
+    assert_budget_fails("budget_rss_regression_result.json", "peak_rss_bytes regression")
+    assert_budget_fails("budget_timeout_result.json", "timeout regression")
+    assert_budget_fails("budget_missing_result.json", "missing benchmark ids")
+    assert_budget_fails("budget_unknown_id_result.json", "unknown benchmark id")
+    assert_budget_fails("budget_malformed_result.json", "missing metric")
+    assert_waiver_fails("expired_waiver.json", "expired")
+    assert_waiver_fails("malformed_waiver.json", "owner")
+    assert_waiver_fails("correctness_waiver.json", "non-performance")
+
+    active_waiver = load_json(NEGATIVE_ROOT / "active_median_waiver.json")
+    median_regression = load_json(NEGATIVE_ROOT / "budget_median_regression_result.json")
+    check_budgets(manifest, budgets, active_waiver, median_regression)
+
+
+def assert_budget_fails(seed: str, expected: str) -> None:
+    try:
+        check_budgets(
+            load_json(DEFAULT_MANIFEST),
+            load_json(DEFAULT_BUDGETS),
+            load_json(DEFAULT_WAIVERS),
+            load_json(NEGATIVE_ROOT / seed),
+        )
+    except BudgetError as error:
+        if expected not in str(error):
+            raise BudgetError(f"negative budget seed {seed} failed with wrong diagnostic: {error}") from error
+        return
+    raise BudgetError(f"negative budget seed {seed} did not fail")
+
+
+def assert_waiver_fails(seed: str, expected: str) -> None:
+    try:
+        check_budgets(
+            load_json(DEFAULT_MANIFEST),
+            load_json(DEFAULT_BUDGETS),
+            load_json(NEGATIVE_ROOT / seed),
+            load_json(DEFAULT_BASELINES),
+        )
+    except BudgetError as error:
+        if expected not in str(error):
+            raise BudgetError(f"negative waiver seed {seed} failed with wrong diagnostic: {error}") from error
+        return
+    raise BudgetError(f"negative waiver seed {seed} did not fail")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise BudgetError(f"failed to read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise BudgetError(f"malformed JSON in {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise BudgetError(f"{path} root must be an object")
+    return value
+
+
+def require_string(raw: dict[str, Any], field: str, owner: str) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value:
+        raise BudgetError(f"{owner} field {field} must be a non-empty string")
+    return value
+
+
+def require_string_list(raw: dict[str, Any], field: str, owner: str) -> list[str]:
+    value = raw.get(field)
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+        raise BudgetError(f"{owner} field {field} must be a non-empty string list")
+    return value
+
+
+def require_number(raw: dict[str, Any], field: str, owner: str) -> float:
+    value = raw.get(field)
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise BudgetError(f"{owner} field {field} must be numeric")
+    return float(value)
+
+
+def parse_date(value: str, waiver_id: str, field: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as error:
+        raise BudgetError(f"waiver {waiver_id} field {field} must be ISO date YYYY-MM-DD") from error
+
+
+def make_result_seed(mutator: Any) -> dict[str, Any]:
+    result = copy.deepcopy(load_json(DEFAULT_BASELINES))
+    mutator(result)
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/verification/performance/negative_seeds/active_median_waiver.json
+++ b/verification/performance/negative_seeds/active_median_waiver.json
@@ -1,0 +1,24 @@
+{
+  "description": "Negative and positive waiver validation seeds for check_budgets.py --self-test.",
+  "version": 1,
+  "waivers": [
+    {
+      "benchmark_ids": [
+        "check-single-file-001-arithmetic"
+      ],
+      "budget_ids": [
+        "perf.check.single.arithmetic"
+      ],
+      "created": "2026-05-16",
+      "expires": "2099-12-31",
+      "id": "seed-waiver",
+      "issue": "https://github.com/sifr-lang/sifr/issues/35",
+      "override": {
+        "median_ms": 1344.139
+      },
+      "owner": "sifr-lang/performance",
+      "rationale": "Self-test seed for active median regression waiver validation.",
+      "removal_criteria": "Remove when the self-test no longer needs a positive waiver seed."
+    }
+  ]
+}

--- a/verification/performance/negative_seeds/budget_malformed_result.json
+++ b/verification/performance/negative_seeds/budget_malformed_result.json
@@ -1,0 +1,1392 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1212.854,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_median_regression_result.json
+++ b/verification/performance/negative_seeds/budget_median_regression_result.json
@@ -1,0 +1,1393 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1335.139,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_missing_result.json
+++ b/verification/performance/negative_seeds/budget_missing_result.json
@@ -1,0 +1,1366 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_p95_regression_result.json
+++ b/verification/performance/negative_seeds/budget_p95_regression_result.json
@@ -1,0 +1,1393 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1212.854,
+        "p95_ms": 1420.542,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_rss_regression_result.json
+++ b/verification/performance/negative_seeds/budget_rss_regression_result.json
@@ -1,0 +1,1393 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1212.854,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 342556673
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_timeout_result.json
+++ b/verification/performance/negative_seeds/budget_timeout_result.json
@@ -1,0 +1,1393 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-001-additional-modules",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1212.854,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": true
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/budget_unknown_id_result.json
+++ b/verification/performance/negative_seeds/budget_unknown_id_result.json
@@ -1,0 +1,1393 @@
+{
+  "default_stability_limit": 0.1,
+  "manifest_sha256": "30332d18f325f62f5522899feb67d2fc75d4b64c88d8bc500bbdc47b0ba72663",
+  "metadata": {
+    "architecture": "arm64",
+    "captured_at_unix": 1778968823,
+    "cargo": "cargo 1.94.0 (85eff7c80 2026-01-15)",
+    "cargo_lock_sha256": "01757d41af1080785f61382ecdbdbe4fac07975c2447d742bc03cc753c3719d7",
+    "compiler_fingerprint": "{\"packages\":[{\"name\":\"sifr_diagnostics\",\"version\":\"0.0.0\",\"id\":\"",
+    "host_os": "macOS-26.4.1-arm64-arm-64bit-Mach-O",
+    "python": "3.13.1",
+    "rustc": "rustc 1.94.0 (4a4ef493e 2026-03-02)"
+  },
+  "results": [
+    {
+      "budget_id": "perf.build.project.additional_modules",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "unknown-benchmark",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.066129,
+        "mad_ms": 489.217,
+        "median_ms": 11097.75,
+        "p95_ms": 12567.333,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        11150.056208003662,
+        10608.53225000028,
+        10490.45537499478,
+        12567.332708989852,
+        11097.74950001156
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.branch_paths",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "build-project",
+      "id": "build-project-002-branch-paths",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007308,
+        "mad_ms": 0.805,
+        "median_ms": 1410.82,
+        "p95_ms": 1419.033,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1410.8204999938607,
+        1388.4591670066584,
+        1419.0327499964042,
+        1410.1721669867402,
+        1411.6253749962198
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.cargo_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-003-cargo-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012344,
+        "mad_ms": 4.435,
+        "median_ms": 1431.337,
+        "p95_ms": 1475.042,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9029169954592,
+        1431.2582079874119,
+        1431.337457994232,
+        1475.0415419985075,
+        1448.1686249928316
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.dependency_manifest",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-manifest",
+      "group": "build-project",
+      "id": "build-project-004-dependency-manifest",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006416,
+        "mad_ms": 20.783,
+        "median_ms": 4143.893,
+        "p95_ms": 4170.665,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        4097.181709003053,
+        4161.3324170029955,
+        4143.893250002293,
+        4170.665124998777,
+        4123.110375003307
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "build-project",
+      "id": "build-project-005-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008012,
+        "mad_ms": 5.079,
+        "median_ms": 1422.492,
+        "p95_ms": 1427.57,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1396.5935409942176,
+        1410.8197079913225,
+        1424.0469170035794,
+        1422.4916250095703,
+        1427.5704589963425
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "build-single-file",
+      "id": "build-single-file-001-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.0135,
+        "mad_ms": 9.695,
+        "median_ms": 1428.25,
+        "p95_ms": 1437.945,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1417.4405420053517,
+        1428.249999997206,
+        1430.3822920046514,
+        1437.9448330000741,
+        1383.4906249976484
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "build-single-file",
+      "id": "build-single-file-002-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.006483,
+        "mad_ms": 6.366,
+        "median_ms": 1435.075,
+        "p95_ms": 1443.164,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1443.164207987138,
+        1435.075291999965,
+        1440.8069580094889,
+        1428.7090830039233,
+        1417.361041996628
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-003-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007754,
+        "mad_ms": 4.23,
+        "median_ms": 1463.876,
+        "p95_ms": 1489.194,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1479.659916003584,
+        1463.875540997833,
+        1462.945209001191,
+        1489.1942500107689,
+        1459.6457080042455
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "build-single-file",
+      "id": "build-single-file-004-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007815,
+        "mad_ms": 7.455,
+        "median_ms": 1562.89,
+        "p95_ms": 1570.345,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1542.1013749873964,
+        1563.1624999950873,
+        1562.8897919959854,
+        1570.3448749991367,
+        1540.45270899951
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "build-single-file",
+      "id": "build-single-file-005-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.01841,
+        "mad_ms": 6.871,
+        "median_ms": 1416.903,
+        "p95_ms": 1481.411,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1429.6495000016876,
+        1410.0321250007255,
+        1416.9029579934431,
+        1481.411290995311,
+        1414.0447919926373
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-006-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005662,
+        "mad_ms": 4.224,
+        "median_ms": 1418.518,
+        "p95_ms": 1422.742,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1405.3223750088364,
+        1418.5179170017364,
+        1421.174584000255,
+        1404.1144169896143,
+        1422.7419160015415
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "build-single-file",
+      "id": "build-single-file-007-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.032879,
+        "mad_ms": 8.249,
+        "median_ms": 1488.198,
+        "p95_ms": 1602.286,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1488.1979579949984,
+        1490.0307919888292,
+        1464.4514169922331,
+        1479.9488330027089,
+        1602.286000008462
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "build-single-file",
+      "id": "build-single-file-008-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041827,
+        "mad_ms": 83.235,
+        "median_ms": 7594.255,
+        "p95_ms": 8276.605,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        7640.255916005117,
+        8276.60520900099,
+        7511.019666999346,
+        7594.254708994413,
+        7331.135582993738
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "build-single-file",
+      "id": "build-single-file-009-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.003674,
+        "mad_ms": 2.292,
+        "median_ms": 1483.678,
+        "p95_ms": 1491.061,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1485.9696249914123,
+        1474.2899590055458,
+        1491.0609999933513,
+        1483.6777080054162,
+        1482.8311660094187
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.build.single.generic_identity",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-generics",
+      "group": "build-single-file",
+      "id": "build-single-file-010-generic-identity",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.011826,
+        "mad_ms": 5.556,
+        "median_ms": 1426.988,
+        "p95_ms": 1459.45,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1426.9884170062141,
+        1432.5448750023497,
+        1406.9619169895304,
+        1459.4499999948312,
+        1425.8016249950742
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.imports",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-imports",
+      "group": "check-project",
+      "id": "check-project-001-imports",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.012505,
+        "mad_ms": 7.748,
+        "median_ms": 1228.674,
+        "p95_ms": 1260.624,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.9263330005342,
+        1228.6739160044817,
+        1233.0509159946814,
+        1260.623875001329,
+        1216.7449169937754
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.mode_consistency",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-mode",
+      "group": "check-project",
+      "id": "check-project-002-mode-consistency",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015039,
+        "mad_ms": 9.825,
+        "median_ms": 1236.185,
+        "p95_ms": 1263.315,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1230.1240410015453,
+        1206.8559589970391,
+        1263.3152089983923,
+        1236.1849169974448,
+        1246.0097919974942
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_build",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-build",
+      "group": "check-project",
+      "id": "check-project-003-project-build",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007054,
+        "mad_ms": 7.308,
+        "median_ms": 1222.726,
+        "p95_ms": 1235.819,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1218.16645799845,
+        1215.4182499944,
+        1235.8194169937633,
+        1222.7263750100974,
+        1235.7059999922058
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.project_graph",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-project-imports",
+      "group": "check-project",
+      "id": "check-project-004-project-graph",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.004881,
+        "mad_ms": 5.814,
+        "median_ms": 1234.113,
+        "p95_ms": 1242.342,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1239.9268750014016,
+        1234.1125829989323,
+        1242.341542005306,
+        1233.012750002672,
+        1225.0602499989327
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.project.rooted_entrypoint",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-entrypoint",
+      "group": "check-project",
+      "id": "check-project-005-rooted-entrypoint",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.021288,
+        "mad_ms": 13.503,
+        "median_ms": 1235.395,
+        "p95_ms": 1292.082,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1219.5762089977507,
+        1235.394791001454,
+        1221.8915830017067,
+        1236.0397089942126,
+        1292.0818749989849
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.arithmetic",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-001-arithmetic",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.007604,
+        "mad_ms": 3.983,
+        "median_ms": 1212.854,
+        "p95_ms": 1234.384,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1212.854208992212,
+        1211.279208000633,
+        1208.8711249962216,
+        1234.3837910011644,
+        1220.4590839974117
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.break_continue",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-control-flow",
+      "group": "check-single-file",
+      "id": "check-single-file-002-break-continue",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.00501,
+        "mad_ms": 3.316,
+        "median_ms": 1229.618,
+        "p95_ms": 1241.649,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1229.6182499994757,
+        1241.6488750022836,
+        1223.2104580034502,
+        1227.7600419911323,
+        1232.9343750025146
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_any_all",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-builtins",
+      "group": "check-single-file",
+      "id": "check-single-file-003-builtin-any-all",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.041338,
+        "mad_ms": 12.556,
+        "median_ms": 1231.305,
+        "p95_ms": 1347.412,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1231.3050829980057,
+        1200.8212079963414,
+        1240.3193750069477,
+        1218.7489589996403,
+        1347.4117090081563
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.builtin_enumerate_zip",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-004-builtin-enumerate-zip",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.014622,
+        "mad_ms": 2.813,
+        "median_ms": 1213.854,
+        "p95_ms": 1256.74,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1208.4342500020284,
+        1213.8544580084272,
+        1211.4741249970393,
+        1216.6675829939777,
+        1256.7395420046523
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.bytes_constructors",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-bytes",
+      "group": "check-single-file",
+      "id": "check-single-file-005-bytes-constructors",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008711,
+        "mad_ms": 10.499,
+        "median_ms": 1217.271,
+        "p95_ms": 1234.049,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1234.0487499895971,
+        1217.270749999443,
+        1208.9711250009714,
+        1206.7717089958023,
+        1228.1768749962794
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.class_methods",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-classes",
+      "group": "check-single-file",
+      "id": "check-single-file-006-class-methods",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.042849,
+        "mad_ms": 2.044,
+        "median_ms": 1213.49,
+        "p95_ms": 1348.809,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.49008299876,
+        1211.4461669989396,
+        1213.2383330026641,
+        1227.695167006459,
+        1348.8094579952303
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.collection_len",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-007-collection-len",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.017598,
+        "mad_ms": 4.817,
+        "median_ms": 1223.064,
+        "p95_ms": 1276.113,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1220.1942079991568,
+        1276.112750012544,
+        1223.0642499926034,
+        1228.9126249961555,
+        1218.2467920065392
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.comp_set",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-collections",
+      "group": "check-single-file",
+      "id": "check-single-file-008-comp-set",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008055,
+        "mad_ms": 5.732,
+        "median_ms": 1227.463,
+        "p95_ms": 1239.319,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1209.1549580072751,
+        1228.829042011057,
+        1221.7314580047969,
+        1227.4634579953272,
+        1239.31858400465
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.decimal_conversions",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-decimal-integer",
+      "group": "check-single-file",
+      "id": "check-single-file-009-decimal-conversions",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.010145,
+        "mad_ms": 11.863,
+        "median_ms": 1222.887,
+        "p95_ms": 1236.324,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.5089999937918,
+        1203.8760419964092,
+        1236.3237090030452,
+        1222.8872080013389,
+        1234.7503330092877
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.check.single.dict_get_option",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "phase34-result-option",
+      "group": "check-single-file",
+      "id": "check-single-file-010-dict-get-option",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.008175,
+        "mad_ms": 7.986,
+        "median_ms": 1220.022,
+        "p95_ms": 1238.336,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1238.3364169945708,
+        1220.0218750076601,
+        1221.1476660013432,
+        1210.138416994596,
+        1212.0358340034727
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-hit",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-001-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.02192,
+        "mad_ms": 0.001,
+        "median_ms": 0.113,
+        "p95_ms": 0.117,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.11134084000000001,
+        0.1143575,
+        0.11339749999999998,
+        0.11186042,
+        0.10883000000000001,
+        0.11246249999999999,
+        0.11014125,
+        0.11544291,
+        0.11156166,
+        0.11214083000000001,
+        0.11406540999999999,
+        0.11702958,
+        0.11149334,
+        0.11274917000000001,
+        0.11391458,
+        0.11675375,
+        0.11199666999999999,
+        0.11362792000000001,
+        0.119855,
+        0.11207541999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.leaf_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "cache-invalidation",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-002-leaf-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.026896,
+        "mad_ms": 0.003,
+        "median_ms": 0.111,
+        "p95_ms": 0.116,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.10622166999999999,
+        0.110515,
+        0.11375333,
+        0.10724249999999999,
+        0.11207999999999999,
+        0.11211208,
+        0.10981209,
+        0.10810666999999999,
+        0.1102475,
+        0.1068675,
+        0.11050834,
+        0.11197708,
+        0.10670417,
+        0.10967542,
+        0.11430749999999999,
+        0.11615916999999999,
+        0.11435791999999999,
+        0.11565542000000001,
+        0.11329374999999998,
+        0.10847625
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.imported_module_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-003-imported-module-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.009029,
+        "mad_ms": 0.002,
+        "median_ms": 0.44,
+        "p95_ms": 0.447,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.44008709,
+        0.43289542,
+        0.44154375,
+        0.44659458,
+        0.44184667,
+        0.43831334,
+        0.438795,
+        0.44643750000000004,
+        0.43622915999999995,
+        0.43770833000000003,
+        0.43378915999999995,
+        0.44090875,
+        0.44235917,
+        0.43932625000000003,
+        0.43764208,
+        0.44847792,
+        0.43988167000000006,
+        0.44115874999999993,
+        0.43583166,
+        0.43693916
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.public_api_change",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 6900,
+      "evidence_category": "dependent-query",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-004-public-api-change",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.011271,
+        "mad_ms": 0.004,
+        "median_ms": 0.456,
+        "p95_ms": 0.462,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.46217458,
+        0.45319541999999996,
+        0.45486457999999996,
+        0.452555,
+        0.45169124999999993,
+        0.46962125,
+        0.4621375,
+        0.45132167,
+        0.45922666999999995,
+        0.45988124999999996,
+        0.46008083,
+        0.45700082999999997,
+        0.45825541999999997,
+        0.44612917,
+        0.45283541,
+        0.46108833000000005,
+        0.45460333999999997,
+        0.45256375,
+        0.45476334,
+        0.46057583
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.incremental.failure_recovery",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 11500,
+      "evidence_category": "recovery",
+      "group": "incremental-local-loop",
+      "id": "incremental-local-loop-005-failure-recovery",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.018871,
+        "mad_ms": 0.002,
+        "median_ms": 0.285,
+        "p95_ms": 0.291,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.28459792,
+        0.28795084,
+        0.28344166000000004,
+        0.28430459,
+        0.28352249999999996,
+        0.285995,
+        0.29126291,
+        0.28978750000000003,
+        0.28475207999999996,
+        0.28127708,
+        0.28085167,
+        0.30605292,
+        0.28438874999999997,
+        0.29096834,
+        0.28753541000000005,
+        0.28344166000000004,
+        0.28298167,
+        0.28197042,
+        0.28460083,
+        0.28895833
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.cold_context_load",
+      "cache": {
+        "hits": 0,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-cold-load",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-001-cold-context-load",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.024,
+        "mad_ms": 0.001,
+        "median_ms": 0.049,
+        "p95_ms": 0.052,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.052313330000000005,
+        0.04879834000000001,
+        0.04922084,
+        0.050728329999999995,
+        0.04953957999999999,
+        0.047785,
+        0.0502675,
+        0.048392080000000004,
+        0.04835,
+        0.04784125,
+        0.04901417,
+        0.051681660000000004,
+        0.04846875,
+        0.04886959,
+        0.049157910000000006,
+        0.04886291,
+        0.048625,
+        0.04897417,
+        0.047853330000000006,
+        0.049493749999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.warm_diagnostics_query",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-diagnostics",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-002-warm-diagnostics-query",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.091581,
+        "mad_ms": 0.002,
+        "median_ms": 0.16,
+        "p95_ms": 0.204,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.16873791999999999,
+        0.17286416,
+        0.20566625000000002,
+        0.20351458,
+        0.19856375,
+        0.16299958999999997,
+        0.15951416,
+        0.16015666000000003,
+        0.15855291000000002,
+        0.15905708000000002,
+        0.17542583,
+        0.16323708,
+        0.15909375,
+        0.15912874999999999,
+        0.15829374999999998,
+        0.16023458000000002,
+        0.15903208,
+        0.15744000000000002,
+        0.15903125,
+        0.15793374999999998
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.unchanged_file_update",
+      "cache": {
+        "hits": 2300,
+        "misses": 2300
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-003-unchanged-file-update",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.033337,
+        "mad_ms": 0.001,
+        "median_ms": 0.066,
+        "p95_ms": 0.07,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.06535416,
+        0.06371125,
+        0.06519417,
+        0.0654525,
+        0.06463375,
+        0.06572833,
+        0.06752459,
+        0.06922125,
+        0.07327584,
+        0.06983750000000001,
+        0.06851625,
+        0.06688042,
+        0.06785875,
+        0.0648575,
+        0.06395667,
+        0.06659916,
+        0.06516292,
+        0.06624292000000001,
+        0.06590459,
+        0.06643958
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.changed_file_invalidation",
+      "cache": {
+        "hits": 0,
+        "misses": 4600
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-document-sync",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-004-changed-file-invalidation",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.014983,
+        "mad_ms": 0.001,
+        "median_ms": 0.265,
+        "p95_ms": 0.27,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.26538458000000004,
+        0.28193667,
+        0.26738042,
+        0.26648834,
+        0.26597375,
+        0.26629625,
+        0.2650125,
+        0.26488167,
+        0.26560125,
+        0.26507125,
+        0.26416124999999996,
+        0.26398999999999995,
+        0.26468875000000003,
+        0.26359583999999997,
+        0.26986875,
+        0.26470333,
+        0.26486041,
+        0.26200208,
+        0.26329291,
+        0.26753290999999996
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.interactive.source_map_lookup",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "diagnostics_count": 0,
+      "evidence_category": "editor-source-map",
+      "group": "interactive-tooling-foundation",
+      "id": "interactive-tooling-foundation-005-source-map-lookup",
+      "kind": "frontend-query",
+      "metrics": {
+        "coefficient_variation": 0.025814,
+        "mad_ms": 0.001,
+        "median_ms": 0.03,
+        "p95_ms": 0.031,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 20,
+      "samples_ms": [
+        0.03129958,
+        0.03012458,
+        0.03123125,
+        0.02971416,
+        0.0299175,
+        0.0307675,
+        0.02933625,
+        0.030227499999999997,
+        0.03108833,
+        0.029264170000000003,
+        0.02965083,
+        0.029689579999999997,
+        0.03073833,
+        0.02963166,
+        0.02917292,
+        0.030638750000000003,
+        0.02882041,
+        0.029385000000000005,
+        0.029766250000000005,
+        0.03153042
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.human_success_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "exit-code",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-001-human-success-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.005931,
+        "mad_ms": 7.138,
+        "median_ms": 1227.674,
+        "p95_ms": 1238.76,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.6736250059912,
+        1230.6176249985583,
+        1220.5352919991128,
+        1218.5453749989392,
+        1238.7603749957634
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.json_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-json",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-002-json-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.026421,
+        "mad_ms": 5.592,
+        "median_ms": 1214.504,
+        "p95_ms": 1293.217,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1253.8687500054948,
+        1212.5427079881774,
+        1208.9117909927154,
+        1214.5042089978233,
+        1293.216542006121
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.compact_diagnostic_schema",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostics-compact",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-003-compact-diagnostic-schema",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015743,
+        "mad_ms": 6.942,
+        "median_ms": 1227.41,
+        "p95_ms": 1272.689,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1227.4097909976263,
+        1220.4674579988932,
+        1239.5988339994801,
+        1272.6888329925714,
+        1221.1634999985108
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.recovery_limit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "diagnostic-recovery",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-004-recovery-limit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.015609,
+        "mad_ms": 20.109,
+        "median_ms": 1231.518,
+        "p95_ms": 1259.924,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1259.9240830022609,
+        1236.7285410000477,
+        1231.517583000823,
+        1211.4089579990832,
+        1206.436250009574
+      ],
+      "timed_out": false
+    },
+    {
+      "budget_id": "perf.phase27.project_error_exit",
+      "cache": {
+        "hits": 0,
+        "misses": 0
+      },
+      "evidence_category": "project-diagnostics",
+      "group": "phase27-non-regression",
+      "id": "phase27-non-regression-005-project-error-exit",
+      "kind": "command",
+      "metrics": {
+        "coefficient_variation": 0.002534,
+        "mad_ms": 3.64,
+        "median_ms": 1217.324,
+        "p95_ms": 1221.378,
+        "peak_rss_bytes": 309002240
+      },
+      "sample_count": 5,
+      "samples_ms": [
+        1213.684458998614,
+        1221.3782500039088,
+        1213.377167005092,
+        1219.0436660021078,
+        1217.3239999974612
+      ],
+      "timed_out": false
+    }
+  ],
+  "runner_version": 1,
+  "schema_version": 1
+}

--- a/verification/performance/negative_seeds/correctness_waiver.json
+++ b/verification/performance/negative_seeds/correctness_waiver.json
@@ -1,0 +1,24 @@
+{
+  "description": "Negative and positive waiver validation seeds for check_budgets.py --self-test.",
+  "version": 1,
+  "waivers": [
+    {
+      "benchmark_ids": [
+        "check-single-file-001-arithmetic"
+      ],
+      "budget_ids": [
+        "perf.check.single.arithmetic"
+      ],
+      "created": "2026-05-16",
+      "expires": "2099-12-31",
+      "id": "correctness-waiver",
+      "issue": "https://github.com/sifr-lang/sifr/issues/35",
+      "override": {
+        "timeout": true
+      },
+      "owner": "sifr-lang/performance",
+      "rationale": "Self-test seed for active median regression waiver validation.",
+      "removal_criteria": "Remove when the self-test no longer needs a positive waiver seed."
+    }
+  ]
+}

--- a/verification/performance/negative_seeds/expired_waiver.json
+++ b/verification/performance/negative_seeds/expired_waiver.json
@@ -1,0 +1,24 @@
+{
+  "description": "Negative and positive waiver validation seeds for check_budgets.py --self-test.",
+  "version": 1,
+  "waivers": [
+    {
+      "benchmark_ids": [
+        "check-single-file-001-arithmetic"
+      ],
+      "budget_ids": [
+        "perf.check.single.arithmetic"
+      ],
+      "created": "2026-05-16",
+      "expires": "2026-01-01",
+      "id": "expired-waiver",
+      "issue": "https://github.com/sifr-lang/sifr/issues/35",
+      "override": {
+        "median_ms": 1344.139
+      },
+      "owner": "sifr-lang/performance",
+      "rationale": "Self-test seed for active median regression waiver validation.",
+      "removal_criteria": "Remove when the self-test no longer needs a positive waiver seed."
+    }
+  ]
+}

--- a/verification/performance/negative_seeds/malformed_waiver.json
+++ b/verification/performance/negative_seeds/malformed_waiver.json
@@ -1,0 +1,24 @@
+{
+  "description": "Negative and positive waiver validation seeds for check_budgets.py --self-test.",
+  "version": 1,
+  "waivers": [
+    {
+      "benchmark_ids": [
+        "check-single-file-001-arithmetic"
+      ],
+      "budget_ids": [
+        "perf.check.single.arithmetic"
+      ],
+      "created": "2026-05-16",
+      "expires": "2099-12-31",
+      "id": "malformed-waiver",
+      "issue": "https://github.com/sifr-lang/sifr/issues/35",
+      "override": {
+        "median_ms": 1344.139
+      },
+      "owner": "",
+      "rationale": "Self-test seed for active median regression waiver validation.",
+      "removal_criteria": "Remove when the self-test no longer needs a positive waiver seed."
+    }
+  ]
+}

--- a/verification/performance/waivers.json
+++ b/verification/performance/waivers.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "description": "Active Phase 35 performance waivers. Waivers may cover temporary performance regressions only; correctness, timeout, diagnostics, cache-staleness, split-brain, and panic-safety failures are not waiverable.",
+  "waivers": []
+}


### PR DESCRIPTION
## Summary
- add Phase 35 performance budgets derived from checked-in m35.1 baselines
- add waiver registry and budget checker with negative regression and waiver seeds
- document budget formulas, waiver constraints, and local commands

## Validation
- python3 verification/performance/check_budgets.py
- python3 verification/performance/check_budgets.py --self-test
- python3 verification/performance/run_benchmarks.py --validate-only
- python3 verification/performance/run_benchmarks.py --self-test
- python3 -m py_compile verification/performance/check_budgets.py verification/performance/run_benchmarks.py
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase35-m35-2-review-pass-1.md: SATISFIED
