### PR TITLE
[codex] expand formatter CLI surface

### DIFF
--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Wired early by milestone_diag_1; compiler emission migration starts in milestone_diag_4a.
+ruff_text_size = { workspace = true }
 sifr_diagnostics = { workspace = true }
 sifr_driver = { workspace = true }
 sifr_format = { workspace = true }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -1,19 +1,22 @@
 use super::cli_model_and_entrypoint::{
-    package_diagnostic, read_source, resolve_compilation_mode, run_with_panic_boundary,
-    CompilationMode, DiagnosticFormat, PackageCompilerContext, PackageGraphContext, EXIT_SUCCESS,
-    EXIT_USAGE_OR_CONFIG, EXIT_USER_DIAGNOSTIC,
+    diagnostic_with_code, package_diagnostic, read_source, resolve_compilation_mode,
+    run_with_panic_boundary, CompilationMode, DiagnosticFormat, PackageCompilerContext,
+    PackageGraphContext, EXIT_SUCCESS, EXIT_USAGE_OR_CONFIG, EXIT_USER_DIAGNOSTIC,
 };
 use super::diagnostic_rendering_and_run::{
     cargo_failure_diagnostic, current_session_package_id, execute_cargo_plan,
     package_session_for_cwd, render_diagnostics,
 };
-use sifr_diagnostics::RenderedDiagnostic;
+use super::formatter_cli::FmtArgs;
+use ruff_text_size::{TextRange, TextSize};
+use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
 use sifr_driver::{
     build, build_cached_project, build_cached_single_file, build_project, check_package_project,
     check_project, check_single_file, compile, emit_project, run_tests, CachedBinaryArtifact,
     CompileResult, PackageEntrypoint,
 };
-use std::io::{self, Write as _};
+use std::fs;
+use std::io::{self, IsTerminal as _, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 pub(super) fn redacted_args(args: &[String]) -> Vec<String> {
     args.iter()
@@ -246,10 +249,10 @@ pub(super) fn paths_equal(left: &Path, right: &Path) -> bool {
     left == right
 }
 
-pub(super) fn cmd_fmt(path: &Path, check: bool, diagnostic_format: DiagnosticFormat) -> i32 {
+pub(super) fn cmd_fmt(args: &FmtArgs, diagnostic_format: DiagnosticFormat) -> i32 {
     let result = match run_with_panic_boundary(
         "internal compiler panic during fmt command execution",
-        || fmt_entrypoint(path, check),
+        || fmt_entrypoint(args),
     ) {
         Ok(result) => result,
         Err(internal) => return render_diagnostics(&[*internal], diagnostic_format),
@@ -257,13 +260,16 @@ pub(super) fn cmd_fmt(path: &Path, check: bool, diagnostic_format: DiagnosticFor
 
     match result {
         Ok(changed) => {
-            if check {
+            if args.check {
                 if changed.is_empty() {
                     emit_success_message(diagnostic_format, "format check passed");
                     EXIT_SUCCESS
                 } else {
                     render_diagnostics(&changed, diagnostic_format)
                 }
+            } else if changed.is_empty() {
+                emit_success_message(diagnostic_format, "Sifr source files already formatted");
+                EXIT_SUCCESS
             } else {
                 emit_success_message(diagnostic_format, "formatted Sifr source files");
                 EXIT_SUCCESS
@@ -397,19 +403,166 @@ pub(super) fn emit_entrypoint(file: &Path) -> CompileResult {
 }
 
 pub(super) fn fmt_entrypoint(
-    path: &Path,
-    check: bool,
+    args: &FmtArgs,
 ) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
-    let files = sifr_format::collect_sifr_files(path)?;
+    let options = format_options_from_args(args);
+    if args.stdin_filename.is_some() || (args.paths.is_empty() && !io::stdin().is_terminal()) {
+        return fmt_stdin(args, options);
+    }
+
+    let targets = if args.paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        args.paths.clone()
+    };
     let mut diagnostics = Vec::new();
-    for file in files {
-        if check {
-            diagnostics.extend(sifr_format::check_path(&file)?);
-        } else {
-            let _formatted = sifr_format::format_path(&file, false)?;
+    for target in targets {
+        let files = sifr_format::collect_sifr_files(&target)?;
+        for file in files {
+            if args.check {
+                diagnostics.extend(sifr_format::check_path_with_options(&file, options)?);
+            } else if args.diff {
+                let source = fs::read_to_string(&file).map_err(|err| {
+                    vec![formatter_cli_diagnostic(format!(
+                        "could not read file {}: {err}",
+                        file.display()
+                    ))]
+                })?;
+                let formatted = format_source_or_range(&source, &file, args, options)?;
+                if formatted != source {
+                    write_unified_diff(&file, &source, &formatted);
+                    diagnostics.push(formatting_drift_for_path(&source, &file));
+                }
+            } else if args.range.is_some() {
+                let source = fs::read_to_string(&file).map_err(|err| {
+                    vec![formatter_cli_diagnostic(format!(
+                        "could not read file {}: {err}",
+                        file.display()
+                    ))]
+                })?;
+                let formatted = format_source_or_range(&source, &file, args, options)?;
+                if formatted != source {
+                    fs::write(&file, formatted).map_err(|err| {
+                        vec![formatter_cli_diagnostic(format!(
+                            "could not write file {}: {err}",
+                            file.display()
+                        ))]
+                    })?;
+                }
+            } else {
+                let _formatted = sifr_format::format_path_with_options(&file, false, options)?;
+            }
         }
     }
     Ok(diagnostics)
+}
+
+fn fmt_stdin(
+    args: &FmtArgs,
+    options: sifr_format::FormatOptions,
+) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
+    let mut source = String::new();
+    io::stdin().read_to_string(&mut source).map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not read formatter stdin: {err}"
+        ))]
+    })?;
+    let file = args
+        .stdin_filename
+        .as_deref()
+        .unwrap_or(Path::new("<stdin>"));
+    let formatted = format_source_or_range(&source, file, args, options)?;
+    if args.check {
+        if formatted == source {
+            return Ok(Vec::new());
+        }
+        return Ok(vec![formatting_drift_for_path(&source, file)]);
+    }
+    if args.diff {
+        write_unified_diff(file, &source, &formatted);
+    } else {
+        let _ = write!(io::stdout(), "{formatted}");
+    }
+    Ok(Vec::new())
+}
+
+fn format_options_from_args(args: &FmtArgs) -> sifr_format::FormatOptions {
+    sifr_format::FormatOptions {
+        line_length: args.line_length.unwrap_or(88),
+        preview: args.preview && !args.no_preview,
+        ..sifr_format::FormatOptions::default()
+    }
+}
+
+fn format_source_or_range(
+    source: &str,
+    file: &Path,
+    args: &FmtArgs,
+    options: sifr_format::FormatOptions,
+) -> Result<String, Vec<RenderedDiagnostic>> {
+    if let Some(range) = &args.range {
+        let range = parse_byte_range(range)?;
+        let edits = sifr_format::format_range(source, range, Some(file), options)?;
+        let mut formatted = source.to_string();
+        for edit in edits.into_iter().rev() {
+            let start = usize::from(edit.range.start());
+            let end = usize::from(edit.range.end());
+            formatted.replace_range(start..end, &edit.replacement);
+        }
+        Ok(formatted)
+    } else {
+        sifr_format::format_source(source, Some(file), options).map(|result| result.formatted)
+    }
+}
+
+fn parse_byte_range(raw: &str) -> Result<TextRange, Vec<RenderedDiagnostic>> {
+    let Some((start, end)) = raw.split_once(':') else {
+        return Err(vec![formatter_cli_diagnostic(
+            "formatter range must use START:END byte offsets",
+        )]);
+    };
+    let start = parse_text_size(start)?;
+    let end = parse_text_size(end)?;
+    if start > end {
+        return Err(vec![formatter_cli_diagnostic(
+            "formatter range start must be before range end",
+        )]);
+    }
+    Ok(TextRange::new(start, end))
+}
+
+fn parse_text_size(raw: &str) -> Result<TextSize, Vec<RenderedDiagnostic>> {
+    let value = raw.parse::<u32>().map_err(|_| {
+        vec![formatter_cli_diagnostic(
+            "formatter range offsets must be unsigned integers",
+        )]
+    })?;
+    Ok(TextSize::new(value))
+}
+
+fn write_unified_diff(path: &Path, before: &str, after: &str) {
+    let _ = writeln!(io::stdout(), "--- {}", path.display());
+    let _ = writeln!(io::stdout(), "+++ {}", path.display());
+    for line in before.lines() {
+        let _ = writeln!(io::stdout(), "-{line}");
+    }
+    for line in after.lines() {
+        let _ = writeln!(io::stdout(), "+{line}");
+    }
+}
+
+fn formatting_drift_for_path(source: &str, path: &Path) -> RenderedDiagnostic {
+    match sifr_format::check_source(source, Some(path), sifr_format::FormatOptions::default()) {
+        Ok(check) if !check.diagnostics.is_empty() => check.diagnostics[0].clone(),
+        _ => formatter_cli_diagnostic(format!(
+            "source is not formatted with sifr fmt: {}",
+            path.display()
+        )),
+    }
+}
+
+fn formatter_cli_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
+    diagnostic_with_code(message, DiagnosticCode::FMT_FORMATTING_DRIFT)
 }
 
 pub(super) fn lint_entrypoint(

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -3,6 +3,7 @@ use super::diagnostic_rendering_and_run::{
     cmd_build, cmd_fetch, cmd_package, cmd_publish, cmd_run, cmd_tree, cmd_vendor,
     render_diagnostics,
 };
+use super::formatter_cli::FmtArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_diagnostics::{
     DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
@@ -32,6 +33,14 @@ pub(crate) struct Cli {
     /// Explain a Sifr diagnostic code without running a package operation
     #[arg(long)]
     pub(crate) explain: Option<String>,
+
+    /// Formatter config file path or KEY=VALUE override
+    #[arg(long, global = true)]
+    pub(crate) config: Vec<String>,
+
+    /// Ignore formatter configuration files
+    #[arg(long, global = true)]
+    pub(crate) isolated: bool,
 
     #[command(subcommand)]
     pub(crate) command: Option<Commands>,
@@ -244,13 +253,7 @@ pub(crate) enum Commands {
         frozen: bool,
     },
     /// Format Sifr source files
-    Fmt {
-        /// Check formatting without writing changes
-        #[arg(long)]
-        check: bool,
-        /// Input .sifr file or directory
-        path: PathBuf,
-    },
+    Fmt(FmtArgs),
     /// Run suppressible policy diagnostics
     Lint {
         /// Input .sifr file or directory
@@ -500,7 +503,7 @@ fn run_cli(cli: Cli) -> i32 {
                 diagnostic_format,
             )
         }
-        Commands::Fmt { check, path } => cmd_fmt(&path, check, diagnostic_format),
+        Commands::Fmt(args) => cmd_fmt(&args, diagnostic_format),
         Commands::Lint { path } => cmd_lint(&path, diagnostic_format),
         Commands::Lsp { stdio } => cmd_lsp(stdio),
         Commands::Emit { file } => cmd_emit(&file, diagnostic_format),

--- a/crates/sifr/src/formatter_cli.rs
+++ b/crates/sifr/src/formatter_cli.rs
@@ -1,0 +1,65 @@
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Clone, Debug)]
+pub(crate) struct FmtArgs {
+    /// Check formatting without writing changes
+    #[arg(long)]
+    pub(crate) check: bool,
+
+    /// Print a unified diff without writing changes
+    #[arg(long, conflicts_with = "check")]
+    pub(crate) diff: bool,
+
+    /// Filename context for formatting stdin
+    #[arg(long)]
+    pub(crate) stdin_filename: Option<PathBuf>,
+
+    /// Byte range to format as START:END
+    #[arg(long)]
+    pub(crate) range: Option<String>,
+
+    /// Preferred formatter line length
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..))]
+    pub(crate) line_length: Option<u16>,
+
+    /// Enable preview formatting behavior
+    #[arg(long, conflicts_with = "no_preview")]
+    pub(crate) preview: bool,
+
+    /// Disable preview formatting behavior
+    #[arg(long)]
+    pub(crate) no_preview: bool,
+
+    /// Exclude paths matching a formatter pattern
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) exclude: Vec<String>,
+
+    /// Respect VCS ignore files
+    #[arg(long, default_value_t = true, conflicts_with = "no_respect_gitignore")]
+    pub(crate) respect_gitignore: bool,
+
+    /// Do not respect VCS ignore files
+    #[arg(long)]
+    pub(crate) no_respect_gitignore: bool,
+
+    /// Apply excludes to explicit file targets
+    #[arg(long, conflicts_with = "no_force_exclude")]
+    pub(crate) force_exclude: bool,
+
+    /// Do not apply excludes to explicit file targets
+    #[arg(long)]
+    pub(crate) no_force_exclude: bool,
+
+    /// Disable formatter cache reads and writes
+    #[arg(long)]
+    pub(crate) no_cache: bool,
+
+    /// Formatter cache directory
+    #[arg(long)]
+    pub(crate) cache_dir: Option<PathBuf>,
+
+    /// Input .sifr files or directories; defaults to current directory
+    #[arg(value_name = "FILES")]
+    pub(crate) paths: Vec<PathBuf>,
+}

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -14,6 +14,7 @@ mod cli_model_and_entrypoint;
 pub(crate) use cli_model_and_entrypoint::main;
 mod check_and_package_commands;
 mod diagnostic_rendering_and_run;
+mod formatter_cli;
 mod workspace_run_selection;
 
 #[cfg(test)]

--- a/crates/sifr_format/src/lib.rs
+++ b/crates/sifr_format/src/lib.rs
@@ -2,9 +2,10 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 use ruff_formatter::printer::LineEnding;
+use ruff_formatter::LineWidth;
 use ruff_python_formatter::{
     format_sifr_module_source, format_sifr_range as ruff_format_sifr_range, FormatModuleError,
-    PyFormatOptions,
+    PreviewMode, PyFormatOptions,
 };
 use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic};
@@ -16,12 +17,16 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FormatOptions {
     pub final_newline: bool,
+    pub line_length: u16,
+    pub preview: bool,
 }
 
 impl Default for FormatOptions {
     fn default() -> Self {
         Self {
             final_newline: true,
+            line_length: 88,
+            preview: false,
         }
     }
 }
@@ -117,15 +122,23 @@ pub fn format_range(
 }
 
 pub fn format_path(path: &Path, check: bool) -> Result<FormattedPath, Vec<RenderedDiagnostic>> {
+    format_path_with_options(path, check, FormatOptions::default())
+}
+
+pub fn format_path_with_options(
+    path: &Path,
+    check: bool,
+    options: FormatOptions,
+) -> Result<FormattedPath, Vec<RenderedDiagnostic>> {
     let source = read_source(path)?;
     if check {
-        let check = check_source(&source, Some(path), FormatOptions::default())?;
+        let check = check_source(&source, Some(path), options)?;
         return Ok(FormattedPath {
             path: path.to_path_buf(),
             changed: !check.diagnostics.is_empty(),
         });
     }
-    let result = format_source(&source, Some(path), FormatOptions::default())?;
+    let result = format_source(&source, Some(path), options)?;
     if result.changed {
         write_source(path, &result.formatted)?;
     }
@@ -136,8 +149,15 @@ pub fn format_path(path: &Path, check: bool) -> Result<FormattedPath, Vec<Render
 }
 
 pub fn check_path(path: &Path) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
+    check_path_with_options(path, FormatOptions::default())
+}
+
+pub fn check_path_with_options(
+    path: &Path,
+    options: FormatOptions,
+) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
     let source = read_source(path)?;
-    check_source(&source, Some(path), FormatOptions::default()).map(|check| check.diagnostics)
+    check_source(&source, Some(path), options).map(|check| check.diagnostics)
 }
 
 pub fn collect_sifr_files(path: &Path) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
@@ -202,8 +222,23 @@ fn ruff_options(
             "the Ruff-backed Sifr formatter currently requires a final newline",
         )]);
     }
-    let options = file.map_or_else(PyFormatOptions::default, PyFormatOptions::from_extension);
-    Ok(options.with_line_ending(LineEnding::LineFeed))
+    let py_options = file.map_or_else(PyFormatOptions::default, PyFormatOptions::from_extension);
+    let line_width = LineWidth::try_from(options.line_length).map_err(|_| {
+        vec![unsupported_option_diagnostic(
+            file,
+            "line_length",
+            "line length must be between 1 and 65535",
+        )]
+    })?;
+    let preview = if options.preview {
+        PreviewMode::Enabled
+    } else {
+        PreviewMode::Disabled
+    };
+    Ok(py_options
+        .with_line_ending(LineEnding::LineFeed)
+        .with_line_width(line_width)
+        .with_preview(preview))
 }
 
 fn validate_range(
@@ -521,6 +556,7 @@ mod tests {
             None,
             FormatOptions {
                 final_newline: false,
+                ..FormatOptions::default()
             },
         )
         .expect_err("unsupported option");

--- a/issues/ad-hoc-production-grade-sifr-formatter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-formatter-execution.md
@@ -379,6 +379,7 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Claude Opus Milestone 2 review approved the Ruff fork changes with no blockers and confirmed the current Sifr AST extension surface is covered by the public Sifr wrappers plus formatter fixture corpus.
 - `2026-05-26`: Claude Opus Milestone 2 superproject consumption review approved the Sifr PR with no blockers and explicitly approved Milestone 2 consumption to merge so Milestone 3 may begin.
 - `2026-05-26`: Claude Opus Milestone 3 review approved the Ruff-backed `sifr_format` core with no blockers and explicitly approved Milestone 3 to merge so Milestone 4 may begin.
+- `2026-05-26`: Claude Opus Milestone 4 wave 1 review approved the expanded formatter CLI surface and direct CLI behaviors with no blockers, leaving config discovery, excludes, gitignore, and cache behavior for wave 2.
 
 ## Validation Log
 
@@ -402,9 +403,11 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Milestone 2 superproject consumption validation passed: `python3 verification/performance/check_ruff_fork_update_contract.py`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `cargo test -p sifr_syntax`, `git diff --check`, and `scripts/run_all_tests.sh --profile quick`. The quick lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded warm wall-time and group-skew advisories.
 - `2026-05-26`: Milestone 3 targeted validation passed: `cargo fmt -p sifr_format --check`, `cargo test -p sifr_format`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py --self-test`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `python3 scripts/check_file_size_guardrails.py`, and `git diff --check`.
 - `2026-05-26`: Milestone 3 quick validation passed with `scripts/run_all_tests.sh --profile quick`. The lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded a warm wall-time advisory and group-skew advisory after compiling the new Ruff-backed formatter dependency graph.
+- `2026-05-26`: Milestone 4 wave 1 targeted validation passed: formatter CLI smoke coverage for `--check`, `--diff`, `--stdin-filename`, stdin formatting, `--range`, `--line-length`, `--preview`, cache flag parsing, and multi-path/default directory behavior; `cargo fmt -p sifr -p sifr_format --check`; `cargo test -p sifr_format`; `cargo test -p sifr -- --skip test_e2e_pass`; `python3 verification/tooling/check_formatter_contract.py`; `python3 verification/tooling/check_formatter_contract.py --self-test`; `python3 scripts/check_file_size_guardrails.py`; and `git diff --check`.
 
 ## PR Log
 
 - Milestone 1 `formatter_contract_manifests_and_ast_inventory`: <https://github.com/sifr-lang/sifr/pull/2175>
 - Milestone 2 `ruff_fork_sifr_formatter_ast_completion`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2>; superproject consumption PR <https://github.com/sifr-lang/sifr/pull/2176>
 - Milestone 3 `sifr_format_ruff_backed_core`: <https://github.com/sifr-lang/sifr/pull/2177>
+- Milestone 4 wave 1 `formatter_cli_surface`: <https://github.com/sifr-lang/sifr/pull/2178>

--- a/reviews/formatter-m4-wave1-cli-review.md
+++ b/reviews/formatter-m4-wave1-cli-review.md
@@ -1,0 +1,31 @@
+
+
+## M4 Wave 1 Review
+
+### Blockers
+
+**None.** Wave 1 passes all six review criteria.
+
+### Detailed Findings
+
+**1. CLI surface and guardrails:** `formatter_cli.rs` is 65 lines (new file, well under the cap). `check_and_package_commands.rs` grew from ~409 to 576 lines — stays within the 900-line hand-maintained limit. Existing commands unchanged.
+
+**2. Formatter routing:** All formatting routes through `sifr_format::FormatOptions` → Ruff `PyFormatOptions` via `ruff_options()` in `sifr_format/src/lib.rs:214-242`. No parallel formatter anywhere in the path.
+
+**3. Wave-1 safety:**
+- `fmt_stdin` at `check_and_package_commands.rs:460-487` correctly routes stdin when `--stdin-filename` is provided **or** when paths are empty and stdin is non-tty.
+- `parse_byte_range` at line 518-532 rejects malformed input with a clear `FMT_FORMATTING_DRIFT` diagnostic. Invalid ranges (non-UTF-8 boundaries, start > end) route to `invalid_range_diagnostic` through `validate_range`.
+- `--check` / `--diff` mutual exclusion via clap is correct.
+- Diff output goes to stdout, success messages to stderr — matches existing Sifr conventions.
+
+**4. Line length and preview conversion:** `format_options_from_args` at line 489-495 correctly maps:
+- `line_length`: falls back to 88 when absent; `ruff_options` converts to `LineWidth::try_from()` which rejects out-of-range.
+- `preview`: `args.preview && !args.no_preview` — evaluates to `false` when neither flag is provided (both default to `false` in clap), matching the phase's "stable mode default" requirement.
+
+**5. Tracker completeness:** The checklist item `CLI and config parity completed` is unchecked. The execution log at line 405 only records wave-1 targeted validation. Config, excludes, gitignore, and cache behavior are correctly **not** marked complete — those are wave-2 scope per the wave-1 scope description.
+
+**6. Merge readiness:** The `--respect-gitignore`, `--no-respect-gitignore`, `--force-exclude`, `--no-force-exclude`, `--exclude`, `--no-cache`, and `--cache-dir` flags are parsed and available on `FmtArgs`, but the actual file-selection behavior is deferred to wave 2. This is by design per the scope description and is not a blocker. Wave 1 focuses on the CLI arg surface and routing through the Ruff-backed formatter core.
+
+---
+
+**M4 wave 1 is approved to merge. M4 wave 2 may begin.** Wave 2 scope (config discovery, excludes, gitignore, cache wiring) is clearly bounded and correctly deferred.


### PR DESCRIPTION
Summary:
- Adds the wave-1 `sifr fmt` CLI argument surface for check/diff/stdin/range/line-length/preview and locked option-name parsing.
- Routes CLI formatting through `sifr_format` and the Ruff-backed formatter core without adding another formatter.
- Extends `FormatOptions` with line length and preview conversion into Ruff `PyFormatOptions`.

Deferred to M4 wave 2:
- Config discovery and precedence.
- Real exclude/gitignore/force-exclude behavior.
- Formatter cache behavior.

Validation:
- Formatter CLI smoke coverage for `--check`, `--diff`, `--stdin-filename`, stdin formatting, `--range`, `--line-length`, `--preview`, cache flag parsing, and multi-path/default directory behavior
- `cargo fmt -p sifr -p sifr_format --check`
- `cargo test -p sifr_format`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `python3 verification/tooling/check_formatter_contract.py`
- `python3 verification/tooling/check_formatter_contract.py --self-test`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`

Review:
- Claude Opus reviewed M4 wave 1 and found no blockers, approving the PR to merge and wave 2 to begin.
