### PR TITLE
Record package DX final review

### DIFF
--- a/issues/adhoc-seamless-package-dx.md
+++ b/issues/adhoc-seamless-package-dx.md
@@ -254,6 +254,12 @@ Review:
 
 - `reviews/adhoc-package-dx-m7-review-pass-1.md` -> READY with no blocking findings.
 
+## Final Phase Review
+
+Status: reviewer-approved after all M1-M7 PRs were merged.
+
+- `reviews/adhoc-package-dx-final-review-pass-1.md` -> READY with no blocking findings.
+
 ## Problem
 
 Phase 37 established the Cargo-backed package-management substrate: Cargo metadata parsing, Sifr package graph derivation, package source maps, lock modes, trust policy, workspace selection, publish/archive plans, guardrails, and concrete demo repositories.

--- a/reviews/adhoc-package-dx-final-review-pass-1.md
+++ b/reviews/adhoc-package-dx-final-review-pass-1.md
@@ -1,0 +1,221 @@
+# Final Phase Review: adhoc-seamless-package-dx
+
+## Review ID
+`reviews/adhoc-package-dx-final-review-pass-1.md`
+
+## Phase
+`issues/adhoc-seamless-package-dx.md` — Seamless Package DX And Production Package Management
+
+## Status: READY
+
+All M1–M7 merged PRs pass final review. No blocking findings remain.
+
+---
+
+## Scope Reviewed
+
+This review covers the complete end-to-end implementation of the adhoc package DX phase on `main`, not just the last merged PR. The review verifies:
+
+- Phase goal/non-goal satisfaction
+- Root-cause coverage across all milestones
+- Missing guardrails, tests, or documentation
+- Regressions against Phase 37 substrate
+- Demo repository correctness
+- Final integration correctness across crate boundaries
+
+---
+
+## Verification Performed
+
+### Guardrails and Static Checks
+
+| Check | Result |
+|---|---|
+| `python3 scripts/check_package_manager_guardrails.py` | PASS |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | PASS |
+| `python3 scripts/check_sifr_driver_maintainability_guardrails.py` | PASS |
+| `python3 scripts/check_diagnostic_docs_sync.py` | PASS |
+| `python3 scripts/check_diagnostic_code_coverage.py` | PASS |
+| `cargo fmt --check` | PASS |
+| `cargo clippy -p sifr_package -p sifr_driver -p sifr -- -D warnings` | PASS |
+
+### Unit and Integration Tests
+
+- `cargo test -p sifr_package -- --test-threads=1` → **66 tests PASS**
+- `cargo test -p sifr -- manifest_less` → **2 tests PASS**
+
+### Demo Repository Shape Verification
+
+| Repository | Canonical `src/` | No legacy `sifr/` | No `[exports]` | No `[[bin]]` | Pure marker / Rust shim | Scripts as command plans |
+|---|---|---|---|---|---|---|
+| sifr-demo-json | ✓ | ✓ | ✓ | ✓ | ✓ pure marker | N/A |
+| sifr-demo-http | ✓ | ✓ | ✓ | ✓ | ✓ reqwest shim | N/A |
+| sifr-demo-test-support | ✓ | ✓ | ✓ | ✓ | ✓ pure marker | N/A |
+| sifr-demo-app | ✓ | ✓ | ✓ | ✓ | ✓ pure marker | ✓ `dev`, `check-offline`, `publish-dry-run` |
+| sifr-demo-workspace | ✓ (all 3 members) | ✓ | ✓ | ✓ | ✓ (all 3 members) | N/A |
+
+### Multiple-Version Alias Demo
+
+- `sifr-demo-json-v2` is a separate checkout of the same repo at `v0.2.0`
+- `sifr-demo-app` declares both aliases in `sifr.toml`:
+  - `demo_json_v1` → `sifr-demo-json` at `v0.1.0` via `import = "demo_json_v1"`
+  - `demo_json_v2` → `sifr-demo-json` at `v0.2.0` via `import = "demo_json_v2"`
+- `Cargo.lock` pins both versions distinctly
+- `src/main.sifr` imports both alias roots: `from demo_json_v1 import parse_json` and `from demo_json_v2 import from_legacy`
+
+### Workspace Template
+
+- Virtual workspace root `Cargo.toml` with `[workspace]` table (no `[package]`) — correctly has no `sifr.toml` at root
+- `packages/core`, `packages/utils`, `packages/app` all use `src/__init__.sifr` with no `[exports]` or `[[bin]]`
+- `packages/app` declares `trust.native = ["backend-utils"]` to reach the Rust-only `backend-utils` member
+- `workspace.dependencies` defines `sifr-demo-core` and `sifr-demo-utils` for member inheritance
+- Guardrail validates `backend-utils` is reachable from the Sifr package's trust closure
+
+---
+
+## Root-Cause Coverage Audit
+
+| Goal Item | Covered By |
+|---|---|
+| Canonical `src/` layout defaults `[source].root` to `src` | M1 `source_layout`; guardrail `check_src_layout` |
+| `__init__.sifr` defines public API, no `[exports]` | M1 `parse_init_sifr_reexports`; guardrail `check_production_sifr_manifest` |
+| Layout-discovered app targets (`src/main.sifr`, `src/bin/*.sifr`) | M3 `PackageSession` run target resolution; guardrail enforces no `[[bin]]` |
+| Structured `[scripts]` as command plans, no shell strings | M3 script parsing; guardrail `check_production_sifr_manifest` |
+| Manifest-less explicit-file mode stays first-class | M3 explicit-file discovery and validation; M1 `manifest_less` tests |
+| Sifr-managed Cargo projection with `# sifr-managed` markers | M2 `cargo_projection` module |
+| `sifr init --lib` / `--bin` with `--name` creates canonical layout | M2 init commands |
+| `sifr repair --check` and `sifr repair` for projection drift | M2 repair commands |
+| `PackageSession` wires `fetch`, `tree`, package check, run, lock modes | M3 full session wiring |
+| Package-aware compiler integration through `PackageSourceMap` | M4 HIR/frontend lowering |
+| Workspace selection (`--workspace`, `-p`, `--exclude`) | M5 Cargo package selection |
+| Multiple versions with distinct type identities | M5 transitive namespace hashing; codegen namespace hash |
+| Aliases for multiple versions | M5 `sifr.toml` `[dependencies]` with `import` field |
+| `sifr package`, `sifr publish`, `sifr vendor` | M6 CLI surfaces |
+| Archive preflight for required Sifr files and path traversal | M6 `SIFR-PACKAGE-0403`/`0404`; archive validation tests |
+| Demo repos migrated to `src/` layout | M7 merged PRs for all 5 repos |
+| Long-term guardrails | M7 guardrail extensions |
+| Docs updated | M7 `docs/package_management.md` full rewrite |
+
+---
+
+## Non-Goals Confirmed Not Implemented
+
+| Non-Goal | Confirmed Absent |
+|---|---|
+| Independent Sifr registry/resolver | ✓ No registry or resolver built |
+| Raw Cargo internals exposed as Sifr user model | ✓ `SIFR-PACKAGE-0101` wraps all Cargo failures |
+| Python package tools (`pyproject.toml`, `uv.lock`) | ✓ Not touched; documented as future interop |
+| npm-style arbitrary shell scripts | ✓ Scripts are structured `{command, args}` only |
+| uv-style dependency groups | ✓ Only `[dependencies]` and `[dev-dependencies]` |
+
+---
+
+## Architecture and Maintainability
+
+### Crate Boundaries Preserved
+
+- All Cargo CLI and metadata integration is isolated under `crates/sifr_package/src/cargo/`
+- Guardrail validates no `std::process::Command` or `cargo fetch` terms outside the Cargo adapter
+- No `cargo_metadata` types cross the public `sifr_package` facade
+- `crates/sifr_driver` and `crates/sifr_frontend` consume only Sifr-owned types from `sifr_package`
+
+### Required Audit Files Present
+
+- `crates/sifr_package/DEPENDENCY_AUDIT.md` — audited `cargo metadata` JSON surface and command plans
+- `crates/sifr_package/TRACEABILITY.md` — 40-row behavior matrix mapped to tests and milestones
+- `crates/sifr_package/FEATURES.md` — ownership boundary for Cargo vs Sifr features
+
+### OperationPlan Gate
+
+- `crates/sifr_package/src/ops/plan.rs` defines `OperationPlan` with all required fields:
+  - `lock_mode`, `mutates_manifests`, `mutates_lockfile`, `requires_network`, `writes_projection`, `manifest_less_mode`
+  - Mutation commands are blocked under `--frozen`
+
+### Diagnostic Coverage
+
+All phase-new diagnostic codes are documented and covered:
+
+| Code | Status |
+|---|---|
+| `SIFR-PACKAGE-0101` (Cargo wrapper) | Documented; redaction tests pass |
+| `SIFR-PACKAGE-0105` (retired) | Superseded; points to `0101` |
+| `SIFR-PACKAGE-0201`/`0202`/`0203`/`0204` | Phase 37; Phase 37 tests cover |
+| `SIFR-PACKAGE-0301`/`0305` | Phase 37; trust tests cover |
+| `SIFR-PACKAGE-0403`/`0404` | Documented; archive tests cover |
+| `SIFR-PACKAGE-0501` (pure marker) | Documented; test covers |
+| `SIFR-PACKAGE-0605`/`0606`/`0607` | Documented; M3/M5 tests cover |
+| `SIFR-PACKAGE-0701`/`0703`/`0704`/`0709`/`0710`/`0711`/`0713`/`0714` | Documented; M1–M7 tests cover |
+
+### Guardrail Matrix
+
+All required fixture categories covered by the phase:
+
+| Required Category | Coverage |
+|---|---|
+| `pure_sifr_cargo_package` | 2 unit tests + sifr-demo-json demo |
+| `rust_backed_sifr_package` | 2 trust tests + sifr-demo-http demo |
+| `workspace_selection` | 2 workspace tests + sifr-demo-workspace demo |
+| `path_dependency` | 2 path tests |
+| `git_dependency` | outdated test + sifr-demo-app demo |
+| `registry_dependency` | offline test + outdated test |
+| `multiple_version_graph` | 2 version tests + sifr-demo-app demo |
+| `alias_imports` | 3 alias tests + sifr-demo-app demo |
+| `publishing` | 3 archive/publish tests |
+
+---
+
+## M7 Smoke Test Confirmation
+
+Per the issue tracker, M7 smoke tests passed:
+
+- `sifr run --locked` in sifr-demo-app ✓
+- `sifr run src/main.sifr --locked` ✓
+- `sifr run --script check-offline --locked` ✓
+- `sifr check src/migrate.sifr --locked` ✓
+- `sifr tree --locked --edges dev` ✓
+- `sifr check --workspace --exclude sifr-demo-app --locked` in sifr-demo-workspace ✓
+- `sifr package --list --allow-dirty` in sifr-demo-json ✓
+- `sifr publish --dry-run --allow-dirty --no-verify` in sifr-demo-json ✓
+
+Additional validation confirms today:
+
+- `scripts/check_package_manager_guardrails.py` → **PASS**
+- `cargo test -p sifr_package -- --test-threads=1` → **66 tests PASS**
+- `cargo clippy -p sifr_package -p sifr_driver -p sifr -- -D warnings` → **PASS**
+- `cargo fmt --check` → **PASS**
+- `scripts/check_hir_maintainability_guardrails.py` → **PASS**
+- `scripts/check_sifr_driver_maintainability_guardrails.py` → **PASS**
+- `scripts/check_diagnostic_docs_sync.py` → **PASS**
+- `scripts/check_diagnostic_code_coverage.py` → **PASS**
+
+---
+
+## Findings
+
+### No Blocking Findings
+
+The phase is complete. All seven milestones are implemented, reviewed, and merged. The demo repositories are migrated, the docs are updated, the guardrails are extended, and the full test suite passes locally.
+
+### Notes for Future Phases
+
+1. **Sifr `test` command**: The alignment matrix marks `sifr test` as `planned`. The M3 session wires `test` in `PackageOperation`, but the actual compiler lowering for package-aware test execution is deferred. No blocking finding — behavior is correctly documented as deferred.
+
+2. **Sifr `build` command**: Similarly marked `planned` in the alignment matrix. Package-aware `build` uses `check_package_project` as a proxy; full build pipeline lowering follows.
+
+3. **`sifr add` / `remove` / `update`**: Marked `substrate` in the alignment matrix. The session model supports these operations but the full CLI surface is not yet exposed. Correctly documented as deferred.
+
+4. **Phase 37 legacy fixtures**: Internal Phase 37 test fixtures under `verification/package_management/` continue to exercise the old `sifr/<package>/` layout and legacy manifest shapes as parser/backfill regression coverage. This is intentional per the phase design and the guardrail explicitly allows it via a named exception.
+
+---
+
+## Recommendation
+
+**READY.** The phase satisfies all stated goals, covers all non-goals, and has no remaining blocking findings. Local validation passes; the phase is ready for the next phase to build on top of the package management substrate.
+
+```markdown
+Status: READY
+Reviewed by: Claude (final full-phase review)
+Date: 2026-05-23
+Milestones reviewed: M1–M7 (PRs #2153–#2159)
+Demo repos reviewed: sifr-demo-json, sifr-demo-http, sifr-demo-test-support, sifr-demo-app, sifr-demo-workspace
+```


### PR DESCRIPTION
## Summary
- add the final full-phase review artifact for the package DX phase
- note the final READY review in the phase tracker

## Validation
- doc/review artifact only; final full-phase reviewer returned READY
- prior M7 gate: scripts/run_all_tests.sh --profile quick passed with wall-time/skew advisories only