### PR TITLE
Phase 35 m35.3 performance budget enforcement

### DIFF
--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -33,6 +33,17 @@ Run the budget gate against checked-in baselines:
 python3 verification/performance/check_budgets.py
 ```
 
+`scripts/run_all_tests.sh --profile quick` runs manifest validation, benchmark
+negative seeds, budget/waiver negative seeds, the checked-in baseline budget
+gate, and a minimal frontend-query smoke. `--profile pr`, `nightly`, and
+`release` run the same schema and negative checks, execute a reviewed
+representative subset with the manifest sample counts into
+`target/performance/<profile>.budget.latest.json`, and run `check_budgets.py
+--allow-subset` against that result file. The subset covers single-file check,
+project check, single-file build, project build, incremental cache behavior,
+interactive diagnostics, and Phase 27 diagnostic/exit-code non-regression.
+Full-corpus benchmark execution and baseline refresh remain explicit:
+
 Refresh baselines intentionally after review:
 
 ```bash

--- a/issues/phase35-performance-benchmarking-execution.md
+++ b/issues/phase35-performance-benchmarking-execution.md
@@ -11,7 +11,7 @@ status: in_progress
 - [x] m35.4a Ruff fork fixture revalidation contract added.
 - [x] m35.1 baseline benchmark suite.
 - [x] m35.2 budget and waiver policy.
-- [ ] m35.3 enforcement integration for performance budgets.
+- [x] m35.3 enforcement integration for performance budgets.
 - [ ] m35.4b full CLI adoption and query regression lock.
 
 ## Validation Evidence
@@ -26,7 +26,7 @@ status: in_progress
 - `python3 verification/performance/check_frontend_cache_contract.py` -> PASS.
 - `reviews/phase35-m35-4a-review-pass-1.md` -> NOT SATISFIED; blockers B1/B2 fixed.
 - `reviews/phase35-m35-4a-review-pass-2.md` -> SATISFIED for m35.4a.
-- `scripts/run_all_tests.sh --profile quick` -> PASS for m35.1 (`wall_time=944.94s`) and m35.2 (`wall_time=748.90s`); wall-time advisories recorded in `target/validation_lane_reports/quick.latest.json`, report signature `f808284595f17a99`.
+- `scripts/run_all_tests.sh --profile quick` -> PASS for m35.1 (`wall_time=944.94s`), m35.2 (`wall_time=748.90s`), and m35.3 (`wall_time=564.73s`); wall-time advisories recorded in `target/validation_lane_reports/quick.latest.json`, report signature `f808284595f17a99`.
 - `verification/performance/manifest.json` -> 45 benchmark cases across the required Phase 35 groups.
 - `verification/performance/baselines.json` -> captured with all 45 manifest cases; maximum coefficient of variation `0.091581`.
 - `python3 verification/performance/run_benchmarks.py --validate-only` -> PASS.
@@ -44,6 +44,12 @@ status: in_progress
 - `python3 verification/performance/check_budgets.py --self-test` -> PASS; seeded median, p95, RSS, timeout, missing-result, unknown-id, malformed-result, expired-waiver, malformed-waiver, and correctness-waiver failures are rejected.
 - `python3 -m py_compile verification/performance/check_budgets.py verification/performance/run_benchmarks.py` -> PASS.
 - `reviews/phase35-m35-2-review-pass-1.md` -> SATISFIED for m35.2.
+- `scripts/run_all_tests.sh` -> adds "Performance Budget Checks" after Phase 35 frontend/syntax guardrails.
+- Quick lane performance checks -> manifest validation, benchmark self-test, checked-in baseline budget gate, budget self-test, and a two-case frontend-query smoke.
+- PR/nightly/release performance checks -> same schema/negative checks plus a reviewed seven-case representative benchmark subset with budget comparison against `target/performance/<profile>.budget.latest.json`.
+- `python3 verification/performance/run_benchmarks.py --case check-single-file-001-arithmetic --case check-project-004-project-graph --case build-single-file-001-break-continue --case build-project-001-additional-modules --case incremental-local-loop-001-unchanged-file-update --case interactive-tooling-foundation-002-warm-diagnostics-query --case phase27-non-regression-002-json-diagnostic-schema --json-out target/performance/test.pr.subset.budget.json && python3 verification/performance/check_budgets.py --results target/performance/test.pr.subset.budget.json --allow-subset` -> PASS.
+- `bash -n scripts/run_all_tests.sh` -> PASS.
+- `reviews/phase35-m35-3-review-pass-1.md` -> SATISFIED for m35.3.
 
 ## Open Migration Targets
 

--- a/reviews/phase35-m35-3-review-pass-1.md
+++ b/reviews/phase35-m35-3-review-pass-1.md
@@ -1,0 +1,50 @@
+
+
+Based on my thorough review of all five changed files against the Phase 35 m35.3 specification, here is my assessment:
+
+---
+
+## Code Review: Phase 35 m35.3 — Enforcement Integration
+
+### SATISFIED
+
+The implementation satisfies m35.3. Below are the blockers and non-blocking follow-ups.
+
+---
+
+### Blockers
+
+**None.**
+
+All six critical dimensions pass:
+
+| Dimension | Evidence | Status |
+|---|---|---|
+| Local/CI parity | All four profiles (quick/pr/nightly/release) execute identical performance check commands in `run_all_tests.sh:123-147` | ✅ |
+| Quick stays fast | Runs `--validate-only`, `--self-test` (×2), baseline-gate, and `--sample-scale smoke` (2 cases, 1 iteration) instead of full corpus | ✅ |
+| PR+ representative subset | 7 reviewed cases explicitly named in script + documented in `performance_budgets.md:40-44` with full-corpus documented in `:45-51` | ✅ |
+| Failure includes id/threshold/measured/waiver-status | `format_failure()` at `check_budgets.py:302-318` emits `case_id (budget_id) metric regression: measured=X threshold=Y waiver_status=Z` | ✅ |
+| `--allow-subset` scoped to representative lane | `allow_subset` guards only the missing-result skip at `check_budgets.py:76-78`; all other errors (malformed, unknown-id, regressions) remain hard failures regardless of `--allow-subset` | ✅ |
+| No CI-only behavior | Both local and CI invoke the same `python3 verification/performance/run_benchmarks.py` / `check_budgets.py` commands via the same `run_all_tests.sh` entry point | ✅ |
+
+---
+
+### Non-Blocking Follow-Ups
+
+1. **`internal_docs/phases/35_performance_benchmarking_and_budgets.md`**: The m35.3 DoD at line 617 states `m35.3` enforcement is complete but the document `status:` at line 3 still reads `in_progress`. Update to `status: complete` and check m35.4b status after that milestone is merged.
+
+2. **`reviews/phase35-m35-3-review-pass-1.md`**: The review file exists but is empty (1 line). This may be a pre-review placeholder. No action required unless you intend to document the review record here.
+
+3. **Full-corpus commands**: `performance_budgets.md:45-51` correctly documents full-corpus benchmark execution and baseline refresh as explicit commands rather than implicit CI-only behavior. No change needed—this is correct.
+
+---
+
+### Validation Summary
+
+All pre-submission checks pass:
+- `bash -n` syntax check: PASS
+- `py_compile` syntax check on both scripts: PASS
+- `--self-test` for both `run_benchmarks.py` and `check_budgets.py`: PASS
+- `--validate-only` manifest check: PASS
+- PR-style representative subset with `--allow-subset`: PASS
+- Quick lane smoke (2 cases × `--sample-scale smoke`): PASS

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -120,6 +120,32 @@ python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.p
 python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.py" --self-test
 python3 "${SCRIPT_DIR}/../verification/performance/check_frontend_cache_contract.py"
 
+echo "Running Performance Budget Checks"
+python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --validate-only
+python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --self-test
+python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py"
+python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" --self-test
+if [[ "${PROFILE}" == "quick" ]]; then
+  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
+    --sample-scale smoke \
+    --case incremental-local-loop-001-unchanged-file-update \
+    --case interactive-tooling-foundation-002-warm-diagnostics-query
+else
+  PERF_RESULTS="target/performance/${PROFILE}.budget.latest.json"
+  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
+    --case check-single-file-001-arithmetic \
+    --case check-project-004-project-graph \
+    --case build-single-file-001-break-continue \
+    --case build-project-001-additional-modules \
+    --case incremental-local-loop-001-unchanged-file-update \
+    --case interactive-tooling-foundation-002-warm-diagnostics-query \
+    --case phase27-non-regression-002-json-diagnostic-schema \
+    --json-out "${PERF_RESULTS}"
+  python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" \
+    --results "${PERF_RESULTS}" \
+    --allow-subset
+fi
+
 echo "Running verification hardening script self-tests"
 python3 "${SCRIPT_DIR}/run_verification_hardening.py" --self-test
 

--- a/verification/performance/check_budgets.py
+++ b/verification/performance/check_budgets.py
@@ -33,6 +33,7 @@ def main() -> int:
     parser.add_argument("--results", default=str(DEFAULT_BASELINES))
     parser.add_argument("--budgets", default=str(DEFAULT_BUDGETS))
     parser.add_argument("--waivers", default=str(DEFAULT_WAIVERS))
+    parser.add_argument("--allow-subset", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -46,7 +47,7 @@ def main() -> int:
         budgets = load_json(Path(args.budgets))
         waivers = load_json(Path(args.waivers))
         results = load_json(Path(args.results))
-        check_budgets(manifest, budgets, waivers, results)
+        check_budgets(manifest, budgets, waivers, results, allow_subset=args.allow_subset)
         print("performance budget check passed")
         return 0
     except BudgetError as error:
@@ -59,18 +60,21 @@ def check_budgets(
     budgets: dict[str, Any],
     waivers: dict[str, Any],
     results: dict[str, Any],
+    *,
+    allow_subset: bool = False,
 ) -> None:
     cases = validate_manifest(manifest)
     budget_entries = validate_budgets(budgets, cases)
     waiver_entries = validate_waivers(waivers, cases, budget_entries)
-    validate_results_shape(results, cases)
+    validate_results_shape(results, cases, allow_subset=allow_subset)
 
     results_by_id = {result["id"]: result for result in results["results"]}
     failures: list[str] = []
     for case_id, budget in budget_entries.items():
         result = results_by_id.get(case_id)
         if result is None:
-            failures.append(f"{case_id}: missing result for budget {budget['budget_id']}")
+            if not allow_subset:
+                failures.append(f"{case_id}: missing result for budget {budget['budget_id']}")
             continue
         failures.extend(compare_result(result, budget, waiver_entries))
 
@@ -201,7 +205,12 @@ def validate_waivers(
     return validated
 
 
-def validate_results_shape(results: dict[str, Any], cases: dict[str, dict[str, Any]]) -> None:
+def validate_results_shape(
+    results: dict[str, Any],
+    cases: dict[str, dict[str, Any]],
+    *,
+    allow_subset: bool = False,
+) -> None:
     if results.get("schema_version") != 1:
         raise BudgetError("benchmark results schema_version must be 1")
     if results.get("runner_version") != RUNNER_VERSION:
@@ -235,7 +244,7 @@ def validate_results_shape(results: dict[str, Any], cases: dict[str, dict[str, A
             raise BudgetError(f"benchmark result {result_id} is missing cache hit/miss metrics")
 
     missing = sorted(set(cases) - seen)
-    if missing:
+    if missing and not allow_subset:
         raise BudgetError(f"benchmark results are missing benchmark ids: {missing}")
 
 

--- a/verification/performance/run_benchmarks.py
+++ b/verification/performance/run_benchmarks.py
@@ -79,6 +79,7 @@ def main() -> int:
     parser.add_argument("--validate-only", action="store_true")
     parser.add_argument("--capture-baseline", action="store_true")
     parser.add_argument("--baseline-output", default="")
+    parser.add_argument("--json-out", default="")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -105,6 +106,8 @@ def main() -> int:
 
         run_report = run_cases(selected, Path(args.output_root), args.sample_scale)
         evidence_path = write_run_report(run_report, Path(args.output_root))
+        if args.json_out:
+            write_json((REPO_ROOT / args.json_out).resolve(), run_report)
         if args.capture_baseline:
             validate_baseline_capture(run_report, {case.id: case for case in cases})
             baseline = baseline_from_run(run_report, manifest)


### PR DESCRIPTION
## Summary
- wire a clearly named Performance Budget Checks step into run_all_tests.sh
- keep quick fast with schema, negative seed, baseline budget, and two-case frontend smoke checks
- run PR+ representative benchmark subset with budget comparison through the same local script path

## Validation
- python3 verification/performance/check_budgets.py --self-test
- python3 verification/performance/run_benchmarks.py --validate-only
- python3 verification/performance/run_benchmarks.py --self-test
- python3 -m py_compile verification/performance/run_benchmarks.py verification/performance/check_budgets.py
- bash -n scripts/run_all_tests.sh
- representative subset benchmark + check_budgets --allow-subset
- scripts/run_all_tests.sh --profile quick

## Review
- reviews/phase35-m35-3-review-pass-1.md: SATISFIED
