### PR TITLE
[codex] consume Sifr formatter Ruff update

### DIFF
--- a/issues/ad-hoc-production-grade-sifr-formatter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-formatter-execution.md
@@ -9,7 +9,7 @@ Phase contract: `issues/ad-hoc-production-grade-sifr-formatter.md`
 - [x] Phase plan reviewed and approved for implementation
 - [x] Ruff fork parameter-convention formatter PR merged and submodule pinned
 - [x] Ruff-to-Sifr formatter capability matrix created
-- [ ] Ruff fork formatter Sifr AST support completed
+- [x] Ruff fork formatter Sifr AST support completed
 - [ ] Sifr formatter core switched to Ruff-backed in-process formatting
 - [ ] CLI and config parity completed
 - [ ] Analysis, LSP, and editor integration formatting parity completed
@@ -376,6 +376,8 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Milestone 1 implementation review requested for checked formatter capability, CLI parity, AST coverage, and Ruff baseline manifests.
 - `2026-05-26`: Claude Opus Milestone 1 review pass 1 approved the manifests and baseline checks, with one blocking pre-existing validation issue: `verification/tooling/check_phase36_closeout.py` still referenced the pre-archive Phase 36 execution issue path.
 - `2026-05-26`: Claude Opus Milestone 1 review pass 2 confirmed the archive-path fix resolves the pass-1 blocker and explicitly approved Milestone 1 to close so Milestone 2 may begin.
+- `2026-05-26`: Claude Opus Milestone 2 review approved the Ruff fork changes with no blockers and confirmed the current Sifr AST extension surface is covered by the public Sifr wrappers plus formatter fixture corpus.
+- `2026-05-26`: Claude Opus Milestone 2 superproject consumption review approved the Sifr PR with no blockers and explicitly approved Milestone 2 consumption to merge so Milestone 3 may begin.
 
 ## Validation Log
 
@@ -394,7 +396,11 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Milestone 1 fixed the Phase 36 closeout guardrail to reference `issues/archive/phase36-developer-tooling-execution.md`, matching the archived issue layout.
 - `2026-05-26`: `python3 verification/tooling/check_phase36_closeout.py`, `python3 verification/tooling/check_phase36_closeout.py --self-test`, and `git diff --check` passed after the archive-path fix.
 - `2026-05-26`: `scripts/run_all_tests.sh --profile quick` passed end to end after the archive-path fix. The lane report was written to `target/validation_lane_reports/quick.latest.json`; it recorded a warm wall-time advisory but exit status was 0.
+- `2026-05-26`: Milestone 2 Ruff fork validation passed from `third_party/ruff`: `cargo fmt -p ruff_python_formatter --check`, `cargo test -p ruff_python_formatter sifr_ --quiet`, `cargo test -p ruff_python_formatter --test fixtures sifr_extensions --quiet`, `cargo test -p ruff_python_formatter --lib --quiet`, and `git -C third_party/ruff diff --check`.
+- `2026-05-26`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2> merged into `sifr/0.15.12-maintenance` as `f9da46641894c8a2380b1e0f17bed68f09c46643`, adding public Sifr formatter wrapper entrypoints and Sifr formatter fixture coverage.
+- `2026-05-26`: Milestone 2 superproject consumption validation passed: `python3 verification/performance/check_ruff_fork_update_contract.py`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `cargo test -p sifr_syntax`, `git diff --check`, and `scripts/run_all_tests.sh --profile quick`. The quick lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded warm wall-time and group-skew advisories.
 
 ## PR Log
 
 - Milestone 1 `formatter_contract_manifests_and_ast_inventory`: <https://github.com/sifr-lang/sifr/pull/2175>
+- Milestone 2 `ruff_fork_sifr_formatter_ast_completion`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2>; superproject consumption PR <https://github.com/sifr-lang/sifr/pull/2176>

--- a/reviews/formatter-m2-consumption-review.md
+++ b/reviews/formatter-m2-consumption-review.md
@@ -1,0 +1,38 @@
+
+
+---
+
+## Milestone 2 Superproject Consumption Review
+
+### Blocker Check
+
+| Check | Status | Evidence |
+|---|---|---|
+| `third_party/ruff` → `f9da46641894c8a2380b1e0f17bed68f09c46643` | PASS | `git log -1` in submodule returns `f9da46641894c8a2380b1e0f17bed68f09c46643 Complete Sifr formatter AST coverage` |
+| `ruff_fork_revalidation.json` pin matches | PASS | `"ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643"` |
+| All 5 sifr_syntax_token_fixtures revised to same pin | PASS | Diff vs origin/main shows all 5 fixtures updated from `b2516566...` → `f9da4664...` |
+| Execution tracker records M2 review, validation, PR links | PASS | Log entry at line 379 (Ruff fork review) + line 399 (consumption validation) + line 405 (PR link) |
+| No missing validation, stale metadata, or phase contract issue | PASS | `ruff_fork_revalidation.json` rationale correctly attributes that the M2 commit changes formatter integration points, not parser tokenization — so fixture metadata stays valid |
+| Prior Ruff fork review (`formatter-m2-ruff-fork-review.md`) exists | PASS | File present with full finding documentation |
+| `.gitmodules` points at `sifr/0.15.12-maintenance` | PASS | Line 4 of `.gitmodules` confirms branch tracking |
+| Single consumption commit `952c4922c` | PASS | Branch has exactly one commit beyond main |
+
+### Known Validation Confirmation
+
+All listed validations were run locally and passed per the execution tracker (lines 398–400):
+- ✓ `cargo fmt -p ruff_python_formatter --check` in third_party/ruff
+- ✓ `cargo test -p ruff_python_formatter sifr_ --quiet` in third_party/ruff
+- ✓ `cargo test -p ruff_python_formatter --test fixtures sifr_extensions --quiet` in third_party/ruff
+- ✓ `cargo test -p ruff_python_formatter --lib --quiet` in third_party/ruff
+- ✓ `git -C third_party/ruff diff --check`
+- ✓ `python3 verification/performance/check_ruff_fork_update_contract.py`
+- ✓ `python3 verification/tooling/check_formatter_phase_manifests.py`
+- ✓ `cargo test -p sifr_syntax`
+- ✓ `git diff --check`
+- ✓ `scripts/run_all_tests.sh --profile quick` (exit 0)
+
+### No Blockers
+
+All four blocker criteria are satisfied. The execution tracker is accurate and complete.
+
+**Milestone 2 superproject consumption PR is approved to merge. Milestone 3 may begin.**

--- a/reviews/formatter-m2-ruff-fork-review.md
+++ b/reviews/formatter-m2-ruff-fork-review.md
@@ -1,0 +1,121 @@
+Based on my review of the Milestone 2 changes, here are my findings:
+
+---
+
+## Milestone 2 Review: Ruff Fork Formatter AST Completion
+
+### Change Set Summary
+| File | Change |
+|------|--------|
+| `crates/ruff_python_formatter/src/lib.rs` | +78/-2: Public Sifr wrapper functions + unit tests |
+| `crates/ruff_python_formatter/resources/test/fixtures/ruff/sifr_extensions.py` | New: Fixture coverage |
+| `crates/ruff_python_formatter/tests/snapshots/format@sifr_extensions.py.snap` | New: Expected output |
+
+The parameter convention formatter rule (`parameter.rs`) was already added in seed commit `b251656613629e054308951a4df1928b3f749b1b`.
+
+---
+
+### Finding 1: One-Source-of-Truth / No Post-Processing (NO BLOCKER)
+**Location:** `lib.rs:155-170`
+
+The public wrappers delegate directly:
+```rust
+pub fn format_sifr_module_source(...) -> Result<Printed, FormatModuleError> {
+    format_module_source(source, options)  // Direct delegation
+}
+
+pub fn format_sifr_range(...) -> Result<PrintedRange, FormatModuleError> {
+    format_range(source, range, options)  // Direct delegation
+}
+```
+
+No source text manipulation occurs after the formatter core returns. **Verdict: BLOCKER-FREE**
+
+---
+
+### Finding 2: Fixture Coverage Sufficiency (NO BLOCKER)
+
+Mapping each AST coverage manifest row:
+
+| Manifest Row | Coverage | Evidence |
+|--------------|----------|----------|
+| `param_default_borrow` | ✓ | Implicit in `parameter.rs:19` (default branch) |
+| `param_mut` | ✓ | Rule at `parameter.rs:20-23` + fixture line 3 |
+| `param_own` | ✓ | Rule at `parameter.rs:24-27` + fixture line 4 |
+| `param_own_mut` | ✓ | Rule at `parameter.rs:28-33` + fixture lines 4,23 |
+| `param_mut_own_tolerant` | ✓ | Canonicalization in rule + snapshot line 47 proves it |
+| `sifr_type_annotations` | ✓ | Fixture: `list[int]`, `dict[str, list[int]]`, `Result[...]` |
+| `sifr_generics` | ✓ | Fixture: `class Box[T]` |
+| `match_case` | ✓ | Fixture: full match statement |
+| `ownership_aware_collections` | ✓ | Fixture: `Result`, list comprehension |
+| `formatter_pragmas` | ✓ | Fixture: `# fmt: off/on` |
+| `docstring_code_snippets` | ✓ | Uses existing Ruff docstring formatting |
+
+The context note is correct: only parameter conventions are Sifr-specific AST extensions. All other Sifr syntax uses existing Ruff AST nodes and formatter rules. **Verdict: BLOCKER-FREE**
+
+---
+
+### Finding 3: Missing Formatter Implementation (NO BLOCKER)
+
+The seed commit `b251656613629e054308951a4df1928b3f749b1b` already implemented `crates/ruff_python_formatter/src/other/parameter.rs` with:
+- `mut` → `token("mut")`
+- `own` → `token("own")`
+- `own mut` → `token("own")` + space + `token("mut")`
+- Canonical ordering enforced via tuple match on `(ownership, mutability)`
+
+All current Sifr AST nodes have coverage. **Verdict: BLOCKER-FREE**
+
+---
+
+### Finding 4: Test Coverage (NO BLOCKER)
+
+| Requirement | Coverage |
+|-------------|----------|
+| Idempotence | ✓ `ensure_stability_when_formatting_twice` in fixture harness |
+| Parser roundtrip | ✓ `ensure_unchanged_ast` in fixture harness |
+| Fail-closed invalid source | ✓ `sifr_public_wrapper_rejects_invalid_source` test at `lib.rs:352-356` |
+| `mut own` → `own mut` canonicalization | ✓ `sifr_mut_own_parameter_convention_canonicalizes_to_own_mut` at `lib.rs:295-308` |
+| Public wrapper parity | ✓ `sifr_public_wrapper_matches_formatter_core` at `lib.rs:311-330` |
+| Range wrapper parity | ✓ `sifr_public_range_wrapper_matches_formatter_core` at `lib.rs:333-349` |
+
+**Verdict: BLOCKER-FREE**
+
+---
+
+### Finding 5: Validation Results (NO BLOCKER)
+
+All requested validations pass:
+
+```
+✓ cargo fmt -p ruff_python_formatter --check  (no output = pass)
+✓ cargo test -p ruff_python_formatter sifr_   (5 tests pass)
+✓ cargo test -p ruff_python_formatter --test fixtures sifr_extensions  (1 test pass)
+✓ cargo test -p ruff_python_formatter --lib   (56 tests pass, 2 ignored)
+✓ git -C third_party/ruff diff --check  (no whitespace errors)
+```
+
+---
+
+### Finding 6: Integration Point Stability
+
+The public API at `lib.rs:154-170` exposes:
+- `format_sifr_module_source(source, options) → Result<Printed, FormatModuleError>`
+- `format_sifr_range(source, range, options) → Result<PrintedRange, FormatModuleError>`
+
+These are stable Rust APIs with proper error types (`FormatModuleError`) that wrap `ParseError`/`FormatError`/`PrintError`. The error type provides `range()` for diagnostic attachment.
+
+---
+
+## Conclusion
+
+**No blockers identified.**
+
+The Milestone 2 Ruff fork changes correctly:
+1. Delegate to the Ruff formatter core without post-processing
+2. Cover all AST coverage manifest rows via fixture corpus
+3. Rely on the seed commit's `parameter.rs` for Sifr-specific formatting
+4. Provide idempotence and parser roundtrip via the fixture harness
+5. Fail closed for invalid source
+6. Expose stable public APIs for Sifr crates to consume
+
+**Milestone 2 Ruff fork changes are approved for PR and merge.**

--- a/verification/performance/ruff_fork_revalidation.json
+++ b/verification/performance/ruff_fork_revalidation.json
@@ -1,6 +1,6 @@
 {
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "validated_by": "verification/performance/check_ruff_fork_update_contract.py",
   "fixture_directory": "verification/performance/sifr_syntax_token_fixtures",
-  "rationale": "Production formatter Milestone 1 revalidation for the merged Sifr Ruff formatter seed. Commit b251656613629e054308951a4df1928b3f749b1b changes Ruff formatter integration points only; representative Sifr token fixture expectations remain valid for the checked-in fork pin."
+  "rationale": "Production formatter Milestone 2 revalidation for the merged Sifr Ruff formatter AST coverage update. Commit f9da46641894c8a2380b1e0f17bed68f09c46643 changes Ruff formatter integration points and fixtures only; representative Sifr token fixture expectations remain valid for the checked-in fork pin."
 }

--- a/verification/performance/sifr_syntax_token_fixtures/async_and_error_handling.json
+++ b/verification/performance/sifr_syntax_token_fixtures/async_and_error_handling.json
@@ -1,7 +1,7 @@
 {
   "id": "async-and-error-handling",
   "source_path": "inline",
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "source": "async def fetch() -> Result[str, Error]:\n    result = await worker()\n    if result.is_err():\n        return Err(ValueError(\"failed\"))\n    return Ok(result.unwrap())\n",
   "expected_token_kinds": [
     "Async",

--- a/verification/performance/sifr_syntax_token_fixtures/basic_module.json
+++ b/verification/performance/sifr_syntax_token_fixtures/basic_module.json
@@ -1,7 +1,7 @@
 {
   "id": "basic-module",
   "source_path": "inline",
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "source": "from helper import value\n\ndef main():\n    reveal_type(value)\n",
   "expected_token_kinds": [
     "From",

--- a/verification/performance/sifr_syntax_token_fixtures/class_and_methods.json
+++ b/verification/performance/sifr_syntax_token_fixtures/class_and_methods.json
@@ -1,7 +1,7 @@
 {
   "id": "class-and-methods",
   "source_path": "inline",
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "source": "class Counter:\n    value: int\n\n    def inc(mut self, amount: int) -> int:\n        self.value = self.value + amount\n        return self.value\n",
   "expected_token_kinds": [
     "Class",

--- a/verification/performance/sifr_syntax_token_fixtures/collections_and_generics.json
+++ b/verification/performance/sifr_syntax_token_fixtures/collections_and_generics.json
@@ -1,7 +1,7 @@
 {
   "id": "collections-and-generics",
   "source_path": "inline",
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "source": "def total(values: list[int]) -> int:\n    acc: int = 0\n    for value in values:\n        acc = acc + value\n    return acc\n",
   "expected_token_kinds": [
     "Def",

--- a/verification/performance/sifr_syntax_token_fixtures/control_flow_match.json
+++ b/verification/performance/sifr_syntax_token_fixtures/control_flow_match.json
@@ -1,7 +1,7 @@
 {
   "id": "control-flow-match",
   "source_path": "inline",
-  "ruff_fork_revision": "b251656613629e054308951a4df1928b3f749b1b",
+  "ruff_fork_revision": "f9da46641894c8a2380b1e0f17bed68f09c46643",
   "source": "def classify(value: int) -> str:\n    if value < 0:\n        return \"negative\"\n    elif value == 0:\n        return \"zero\"\n    else:\n        match value:\n            case 1:\n                return \"one\"\n            case _:\n                return \"many\"\n",
   "expected_token_kinds": [
     "Def",


### PR DESCRIPTION
Summary:
- Advances `third_party/ruff` to `f9da46641894c8a2380b1e0f17bed68f09c46643`, which merged `sifr-lang/ruff#2`.
- Records Milestone 2 validation and Claude Opus review evidence.
- Updates fork revalidation metadata and syntax token fixture revisions to the merged formatter-only Ruff revision.

Validation:
- `cargo fmt -p ruff_python_formatter --check` (in `third_party/ruff`)
- `cargo test -p ruff_python_formatter sifr_ --quiet` (in `third_party/ruff`)
- `cargo test -p ruff_python_formatter --test fixtures sifr_extensions --quiet` (in `third_party/ruff`)
- `cargo test -p ruff_python_formatter --lib --quiet` (in `third_party/ruff`)
- `git -C third_party/ruff diff --check`
- `python3 verification/performance/check_ruff_fork_update_contract.py`
- `python3 verification/tooling/check_formatter_phase_manifests.py`
- `cargo test -p sifr_syntax`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

Review:
- Claude Opus reviewed Milestone 2 and found no blockers, approving Ruff fork changes for PR and merge.
