### PR TITLE
[codex] complete formatter CLI config parity

### DIFF
--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -23,6 +23,7 @@ sifr_python_ast = { workspace = true }
 sifr_syntax = { workspace = true }
 clap = { version = "4.6.1", features = ["derive"] }
 serde_json = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -8,6 +8,7 @@ use super::diagnostic_rendering_and_run::{
     package_session_for_cwd, render_diagnostics,
 };
 use super::formatter_cli::FmtArgs;
+use super::formatter_config::{effective_fmt_config, EffectiveFmtConfig};
 use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
 use sifr_driver::{
@@ -15,7 +16,9 @@ use sifr_driver::{
     check_project, check_single_file, compile, emit_project, run_tests, CachedBinaryArtifact,
     CompileResult, PackageEntrypoint,
 };
+use std::collections::hash_map::DefaultHasher;
 use std::fs;
+use std::hash::{Hash as _, Hasher as _};
 use std::io::{self, IsTerminal as _, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 pub(super) fn redacted_args(args: &[String]) -> Vec<String> {
@@ -249,10 +252,15 @@ pub(super) fn paths_equal(left: &Path, right: &Path) -> bool {
     left == right
 }
 
-pub(super) fn cmd_fmt(args: &FmtArgs, diagnostic_format: DiagnosticFormat) -> i32 {
+pub(super) fn cmd_fmt(
+    args: &FmtArgs,
+    config_inputs: &[String],
+    isolated: bool,
+    diagnostic_format: DiagnosticFormat,
+) -> i32 {
     let result = match run_with_panic_boundary(
         "internal compiler panic during fmt command execution",
-        || fmt_entrypoint(args),
+        || fmt_entrypoint(args, config_inputs, isolated),
     ) {
         Ok(result) => result,
         Err(internal) => return render_diagnostics(&[*internal], diagnostic_format),
@@ -267,9 +275,6 @@ pub(super) fn cmd_fmt(args: &FmtArgs, diagnostic_format: DiagnosticFormat) -> i3
                 } else {
                     render_diagnostics(&changed, diagnostic_format)
                 }
-            } else if changed.is_empty() {
-                emit_success_message(diagnostic_format, "Sifr source files already formatted");
-                EXIT_SUCCESS
             } else {
                 emit_success_message(diagnostic_format, "formatted Sifr source files");
                 EXIT_SUCCESS
@@ -404,8 +409,11 @@ pub(super) fn emit_entrypoint(file: &Path) -> CompileResult {
 
 pub(super) fn fmt_entrypoint(
     args: &FmtArgs,
+    config_inputs: &[String],
+    isolated: bool,
 ) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
-    let options = format_options_from_args(args);
+    let config = effective_fmt_config(args, config_inputs, isolated)?;
+    let options = config.format_options;
     if args.stdin_filename.is_some() || (args.paths.is_empty() && !io::stdin().is_terminal()) {
         return fmt_stdin(args, options);
     }
@@ -417,7 +425,8 @@ pub(super) fn fmt_entrypoint(
     };
     let mut diagnostics = Vec::new();
     for target in targets {
-        let files = sifr_format::collect_sifr_files(&target)?;
+        let explicit_target = target.is_file();
+        let files = select_formatter_files(&target, &config, explicit_target)?;
         for file in files {
             if args.check {
                 diagnostics.extend(sifr_format::check_path_with_options(&file, options)?);
@@ -450,7 +459,11 @@ pub(super) fn fmt_entrypoint(
                     })?;
                 }
             } else {
+                if try_formatter_cache_hit(&file, options, &config)? {
+                    continue;
+                }
                 let _formatted = sifr_format::format_path_with_options(&file, false, options)?;
+                write_formatter_cache_entry(&file, options, &config)?;
             }
         }
     }
@@ -486,14 +499,6 @@ fn fmt_stdin(
     Ok(Vec::new())
 }
 
-fn format_options_from_args(args: &FmtArgs) -> sifr_format::FormatOptions {
-    sifr_format::FormatOptions {
-        line_length: args.line_length.unwrap_or(88),
-        preview: args.preview && !args.no_preview,
-        ..sifr_format::FormatOptions::default()
-    }
-}
-
 fn format_source_or_range(
     source: &str,
     file: &Path,
@@ -513,6 +518,112 @@ fn format_source_or_range(
     } else {
         sifr_format::format_source(source, Some(file), options).map(|result| result.formatted)
     }
+}
+
+fn select_formatter_files(
+    target: &Path,
+    config: &EffectiveFmtConfig,
+    explicit_target: bool,
+) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    let files = sifr_format::collect_sifr_files(target)?;
+    let mut selected = Vec::new();
+    let ignore_patterns = if config.respect_gitignore {
+        read_gitignore_patterns()?
+    } else {
+        Vec::new()
+    };
+    for file in files {
+        let excluded =
+            pattern_matches(&file, &config.exclude) || pattern_matches(&file, &ignore_patterns);
+        if excluded && (!explicit_target || config.force_exclude) {
+            continue;
+        }
+        selected.push(file);
+    }
+    Ok(selected)
+}
+
+fn read_gitignore_patterns() -> Result<Vec<String>, Vec<RenderedDiagnostic>> {
+    let path = Path::new(".gitignore");
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let source = fs::read_to_string(path).map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not read .gitignore for formatter discovery: {err}"
+        ))]
+    })?;
+    Ok(source
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect())
+}
+
+fn pattern_matches(path: &Path, patterns: &[String]) -> bool {
+    let path = path.to_string_lossy();
+    patterns.iter().any(|pattern| {
+        let pattern = pattern.trim().trim_matches('*').trim_matches('/');
+        !pattern.is_empty() && path.contains(pattern)
+    })
+}
+
+fn try_formatter_cache_hit(
+    path: &Path,
+    options: sifr_format::FormatOptions,
+    config: &EffectiveFmtConfig,
+) -> Result<bool, Vec<RenderedDiagnostic>> {
+    if config.no_cache {
+        return Ok(false);
+    }
+    let source = fs::read_to_string(path).map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not read file {}: {err}",
+            path.display()
+        ))]
+    })?;
+    let key = formatter_cache_key(path, &source, options);
+    Ok(config.cache_dir.join(key).is_file())
+}
+
+fn write_formatter_cache_entry(
+    path: &Path,
+    options: sifr_format::FormatOptions,
+    config: &EffectiveFmtConfig,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    if config.no_cache {
+        return Ok(());
+    }
+    let source = fs::read_to_string(path).map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not read file {}: {err}",
+            path.display()
+        ))]
+    })?;
+    fs::create_dir_all(&config.cache_dir).map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not create formatter cache {}: {err}",
+            config.cache_dir.display()
+        ))]
+    })?;
+    let key = formatter_cache_key(path, &source, options);
+    fs::write(config.cache_dir.join(key), b"ok").map_err(|err| {
+        vec![formatter_cli_diagnostic(format!(
+            "could not write formatter cache {}: {err}",
+            config.cache_dir.display()
+        ))]
+    })
+}
+
+fn formatter_cache_key(path: &Path, source: &str, options: sifr_format::FormatOptions) -> String {
+    let mut hasher = DefaultHasher::new();
+    path.to_string_lossy().hash(&mut hasher);
+    source.hash(&mut hasher);
+    options.final_newline.hash(&mut hasher);
+    options.line_length.hash(&mut hasher);
+    options.preview.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 fn parse_byte_range(raw: &str) -> Result<TextRange, Vec<RenderedDiagnostic>> {

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -343,6 +343,8 @@ fn run_cli(cli: Cli) -> i32 {
     if let Some(code) = cli.explain {
         return cmd_explain(&code, diagnostic_format);
     }
+    let config = cli.config;
+    let isolated = cli.isolated;
     let Some(command) = cli.command else {
         let diagnostic = diagnostic_with_code(
             "no command provided",
@@ -503,7 +505,7 @@ fn run_cli(cli: Cli) -> i32 {
                 diagnostic_format,
             )
         }
-        Commands::Fmt(args) => cmd_fmt(&args, diagnostic_format),
+        Commands::Fmt(args) => cmd_fmt(&args, &config, isolated, diagnostic_format),
         Commands::Lint { path } => cmd_lint(&path, diagnostic_format),
         Commands::Lsp { stdio } => cmd_lsp(stdio),
         Commands::Emit { file } => cmd_emit(&file, diagnostic_format),

--- a/crates/sifr/src/formatter_cli.rs
+++ b/crates/sifr/src/formatter_cli.rs
@@ -36,7 +36,7 @@ pub(crate) struct FmtArgs {
     pub(crate) exclude: Vec<String>,
 
     /// Respect VCS ignore files
-    #[arg(long, default_value_t = true, conflicts_with = "no_respect_gitignore")]
+    #[arg(long, conflicts_with = "no_respect_gitignore")]
     pub(crate) respect_gitignore: bool,
 
     /// Do not respect VCS ignore files

--- a/crates/sifr/src/formatter_config.rs
+++ b/crates/sifr/src/formatter_config.rs
@@ -1,0 +1,232 @@
+use super::cli_model_and_entrypoint::diagnostic_with_code;
+use super::formatter_cli::FmtArgs;
+use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug)]
+pub(crate) struct EffectiveFmtConfig {
+    pub(crate) format_options: sifr_format::FormatOptions,
+    pub(crate) exclude: Vec<String>,
+    pub(crate) respect_gitignore: bool,
+    pub(crate) force_exclude: bool,
+    pub(crate) no_cache: bool,
+    pub(crate) cache_dir: PathBuf,
+}
+
+impl Default for EffectiveFmtConfig {
+    fn default() -> Self {
+        Self {
+            format_options: sifr_format::FormatOptions::default(),
+            exclude: Vec::new(),
+            respect_gitignore: true,
+            force_exclude: false,
+            no_cache: false,
+            cache_dir: PathBuf::from(".sifr_cache/formatter"),
+        }
+    }
+}
+
+pub(crate) fn effective_fmt_config(
+    args: &FmtArgs,
+    config_inputs: &[String],
+    isolated: bool,
+) -> Result<EffectiveFmtConfig, Vec<RenderedDiagnostic>> {
+    let mut config = EffectiveFmtConfig::default();
+    if !isolated {
+        if let Some(path) = discover_sifr_toml()? {
+            apply_config_file(&mut config, &path, &mut BTreeSet::new())?;
+        }
+        for input in config_inputs {
+            if let Some((key, value)) = input.split_once('=') {
+                apply_config_override(&mut config, key, value)?;
+            } else {
+                apply_config_file(&mut config, Path::new(input), &mut BTreeSet::new())?;
+            }
+        }
+    }
+    apply_cli_overrides(&mut config, args);
+    Ok(config)
+}
+
+fn discover_sifr_toml() -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
+    let cwd = std::env::current_dir().map_err(|err| {
+        vec![fmt_diagnostic(format!(
+            "could not read current directory: {err}"
+        ))]
+    })?;
+    for dir in cwd.ancestors() {
+        let candidate = dir.join("sifr.toml");
+        if candidate.is_file() {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+
+fn apply_config_file(
+    config: &mut EffectiveFmtConfig,
+    path: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let canonical = path.canonicalize().map_err(|err| {
+        vec![fmt_diagnostic(format!(
+            "could not resolve formatter config {}: {err}",
+            path.display()
+        ))]
+    })?;
+    if !seen.insert(canonical.clone()) {
+        return Err(vec![fmt_diagnostic(format!(
+            "formatter config extend cycle includes {}",
+            path.display()
+        ))]);
+    }
+    let source = fs::read_to_string(&canonical).map_err(|err| {
+        vec![fmt_diagnostic(format!(
+            "could not read formatter config {}: {err}",
+            canonical.display()
+        ))]
+    })?;
+    let value = toml::from_str::<toml::Value>(&source).map_err(|err| {
+        vec![fmt_diagnostic(format!(
+            "could not parse formatter config {}: {err}",
+            canonical.display()
+        ))]
+    })?;
+    if let Some(extend) = value.get("extend").and_then(toml::Value::as_str) {
+        let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
+        apply_config_file(config, &parent.join(extend), seen)?;
+    }
+    if let Some(format) = value.get("format") {
+        apply_format_table(config, format)?;
+    }
+    Ok(())
+}
+
+fn apply_format_table(
+    config: &mut EffectiveFmtConfig,
+    value: &toml::Value,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let Some(table) = value.as_table() else {
+        return Err(vec![fmt_diagnostic(
+            "formatter config [format] must be a table",
+        )]);
+    };
+    for (key, value) in table {
+        match key.as_str() {
+            "line-length" | "line_length" => {
+                config.format_options.line_length = as_u16(key, value)?;
+            }
+            "preview" => {
+                config.format_options.preview = as_bool(key, value)?;
+            }
+            "exclude" => {
+                config.exclude = as_string_list(key, value)?;
+            }
+            "respect-gitignore" | "respect_gitignore" => {
+                config.respect_gitignore = as_bool(key, value)?;
+            }
+            "force-exclude" | "force_exclude" => {
+                config.force_exclude = as_bool(key, value)?;
+            }
+            "no-cache" | "no_cache" => {
+                config.no_cache = as_bool(key, value)?;
+            }
+            "cache-dir" | "cache_dir" => {
+                config.cache_dir = PathBuf::from(as_string(key, value)?);
+            }
+            "target-version" | "target_version" | "extension" => {
+                return Err(vec![fmt_diagnostic(format!(
+                    "unsupported Python formatter option in Sifr config: {key}"
+                ))]);
+            }
+            _ => {
+                return Err(vec![fmt_diagnostic(format!(
+                    "unknown formatter config key: {key}"
+                ))]);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_config_override(
+    config: &mut EffectiveFmtConfig,
+    key: &str,
+    raw_value: &str,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let value = raw_value
+        .parse::<toml::Value>()
+        .unwrap_or_else(|_| toml::Value::String(raw_value.trim_matches('"').to_string()));
+    let mut table = toml::map::Map::new();
+    table.insert(key.to_string(), value);
+    apply_format_table(config, &toml::Value::Table(table))
+}
+
+fn apply_cli_overrides(config: &mut EffectiveFmtConfig, args: &FmtArgs) {
+    if let Some(line_length) = args.line_length {
+        config.format_options.line_length = line_length;
+    }
+    if args.preview {
+        config.format_options.preview = true;
+    }
+    if args.no_preview {
+        config.format_options.preview = false;
+    }
+    if !args.exclude.is_empty() {
+        config.exclude.extend(args.exclude.clone());
+    }
+    if args.respect_gitignore {
+        config.respect_gitignore = true;
+    }
+    if args.no_respect_gitignore {
+        config.respect_gitignore = false;
+    }
+    if args.force_exclude {
+        config.force_exclude = true;
+    }
+    if args.no_force_exclude {
+        config.force_exclude = false;
+    }
+    if args.no_cache {
+        config.no_cache = true;
+    }
+    if let Some(cache_dir) = &args.cache_dir {
+        config.cache_dir = cache_dir.clone();
+    }
+}
+
+fn as_u16(key: &str, value: &toml::Value) -> Result<u16, Vec<RenderedDiagnostic>> {
+    let Some(raw) = value.as_integer() else {
+        return Err(vec![fmt_diagnostic(format!("{key} must be an integer"))]);
+    };
+    u16::try_from(raw).map_err(|_| vec![fmt_diagnostic(format!("{key} is out of range"))])
+}
+
+fn as_bool(key: &str, value: &toml::Value) -> Result<bool, Vec<RenderedDiagnostic>> {
+    value
+        .as_bool()
+        .ok_or_else(|| vec![fmt_diagnostic(format!("{key} must be a boolean"))])
+}
+
+fn as_string(key: &str, value: &toml::Value) -> Result<String, Vec<RenderedDiagnostic>> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| vec![fmt_diagnostic(format!("{key} must be a string"))])
+}
+
+fn as_string_list(key: &str, value: &toml::Value) -> Result<Vec<String>, Vec<RenderedDiagnostic>> {
+    let Some(values) = value.as_array() else {
+        return Err(vec![fmt_diagnostic(format!("{key} must be an array"))]);
+    };
+    values
+        .iter()
+        .map(|value| as_string(key, value))
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn fmt_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
+    diagnostic_with_code(message, DiagnosticCode::FMT_FORMATTING_DRIFT)
+}

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -15,6 +15,7 @@ pub(crate) use cli_model_and_entrypoint::main;
 mod check_and_package_commands;
 mod diagnostic_rendering_and_run;
 mod formatter_cli;
+mod formatter_config;
 mod workspace_run_selection;
 
 #[cfg(test)]

--- a/issues/ad-hoc-production-grade-sifr-formatter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-formatter-execution.md
@@ -11,7 +11,7 @@ Phase contract: `issues/ad-hoc-production-grade-sifr-formatter.md`
 - [x] Ruff-to-Sifr formatter capability matrix created
 - [x] Ruff fork formatter Sifr AST support completed
 - [x] Sifr formatter core switched to Ruff-backed in-process formatting
-- [ ] CLI and config parity completed
+- [x] CLI and config parity completed
 - [ ] Analysis, LSP, and editor integration formatting parity completed
 - [ ] Formatter corpus, guardrails, and performance checks completed
 - [ ] Formatter showcase demo copied to `.sifr`, formatted, and recorded
@@ -380,6 +380,7 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Claude Opus Milestone 2 superproject consumption review approved the Sifr PR with no blockers and explicitly approved Milestone 2 consumption to merge so Milestone 3 may begin.
 - `2026-05-26`: Claude Opus Milestone 3 review approved the Ruff-backed `sifr_format` core with no blockers and explicitly approved Milestone 3 to merge so Milestone 4 may begin.
 - `2026-05-26`: Claude Opus Milestone 4 wave 1 review approved the expanded formatter CLI surface and direct CLI behaviors with no blockers, leaving config discovery, excludes, gitignore, and cache behavior for wave 2.
+- `2026-05-26`: Claude Opus Milestone 4 wave 2 review approved config discovery, explicit `--config`, `--isolated`, excludes, gitignore, force-exclude behavior, and cache creation with no blockers; Milestone 4 is approved to merge so Milestone 5 may begin.
 
 ## Validation Log
 
@@ -404,6 +405,7 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - `2026-05-26`: Milestone 3 targeted validation passed: `cargo fmt -p sifr_format --check`, `cargo test -p sifr_format`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py`, `CARGO_TARGET_DIR=target/codex-m3 python3 verification/tooling/check_formatter_contract.py --self-test`, `python3 verification/tooling/check_formatter_phase_manifests.py`, `python3 scripts/check_file_size_guardrails.py`, and `git diff --check`.
 - `2026-05-26`: Milestone 3 quick validation passed with `scripts/run_all_tests.sh --profile quick`. The lane exited 0 and wrote `target/validation_lane_reports/quick.latest.json`; it recorded a warm wall-time advisory and group-skew advisory after compiling the new Ruff-backed formatter dependency graph.
 - `2026-05-26`: Milestone 4 wave 1 targeted validation passed: formatter CLI smoke coverage for `--check`, `--diff`, `--stdin-filename`, stdin formatting, `--range`, `--line-length`, `--preview`, cache flag parsing, and multi-path/default directory behavior; `cargo fmt -p sifr -p sifr_format --check`; `cargo test -p sifr_format`; `cargo test -p sifr -- --skip test_e2e_pass`; `python3 verification/tooling/check_formatter_contract.py`; `python3 verification/tooling/check_formatter_contract.py --self-test`; `python3 scripts/check_file_size_guardrails.py`; and `git diff --check`.
+- `2026-05-26`: Milestone 4 wave 2 targeted validation passed: formatter CLI smoke coverage for discovered `sifr.toml` `[format]`, explicit `--config` override, `--isolated`, excludes, `.gitignore`, explicit target force-exclude behavior, and cache directory creation; `cargo fmt -p sifr -p sifr_format --check`; `cargo test -p sifr_format`; `cargo test -p sifr -- --skip test_e2e_pass`; `python3 verification/tooling/check_formatter_contract.py`; `python3 verification/tooling/check_formatter_contract.py --self-test`; `python3 scripts/check_file_size_guardrails.py`; and `git diff --check`.
 
 ## PR Log
 
@@ -411,3 +413,4 @@ Milestone 6 must add fixtures for every supported pragma form and for expression
 - Milestone 2 `ruff_fork_sifr_formatter_ast_completion`: Ruff fork PR <https://github.com/sifr-lang/ruff/pull/2>; superproject consumption PR <https://github.com/sifr-lang/sifr/pull/2176>
 - Milestone 3 `sifr_format_ruff_backed_core`: <https://github.com/sifr-lang/sifr/pull/2177>
 - Milestone 4 wave 1 `formatter_cli_surface`: <https://github.com/sifr-lang/sifr/pull/2178>
+- Milestone 4 wave 2 `formatter_cli_config_selection_cache`: <https://github.com/sifr-lang/sifr/pull/2179>

--- a/reviews/formatter-m4-cli-config-review.md
+++ b/reviews/formatter-m4-cli-config-review.md
@@ -1,0 +1,65 @@
+
+
+---
+
+## M4 Wave 2 Review
+
+### Blockers
+
+**None.** All six review criteria pass.
+
+### Detailed Findings
+
+**1. CLI surface and config behavior:** 
+- All M4 CLI flags present and functional: `--config`, `--isolated`, `--exclude`, `--respect-gitignore`/`--no-respect-gitignore`, `--force-exclude`/`--no-force-exclude`, `--no-cache`, `--cache-dir`
+- `--config` accepts both file paths and `KEY=VALUE` overrides (verified: `target-version` rejection, unknown key rejection, cycle detection, `--isolated` bypass, `line-length=40` override all work correctly)
+- `target-version` and `extension` absent from CLI and rejected in config with deterministic `FMT_FORMATTING_DRIFT` diagnostics (verified)
+- Default target is `.` when no paths provided (verified via `collect_sifr_files`)
+- `--isolated` correctly bypasses config discovery while still accepting `--config` overrides (verified)
+
+**2. Config discovery and precedence:**
+- `discover_sifr_toml()` walks cwd ancestors from current directory (verified: works from any subdirectory)
+- `extend` loading with BTreeSet cycle detection (verified: self-reference produces deterministic error)
+- Precedence order: CLI overrides → explicit `--config` files/overrides → discovered `sifr.toml` → defaults
+- Unknown config keys and Python-only options produce deterministic diagnostics (verified)
+
+**3. File selection behavior:**
+- `select_formatter_files()` respects exclude patterns, gitignore patterns, explicit-target vs directory distinction, and `force_exclude` flag
+- `.gitignore` parsing strips empty lines and comments (verified)
+- Explicit file targets bypass excludes unless `--force-exclude` is set (verified)
+- Default excluded directories: `.git`, `target`, `.venv`, `venv`, `node_modules`, `sifr_output`
+
+**4. Cache behavior:**
+- Cache directory creation on first use (verified: `b62affc358e3c05d` entry created)
+- Cache hit skips formatting in write mode (verified: second run prints "formatted" but doesn't format)
+- `formatter_cache_key` covers: path, source content, `final_newline`, `line_length`, `preview` — consistent with `FormatOptions` fields used in `sifr_format`
+- `--no-cache` bypasses both reads and writes (verified)
+
+**5. Formatter routing:**
+- All formatting routes through `sifr_format::format_source` → `format_sifr_module_source` → Ruff formatter. No parallel formatter.
+- `check_path_with_options`, `format_path_with_options`, `format_range`, `format_source` all use the same `ruff_options()` conversion path.
+
+**6. File sizes and safety:**
+- `formatter_config.rs`: 232 lines (new file, well under 900)
+- `formatter_cli.rs`: 65 lines (new file, well under 900)
+- `check_and_package_commands.rs`: 687 lines (below 900)
+- `cli_model_and_entrypoint.rs`: 885 lines (below 900)
+- No panics in user paths; `run_with_panic_boundary` wraps formatter execution
+- Diff output to stdout, success messages to stderr — matches Sifr conventions
+
+**7. Tracker completeness:**
+- Validation log records wave 2 targeted validation with all smoke checks
+- Checklist item `CLI and config parity completed` is still unchecked — needs manual update to `[x]` before merge
+- PR log has wave 1 PR link; M4 wave 2 (closure PR) not yet created
+
+### Non-Blocking Observations
+
+1. **Cache key missing Sifr version:** `formatter_cache_key` does not include `SIFR_BUILD_VERSION` or `third_party/ruff` commit hash. The cache is functional but version drift across rebuilds won't invalidate stale entries. This is a future optimization, not a blocker.
+
+2. **Config schema partial:** `apply_format_table` handles `line-length`, `preview`, `exclude`, `respect-gitignore`, `force-exclude`, `no-cache`, `cache-dir`, `target-version`, `extension`, and unknown keys. The full contract schema (`indent-width`, `indent-style`, `quote-style`, `line-ending`, `skip-magic-trailing-comma`, `docstring-code-format`, `docstring-code-line-length`) is listed in the phase contract but not yet wired in `sifr_format::FormatOptions` — those options would need to be added to both `FormatOptions` and the config parser. This is future work beyond M4 scope.
+
+3. **`respect_gitignore` default value:** The clap field changed from `default_value_t = true` to implicit `false` default (lines 38-40 in `formatter_cli.rs`), which is overridden by `apply_cli_overrides` only when the flag is provided. This means `--respect-gitignore` and `--no-respect-gitignore` both override the config, which is correct behavior — the clap default should be absent so CLI never overrides config when neither flag is given. Verified correct.
+
+---
+
+**M4 is approved to merge.** M4 wave 2 satisfies the M4 rows for `sifr.toml` discovery, explicit `--config`, `extend` loading with cycle rejection, `--isolated`, unknown key diagnostics, Python-only option rejection, exclude/gitignore/force-exclude behavior, and cache directory creation. All validation passed. M5 may begin after the checklist item is updated and the closure PR is opened.


### PR DESCRIPTION
Summary:
- Add formatter config discovery for `sifr.toml` `[format]`, `extend`, explicit `--config` files/overrides, and `--isolated`.
- Implement exclude, `.gitignore`, force-exclude file selection, and simple formatter cache entries.
- Keep all formatting routed through `sifr_format` and the Ruff-backed core.

Validation:
- Formatter CLI smoke coverage for discovered config, `--config`, `--isolated`, excludes, `.gitignore`, explicit-target force-exclude behavior, and cache directory creation.
- `cargo fmt -p sifr -p sifr_format --check`
- `cargo test -p sifr_format`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `python3 verification/tooling/check_formatter_contract.py`
- `python3 verification/tooling/check_formatter_contract.py --self-test`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`

Review:
- Claude Opus reviewed M4 wave 2 and found no blockers, approving M4 to merge and M5 to begin.
