### PR TITLE
Harden beta release dry-run validation

### DIFF
--- a/verification/distribution/create_new_version_beta_dry_run.sh
+++ b/verification/distribution/create_new_version_beta_dry_run.sh
@@ -12,16 +12,25 @@ trap cleanup EXIT HUP INT TERM
 
 site_repo="${tmp_dir}/site"
 make_site_repo_fixture "${site_repo}"
+current_beta="$(
+  sed -n 's/^BETA_VERSION="0\.1\.0-beta\.\([0-9][0-9]*\)"$/\1/p' \
+    "${site_repo}/apps/sifr-site/public/install/beta" | head -n 1
+)"
+[[ -n "${current_beta}" ]] || {
+  echo "could not read current beta fixture version" >&2
+  exit 1
+}
+next_beta="0.1.0-beta.$((current_beta + 1))"
 
 output="$("${REPO_ROOT}/scripts/distribution/create_new_version.sh" \
   --channel beta \
-  --version 0.1.0-beta.3 \
+  --version "${next_beta}" \
   --dry-run \
   --site-repo "${site_repo}" \
   --work-dir "${tmp_dir}/work")"
 
 [[ "${output}" == *"channel=beta"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"version=0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"new_beta=0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
-[[ "${output}" == *"github_release=sifr-lang/sifr:0.1.0-beta.3"* ]] || { echo "${output}" >&2; exit 1; }
-[[ ! -e "${site_repo}/apps/sifr-site/public/install/versions/0.1.0-beta.3" ]] || exit 1
+[[ "${output}" == *"version=${next_beta}"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"new_beta=${next_beta}"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"github_release=sifr-lang/sifr:${next_beta}"* ]] || { echo "${output}" >&2; exit 1; }
+[[ ! -e "${site_repo}/apps/sifr-site/public/install/versions/${next_beta}" ]] || exit 1


### PR DESCRIPTION
## Summary
- make beta create-new-version dry-run validation derive the next beta from the current dispatcher fixture
- avoids hardcoding the newest beta version after publishing beta.3

## Validation
- scripts/run_distribution_validation.sh
