### PR TITLE
[codex] Report successful package fetch

### DIFF
--- a/crates/sifr/src/diagnostic_rendering_and_run.rs
+++ b/crates/sifr/src/diagnostic_rendering_and_run.rs
@@ -442,7 +442,15 @@ pub(super) fn cmd_fetch(
     let Some(cargo) = session.plan_fetch().cargo else {
         return EXIT_SUCCESS;
     };
-    execute_cargo_plan(&cargo, lock_mode, diagnostic_format)
+    let exit = execute_cargo_plan(&cargo, lock_mode, diagnostic_format);
+    if exit == EXIT_SUCCESS {
+        let _ = writeln!(io::stderr(), "{}", fetch_success_message());
+    }
+    exit
+}
+
+pub(super) const fn fetch_success_message() -> &'static str {
+    "fetched package dependencies successfully"
 }
 
 pub(super) fn cmd_tree(

--- a/crates/sifr/src/mode_resolution_tests.rs
+++ b/crates/sifr/src/mode_resolution_tests.rs
@@ -4,7 +4,7 @@ use crate::cli_model_and_entrypoint::{
     Cli, Commands, CompilationMode, DiagnosticFormat, InvocationWorkspace, EXIT_SUCCESS,
     EXIT_USER_DIAGNOSTIC,
 };
-use crate::diagnostic_rendering_and_run::cmd_run;
+use crate::diagnostic_rendering_and_run::{cmd_run, fetch_success_message};
 use clap::Parser;
 use sifr_diagnostics::{DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity};
 use std::collections::BTreeMap;
@@ -446,6 +446,14 @@ pub(super) fn test_package_cli_run_selects_workspace_package_from_root() {
     };
 
     assert_eq!(exit_codes, [EXIT_SUCCESS; 4]);
+}
+
+#[test]
+pub(super) fn test_package_cli_fetch_success_message_is_user_visible() {
+    assert_eq!(
+        fetch_success_message(),
+        "fetched package dependencies successfully"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Print a user-visible success message after `sifr fetch` completes successfully.
- Add a small unit assertion for the fetch success message text.

## Validation

- `cargo fmt --check` passed.
- `cargo test -p sifr --bin sifr fetch_success_message -- --test-threads=1` was attempted, but local Cargo/rustc stalled idle on this machine and was stopped after cleanup.
