### PR TITLE
Clean expr render integer promotion naming

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers.rs
@@ -6,9 +6,9 @@ mod field_and_stdlib_rewrites;
 mod operator_rewrites;
 mod sifr_int_parse_helpers;
 use sifr_int_parse_helpers::{
-    is_legacy_i64_type, is_proven_nonzero_integer_expr, is_result_legacy_i64_type,
+    is_plain_i64_storage_type, is_proven_nonzero_integer_expr, is_result_plain_i64_storage_type,
     is_sifr_int_arithmetic_op, is_sifr_int_checked_floor_op, is_sifr_int_comparison_op,
-    is_sifr_int_operand_coercion_op, result_i64_type_to_sifr_int, rust_expr_identifier_path,
+    is_sifr_int_operand_coercion_op, promote_result_i64_ok_to_sifr_int, rust_expr_identifier_path,
 };
 #[cfg(test)]
 mod tests;

--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -1,7 +1,7 @@
 use super::{
-    is_legacy_i64_type, is_proven_nonzero_integer_expr, is_result_legacy_i64_type,
+    is_plain_i64_storage_type, is_proven_nonzero_integer_expr, is_result_plain_i64_storage_type,
     is_sifr_int_arithmetic_op, is_sifr_int_checked_floor_op, is_sifr_int_comparison_op,
-    is_sifr_int_operand_coercion_op, result_i64_type_to_sifr_int, rust_expr_identifier_path,
+    is_sifr_int_operand_coercion_op, promote_result_i64_ok_to_sifr_int, rust_expr_identifier_path,
 };
 use crate::helpers::needs_clone_for_type;
 use crate::RustEmitter;
@@ -546,27 +546,29 @@ impl RustEmitter {
                 let force_sifr_int = self.is_forced_sifr_int_local(&name);
                 let value_is_sifr_int = self.is_sifr_int_expr(&value);
                 let value_is_sifr_int_result = self.is_sifr_int_result_expr(&value);
-                let (ty, value) =
-                    if is_legacy_i64_type(ty.as_ref()) && (value_is_sifr_int || force_sifr_int) {
-                        let value = self.coerce_expr_to_sifr_int_value(value);
-                        self.sifr_int_local_bindings
-                            .borrow_mut()
-                            .insert(name.clone());
-                        (Some(crate::RustType::Named("SifrInt".to_string())), value)
-                    } else if is_result_legacy_i64_type(ty.as_ref()) && value_is_sifr_int_result {
-                        self.sifr_int_result_local_bindings
-                            .borrow_mut()
-                            .insert(name.clone());
-                        (ty.map(result_i64_type_to_sifr_int), value)
-                    } else {
-                        if !force_sifr_int {
-                            self.sifr_int_local_bindings.borrow_mut().remove(&name);
-                        }
-                        self.sifr_int_result_local_bindings
-                            .borrow_mut()
-                            .remove(&name);
-                        (ty, value)
-                    };
+                let (ty, value) = if is_plain_i64_storage_type(ty.as_ref())
+                    && (value_is_sifr_int || force_sifr_int)
+                {
+                    let value = self.coerce_expr_to_sifr_int_value(value);
+                    self.sifr_int_local_bindings
+                        .borrow_mut()
+                        .insert(name.clone());
+                    (Some(crate::RustType::Named("SifrInt".to_string())), value)
+                } else if is_result_plain_i64_storage_type(ty.as_ref()) && value_is_sifr_int_result
+                {
+                    self.sifr_int_result_local_bindings
+                        .borrow_mut()
+                        .insert(name.clone());
+                    (ty.map(promote_result_i64_ok_to_sifr_int), value)
+                } else {
+                    if !force_sifr_int {
+                        self.sifr_int_local_bindings.borrow_mut().remove(&name);
+                    }
+                    self.sifr_int_result_local_bindings
+                        .borrow_mut()
+                        .remove(&name);
+                    (ty, value)
+                };
                 crate::RustStmt::Let {
                     mutable,
                     name,

--- a/crates/sifr_codegen/src/expr_render_helpers/sifr_int_parse_helpers.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/sifr_int_parse_helpers.rs
@@ -413,24 +413,24 @@ pub(super) fn is_sifr_int_operand_coercion_op(op: &str) -> bool {
     is_sifr_int_arithmetic_op(op) || is_sifr_int_comparison_op(op)
 }
 
-pub(super) fn is_legacy_i64_type(ty: Option<&crate::RustType>) -> bool {
+pub(super) fn is_plain_i64_storage_type(ty: Option<&crate::RustType>) -> bool {
     matches!(ty, Some(crate::RustType::I64))
         || matches!(ty, Some(crate::RustType::Named(name)) if name == "i64")
 }
 
-pub(super) fn is_result_legacy_i64_type(ty: Option<&crate::RustType>) -> bool {
-    matches!(ty, Some(crate::RustType::Result(ok, _)) if is_legacy_i64_rust_type(ok))
+pub(super) fn is_result_plain_i64_storage_type(ty: Option<&crate::RustType>) -> bool {
+    matches!(ty, Some(crate::RustType::Result(ok, _)) if is_plain_i64_rust_type(ok))
         || matches!(ty, Some(crate::RustType::Named(name)) if name.starts_with("Result<i64, "))
 }
 
-pub(super) fn is_legacy_i64_rust_type(ty: &crate::RustType) -> bool {
+pub(super) fn is_plain_i64_rust_type(ty: &crate::RustType) -> bool {
     matches!(ty, crate::RustType::I64)
         || matches!(ty, crate::RustType::Named(name) if name == "i64")
 }
 
-pub(super) fn result_i64_type_to_sifr_int(ty: crate::RustType) -> crate::RustType {
+pub(super) fn promote_result_i64_ok_to_sifr_int(ty: crate::RustType) -> crate::RustType {
     match ty {
-        crate::RustType::Result(ok, err) if is_legacy_i64_rust_type(&ok) => {
+        crate::RustType::Result(ok, err) if is_plain_i64_rust_type(&ok) => {
             crate::RustType::Result(Box::new(crate::RustType::Named("SifrInt".to_string())), err)
         }
         crate::RustType::Named(name) if name.starts_with("Result<i64, ") => {

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -100,23 +100,23 @@ pub struct RustEmitter {
     pub(crate) local_binding_types: HashMap<String, Type>,
     /// Local names widened to `T | None` due `name = None` reassignment in current scope.
     pub(crate) none_widened_local_bindings: HashSet<String>,
-    /// Local names whose generated Rust binding has been promoted from legacy `i64` to `SifrInt`.
+    /// Local names whose generated Rust binding has been promoted from plain `i64` storage to `SifrInt`.
     pub(crate) sifr_int_local_bindings: RefCell<HashSet<String>>,
     /// Local names pre-promoted to `SifrInt` because a later assignment needs exact-int storage.
     pub(crate) sifr_int_forced_local_bindings: RefCell<HashSet<String>>,
     /// Local names whose generated Rust `Result[int, E]` binding payload is `SifrInt`.
     pub(crate) sifr_int_result_local_bindings: RefCell<HashSet<String>>,
-    /// Function names whose generated Rust return type has been promoted from legacy `i64` to `SifrInt`.
+    /// Function names whose generated Rust return type has been promoted from plain `i64` storage to `SifrInt`.
     pub(crate) sifr_int_function_returns: RefCell<HashSet<String>>,
     /// Function names whose `Result[int, E]` generated Rust return payload is `SifrInt`.
     pub(crate) sifr_int_result_function_returns: RefCell<HashSet<String>>,
     /// Class method keys whose `Result[int, E]` generated Rust return payload is `SifrInt`.
     pub(crate) sifr_int_result_method_returns: RefCell<HashSet<String>>,
-    /// Module-level function `int` parameters promoted from legacy `i64` to `SifrInt`.
+    /// Module-level function `int` parameters promoted from plain `i64` storage to `SifrInt`.
     pub(crate) sifr_int_function_params: RefCell<HashMap<String, HashSet<usize>>>,
-    /// Module-level function `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
+    /// Module-level function `Result[int, E]` parameters promoted from plain `i64` payloads to `SifrInt`.
     pub(crate) sifr_int_result_function_params: RefCell<HashMap<String, HashSet<usize>>>,
-    /// Class method `Result[int, E]` parameters promoted from legacy `i64` payloads to `SifrInt`.
+    /// Class method `Result[int, E]` parameters promoted from plain `i64` payloads to `SifrInt`.
     pub(crate) sifr_int_result_method_params: RefCell<HashMap<String, HashSet<usize>>>,
     /// Whether the active function-like body returns `SifrInt` for source-level `int`.
     pub(crate) current_sifr_int_return: Cell<bool>,

--- a/issues/adhoc-file-size-guardrail.md
+++ b/issues/adhoc-file-size-guardrail.md
@@ -350,6 +350,9 @@ Validation notes:
 - Codegen refactor polish replaced the remaining broad root re-exports in the touched statement-lowering roots with explicit surfaces, split near-cap statement-support and lower-statement modules by responsibility, and kept test functions private while retaining explicit helper visibility only for sibling test modules.
 - Codegen refactor polish validation passed with `cargo fmt --check`, `python3 scripts/check_hir_maintainability_guardrails.py`, focused scans for `include!` and wildcard re-exports in the touched codegen roots/modules, and `scripts/run_all_tests.sh --profile quick`.
 - Codegen refactor polish Claude review returned `SATISFIED` in `reviews/codegen-refactor-polish-review-round1.md`.
+- Expr render cleanup removed stale `legacy_i64` terminology from the SifrInt promotion helpers and adjacent state comments, replacing it with current plain-`i64` storage naming.
+- Expr render cleanup validation passed with `cargo fmt --check`, `cargo check -p sifr_codegen`, focused legacy/backcompat scans, and `cargo test -p sifr_codegen expr_render_helpers::tests`.
+- Expr render cleanup Claude review returned `SATISFIED` in `reviews/expr-render-legacy-cleanup-review-round1.md`. The attempted quick validation progressed through the earlier guardrail and package lanes but was stopped after reproducing a pre-existing `cargo test -p sifr_lsp --doc` hang unrelated to this cleanup.
 
 ## Done Criteria
 

--- a/reviews/expr-render-legacy-cleanup-review-round1.md
+++ b/reviews/expr-render-legacy-cleanup-review-round1.md
@@ -1,0 +1,65 @@
+
+
+Based on my review, here is the code review:
+
+---
+
+## Code Review: expr_render_helpers legacy naming cleanup
+
+### Summary
+
+The diff renames four functions to eliminate stale legacy/backcompat terminology:
+
+| Old Name | New Name |
+|----------|----------|
+| `is_legacy_i64_type` | `is_plain_i64_storage_type` |
+| `is_result_legacy_i64_type` | `is_result_plain_i64_storage_type` |
+| `is_legacy_i64_rust_type` | `is_plain_i64_rust_type` |
+| `result_i64_type_to_sifr_int` | `promote_result_i64_ok_to_sifr_int` |
+
+Plus updates 5 doc comments in `lib_emitter_state.rs` from "legacy `i64`" to "plain `i64` storage".
+
+### Q1: Is the new naming accurate and idiomatic?
+
+**Yes.** 
+- `is_plain_i64_storage_type` — neutral, descriptive. "Plain" conveys non-wrapped, non-reference storage.
+- `is_result_plain_i64_storage_type` — accurate for Result<ok, err> where ok is plain i64.
+- `is_plain_i64_rust_type` — same, for the non-Option variant.
+- `promote_result_i64_ok_to_sifr_int` — describes the transformation: promote the `ok` payload from `Result<i64, E>` to `Result<SifrInt, E>`.
+
+### Q2: Did this accidentally change semantics or miss a call site?
+
+**No.** All call sites updated. I verified:
+- Three files use the new public functions (`expr_render_helpers.rs`, `field_and_stdlib_rewrites.rs`, `sifr_int_parse_helpers.rs`).
+- The private helper `is_plain_i64_rust_type` is only used within `sifr_int_parse_helpers.rs` and its callers (`is_result_plain_i64_storage_type`, `promote_result_i64_ok_to_sifr_int`) — all internal, consistent.
+- No leftover `legacy_i64` references anywhere in the scoped area.
+
+### Q3: Remaining legacy/backcompat smells?
+
+**None in scope.** The "legacy i64" terminology is gone from:
+- Function names (4 renamed)
+- Field doc comments (5 updated in `lib_emitter_state.rs`)
+- Internal helper references (all updated)
+
+### Q4: Are changes appropriately scoped?
+
+**Yes.** The scope is tight:
+- Only expr render helper area touched
+- No cascade to callers outside `sifr_codegen/src/expr_render_helpers*`
+- Doc comments updated where they directly described the same promoted-from-legacy behavior
+
+The reformatting in `field_and_stdlib_rewrites.rs:549-571` is a side effect of re-writing the condition to use the new function name — the logic is unchanged.
+
+---
+
+**Blocker check:** I observed 65 test failures in `sifr_codegen` when running with `--skip test_e2e_pass`. After investigation:
+
+1. `test_production_lowering_contract_uses_result_helpers_only` — Pre-existing failure (fails on main too, unrelated to this diff).
+2. `renders_function_type_param_bounds` — Pre-existing snapshot mismatch (`return value` vs `value`), unrelated.
+3. Remaining failures are e2e-style integration tests that likely have similar pre-existing issues.
+
+The naming changes introduce no new test failures.
+
+---
+
+**SATISFIED.** The rename is clean, accurate, and idiomatic. No semantic changes, no missed call sites, no residual legacy terminology in scope.


### PR DESCRIPTION
## Summary
- rename stale legacy_i64 expr-render helpers to current plain i64 storage terminology
- update adjacent SifrInt promotion state comments to remove migration/backcompat language
- record Claude review evidence in the phase issue

## Validation
- cargo fmt --check
- cargo check -p sifr_codegen
- cargo test -p sifr_codegen expr_render_helpers::tests
- focused scan for legacy/backcompat terminology in expr_render_helpers and adjacent SifrInt state comments
- Claude review: SATISFIED in reviews/expr-render-legacy-cleanup-review-round1.md

## Note
- scripts/run_all_tests.sh --profile quick progressed through earlier guardrail/package lanes but was stopped after reproducing a pre-existing cargo test -p sifr_lsp --doc hang at Doc-tests sifr_lsp; no assertion failure was reported and the hang is unrelated to this rename-only cleanup.