### PR TITLE
Fix installer version state handling

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -93,6 +93,8 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build target binary
+        env:
+          SIFR_RELEASE_VERSION: ${{ needs.validate.outputs.version }}
         run: cargo build --release -p sifr --target "${{ matrix.target }}"
 
       - name: Package artifact

--- a/crates/sifr/build.rs
+++ b/crates/sifr/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=SIFR_RELEASE_VERSION");
+
+    let version = std::env::var("SIFR_RELEASE_VERSION")
+        .or_else(|_| std::env::var("CARGO_PKG_VERSION"))
+        .expect("CARGO_PKG_VERSION should be set by Cargo");
+
+    println!("cargo:rustc-env=SIFR_BUILD_VERSION={version}");
+}

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -27,10 +27,12 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process;
 
+const SIFR_BUILD_VERSION: &str = env!("SIFR_BUILD_VERSION");
+
 #[derive(Parser)]
 #[command(
     name = "sifr",
-    version,
+    version = SIFR_BUILD_VERSION,
     about = "The Sifr programming language compiler"
 )]
 struct Cli {

--- a/scripts/distribution/build_preview_artifacts.sh
+++ b/scripts/distribution/build_preview_artifacts.sh
@@ -118,7 +118,7 @@ mkdir -p "${OUTPUT_DIR}"
 
 for target in "${TARGETS[@]}"; do
   if [[ "${CARGO_BUILD}" -eq 1 ]]; then
-    cargo build --release -p sifr --target "${target}"
+    SIFR_RELEASE_VERSION="${VERSION}" cargo build --release -p sifr --target "${target}"
     binary_path="target/${target}/release/sifr"
   else
     binary_path="${BINARY}"

--- a/scripts/distribution/generate_version_installer.sh
+++ b/scripts/distribution/generate_version_installer.sh
@@ -120,6 +120,7 @@ APP_NAME="sifr"
 APP_VERSION="${VERSION}"
 ARTIFACT_BASE_URL="${ARTIFACT_BASE_URL}"
 NO_MODIFY_PATH="\${SIFR_NO_MODIFY_PATH:-0}"
+FORCE_INSTALL=0
 
 fail() {
   echo "sifr installer: \$*" >&2
@@ -132,10 +133,14 @@ Usage: sifr-installer.sh [options]
 
 Options:
   --no-modify-path    Do not update shell profiles to add Sifr to PATH
+  --force             Reinstall the same version or downgrade from a newer installed version
   --help              Show this help
 
 Environment:
   SIFR_INSTALL_DIR        Install directory (default: \$HOME/.sifr/bin)
+  SIFR_INSTALL_MANIFEST_DIR
+                          Install manifest directory (default: \$HOME/.sifr for the default install dir,
+                          otherwise SIFR_INSTALL_DIR)
   SIFR_NO_MODIFY_PATH=1   Do not update shell profiles
   SIFR_TARGET             Override target triple for validation
 EOFUSAGE
@@ -145,6 +150,10 @@ while [ "\$#" -gt 0 ]; do
   case "\$1" in
     --no-modify-path)
       NO_MODIFY_PATH=1
+      shift
+      ;;
+    --force)
+      FORCE_INSTALL=1
       shift
       ;;
     --help)
@@ -175,6 +184,132 @@ sha256_file() {
   else
     fail "sha256sum or shasum is required to verify artifacts"
   fi
+}
+
+semver_parts() {
+  version="\$1"
+  core="\${version%%-*}"
+  prerelease=""
+  if [ "\${core}" != "\${version}" ]; then
+    prerelease="\${version#*-}"
+  fi
+
+  major="\${core%%.*}"
+  rest="\${core#*.}"
+  minor="\${rest%%.*}"
+  patch="\${rest#*.}"
+  rank=4
+  prerelease_number=0
+
+  if [ -n "\${prerelease}" ]; then
+    prerelease_label="\${prerelease%%.*}"
+    prerelease_number="\${prerelease#*.}"
+    case "\${prerelease_label}" in
+      alpha)
+        rank=1
+        ;;
+      beta)
+        rank=2
+        ;;
+      rc)
+        rank=3
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
+
+  printf '%s %s %s %s %s\n' "\${major}" "\${minor}" "\${patch}" "\${rank}" "\${prerelease_number}"
+}
+
+compare_numbers() {
+  left="\$1"
+  right="\$2"
+  if [ "\${left}" -lt "\${right}" ]; then
+    echo -1
+  elif [ "\${left}" -gt "\${right}" ]; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+compare_versions() {
+  left_parts="\$(semver_parts "\$1")" || return 1
+  right_parts="\$(semver_parts "\$2")" || return 1
+
+  set -- \${left_parts}
+  left_major="\$1"
+  left_minor="\$2"
+  left_patch="\$3"
+  left_rank="\$4"
+  left_prerelease_number="\$5"
+
+  set -- \${right_parts}
+  right_major="\$1"
+  right_minor="\$2"
+  right_patch="\$3"
+  right_rank="\$4"
+  right_prerelease_number="\$5"
+
+  result="\$(compare_numbers "\${left_major}" "\${right_major}")"
+  [ "\${result}" = "0" ] || { echo "\${result}"; return 0; }
+  result="\$(compare_numbers "\${left_minor}" "\${right_minor}")"
+  [ "\${result}" = "0" ] || { echo "\${result}"; return 0; }
+  result="\$(compare_numbers "\${left_patch}" "\${right_patch}")"
+  [ "\${result}" = "0" ] || { echo "\${result}"; return 0; }
+  result="\$(compare_numbers "\${left_rank}" "\${right_rank}")"
+  [ "\${result}" = "0" ] || { echo "\${result}"; return 0; }
+  compare_numbers "\${left_prerelease_number}" "\${right_prerelease_number}"
+}
+
+manifest_version() {
+  manifest_path="\$1"
+  [ -f "\${manifest_path}" ] || return 1
+  sed -n 's/^.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*$/\1/p' "\${manifest_path}" | head -n 1
+}
+
+binary_version() {
+  binary_path="\$1"
+  [ -x "\${binary_path}" ] || return 1
+  version_output="\$("\${binary_path}" --version 2>/dev/null || true)"
+  set -- \${version_output}
+  [ "\${1:-}" = "\${APP_NAME}" ] || return 1
+  case "\${2:-}" in
+    0.0.0)
+      return 1
+      ;;
+    [0-9]*.[0-9]*.[0-9]*)
+      echo "\$2"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+detect_installed_version() {
+  version="\$(manifest_version "\${manifest_path}" || true)"
+  if [ -n "\${version}" ]; then
+    echo "\${version}"
+    return 0
+  fi
+
+  binary_version "\${installed_binary}" || true
+}
+
+write_install_manifest() {
+  mkdir -p "\${manifest_dir}"
+  {
+    printf '%s\n' '{'
+    printf '  "name": "%s",\n' "\${APP_NAME}"
+    printf '  "version": "%s",\n' "\${APP_VERSION}"
+    printf '  "target": "%s",\n' "\${target}"
+    printf '  "install_dir": "%s",\n' "\${install_dir}"
+    printf '  "artifact": "%s"\n' "\${archive_name}"
+    printf '%s\n' '}'
+  } >"\${manifest_path}"
 }
 
 detect_target() {
@@ -332,6 +467,48 @@ if [ -z "\${install_dir}" ]; then
   install_dir="\${HOME}/.sifr/bin"
 fi
 
+manifest_dir="\${SIFR_INSTALL_MANIFEST_DIR:-}"
+if [ -z "\${manifest_dir}" ]; then
+  if [ -n "\${HOME:-}" ] && [ "\${install_dir}" = "\${HOME}/.sifr/bin" ]; then
+    manifest_dir="\${HOME}/.sifr"
+  else
+    manifest_dir="\${install_dir}"
+  fi
+fi
+manifest_path="\${manifest_dir}/install.json"
+installed_binary="\${install_dir}/sifr"
+installed_version="\$(detect_installed_version)"
+
+if [ -x "\${installed_binary}" ] && [ -n "\${installed_version}" ]; then
+  version_order="\$(compare_versions "\${installed_version}" "\${APP_VERSION}")" || version_order=""
+  case "\${version_order}" in
+    0)
+      if [ "\${FORCE_INSTALL}" = "0" ]; then
+        echo "Sifr \${APP_VERSION} is already installed at \${installed_binary}"
+        configure_path
+        exit 0
+      fi
+      echo "Reinstalling Sifr \${APP_VERSION} at \${installed_binary}"
+      ;;
+    -1)
+      echo "Updating Sifr \${installed_version} -> \${APP_VERSION}"
+      ;;
+    1)
+      if [ "\${FORCE_INSTALL}" = "0" ]; then
+        fail "installed Sifr \${installed_version} is newer than requested \${APP_VERSION}; use --force to downgrade"
+      fi
+      echo "Downgrading Sifr \${installed_version} -> \${APP_VERSION} (--force)"
+      ;;
+    *)
+      echo "Updating existing Sifr installation (version unknown) -> \${APP_VERSION}"
+      ;;
+  esac
+elif [ -x "\${installed_binary}" ]; then
+  echo "Updating existing Sifr installation (version unknown) -> \${APP_VERSION}"
+else
+  echo "Installing Sifr \${APP_VERSION}"
+fi
+
 if [ "\${SIFR_INSTALLER_TRACE:-0}" = "1" ]; then
   echo "sifr installer version=\${APP_VERSION} target=\${target} archive=\${archive_name}"
 fi
@@ -362,6 +539,7 @@ tmp_binary="\${install_dir}/.sifr.\$\$.tmp"
 cp "\${extract_dir}/sifr" "\${tmp_binary}"
 chmod 755 "\${tmp_binary}"
 mv "\${tmp_binary}" "\${install_dir}/sifr"
+write_install_manifest
 
 echo "installed sifr \${APP_VERSION} to \${install_dir}/sifr"
 configure_path

--- a/verification/distribution/artifact_install_version_state.sh
+++ b/verification/distribution/artifact_install_version_state.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-install-version-state.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+version="0.1.0-beta.3"
+artifact_dir="${tmp_dir}/artifacts"
+installer="${tmp_dir}/installer.sh"
+target="x86_64-unknown-linux-gnu"
+
+make_target_specific_artifacts "${version}" "${artifact_dir}"
+"${REPO_ROOT}/scripts/distribution/generate_version_installer.sh" \
+  --version "${version}" \
+  --artifact-dir "${artifact_dir}" \
+  --out "${installer}" \
+  --artifact-base-url "file://${artifact_dir}" >/dev/null
+
+run_installer() {
+  local install_dir="$1"
+  shift
+  SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_INSTALL_DIR="${install_dir}" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path "$@"
+}
+
+fresh_install_dir="${tmp_dir}/fresh/bin"
+fresh_output="$(run_installer "${fresh_install_dir}")"
+[[ "${fresh_output}" == *"Installing Sifr ${version}"* ]] || {
+  echo "fresh install did not report installation" >&2
+  echo "${fresh_output}" >&2
+  exit 1
+}
+grep -F "\"version\": \"${version}\"" "${fresh_install_dir}/install.json" >/dev/null
+
+same_output="$(run_installer "${fresh_install_dir}")"
+[[ "${same_output}" == *"Sifr ${version} is already installed"* ]] || {
+  echo "same-version install did not report already installed" >&2
+  echo "${same_output}" >&2
+  exit 1
+}
+
+force_same_output="$(run_installer "${fresh_install_dir}" --force)"
+[[ "${force_same_output}" == *"Reinstalling Sifr ${version} at ${fresh_install_dir}/sifr"* ]] || {
+  echo "same-version force install did not report reinstall" >&2
+  echo "${force_same_output}" >&2
+  exit 1
+}
+
+custom_manifest_install_dir="${tmp_dir}/custom-manifest/bin"
+custom_manifest_dir="${tmp_dir}/custom-manifest/state"
+custom_manifest_output="$(
+  SIFR_TARGET="${target}" \
+    SIFR_ARTIFACT_BASE_URL="file://${artifact_dir}" \
+    SIFR_INSTALL_DIR="${custom_manifest_install_dir}" \
+    SIFR_INSTALL_MANIFEST_DIR="${custom_manifest_dir}" \
+    SIFR_NO_MODIFY_PATH=1 \
+    sh "${installer}" --no-modify-path
+)"
+[[ "${custom_manifest_output}" == *"Installing Sifr ${version}"* ]] || {
+  echo "custom manifest install did not report installation" >&2
+  echo "${custom_manifest_output}" >&2
+  exit 1
+}
+grep -F "\"version\": \"${version}\"" "${custom_manifest_dir}/install.json" >/dev/null
+[[ ! -e "${custom_manifest_install_dir}/install.json" ]] || {
+  echo "installer ignored custom manifest directory" >&2
+  exit 1
+}
+
+known_old_dir="${tmp_dir}/known-old/bin"
+mkdir -p "${known_old_dir}"
+make_mock_binary "${known_old_dir}/sifr" "old known fixture"
+printf '%s\n' '{"name":"sifr","version":"0.1.0-beta.2"}' >"${known_old_dir}/install.json"
+known_old_output="$(run_installer "${known_old_dir}")"
+[[ "${known_old_output}" == *"Updating Sifr 0.1.0-beta.2 -> ${version}"* ]] || {
+  echo "known older install did not report update" >&2
+  echo "${known_old_output}" >&2
+  exit 1
+}
+
+unknown_old_dir="${tmp_dir}/unknown-old/bin"
+mkdir -p "${unknown_old_dir}"
+cat >"${unknown_old_dir}/sifr" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  echo "sifr 0.0.0"
+else
+  echo "legacy fixture"
+fi
+EOF
+chmod 755 "${unknown_old_dir}/sifr"
+unknown_old_output="$(run_installer "${unknown_old_dir}")"
+[[ "${unknown_old_output}" == *"Updating existing Sifr installation (version unknown) -> ${version}"* ]] || {
+  echo "unknown existing install did not report version-unknown update" >&2
+  echo "${unknown_old_output}" >&2
+  exit 1
+}
+
+newer_dir="${tmp_dir}/newer/bin"
+mkdir -p "${newer_dir}"
+make_mock_binary "${newer_dir}/sifr" "newer fixture"
+cat >"${newer_dir}/install.json" <<'EOF'
+{
+  "name": "sifr",
+  "version": "0.1.0-beta.4"
+}
+EOF
+require_failure_contains \
+  "installed Sifr 0.1.0-beta.4 is newer than requested ${version}; use --force to downgrade" \
+  run_installer "${newer_dir}"
+
+force_output="$(run_installer "${newer_dir}" --force)"
+[[ "${force_output}" == *"Downgrading Sifr 0.1.0-beta.4 -> ${version} (--force)"* ]] || {
+  echo "forced downgrade did not report downgrade" >&2
+  echo "${force_output}" >&2
+  exit 1
+}

--- a/verification/distribution/create_new_version_beta_dry_run.sh
+++ b/verification/distribution/create_new_version_beta_dry_run.sh
@@ -15,13 +15,13 @@ make_site_repo_fixture "${site_repo}"
 
 output="$("${REPO_ROOT}/scripts/distribution/create_new_version.sh" \
   --channel beta \
-  --version 0.1.0-beta.2 \
+  --version 0.1.0-beta.3 \
   --dry-run \
   --site-repo "${site_repo}" \
   --work-dir "${tmp_dir}/work")"
 
 [[ "${output}" == *"channel=beta"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"version=0.1.0-beta.2"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"new_beta=0.1.0-beta.2"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"github_release=sifr-lang/sifr:0.1.0-beta.2"* ]] || { echo "${output}" >&2; exit 1; }
-[[ ! -e "${site_repo}/apps/sifr-site/public/install/versions/0.1.0-beta.2" ]] || exit 1
+[[ "${output}" == *"version=0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"new_beta=0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"github_release=sifr-lang/sifr:0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
+[[ ! -e "${site_repo}/apps/sifr-site/public/install/versions/0.1.0-beta.3" ]] || exit 1

--- a/verification/distribution/create_new_version_site_dispatcher_drift_rejected.sh
+++ b/verification/distribution/create_new_version_site_dispatcher_drift_rejected.sh
@@ -12,7 +12,11 @@ trap cleanup EXIT HUP INT TERM
 
 site_repo="${tmp_dir}/site"
 make_site_repo_fixture "${site_repo}"
-sed -i.bak 's/BETA_VERSION="0.1.0-beta.1"/BETA_VERSION="0.1.0-alpha.1"/' \
+current_beta="$(
+  sed -n 's/^BETA_VERSION="\([^"]*\)"$/\1/p' \
+    "${site_repo}/apps/sifr-site/public/install/beta" | head -n 1
+)"
+sed -i.bak "s/BETA_VERSION=\"${current_beta}\"/BETA_VERSION=\"0.1.0-alpha.1\"/" \
   "${site_repo}/apps/sifr-site/public/install/beta"
 
 require_failure_contains \


### PR DESCRIPTION
## Summary
- embed preview release versions into future sifr release binaries via SIFR_RELEASE_VERSION
- make generated installers detect install/update/already-installed/downgrade states, write install manifests, and require --force for downgrades
- add distribution coverage for installer state transitions and update release tests that assumed beta.2 was unreleased

## Review
- Claude Opus reviewed the patch twice and was satisfied after follow-up coverage additions

## Validation
- scripts/run_distribution_validation.sh
- cargo fmt --check
- cargo test -p sifr -- --skip test_e2e_pass
- SIFR_RELEASE_VERSION=0.1.0-beta.99 cargo run -q -p sifr -- --version
- cargo run -q -p sifr -- --version
- scripts/run_all_tests.sh --profile quick (passed before moving this patch to main-based branch; reran focused gates on the main-based branch afterward)
