### PR TITLE
[codex] switch sifr formatter core to Ruff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ ruff_text_size = { path = "third_party/ruff/crates/ruff_text_size" }
 ruff_source_file = { path = "third_party/ruff/crates/ruff_source_file" }
 ruff_python_trivia = { path = "third_party/ruff/crates/ruff_python_trivia" }
 ruff_python_literal = { path = "third_party/ruff/crates/ruff_python_literal" }
+ruff_formatter = { path = "third_party/ruff/crates/ruff_formatter" }
+ruff_python_formatter = { path = "third_party/ruff/crates/ruff_python_formatter" }
 
 # Parser/AST crates -- maintained in the Ruff fork submodule and imported under Sifr crate aliases.
 ruff_python_ast = { path = "third_party/ruff/crates/ruff_python_ast" }

--- a/crates/sifr_format/Cargo.toml
+++ b/crates/sifr_format/Cargo.toml
@@ -7,9 +7,11 @@ rust-version = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+ruff_formatter = { workspace = true }
+ruff_python_formatter = { workspace = true }
+ruff_text_size = { workspace = true }
 sifr_diagnostics = { workspace = true }
 sifr_syntax = { workspace = true }
-ruff_text_size = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sifr_format/src/lib.rs
+++ b/crates/sifr_format/src/lib.rs
@@ -1,12 +1,12 @@
-//! Sifr-owned formatter foundation over `sifr_syntax`.
-//!
-//! The formatter deliberately starts with conservative, syntax-validated edits:
-//! normalize line endings to LF, trim trailing horizontal whitespace outside
-//! string tokens, and ensure a final newline. This keeps formatting idempotent
-//! and parser-round-tripped while preserving comments and string contents.
+//! Sifr-owned formatter API backed by the Sifr-aware Ruff formatter.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
-use ruff_text_size::{Ranged as _, TextRange, TextSize};
+use ruff_formatter::printer::LineEnding;
+use ruff_python_formatter::{
+    format_sifr_module_source, format_sifr_range as ruff_format_sifr_range, FormatModuleError,
+    PyFormatOptions,
+};
+use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic};
 use sifr_syntax::{parse_module, SourceText};
 use std::collections::BTreeMap;
@@ -55,17 +55,10 @@ pub fn format_source(
     file: Option<&Path>,
     options: FormatOptions,
 ) -> Result<FormatResult, Vec<RenderedDiagnostic>> {
-    let parsed = parse_module(
-        source,
-        file.map(|path| path.display().to_string()).as_deref(),
-    )?;
-    let protected = parsed
-        .tokens()
-        .iter()
-        .filter(|token| token.kind.as_str() == "String")
-        .map(|token| token.range)
-        .collect::<Vec<_>>();
-    let formatted = normalize_source(source, &protected, options);
+    let ruff_options = ruff_options(file, options)?;
+    let formatted = format_sifr_module_source(source, ruff_options)
+        .map_err(|error| vec![format_module_error_diagnostic(source, file, &error)])?
+        .into_code();
     parse_module(
         &formatted,
         file.map(|path| path.display().to_string()).as_deref(),
@@ -99,20 +92,27 @@ pub fn format_range(
     file: Option<&Path>,
     options: FormatOptions,
 ) -> Result<Vec<TextEdit>, Vec<RenderedDiagnostic>> {
-    let result = format_source(source, file, options)?;
-    if !result.changed {
+    let ruff_options = ruff_options(file, options)?;
+    validate_range(source, range, file)?;
+    let printed = ruff_format_sifr_range(source, range, ruff_options)
+        .map_err(|error| vec![format_module_error_diagnostic(source, file, &error)])?;
+    let edit_range = printed.source_range();
+    if edit_range.is_empty() {
         return Ok(Vec::new());
     }
-    let full = full_range(source);
-    if range != full {
-        return Ok(vec![TextEdit {
-            range: full,
-            replacement: result.formatted,
-        }]);
+    let replacement = printed.into_code();
+    if source_slice(source, edit_range).is_some_and(|current| current == replacement) {
+        return Ok(Vec::new());
     }
+    let roundtripped = source_with_edit(source, edit_range, &replacement)
+        .ok_or_else(|| vec![invalid_range_diagnostic(source, file, edit_range)])?;
+    parse_module(
+        &roundtripped,
+        file.map(|path| path.display().to_string()).as_deref(),
+    )?;
     Ok(vec![TextEdit {
-        range,
-        replacement: result.formatted,
+        range: edit_range,
+        replacement,
     }])
 }
 
@@ -191,55 +191,147 @@ fn collect_sifr_files_inner(
     Ok(())
 }
 
-fn normalize_source(source: &str, protected: &[TextRange], options: FormatOptions) -> String {
-    let normalized = source.replace("\r\n", "\n").replace('\r', "\n");
-    let mut output = String::with_capacity(normalized.len() + 1);
-    let mut offset = 0usize;
-    for segment in normalized.split_inclusive('\n') {
-        let line = segment.strip_suffix('\n').unwrap_or(segment);
-        let trimmed_len = trim_line_len_outside_protected(line, offset, protected);
-        output.push_str(&line[..trimmed_len]);
-        if segment.ends_with('\n') {
-            output.push('\n');
-        }
-        offset = offset.saturating_add(segment.len());
+fn ruff_options(
+    file: Option<&Path>,
+    options: FormatOptions,
+) -> Result<PyFormatOptions, Vec<RenderedDiagnostic>> {
+    if !options.final_newline {
+        return Err(vec![unsupported_option_diagnostic(
+            file,
+            "final_newline=false",
+            "the Ruff-backed Sifr formatter currently requires a final newline",
+        )]);
     }
-    if options.final_newline && !output.is_empty() && !output.ends_with('\n') {
-        output.push('\n');
-    }
-    output
+    let options = file.map_or_else(PyFormatOptions::default, PyFormatOptions::from_extension);
+    Ok(options.with_line_ending(LineEnding::LineFeed))
 }
 
-fn trim_line_len_outside_protected(
-    line: &str,
-    line_offset: usize,
-    protected: &[TextRange],
-) -> usize {
-    let mut end = line.len();
-    while end > 0 {
-        let Some(ch) = line[..end].chars().next_back() else {
-            break;
-        };
-        if ch != ' ' && ch != '\t' {
-            break;
-        }
-        let byte_start = end.saturating_sub(ch.len_utf8());
-        if protected_contains(protected, line_offset.saturating_add(byte_start)) {
-            break;
-        }
-        end = byte_start;
+fn validate_range(
+    source: &str,
+    range: TextRange,
+    file: Option<&Path>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    if end > source.len()
+        || start > end
+        || !source.is_char_boundary(start)
+        || !source.is_char_boundary(end)
+    {
+        return Err(vec![invalid_range_diagnostic(source, file, range)]);
     }
-    end
+    Ok(())
 }
 
-fn protected_contains(protected: &[TextRange], offset: usize) -> bool {
-    let Ok(raw) = u32::try_from(offset) else {
-        return false;
+fn source_slice(source: &str, range: TextRange) -> Option<&str> {
+    source.get(usize::from(range.start())..usize::from(range.end()))
+}
+
+fn source_with_edit(source: &str, range: TextRange, replacement: &str) -> Option<String> {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    source.get(start..end)?;
+    let mut output = String::with_capacity(
+        source
+            .len()
+            .saturating_sub(end.saturating_sub(start))
+            .saturating_add(replacement.len()),
+    );
+    output.push_str(source.get(..start)?);
+    output.push_str(replacement);
+    output.push_str(source.get(end..)?);
+    Some(output)
+}
+
+fn format_module_error_diagnostic(
+    source: &str,
+    file: Option<&Path>,
+    error: &FormatModuleError,
+) -> RenderedDiagnostic {
+    let (message, help) = match error {
+        FormatModuleError::ParseError(_) => (
+            "formatter could not parse Sifr source",
+            Some("fix the syntax error before running `sifr fmt`"),
+        ),
+        FormatModuleError::FormatError(_) => (
+            "formatter could not format Sifr source",
+            Some("reduce the formatted range or report this formatter case"),
+        ),
+        FormatModuleError::PrintError(_) => (
+            "formatter could not print Sifr source",
+            Some("report this formatter print failure"),
+        ),
     };
-    let offset = TextSize::new(raw);
-    protected
-        .iter()
-        .any(|range| range.start() <= offset && offset < range.end())
+    let spans = error
+        .range()
+        .and_then(|range| span_for_range(source, file, range, "formatter failed here"))
+        .into_iter()
+        .collect();
+    diagnostic(
+        DiagnosticCode::FMT_FORMATTING_DRIFT,
+        message,
+        [
+            ("path", file_display(file)),
+            ("formatter_error", error.to_string()),
+        ],
+        spans,
+        help,
+    )
+}
+
+fn invalid_range_diagnostic(
+    source: &str,
+    file: Option<&Path>,
+    range: TextRange,
+) -> RenderedDiagnostic {
+    let spans = span_for_range(source, file, range, "invalid formatter range")
+        .into_iter()
+        .collect();
+    diagnostic(
+        DiagnosticCode::FMT_FORMATTING_DRIFT,
+        "formatter range is outside Sifr source bounds or not on UTF-8 boundaries",
+        [("path", file_display(file))],
+        spans,
+        Some("request formatting for a valid source range"),
+    )
+}
+
+fn unsupported_option_diagnostic(
+    file: Option<&Path>,
+    option: &str,
+    help: &str,
+) -> RenderedDiagnostic {
+    diagnostic(
+        DiagnosticCode::FMT_FORMATTING_DRIFT,
+        format!("unsupported formatter option: {option}"),
+        [("path", file_display(file)), ("option", option.to_string())],
+        Vec::new(),
+        Some(help),
+    )
+}
+
+fn span_for_range(
+    source: &str,
+    file: Option<&Path>,
+    range: TextRange,
+    label: &str,
+) -> Option<DiagnosticSpan> {
+    let source_text = SourceText::new(source.to_string());
+    let start = range.start().to_u32();
+    let end = range.end().to_u32().max(start.saturating_add(1));
+    let position = source_text.text_position(TextSize::new(start))?;
+    Some(DiagnosticSpan {
+        file: file.map(|path| path.display().to_string()),
+        byte_start: start,
+        byte_end: end,
+        line: Some(position.line.saturating_add(1)),
+        column: Some(position.character.saturating_add(1)),
+        end_line: Some(position.line.saturating_add(1)),
+        end_column: Some(position.character.saturating_add(2)),
+        is_primary: true,
+        label: Some(label.to_string()),
+        lines: Vec::new(),
+    })
 }
 
 fn formatting_drift_diagnostic(
@@ -339,11 +431,6 @@ fn diagnostic(
     }
 }
 
-fn full_range(source: &str) -> TextRange {
-    let end = u32::try_from(source.len()).unwrap_or(u32::MAX);
-    TextRange::new(TextSize::new(0), TextSize::new(end))
-}
-
 fn file_display(file: Option<&Path>) -> String {
     file.map_or_else(|| "<memory>".to_string(), |path| path.display().to_string())
 }
@@ -367,8 +454,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn formatter_is_idempotent_and_preserves_string_trailing_space() {
-        let source = "def main():  \n    value: str = \"kept \"  \n    print(value)\n";
+    fn formatter_is_ruff_backed_and_preserves_string_contents() {
+        let source = "def main():\n    value: str = \"kept \"\n    print(  value  )\n";
         let first = format_source(source, None, FormatOptions::default())
             .expect("source should format")
             .formatted;
@@ -377,13 +464,70 @@ mod tests {
             .formatted;
         assert_eq!(first, second);
         assert!(first.contains("\"kept \""));
-        assert!(!first.contains("def main():  \n"));
+        assert!(first.contains("print(value)"));
+        parse_module(&first, None).expect("formatted source should parse");
+    }
+
+    #[test]
+    fn formatter_canonicalizes_sifr_parameter_conventions() {
+        let source = "def consume(mut own data: list[int]) -> Result[int, Error]:\n    match data:\n        case []:\n            return 0\n        case _:\n            return data[0]\n";
+        let formatted = format_source(source, None, FormatOptions::default())
+            .expect("source should format")
+            .formatted;
+        assert!(formatted.contains("def consume(own mut data: list[int]) -> Result[int, Error]:"));
+        assert!(!formatted.contains("mut own data"));
+        parse_module(&formatted, None).expect("formatted Sifr extensions should parse");
+    }
+
+    #[test]
+    fn range_formatting_returns_minimal_text_edit() {
+        let source = "def main():\n    x=1\n    y = 2\n";
+        let range = TextRange::new(TextSize::new(16), TextSize::new(19));
+        let edits = format_range(source, range, None, FormatOptions::default())
+            .expect("range should format");
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].replacement, "    x = 1");
+        let formatted = source_with_edit(source, edits[0].range, &edits[0].replacement)
+            .expect("edit should apply");
+        assert_eq!(formatted, "def main():\n    x = 1\n    y = 2\n");
     }
 
     #[test]
     fn check_reports_formatting_drift() {
-        let check = check_source("def main():  \n    pass", None, FormatOptions::default())
-            .expect("check should run");
+        let check = check_source(
+            "def main():\n    print( 1 )\n",
+            None,
+            FormatOptions::default(),
+        )
+        .expect("check should run");
         assert_eq!(check.diagnostics[0].code, "SIFR-FMT-0001");
+    }
+
+    #[test]
+    fn invalid_source_reports_sifr_diagnostic() {
+        let diagnostics =
+            format_source("def broken(:\n", None, FormatOptions::default()).expect_err("invalid");
+        assert_eq!(diagnostics[0].code, "SIFR-FMT-0001");
+        assert_eq!(
+            diagnostics[0].message,
+            "formatter could not parse Sifr source"
+        );
+    }
+
+    #[test]
+    fn unsupported_final_newline_option_reports_diagnostic() {
+        let diagnostics = format_source(
+            "def main():\n    pass\n",
+            None,
+            FormatOptions {
+                final_newline: false,
+            },
+        )
+        .expect_err("unsupported option");
+        assert_eq!(diagnostics[0].code, "SIFR-FMT-0001");
+        assert_eq!(
+            diagnostics[0].message,
+            "unsupported formatter option: final_newline=false"
+        );
     }
 }

--- a/issues/ad-hoc-production-grade-sifr-formatter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-formatter-execution.md
@@ -10,7 +10,7 @@ Phase contract: `issues/ad-hoc-production-grade-sifr-formatter.md`
 - [x] Ruff fork parameter-convention formatter PR merged and submodule pinned
 - [x] Ruff-to-Sifr formatter capability matrix created
 - [x] Ruff fork formatter Sifr AST support completed
-- [ ] Sifr formatter core switched to Ruff-backed in-process formatting
+- [x] Sifr formatter core switched to Ruff-backed in-process formatting
 - [ ] CLI and config parity completed
 - [ ] Analysis, LSP, and editor integration formatting parity completed
 - [ ] Formatter corpus, guardrails, and performance checks completed
@@ -378,6 +378,7 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Claude Opus Milestone 1 review pass 2 confirmed the archive-path fix resolves the pass-1 blocker and explicitly approved Milestone 1 to close so Milestone 2 may begin.
 - `2026-05-26`: Claude Opus Milestone 2 review approved the Ruff fork changes with no blockers and confirmed the current Sifr AST extension surface is covered by the public Sifr wrappers plus formatter fixture corpus.
 - `2026-05-26`: Claude Opus Milestone 2 superproject consumption review approved the Sifr PR with no blockers and explicitly approved Milestone 2 consumption to merge so Milestone 3 may begin.
+- `2026-05-26`: Claude Opus Milestone 3 review approved the Ruff-backed `sifr_format` core with no blockers and explicitly approved Milestone 3 to merge so Milestone 4 may begin.
 
 ## Validation Log
 
@@ -399,8 +400,11 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Milestone 2 Ruff fork validation passed from `third_party/ruff`: `cargo fmt -p ruff_python_formatter --check`, `cargo test -p ruff_python_formatter sifr_ --quiet`, `cargo test -p ruff_python_formatter --test fixtures sifr_extensions --quiet`, `cargo test -p ruff_python_formatter --lib --quiet`, and `git -C third_party/ruff diff --check`.
 - `2026-05-26`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2> merged into `sifr/0.15.12-maintenance` as `f9da46641894c8a2380b1e0f17bed68f09c46643`, adding public Sifr formatter wrapper entrypoints and Sifr formatter fixture coverage.
 - `2026-05-26`: Milestone 2 superproject consumption validation passed: `python3 verification/performance/check_ruff_fork_update_contract.py`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `cargo test -p sifr_syntax`, `git diff --check`, and `scripts/run_all_tests.sh --profile quick`. The quick lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded warm wall-time and group-skew advisories.
+- `2026-05-26`: Milestone 3 targeted validation passed: `cargo fmt -p sifr_format --check`, `cargo test -p sifr_format`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py --self-test`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `python3 scripts/check_file_size_guardrails.py`, and `git diff --check`.
+- `2026-05-26`: Milestone 3 quick validation passed with `scripts/run_all_tests.sh --profile quick`. The lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded a warm wall-time advisory and group-skew advisory after compiling the new Ruff-backed formatter dependency graph.
 
 ## PR Log
 
 - Milestone 1 `formatter_contract_manifests_and_ast_inventory`: <https://github.com/sifr-lang/sifr/pull/2175>
 - Milestone 2 `ruff_fork_sifr_formatter_ast_completion`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2>; superproject consumption PR <https://github.com/sifr-lang/sifr/pull/2176>
+- Milestone 3 `sifr_format_ruff_backed_core`: <https://github.com/sifr-lang/sifr/pull/2177>

--- a/reviews/formatter-m3-ruff-core-review.md
+++ b/reviews/formatter-m3-ruff-core-review.md
@@ -1,0 +1,68 @@
+
+
+---
+
+## Milestone 3 Review
+
+**No blockers.** Milestone 3 is approved to merge. Milestone 4 may begin.
+
+---
+
+### Checklist Results
+
+**1. format_source and format_range routing** ✅
+
+`format_source` at `lib.rs:59` calls `format_sifr_module_source`. `format_range` at `lib.rs:97` calls `format_sifr_range` (aliased as `ruff_format_sifr_range`). Both route through the public Ruff fork Sifr formatter wrappers from `third_party/ruff/crates/ruff_python_formatter/src/lib.rs`. The wrappers were added in Milestone 2 (Ruff PR `sifr-lang/ruff#2`, commit `f9da466`).
+
+**2. Old whitespace normalizer removed** ✅
+
+The Phase 36 whitespace-only formatter path is completely removed:
+
+- `normalize_source`, `trim_line_len_outside_protected`, `protected_contains`, `full_range` — all deleted
+- No fallback path remains
+- The 389-line old lib.rs is replaced with a 534-line Ruff-backed version (net +145 lines, accounting for Ruff error handling, range validation, and new tests)
+
+**3. Test coverage** ✅
+
+6 tests cover the required cases:
+
+| Test | Covers |
+|---|---|
+| `formatter_is_ruff_backed_and_preserves_string_contents` | Idempotence, string contents, parser roundtrip |
+| `formatter_canonicalizes_sifr_parameter_conventions` | `mut own` → `own mut`, Sifr param conventions |
+| `range_formatting_returns_minimal_text_edit` | Range edits, byte-level correctness |
+| `check_reports_formatting_drift` | Check mode, diagnostic code |
+| `invalid_source_reports_sifr_diagnostic` | Parse errors → `SIFR-FMT-0001` |
+| `unsupported_final_newline_option_reports_diagnostic` | Unsupported option → diagnostic |
+
+**4. Ruff error conversion** ✅
+
+`FormatModuleError` variants (`ParseError`, `FormatError`, `PrintError`) are converted into deterministic `RenderedDiagnostic` values at `lib.rs:246–280` with stable Sifr codes (`SIFR-FMT-0001`). Raw Ruff types are not exposed to callers.
+
+**5. Cargo dependencies** ✅
+
+- `ruff_formatter` and `ruff_python_formatter` added to workspace `Cargo.toml` under `third_party/ruff` path
+- `sifr_format/Cargo.toml` uses `{ workspace = true }` for both
+- Consistent with existing submodule/workspace strategy (no external crates.io additions)
+
+**6. check_formatter_contract.py update** ✅
+
+Self-test updated to check for `SIFR-FMT-0001` and `"formatter could not parse Sifr source"` — aligned with the new fail-closed Ruff-backed diagnostic surface. Both `run_positive()` and `run_self_test()` pass.
+
+**7. Merging readiness** ✅
+
+All changed files pass validation:
+- `cargo test -p sifr_format` — 6/6 pass
+- `python3 verification/tooling/check_formatter_contract.py` — PASS
+- `python3 verification/tooling/check_formatter_contract.py --self-test` — PASS
+- `git diff --check` — clean
+
+Changed files: `Cargo.toml`, `crates/sifr_format/Cargo.toml`, `crates/sifr_format/src/lib.rs`, `verification/tooling/check_formatter_contract.py`, `issues/ad-hoc-production-grade-sifr-formatter-execution.md` (execution log update).
+
+---
+
+### Notes for Milestone 4
+
+- `FormatOptions` currently only has `final_newline`; the locked public API in the phase contract specifies full `FormatOptions` with `line_length`, `indent_width`, `indent_style`, `quote_style`, `line_ending`, `magic_trailing_comma`, `preview`, `docstring_code_format`, `docstring_code_line_length`
+- The CLI currently has only `--check`; the full locked CLI surface is in the CLI parity manifest
+- Config discovery (`sifr.toml`, Ruff migration config, CLI overrides, extend) is Milestone 4 scope, not a Milestone 3 gap

--- a/verification/tooling/check_formatter_contract.py
+++ b/verification/tooling/check_formatter_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the Phase 36 formatter foundation contract."""
+"""Validate the Sifr formatter contract."""
 
 from __future__ import annotations
 
@@ -50,7 +50,10 @@ def run_self_test() -> None:
             ["cargo", "run", "-q", "-p", "sifr", "--", "fmt", "--check", str(source)],
             expect=1,
         )
-        if "SIFR-PARSE-" not in completed.stderr and "parse error" not in completed.stderr:
+        if (
+            "SIFR-FMT-0001" not in completed.stderr
+            and "formatter could not parse Sifr source" not in completed.stderr
+        ):
             raise SystemExit("formatter self-test failed: invalid syntax did not fail closed")
     print("formatter contract self-test: PASS")
 


### PR DESCRIPTION
Summary:
- Routes `sifr_format::format_source` and `format_range` through the Sifr-aware Ruff formatter wrappers.
- Removes the old whitespace/trailing-space normalizer fallback path.
- Adds Sifr-owned diagnostics for Ruff parse/format/print errors, invalid ranges, and unsupported `final_newline=false`.
- Updates the formatter contract self-test for the Ruff-backed fail-closed diagnostic surface.

Validation:
- `cargo fmt -p sifr_format --check`
- `cargo test -p sifr_format`
- `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py`
- `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py --self-test`
- `python3 verification/tooling/check_formatter_phase_manifests.py`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`
- `scripts/run_all_tests.sh --profile quick`

Review:
- Claude Opus reviewed Milestone 3 and found no blockers, approving the PR to merge and Milestone 4 to begin.
