### PR TITLE
Add workspace package run ergonomics

### DIFF
--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -160,8 +160,17 @@ pub(super) fn load_package_graph_context(
     if session.manifest_less_mode {
         return Ok(None);
     }
+    load_package_graph_context_from_root(&session.workspace_root, lock_mode, diagnostic_format)
+        .map(Some)
+}
+
+pub(super) fn load_package_graph_context_from_root(
+    workspace_root: &Path,
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+) -> Result<PackageGraphContext, i32> {
     let metadata_plan =
-        sifr_package::CargoCommandPlan::metadata(session.workspace_root.clone(), lock_mode);
+        sifr_package::CargoCommandPlan::metadata(workspace_root.to_path_buf(), lock_mode);
     let output = match std::process::Command::new(&metadata_plan.program)
         .args(&metadata_plan.args)
         .current_dir(&metadata_plan.current_dir)
@@ -224,11 +233,11 @@ pub(super) fn load_package_graph_context(
             return Err(EXIT_USER_DIAGNOSTIC);
         }
     };
-    Ok(Some(PackageGraphContext {
+    Ok(PackageGraphContext {
         metadata: normalized,
         graph,
         source_map,
-    }))
+    })
 }
 
 pub(super) fn paths_equal(left: &Path, right: &Path) -> bool {

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -51,6 +51,9 @@ pub(crate) enum Commands {
     Run {
         /// Input .sifr file, app target, or script name
         target: Option<String>,
+        /// Select a workspace package by Cargo package name
+        #[arg(short = 'p', long = "package")]
+        packages: Vec<String>,
         /// Select a layout-discovered app target
         #[arg(long)]
         bin: Option<String>,
@@ -349,6 +352,7 @@ fn run_cli(cli: Cli) -> i32 {
         Commands::Build { file, output } => cmd_build(&file, &output, diagnostic_format),
         Commands::Run {
             target,
+            packages,
             bin,
             script,
             locked,
@@ -359,6 +363,7 @@ fn run_cli(cli: Cli) -> i32 {
             target.as_deref(),
             bin.as_deref(),
             script.as_deref(),
+            &packages,
             &args,
             lock_mode_from_flags(locked, offline, frozen),
             diagnostic_format,

--- a/crates/sifr/src/diagnostic_rendering_and_run.rs
+++ b/crates/sifr/src/diagnostic_rendering_and_run.rs
@@ -8,6 +8,7 @@ use super::cli_model_and_entrypoint::{
     DiagnosticFormat, PackageGraphContext, EXIT_INTERNAL_COMPILER_FAILURE, EXIT_SUCCESS,
     EXIT_USAGE_OR_CONFIG, EXIT_USER_DIAGNOSTIC, MAX_COMPACT_REPRESENTATIVE_LOCATIONS,
 };
+use super::workspace_run_selection::resolve_run_session;
 use sifr_diagnostics::{ChildSeverity, DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
 use sifr_driver::{
     apply_diagnostic_recovery_limits, build_cached_package_project, CachedBinaryArtifact,
@@ -171,6 +172,7 @@ pub(super) fn cmd_run(
     target: Option<&str>,
     bin: Option<&str>,
     script: Option<&str>,
+    packages: &[String],
     app_args: &[String],
     lock_mode: sifr_package::CargoLockMode,
     diagnostic_format: DiagnosticFormat,
@@ -197,12 +199,39 @@ pub(super) fn cmd_run(
                 return EXIT_USAGE_OR_CONFIG;
             }
         };
+    let session = match resolve_run_session(session, target, packages, lock_mode, diagnostic_format)
+    {
+        Ok(session) => session,
+        Err(exit_code) => return exit_code,
+    };
+    cmd_run_with_session(
+        &session,
+        target,
+        bin,
+        script,
+        app_args,
+        lock_mode,
+        diagnostic_format,
+        0,
+    )
+}
+
+fn cmd_run_with_session(
+    session: &sifr_package::PackageSession,
+    target: Option<&str>,
+    bin: Option<&str>,
+    script: Option<&str>,
+    app_args: &[String],
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+    script_depth: u8,
+) -> i32 {
     let plan = session.plan_run(&sifr_package::PackageRunRequest {
         target_or_path: target.map(str::to_string),
         bin: bin.map(str::to_string),
         script: script.map(str::to_string),
         app_args: app_args.to_vec(),
-        script_depth: 0,
+        script_depth,
     });
     let plan = match plan {
         Ok(plan) => plan,
@@ -212,7 +241,7 @@ pub(super) fn cmd_run(
         }
     };
     if let Some(origin) = plan.script_origin {
-        return cmd_script(&origin, diagnostic_format);
+        return cmd_script(&origin, Some(session), lock_mode, diagnostic_format);
     }
     if let Some(
         sifr_package::ResolvedRunTarget::File(path)
@@ -232,17 +261,35 @@ pub(super) fn cmd_run(
 
 pub(super) fn cmd_script(
     origin: &sifr_package::ScriptOrigin,
+    run_session: Option<&sifr_package::PackageSession>,
+    lock_mode: sifr_package::CargoLockMode,
     diagnostic_format: DiagnosticFormat,
 ) -> i32 {
     match origin.command.as_str() {
-        "run" => cmd_run(
-            origin.args.first().map(String::as_str),
-            None,
-            None,
-            &[],
-            sifr_package::CargoLockMode::Normal,
-            diagnostic_format,
-        ),
+        "run" => {
+            if let Some(session) = run_session {
+                cmd_run_with_session(
+                    session,
+                    origin.args.first().map(String::as_str),
+                    None,
+                    None,
+                    &[],
+                    lock_mode,
+                    diagnostic_format,
+                    1,
+                )
+            } else {
+                cmd_run(
+                    origin.args.first().map(String::as_str),
+                    None,
+                    None,
+                    &[],
+                    &[],
+                    lock_mode,
+                    diagnostic_format,
+                )
+            }
+        }
         "check" => cmd_check(
             origin
                 .args
@@ -251,19 +298,15 @@ pub(super) fn cmd_script(
                 .map(Path::new),
             None,
             &sifr_package::CargoPackageSelection::default(),
-            sifr_package::CargoLockMode::Normal,
+            lock_mode,
             diagnostic_format,
         ),
-        "fetch" => cmd_fetch(sifr_package::CargoLockMode::Normal, diagnostic_format),
-        "tree" => cmd_tree(
-            sifr_package::CargoLockMode::Normal,
-            &origin.args,
-            diagnostic_format,
-        ),
+        "fetch" => cmd_fetch(lock_mode, diagnostic_format),
+        "tree" => cmd_tree(lock_mode, &origin.args, diagnostic_format),
         "package" => cmd_package(
             &sifr_package::CargoPackageSelection::default(),
             &sifr_package::CargoPackageArchiveOptions::default(),
-            sifr_package::CargoLockMode::Normal,
+            lock_mode,
             diagnostic_format,
         ),
         "publish" => cmd_publish(
@@ -272,7 +315,7 @@ pub(super) fn cmd_script(
                 dry_run: origin.args.iter().any(|arg| arg == "--dry-run"),
                 ..sifr_package::CargoPublishOptions::default()
             },
-            sifr_package::CargoLockMode::Normal,
+            lock_mode,
             diagnostic_format,
         ),
         "vendor" => cmd_vendor(
@@ -282,7 +325,7 @@ pub(super) fn cmd_script(
                 .map(Path::new)
                 .unwrap_or_else(|| Path::new("vendor")),
             &sifr_package::CargoVendorOptions::default(),
-            sifr_package::CargoLockMode::Normal,
+            lock_mode,
             diagnostic_format,
         ),
         _ => {

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -14,6 +14,7 @@ mod cli_model_and_entrypoint;
 pub(crate) use cli_model_and_entrypoint::main;
 mod check_and_package_commands;
 mod diagnostic_rendering_and_run;
+mod workspace_run_selection;
 
 #[cfg(test)]
 mod diagnostics_and_packages_tests;

--- a/crates/sifr/src/mode_resolution_tests.rs
+++ b/crates/sifr/src/mode_resolution_tests.rs
@@ -4,6 +4,7 @@ use crate::cli_model_and_entrypoint::{
     Cli, Commands, CompilationMode, DiagnosticFormat, InvocationWorkspace, EXIT_SUCCESS,
     EXIT_USER_DIAGNOSTIC,
 };
+use crate::diagnostic_rendering_and_run::cmd_run;
 use clap::Parser;
 use sifr_diagnostics::{DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity};
 use std::collections::BTreeMap;
@@ -346,11 +347,12 @@ pub(super) fn test_package_cli_repair_check_reports_projection_drift() {
 #[test]
 pub(super) fn test_package_cli_parses_run_script_bin_and_app_args() {
     let cli = Cli::try_parse_from([
-        "sifr", "run", "--script", "dev", "--locked", "--", "--port", "8080",
+        "sifr", "run", "-p", "demo-app", "--script", "dev", "--locked", "--", "--port", "8080",
     ])
     .expect("run script cli parses");
 
     let Some(Commands::Run {
+        packages,
         script,
         locked,
         args,
@@ -359,6 +361,7 @@ pub(super) fn test_package_cli_parses_run_script_bin_and_app_args() {
     else {
         panic!("expected run command");
     };
+    assert_eq!(packages, ["demo-app"]);
     assert_eq!(script.as_deref(), Some("dev"));
     assert!(locked);
     assert_eq!(args, ["--port", "8080"]);
@@ -368,6 +371,81 @@ pub(super) fn test_package_cli_parses_run_script_bin_and_app_args() {
         panic!("expected run command");
     };
     assert_eq!(bin.as_deref(), Some("admin"));
+}
+
+#[test]
+pub(super) fn test_package_cli_run_selects_workspace_package_from_root() {
+    let project = TestProject::new("package_cli_workspace_run_selection");
+    project.write(
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"packages/app\"]\ndefault-members = [\"packages/app\"]\nresolver = \"2\"\n",
+        "workspace manifest should be written",
+    );
+    let app_root = project.dir.join("packages/app");
+    write_real_sifr_package(&app_root, "sifr-demo-app", "demo_app", "");
+    let sifr_manifest = app_root.join("sifr.toml");
+    let manifest_source =
+        std::fs::read_to_string(&sifr_manifest).expect("sifr manifest should be readable");
+    std::fs::write(
+        &sifr_manifest,
+        format!("{manifest_source}\n[scripts]\nadmin-script = {{ command = \"run\", args = [\"admin\"] }}\n"),
+    )
+    .expect("sifr manifest should include script");
+    std::fs::write(
+        app_root.join("src/main.sifr"),
+        "def main():\n    print(\"workspace default\")\n",
+    )
+    .expect("main app should be written");
+    std::fs::create_dir_all(app_root.join("src/bin")).expect("bin dir should exist");
+    std::fs::write(
+        app_root.join("src/bin/admin.sifr"),
+        "def main():\n    print(\"workspace admin\")\n",
+    )
+    .expect("bin app should be written");
+
+    let exit_codes = {
+        let _cwd = enter_test_cwd(&project.dir);
+        [
+            cmd_run(
+                None,
+                None,
+                None,
+                &["sifr-demo-app".to_string()],
+                &[],
+                sifr_package::CargoLockMode::Normal,
+                DiagnosticFormat::Compact,
+            ),
+            cmd_run(
+                None,
+                Some("admin"),
+                None,
+                &["sifr-demo-app".to_string()],
+                &[],
+                sifr_package::CargoLockMode::Normal,
+                DiagnosticFormat::Compact,
+            ),
+            cmd_run(
+                None,
+                None,
+                Some("admin-script"),
+                &["sifr-demo-app".to_string()],
+                &[],
+                sifr_package::CargoLockMode::Normal,
+                DiagnosticFormat::Compact,
+            ),
+            cmd_run(
+                None,
+                None,
+                None,
+                &[],
+                &[],
+                sifr_package::CargoLockMode::Normal,
+                DiagnosticFormat::Compact,
+            ),
+        ]
+    };
+
+    assert_eq!(exit_codes, [EXIT_SUCCESS; 4]);
 }
 
 #[test]

--- a/crates/sifr/src/workspace_run_selection.rs
+++ b/crates/sifr/src/workspace_run_selection.rs
@@ -1,0 +1,122 @@
+use super::check_and_package_commands::load_package_graph_context_from_root;
+use super::cli_model_and_entrypoint::{
+    diagnostic_with_code, package_diagnostic, DiagnosticFormat, PackageGraphContext,
+    EXIT_USER_DIAGNOSTIC,
+};
+use super::diagnostic_rendering_and_run::{render_diagnostics, render_package_diagnostics};
+use sifr_diagnostics::DiagnosticCode;
+use std::path::Path;
+
+pub(super) fn resolve_run_session(
+    session: sifr_package::PackageSession,
+    target: Option<&str>,
+    packages: &[String],
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+) -> Result<sifr_package::PackageSession, i32> {
+    if packages.is_empty() && (!session.manifest_less_mode || run_target_is_explicit_path(target)) {
+        return Ok(session);
+    }
+    let context = load_package_graph_context_from_root(
+        &session.workspace_root,
+        lock_mode,
+        diagnostic_format,
+    )?;
+    if !packages.is_empty() {
+        return selected_run_session(&context, packages, lock_mode, diagnostic_format);
+    }
+    default_workspace_run_session(&context, lock_mode, diagnostic_format)
+}
+
+fn selected_run_session(
+    context: &PackageGraphContext,
+    packages: &[String],
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+) -> Result<sifr_package::PackageSession, i32> {
+    if packages.len() != 1 {
+        let diagnostic = diagnostic_with_code(
+            "sifr run accepts exactly one -p/--package selector",
+            DiagnosticCode::PACKAGE_SELECTOR_AMBIGUOUS,
+        );
+        render_diagnostics(&[diagnostic], diagnostic_format);
+        return Err(EXIT_USER_DIAGNOSTIC);
+    }
+    let selection =
+        sifr_package::explicit_package_selection(&context.metadata, &context.graph, packages)
+            .map_err(|diagnostics| render_package_diagnostics(diagnostics, diagnostic_format))?;
+    let Some(package_id) = selection.selected_sifr_packages.iter().next() else {
+        let diagnostic = sifr_package::PackageDiagnostic::selector_ambiguous(&packages[0], &[]);
+        render_diagnostics(&[package_diagnostic(diagnostic)], diagnostic_format);
+        return Err(EXIT_USER_DIAGNOSTIC);
+    };
+    let Some(package) = context.graph.packages.get(package_id) else {
+        let diagnostic = sifr_package::PackageDiagnostic::selector_ambiguous(&packages[0], &[]);
+        render_diagnostics(&[package_diagnostic(diagnostic)], diagnostic_format);
+        return Err(EXIT_USER_DIAGNOSTIC);
+    };
+    Ok(sifr_package::PackageSession::from_package_metadata(
+        context.metadata.workspace_root.clone(),
+        package,
+        lock_mode,
+    ))
+}
+
+fn default_workspace_run_session(
+    context: &PackageGraphContext,
+    lock_mode: sifr_package::CargoLockMode,
+    diagnostic_format: DiagnosticFormat,
+) -> Result<sifr_package::PackageSession, i32> {
+    let default_members = if context.metadata.workspace_default_members.is_empty() {
+        &context.metadata.workspace_members
+    } else {
+        &context.metadata.workspace_default_members
+    };
+    let mut candidates = Vec::new();
+    for cargo_package_id in default_members {
+        let Some(classification) = context.graph.classifications.get(cargo_package_id) else {
+            continue;
+        };
+        let package_id = match classification {
+            sifr_package::PackageClassification::SifrSource(package_id)
+            | sifr_package::PackageClassification::RustBackedSifr(package_id) => package_id,
+            sifr_package::PackageClassification::BackendRust => continue,
+        };
+        let Some(package) = context.graph.packages.get(package_id) else {
+            continue;
+        };
+        let package_session = sifr_package::PackageSession::from_package_metadata(
+            context.metadata.workspace_root.clone(),
+            package,
+            lock_mode,
+        );
+        match package_session.has_default_runnable_app() {
+            Ok(true) => candidates.push((package.cargo_package_name.clone(), package_session)),
+            Ok(false) => {}
+            Err(error) => {
+                render_diagnostics(&[package_diagnostic(error)], diagnostic_format);
+                return Err(EXIT_USER_DIAGNOSTIC);
+            }
+        }
+    }
+    if candidates.len() == 1 {
+        return Ok(candidates.remove(0).1);
+    }
+    let names = candidates
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+    let diagnostic = sifr_package::PackageDiagnostic::workspace_run_ambiguous(&names);
+    render_diagnostics(&[package_diagnostic(diagnostic)], diagnostic_format);
+    Err(EXIT_USER_DIAGNOSTIC)
+}
+
+fn run_target_is_explicit_path(target: Option<&str>) -> bool {
+    target.is_some_and(|value| {
+        Path::new(value)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("sifr"))
+            || value.contains('/')
+            || value.contains(std::path::MAIN_SEPARATOR)
+    })
+}

--- a/crates/sifr_package/src/cargo/metadata.rs
+++ b/crates/sifr_package/src/cargo/metadata.rs
@@ -51,6 +51,7 @@ pub struct CargoMetadata {
     pub packages: Vec<CargoPackage>,
     pub resolve_edges: Vec<CargoResolveEdge>,
     pub workspace_members: BTreeSet<CargoPackageId>,
+    pub workspace_default_members: BTreeSet<CargoPackageId>,
     pub target_directory: PathBuf,
     pub workspace_root: PathBuf,
 }
@@ -60,6 +61,7 @@ pub struct NormalizedCargoMetadata {
     pub packages: BTreeMap<CargoPackageId, CargoPackage>,
     pub resolve_edges: Vec<CargoResolveEdge>,
     pub workspace_members: BTreeSet<CargoPackageId>,
+    pub workspace_default_members: BTreeSet<CargoPackageId>,
     pub target_directory: PathBuf,
     pub workspace_root: PathBuf,
 }
@@ -106,6 +108,7 @@ impl CargoMetadata {
             packages,
             resolve_edges,
             workspace_members: self.workspace_members,
+            workspace_default_members: self.workspace_default_members,
             target_directory: self.target_directory,
             workspace_root: self.workspace_root,
         }
@@ -124,6 +127,8 @@ struct RawCargoMetadata {
     packages: Vec<RawCargoPackage>,
     resolve: Option<RawCargoResolve>,
     workspace_members: Vec<String>,
+    #[serde(default)]
+    workspace_default_members: Vec<String>,
     target_directory: PathBuf,
     workspace_root: PathBuf,
 }
@@ -211,11 +216,17 @@ impl TryFrom<RawCargoMetadata> for CargoMetadata {
             .into_iter()
             .map(CargoPackageId)
             .collect();
+        let workspace_default_members = raw
+            .workspace_default_members
+            .into_iter()
+            .map(CargoPackageId)
+            .collect();
 
         Ok(Self {
             packages,
             resolve_edges,
             workspace_members,
+            workspace_default_members,
             target_directory: raw.target_directory,
             workspace_root: raw.workspace_root,
         })

--- a/crates/sifr_package/src/diag/package.rs
+++ b/crates/sifr_package/src/diag/package.rs
@@ -274,6 +274,26 @@ impl PackageDiagnostic {
     }
 
     #[must_use]
+    pub fn workspace_run_ambiguous(candidates: &[String]) -> Self {
+        let details = if candidates.is_empty() {
+            "no runnable Sifr app package matched workspace default members".to_string()
+        } else {
+            format!(
+                "workspace default members with runnable Sifr apps: {}",
+                candidates.join(", ")
+            )
+        };
+        Self {
+            code: DiagnosticCode::PACKAGE_RUN_TARGET_AMBIGUOUS,
+            message: format!("ambiguous workspace package run target: {details}"),
+            origin: Box::new(PackageDiagnosticOrigin::CargoMetadata {
+                cargo_package_id: None,
+            }),
+            help: Some("run from a package directory or use `sifr run -p <package>`".to_string()),
+        }
+    }
+
+    #[must_use]
     pub fn invalid_app_target_name(target: &str) -> Self {
         Self {
             code: DiagnosticCode::PACKAGE_INVALID_APP_TARGET_NAME,

--- a/crates/sifr_package/src/milestone_37_4_tests.rs
+++ b/crates/sifr_package/src/milestone_37_4_tests.rs
@@ -78,6 +78,7 @@ fn offline_mode_reports_missing_sifr_source_package() {
         )]),
         resolve_edges: Vec::new(),
         workspace_members: BTreeSet::new(),
+        workspace_default_members: BTreeSet::new(),
         target_directory: PathBuf::from("/ws/target"),
         workspace_root: PathBuf::from("/ws"),
     };

--- a/crates/sifr_package/src/milestone_37_5_tests.rs
+++ b/crates/sifr_package/src/milestone_37_5_tests.rs
@@ -293,6 +293,7 @@ fn graph_and_metadata_without_rust_violation() -> (SifrPackageGraph, NormalizedC
             shared.cargo_package_id.clone(),
             rust_id,
         ]),
+        workspace_default_members: BTreeSet::new(),
         target_directory: PathBuf::from("/ws/target"),
         workspace_root: PathBuf::from("/ws"),
     };

--- a/crates/sifr_package/src/ops/mod.rs
+++ b/crates/sifr_package/src/ops/mod.rs
@@ -6,3 +6,4 @@ pub mod resolve;
 pub mod session;
 mod session_discovery;
 mod session_targets;
+mod workspace_session;

--- a/crates/sifr_package/src/ops/session.rs
+++ b/crates/sifr_package/src/ops/session.rs
@@ -337,7 +337,7 @@ impl PackageSession {
         self.manifest.as_ref()?.scripts.get(name)
     }
 
-    fn find_app_target(&self, name: &str) -> Result<AppTarget, PackageDiagnostic> {
+    pub(super) fn find_app_target(&self, name: &str) -> Result<AppTarget, PackageDiagnostic> {
         self.lookup_app_target(name)?
             .ok_or_else(|| PackageDiagnostic::run_target_ambiguous(name, &[]))
     }
@@ -349,7 +349,7 @@ impl PackageSession {
             .find(|target| target.name == name))
     }
 
-    fn default_app_target(&self) -> Result<Option<AppTarget>, PackageDiagnostic> {
+    pub(super) fn default_app_target(&self) -> Result<Option<AppTarget>, PackageDiagnostic> {
         let targets = self.discover_app_targets()?;
         if let Some(main) = targets
             .iter()

--- a/crates/sifr_package/src/ops/workspace_session.rs
+++ b/crates/sifr_package/src/ops/workspace_session.rs
@@ -1,0 +1,41 @@
+use crate::cargo::lock_modes::CargoLockMode;
+use crate::diag::PackageDiagnostic;
+use crate::graph::derive::SifrPackageMetadata;
+use crate::ops::session::PackageSession;
+use std::path::PathBuf;
+
+impl PackageSession {
+    #[must_use]
+    pub fn from_package_metadata(
+        workspace_root: PathBuf,
+        package: &SifrPackageMetadata,
+        lock_mode: CargoLockMode,
+    ) -> Self {
+        let source_roots = package
+            .manifest
+            .source_roots
+            .iter()
+            .map(|root| package.package_root.join(&root.0))
+            .collect::<Vec<_>>();
+        let source_root = source_roots.first().cloned();
+        Self {
+            workspace_root,
+            manifest_path: Some(package.sifr_manifest.clone()),
+            source_root,
+            source_roots,
+            manifest_less_mode: false,
+            lock_mode,
+            manifest: Some(package.manifest.clone()),
+        }
+    }
+
+    pub fn has_default_runnable_app(&self) -> Result<bool, PackageDiagnostic> {
+        if let Some(manifest) = &self.manifest {
+            if let Some(default_run) = manifest.default_run.as_deref() {
+                self.find_app_target(default_run)?;
+                return Ok(true);
+            }
+        }
+        self.default_app_target().map(|target| target.is_some())
+    }
+}

--- a/docs/package_management.md
+++ b/docs/package_management.md
@@ -158,6 +158,9 @@ sifr check --locked --offline
 cd ../sifr-demo-workspace
 sifr check --workspace --locked
 sifr check --workspace --exclude sifr-demo-app --locked
+sifr run -p sifr-demo-app --locked
+sifr run -p sifr-demo-app --bin status --locked
+sifr run -p sifr-demo-app --script status-smoke --locked
 ```
 
 Development-only dependencies stay in `[dev-dependencies]`; normal `sifr run`, `sifr check`, `sifr package`, and `sifr publish` only expose runtime `[dependencies]` as import roots.

--- a/issues/adhoc-seamless-package-dx.md
+++ b/issues/adhoc-seamless-package-dx.md
@@ -257,7 +257,7 @@ Review:
 
 ### milestone_adhoc_pkg_8: Cargo-compatible workspace run ergonomics
 
-Status: planned.
+Status: implemented locally; reviewer-approved; parent PR pending.
 
 Scope:
 
@@ -269,13 +269,21 @@ Scope:
 
 Validation:
 
-- `cargo test -p sifr_package package_session -- --test-threads=1`
-- `cargo test -p sifr --bin sifr package_cli -- --test-threads=1`
-- `python3 scripts/check_package_manager_guardrails.py`
-- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --locked`
-- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --bin <target> --locked` using a checked-in or temporary `src/bin/*.sifr` target.
-- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --script <script> --locked` once the demo member declares a structured run script.
-- `scripts/run_all_tests.sh --profile quick`
+- `cargo test -p sifr_package package_session -- --test-threads=1` -> PASS.
+- `cargo test -p sifr --bin sifr package_cli -- --test-threads=1` -> PASS.
+- `python3 scripts/check_package_manager_guardrails.py` -> PASS.
+- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --locked` -> PASS, prints `200`.
+- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --bin status --locked` -> PASS, prints `200`.
+- Demo smoke in `sifr-demo-workspace`: `target/debug/sifr run -p sifr-demo-app --script status-smoke --locked` -> PASS, prints `200`.
+- `scripts/run_all_tests.sh --profile quick` -> PASS (warm wall-time/skew advisories only).
+
+Demo PR:
+
+- https://github.com/sifr-lang/sifr-demo-workspace/pull/3
+
+Review:
+
+- `reviews/adhoc-package-dx-m8-review-pass-1.md` -> READY with no blocking findings.
 
 Acceptance:
 

--- a/reviews/adhoc-package-dx-m8-review-pass-1.md
+++ b/reviews/adhoc-package-dx-m8-review-pass-1.md
@@ -1,0 +1,81 @@
+
+
+Based on my thorough review of the working tree, here is my assessment:
+
+---
+
+## Review: milestone_adhoc_pkg_8 — Cargo-compatible workspace run ergonomics
+
+### Files Reviewed- `crates/sifr/src/workspace_run_selection.rs` (122 lines) — new
+- `crates/sifr_package/src/ops/workspace_session.rs` (41 lines) — new
+- `crates/sifr/src/cli_model_and_entrypoint.rs` — additions for Run command wiring
+- `crates/sifr/src/diagnostic_rendering_and_run.rs` — `cmd_run` integration- `crates/sifr/src/check_and_package_commands.rs` — `package_session_for_cwd` to shared module
+- `crates/sifr/src/mode_resolution_tests.rs` — test coverage at line 376-449
+- `crates/sifr_package/src/ops/session.rs` — `PackageSession::discover`, `plan_run`, script handling
+- `crates/sifr_package/src/diag/package.rs` — `workspace_run_ambiguous` diagnostic
+- `crates/sifr_package/src/cargo/metadata.rs` — `workspace_default_members` field- `docs/package_management.md` — updated with demo/examples
+
+---
+
+### 1. Blocking Findings
+**None.** No correctness issues found. The implementation correctly:
+
+- Preserves workspace root throughout the selection chain (uses `self.workspace_root` from discovered session)
+- Resolves source roots from the **selected** package's `sifr.toml` (via `from_package_metadata`)
+- Filters to Sifr-source packages only (skips `BackendRust`) when resolving default members
+- Short-circuits run delegation to Cargo when `--bin` or script creates a fully-qualified plan
+- Has no risk of crossing Sifr packages in the same workspace run unless deliberately selected by name---
+
+### 2. Non-blocking Concerns
+
+**A. Test gap — ambiguity diagnostic coverage**`mode_resolution_tests.rs:376-449` tests4 scenarios (explicit package, `--bin`, `--script`, default-with-exact-members). There is no dedicated test for the **zero-candidates** branch of `default_workspace_run_session` (lines 70-74) or the **multi-candidate ambiguity** path where the diagnostic on line 109 fires. This could be validated silently if behavior regresses.
+
+**B. Guardrail: missing `workspace = true`**  
+The demo `packages/app/Cargo.toml` omits `workspace = true`, which is conventional for workspace members. The guardrail in `check_workspace_template` (line 423-424) does not enforce this. Not a functional issue; purely cosmetic.
+
+**C. No dedicated milestone test file**  
+There is no `milestone_adhoc_pkg_8_tests.rs`. This is acceptable since tests exist in `mode_resolution_tests.rs` and `sifr_package` integration tests, but the pattern of other milestones suggests one may be expected.
+
+---
+
+### 3. Validation Gaps
+
+**Minimal validation gaps** — The user reports the following passed:
+- Unit tests: `cargo test -p sifr_package package_session` and `sifr --bin sifr package_cli`
+- Guardrail: `python3 scripts/check_package_manager_guardrails.py` ✓- E2E from demo workspace: three command forms (`-p`, `--bin`, `--script`)
+
+**Unverified but low-risk:**
+- The `[package].default-run` path (`has_default_runnable_app()` → `manifest.default_run`) — no explicit integration test, but the code path is well-structured.
+- Error path when no candidate matches (diagnostic `workspace_run_ambiguous` with `candidates.is_empty()`) — branch exists in `package.rs:277-294` but not exercised.
+
+---
+
+### 4. File-Size Compliance
+
+| File | Lines | Limit | Status |
+|------|-------|-------|--------|
+| `sifr/src/workspace_run_selection.rs` | 122 | N/A (new) | OK |
+| `sifr_package/src/ops/workspace_session.rs` | 41 | N/A (new) | OK |
+| `sifr_package/src/ops/session.rs` | 401 | 420 | OK |
+| `sifr/src/cli_model_and_entrypoint.rs` | 880 | 900 (hand-maintained cap) | OK |
+| Guardrail script | — | — | PASS |
+
+---
+
+### 5. Final Verdict
+
+**READY**
+
+The implementation is correct by inspection:
+
+1. **`sifr run -p <package>`** creates a session via `from_package_metadata` that correctly isolates source roots, manifest path, and scripts to the selected package while retaining the workspace root for Cargo delegation.
+
+2. **Default-members behavior** honors `workspace.default-members` and falls back to all members; emits `SIFR-PACKAGE-0605` with a clear diagnostic when multiple candidates exist or none are runnable Sifr apps.
+
+3. **Manifest-less mode preserved**: `run_target_is_explicit_path()` filters targets that look like `.sifr` files or contain path separators, passing them through without workspace graph lookup.
+
+4. **Scripts** pass the selected `PackageSession` (with its correct package context) alongside the plan.
+
+5. **Guardrails**: package-manager maintainability checks pass, no module exceeds limits, no banned Cargo terms outside the adapter layer.
+
+The non-blocking concerns are minor test gaps and cosmetic guardrail items; they do not affect correctness or safety. The implementation is ready to ship pending the user's confirmation that the three e2e validations produce the expected output (`200`).

--- a/scripts/check_package_manager_guardrails.py
+++ b/scripts/check_package_manager_guardrails.py
@@ -423,6 +423,12 @@ def check_workspace_template(repo_path: Path, failures: List[str]) -> None:
     app_toml = (repo_path / "packages/app/Cargo.toml").read_text(encoding="utf-8")
     if "workspace = true" not in app_toml or "backend-utils" not in app_toml:
         failures.append("sifr-demo-workspace app must inherit workspace deps and reach backend")
+    app_manifest = load_toml(repo_path / "packages/app/sifr.toml", failures)
+    scripts = app_manifest.get("scripts", {})
+    if "status-smoke" not in scripts:
+        failures.append("sifr-demo-workspace app must define status-smoke run script")
+    if not (repo_path / "packages/app/src/bin/status.sifr").exists():
+        failures.append("sifr-demo-workspace app must include src/bin/status.sifr")
     for member in ["core", "utils", "app"]:
         member_root = repo_path / f"packages/{member}"
         check_production_sifr_manifest(

--- a/verification/package_management/phase37_demo_repositories.json
+++ b/verification/package_management/phase37_demo_repositories.json
@@ -117,6 +117,7 @@
         "packages/app/Cargo.toml",
         "packages/app/sifr.toml",
         "packages/app/src/__init__.sifr",
+        "packages/app/src/bin/status.sifr",
         "packages/app/src/main.sifr",
         "packages/app/src/lib.rs",
         "packages/backend-utils/Cargo.toml",


### PR DESCRIPTION
## Summary
- add Cargo-compatible `sifr run -p/--package` selection from workspace roots
- preserve selected member manifests/source roots/scripts while using the shared Cargo workspace root
- honor workspace default-members when exactly one runnable Sifr app is selected
- update workspace demo, docs, guardrails, and phase tracker

## Validation
- `cargo test -p sifr_package package_session -- --test-threads=1`
- `cargo test -p sifr --bin sifr package_cli -- --test-threads=1`
- `python3 scripts/check_package_manager_guardrails.py`
- `target/debug/sifr run -p sifr-demo-app --locked`
- `target/debug/sifr run -p sifr-demo-app --bin status --locked`
- `target/debug/sifr run -p sifr-demo-app --script status-smoke --locked`
- `scripts/run_all_tests.sh --profile quick` (passes; warm wall-time/skew advisories only)

## Review
- Claude milestone review: `reviews/adhoc-package-dx-m8-review-pass-1.md` -> READY
- Demo PR: https://github.com/sifr-lang/sifr-demo-workspace/pull/3
