### PR TITLE
[codex] Implement lint config and discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ annotate-snippets = { version = "0.12.15", features = ["color"] }
 anyhow = { version = "1.0.102" }
 bitflags = { version = "2.11.1" }
 bstr = { version = "1.12.1" }
+globset = { version = "0.4.18" }
+ignore = { version = "0.4.25" }
 insta = { version = "1.47.2" }
 is-macro = { version = "0.3.7" }
 itertools = { version = "0.14.0" }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -284,25 +284,6 @@ pub(super) fn cmd_fmt(
     }
 }
 
-pub(super) fn cmd_lint(path: &Path, diagnostic_format: DiagnosticFormat) -> i32 {
-    let result = match run_with_panic_boundary(
-        "internal compiler panic during lint command execution",
-        || lint_entrypoint(path),
-    ) {
-        Ok(result) => result,
-        Err(internal) => return render_diagnostics(&[*internal], diagnostic_format),
-    };
-
-    match result {
-        Ok(diagnostics) if diagnostics.is_empty() => {
-            emit_success_message(diagnostic_format, "no lint diagnostics found");
-            EXIT_SUCCESS
-        }
-        Ok(diagnostics) => render_diagnostics(&diagnostics, diagnostic_format),
-        Err(errors) => render_diagnostics(&errors, diagnostic_format),
-    }
-}
-
 pub(super) fn emit_success_message(diagnostic_format: DiagnosticFormat, message: &str) {
     match diagnostic_format {
         DiagnosticFormat::Human => {
@@ -702,14 +683,4 @@ fn formatting_drift_for_path(source: &str, path: &Path) -> RenderedDiagnostic {
 
 fn formatter_cli_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
     diagnostic_with_code(message, DiagnosticCode::FMT_FORMATTING_DRIFT)
-}
-
-pub(super) fn lint_entrypoint(
-    path: &Path,
-) -> Result<Vec<RenderedDiagnostic>, Vec<RenderedDiagnostic>> {
-    let options = sifr_lint::LintOptions {
-        explicit_target: path.is_file(),
-        ..sifr_lint::LintOptions::default()
-    };
-    sifr_lint::lint_path(path, &options).map(|result| result.diagnostics)
 }

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -1,9 +1,10 @@
-use super::check_and_package_commands::{cmd_check, cmd_emit, cmd_fmt, cmd_lint, cmd_test};
+use super::check_and_package_commands::{cmd_check, cmd_emit, cmd_fmt, cmd_test};
 use super::diagnostic_rendering_and_run::{
     cmd_build, cmd_fetch, cmd_package, cmd_publish, cmd_run, cmd_tree, cmd_vendor,
     render_diagnostics,
 };
 use super::formatter_cli::FmtArgs;
+use super::lint_cli::{cmd_lint, LintArgs};
 use clap::{Parser, Subcommand, ValueEnum};
 use sifr_diagnostics::{
     DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
@@ -34,11 +35,11 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) explain: Option<String>,
 
-    /// Formatter config file path or KEY=VALUE override
+    /// Sifr config file path or KEY=VALUE override
     #[arg(long, global = true)]
     pub(crate) config: Vec<String>,
 
-    /// Ignore formatter configuration files
+    /// Ignore Sifr configuration files
     #[arg(long, global = true)]
     pub(crate) isolated: bool,
 
@@ -255,10 +256,7 @@ pub(crate) enum Commands {
     /// Format Sifr source files
     Fmt(FmtArgs),
     /// Run suppressible policy diagnostics
-    Lint {
-        /// Input .sifr file or directory
-        path: PathBuf,
-    },
+    Lint(LintArgs),
     /// Run the native Sifr Language Server Protocol server
     Lsp {
         /// Use stdio transport
@@ -506,7 +504,7 @@ fn run_cli(cli: Cli) -> i32 {
             )
         }
         Commands::Fmt(args) => cmd_fmt(&args, &config, isolated, diagnostic_format),
-        Commands::Lint { path } => cmd_lint(&path, diagnostic_format),
+        Commands::Lint(args) => cmd_lint(&args, &config, isolated, diagnostic_format),
         Commands::Lsp { stdio } => cmd_lsp(stdio),
         Commands::Emit { file } => cmd_emit(&file, diagnostic_format),
         Commands::Test { dir } => cmd_test(&dir, diagnostic_format),

--- a/crates/sifr/src/lint_cli.rs
+++ b/crates/sifr/src/lint_cli.rs
@@ -1,0 +1,355 @@
+use super::cli_model_and_entrypoint::{
+    diagnostic_with_code, run_with_panic_boundary, DiagnosticFormat,
+    EXIT_INTERNAL_COMPILER_FAILURE, EXIT_SUCCESS, EXIT_USAGE_OR_CONFIG, EXIT_USER_DIAGNOSTIC,
+};
+use super::diagnostic_rendering_and_run::render_diagnostic_output;
+use clap::{Args, ValueEnum};
+use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
+use sifr_lint::{EffectiveLintConfig, LintConfigOverrides, PerFileIgnore};
+use std::io::{self, Read as _, Write as _};
+use std::path::{Path, PathBuf};
+
+#[derive(Args, Clone, Debug)]
+pub(crate) struct LintArgs {
+    /// Filename context for linting stdin
+    #[arg(long)]
+    pub(crate) stdin_filename: Option<PathBuf>,
+
+    /// Select Sifr policy rules or categories
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) select: Vec<String>,
+
+    /// Extend selected Sifr policy rules or categories
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) extend_select: Vec<String>,
+
+    /// Ignore Sifr policy rules or categories
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) ignore: Vec<String>,
+
+    /// Ignore rules for files matching a glob, as GLOB:RULE[,RULE]
+    #[arg(long)]
+    pub(crate) per_file_ignores: Vec<String>,
+
+    /// Extend per-file ignores, as GLOB:RULE[,RULE]
+    #[arg(long)]
+    pub(crate) extend_per_file_ignores: Vec<String>,
+
+    /// Lint output format
+    #[arg(long, value_enum)]
+    pub(crate) output_format: Option<LintOutputFormat>,
+
+    /// Write lint output to a file
+    #[arg(long)]
+    pub(crate) output_file: Option<PathBuf>,
+
+    /// Print discovered files without linting
+    #[arg(long, conflicts_with = "show_settings")]
+    pub(crate) show_files: bool,
+
+    /// Print resolved lint settings without linting
+    #[arg(long)]
+    pub(crate) show_settings: bool,
+
+    /// Enable preview policy rules
+    #[arg(long, conflicts_with = "no_preview")]
+    pub(crate) preview: bool,
+
+    /// Disable preview policy rules
+    #[arg(long)]
+    pub(crate) no_preview: bool,
+
+    /// Exclude paths matching a lint glob
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) exclude: Vec<String>,
+
+    /// Extend configured lint excludes
+    #[arg(long, value_delimiter = ',')]
+    pub(crate) extend_exclude: Vec<String>,
+
+    /// Respect VCS ignore files
+    #[arg(long, conflicts_with = "no_respect_gitignore")]
+    pub(crate) respect_gitignore: bool,
+
+    /// Do not respect VCS ignore files
+    #[arg(long)]
+    pub(crate) no_respect_gitignore: bool,
+
+    /// Apply excludes to explicit file targets
+    #[arg(long, conflicts_with = "no_force_exclude")]
+    pub(crate) force_exclude: bool,
+
+    /// Do not apply excludes to explicit file targets
+    #[arg(long)]
+    pub(crate) no_force_exclude: bool,
+
+    /// Exit successfully even when lint diagnostics remain
+    #[arg(long)]
+    pub(crate) exit_zero: bool,
+
+    /// Input .sifr files or directories; defaults to current directory
+    #[arg(value_name = "FILES")]
+    pub(crate) paths: Vec<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum LintOutputFormat {
+    Concise,
+    Full,
+    Json,
+}
+
+impl LintOutputFormat {
+    fn diagnostic_format(self) -> DiagnosticFormat {
+        match self {
+            Self::Concise => DiagnosticFormat::Compact,
+            Self::Full => DiagnosticFormat::Human,
+            Self::Json => DiagnosticFormat::Json,
+        }
+    }
+}
+
+pub(super) fn cmd_lint(
+    args: &LintArgs,
+    config_inputs: &[String],
+    isolated: bool,
+    diagnostic_format: DiagnosticFormat,
+) -> i32 {
+    let lint_format = args
+        .output_format
+        .map_or(diagnostic_format, LintOutputFormat::diagnostic_format);
+    let result = match run_with_panic_boundary(
+        "internal compiler panic during lint command execution",
+        || lint_entrypoint(args, config_inputs, isolated),
+    ) {
+        Ok(result) => result,
+        Err(internal) => return render_lint_diagnostics(&[*internal], lint_format, args, false),
+    };
+
+    match result {
+        Ok(LintCommandResult::Diagnostics(diagnostics)) => {
+            if diagnostics.is_empty() {
+                return emit_success(lint_format, args);
+            }
+            let exit = render_lint_diagnostics(&diagnostics, lint_format, args, false);
+            if args.exit_zero {
+                EXIT_SUCCESS
+            } else {
+                exit
+            }
+        }
+        Ok(LintCommandResult::Text(output)) => write_lint_output(&output, args, true),
+        Err(errors) => render_lint_diagnostics(&errors, lint_format, args, true),
+    }
+}
+
+enum LintCommandResult {
+    Diagnostics(Vec<RenderedDiagnostic>),
+    Text(String),
+}
+
+fn lint_entrypoint(
+    args: &LintArgs,
+    config_inputs: &[String],
+    isolated: bool,
+) -> Result<LintCommandResult, Vec<RenderedDiagnostic>> {
+    let overrides = lint_cli_overrides(args)?;
+    let start_dir = lint_start_dir(args);
+    let config = sifr_lint::effective_lint_config(&start_dir, config_inputs, isolated, &overrides)?;
+    if args.show_settings {
+        return Ok(LintCommandResult::Text(render_settings(&config)));
+    }
+    let targets = lint_targets(args);
+    if args.show_files {
+        let files = sifr_lint::collect_sifr_files_for_targets(&targets, &config.options)?;
+        let output = files
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Ok(LintCommandResult::Text(format!("{output}\n")));
+    }
+    if reads_stdin(args) {
+        let mut source = String::new();
+        io::stdin().read_to_string(&mut source).map_err(|err| {
+            vec![diagnostic_with_code(
+                format!("could not read lint source from stdin: {err}"),
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+            )]
+        })?;
+        let file = args.stdin_filename.as_deref();
+        let diagnostics = sifr_lint::lint_source(&source, file, &config.options).diagnostics;
+        return Ok(LintCommandResult::Diagnostics(diagnostics));
+    }
+    let diagnostics = sifr_lint::lint_paths(&targets, &config.options)?.diagnostics;
+    Ok(LintCommandResult::Diagnostics(diagnostics))
+}
+
+fn lint_cli_overrides(args: &LintArgs) -> Result<LintConfigOverrides, Vec<RenderedDiagnostic>> {
+    Ok(LintConfigOverrides {
+        select: (!args.select.is_empty()).then(|| args.select.clone()),
+        extend_select: args.extend_select.clone(),
+        ignore: args.ignore.clone(),
+        per_file_ignores: parse_per_file_ignores(&args.per_file_ignores)?,
+        extend_per_file_ignores: parse_per_file_ignores(&args.extend_per_file_ignores)?,
+        exclude: args.exclude.clone(),
+        extend_exclude: args.extend_exclude.clone(),
+        respect_gitignore: flag_override(args.respect_gitignore, args.no_respect_gitignore),
+        force_exclude: flag_override(args.force_exclude, args.no_force_exclude),
+        preview: flag_override(args.preview, args.no_preview),
+    })
+}
+
+fn parse_per_file_ignores(
+    values: &[String],
+) -> Result<Vec<PerFileIgnore>, Vec<RenderedDiagnostic>> {
+    let mut ignores = Vec::new();
+    for value in values {
+        let Some((pattern, rules)) = value.split_once(':') else {
+            return Err(vec![diagnostic_with_code(
+                format!("per-file ignore must use GLOB:RULE[,RULE], got {value:?}"),
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+            )]);
+        };
+        let rules = rules
+            .split(',')
+            .map(str::trim)
+            .filter(|rule| !rule.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if pattern.trim().is_empty() || rules.is_empty() {
+            return Err(vec![diagnostic_with_code(
+                format!("per-file ignore must include a glob and at least one rule: {value:?}"),
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+            )]);
+        }
+        ignores.push(PerFileIgnore {
+            pattern: pattern.trim().to_string(),
+            rules,
+        });
+    }
+    Ok(ignores)
+}
+
+fn lint_targets(args: &LintArgs) -> Vec<PathBuf> {
+    if reads_stdin(args) {
+        return Vec::new();
+    }
+    if args.paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        args.paths.clone()
+    }
+}
+
+fn reads_stdin(args: &LintArgs) -> bool {
+    args.paths.iter().any(|path| path == Path::new("-"))
+}
+
+fn lint_start_dir(args: &LintArgs) -> PathBuf {
+    if let Some(path) = args.stdin_filename.as_deref().and_then(Path::parent) {
+        return path.to_path_buf();
+    }
+    args.paths
+        .iter()
+        .find(|path| path != &Path::new("-"))
+        .and_then(|path| {
+            if path.is_dir() {
+                Some(path.as_path())
+            } else {
+                path.parent()
+            }
+        })
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
+}
+
+fn render_settings(config: &EffectiveLintConfig) -> String {
+    let options = &config.options;
+    format!(
+        "config = {}\npreview = {}\nselect = {:?}\nextend_select = {:?}\nignore = {:?}\ninclude = {:?}\nexclude = {:?}\nrespect_gitignore = {}\nforce_exclude = {}\nper_file_ignores = {}\n",
+        config
+            .config_path
+            .as_ref()
+            .map_or_else(|| "<none>".to_string(), |path| path.display().to_string()),
+        options.preview,
+        options.select,
+        options.extend_select,
+        options.ignore,
+        options.include,
+        options.exclude,
+        options.respect_gitignore,
+        options.force_exclude,
+        options.per_file_ignores.len(),
+    )
+}
+
+fn flag_override(enable: bool, disable: bool) -> Option<bool> {
+    if disable {
+        Some(false)
+    } else if enable {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+fn render_lint_diagnostics(
+    diagnostics: &[RenderedDiagnostic],
+    format: DiagnosticFormat,
+    args: &LintArgs,
+    usage_error: bool,
+) -> i32 {
+    let output = match render_diagnostic_output(diagnostics, format) {
+        Ok(output) => output,
+        Err(error) => {
+            let _ = writeln!(
+                io::stderr(),
+                "lint error: failed to serialize diagnostics as json: {error}"
+            );
+            return EXIT_INTERNAL_COMPILER_FAILURE;
+        }
+    };
+    let write_exit = write_lint_output(&output, args, false);
+    if write_exit != EXIT_SUCCESS {
+        return write_exit;
+    }
+    if usage_error {
+        EXIT_USAGE_OR_CONFIG
+    } else {
+        EXIT_USER_DIAGNOSTIC
+    }
+}
+
+fn write_lint_output(output: &str, args: &LintArgs, stdout: bool) -> i32 {
+    if let Some(path) = &args.output_file {
+        return match std::fs::write(path, output) {
+            Ok(()) => EXIT_SUCCESS,
+            Err(error) => {
+                let _ = writeln!(
+                    io::stderr(),
+                    "lint error: could not write output file {}: {error}",
+                    path.display()
+                );
+                EXIT_USAGE_OR_CONFIG
+            }
+        };
+    }
+    if stdout {
+        let _ = write!(io::stdout(), "{output}");
+    } else {
+        let _ = write!(io::stderr(), "{output}");
+    }
+    EXIT_SUCCESS
+}
+
+fn emit_success(format: DiagnosticFormat, args: &LintArgs) -> i32 {
+    let output = match format {
+        DiagnosticFormat::Human => "no lint diagnostics found\n".to_string(),
+        DiagnosticFormat::Json => "[]\n".to_string(),
+        DiagnosticFormat::Compact => {
+            "summary: 0 error(s), 0 warning(s), 0 note(s), 0 help item(s)\n".to_string()
+        }
+    };
+    write_lint_output(&output, args, false)
+}

--- a/crates/sifr/src/main.rs
+++ b/crates/sifr/src/main.rs
@@ -7,7 +7,8 @@
 //!   sifr emit <file.sifr>     Show generated Rust code
 //!   sifr fmt [OPTIONS] [FILES]...
 //!                              Format Sifr source files
-//!   sifr lint <path>          Run suppressible policy diagnostics
+//!   sifr lint [OPTIONS] [FILES]...
+//!                              Run suppressible policy diagnostics
 //!   sifr lsp --stdio          Run the native Language Server Protocol server
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used, dead_code))]
 
@@ -16,6 +17,7 @@ pub(crate) use cli_model_and_entrypoint::main;
 mod check_and_package_commands;
 mod diagnostic_rendering_and_run;
 mod formatter_cli;
+mod lint_cli;
 mod workspace_run_selection;
 
 #[cfg(test)]

--- a/crates/sifr_lint/Cargo.toml
+++ b/crates/sifr_lint/Cargo.toml
@@ -7,7 +7,10 @@ rust-version = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+globset = { workspace = true }
+ignore = { workspace = true }
 sifr_diagnostics = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sifr_lint/src/config.rs
+++ b/crates/sifr_lint/src/config.rs
@@ -1,0 +1,319 @@
+use crate::{
+    lint_config_diagnostic, rule_metadata, EffectiveLintConfig, LintConfigOverrides, LintOptions,
+    PerFileIgnore, RuleSeverity, RULES,
+};
+use sifr_diagnostics::RenderedDiagnostic;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn effective_lint_config(
+    start_dir: &Path,
+    config_inputs: &[String],
+    isolated: bool,
+    overrides: &LintConfigOverrides,
+) -> Result<EffectiveLintConfig, Vec<RenderedDiagnostic>> {
+    let mut config = EffectiveLintConfig::default();
+    if !isolated {
+        if let Some(path) = discover_sifr_toml(start_dir)? {
+            apply_config_file(&mut config, &path, &mut BTreeSet::new())?;
+        }
+    }
+    for input in config_inputs {
+        if let Some((key, value)) = input.split_once('=') {
+            apply_config_override(&mut config, key, value)?;
+        } else if !isolated {
+            apply_config_file(&mut config, Path::new(input), &mut BTreeSet::new())?;
+        }
+    }
+    apply_overrides(&mut config.options, overrides);
+    validate_rule_selectors(&config.options)?;
+    Ok(config)
+}
+
+fn discover_sifr_toml(start_dir: &Path) -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
+    let base = if start_dir.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        start_dir
+    };
+    let canonical = base.canonicalize().map_err(|err| {
+        vec![lint_config_diagnostic(format!(
+            "could not resolve lint config start directory {}: {err}",
+            base.display()
+        ))]
+    })?;
+    for dir in canonical.ancestors() {
+        let candidate = dir.join("sifr.toml");
+        if candidate.is_file() {
+            return Ok(Some(candidate));
+        }
+    }
+    Ok(None)
+}
+
+fn apply_config_file(
+    config: &mut EffectiveLintConfig,
+    path: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let canonical = path.canonicalize().map_err(|err| {
+        vec![lint_config_diagnostic(format!(
+            "could not resolve lint config {}: {err}",
+            path.display()
+        ))]
+    })?;
+    if !seen.insert(canonical.clone()) {
+        return Err(vec![lint_config_diagnostic(format!(
+            "lint config extend cycle includes {}",
+            path.display()
+        ))]);
+    }
+    let source = fs::read_to_string(&canonical).map_err(|err| {
+        vec![lint_config_diagnostic(format!(
+            "could not read lint config {}: {err}",
+            canonical.display()
+        ))]
+    })?;
+    let value = toml::from_str::<toml::Value>(&source).map_err(|err| {
+        vec![lint_config_diagnostic(format!(
+            "could not parse lint config {}: {err}",
+            canonical.display()
+        ))]
+    })?;
+    let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
+    apply_extends(config, value.get("extend"), parent, seen)?;
+    if let Some(lint) = value.get("lint") {
+        apply_extends(config, lint.get("extend"), parent, seen)?;
+        apply_lint_table(&mut config.options, lint)?;
+        config.config_path = Some(canonical);
+    }
+    Ok(())
+}
+
+fn apply_extends(
+    config: &mut EffectiveLintConfig,
+    value: Option<&toml::Value>,
+    parent: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if let Some(path) = value.as_str() {
+        return apply_config_file(config, &parent.join(path), seen);
+    }
+    let Some(paths) = value.as_array() else {
+        return Err(vec![lint_config_diagnostic(
+            "extend must be a string or array",
+        )]);
+    };
+    for path in paths {
+        let path = as_string("extend", path)?;
+        apply_config_file(config, &parent.join(path), seen)?;
+    }
+    Ok(())
+}
+
+fn apply_lint_table(
+    options: &mut LintOptions,
+    value: &toml::Value,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let Some(table) = value.as_table() else {
+        return Err(vec![lint_config_diagnostic("[lint] must be a table")]);
+    };
+    for (key, value) in table {
+        match key.as_str() {
+            "extend" => {}
+            "preview" => options.preview = as_bool(key, value)?,
+            "select" => options.select = as_string_list(key, value)?,
+            "extend-select" | "extend_select" => {
+                options.extend_select.extend(as_string_list(key, value)?);
+            }
+            "ignore" => options.ignore.extend(as_string_list(key, value)?),
+            "include" => options.include = as_string_list(key, value)?,
+            "extend-include" | "extend_include" => {
+                options.include.extend(as_string_list(key, value)?);
+            }
+            "exclude" => options.exclude = as_string_list(key, value)?,
+            "extend-exclude" | "extend_exclude" => {
+                options.exclude.extend(as_string_list(key, value)?);
+            }
+            "respect-gitignore" | "respect_gitignore" => {
+                options.respect_gitignore = as_bool(key, value)?;
+            }
+            "force-exclude" | "force_exclude" => options.force_exclude = as_bool(key, value)?,
+            "rules" => apply_rule_table(options, value)?,
+            "per-file-ignores" | "per_file_ignores" => apply_per_file_ignores(options, value)?,
+            "extend-ignore" | "extend_ignore" | "target-version" | "target_version"
+            | "extension" | "src" | "namespace-packages" | "namespace_packages" | "builtins"
+            | "typing-modules" | "typing_modules" => {
+                return Err(vec![lint_config_diagnostic(format!(
+                    "unsupported Ruff/Python lint option in Sifr config: {key}"
+                ))]);
+            }
+            "fixable" | "extend-fixable" | "extend_fixable" | "unfixable" | "extend-unfixable"
+            | "extend_unfixable" | "unsafe-fixes" | "unsafe_fixes" => {
+                return Err(vec![lint_config_diagnostic(format!(
+                    "lint fix config key is reserved until fix support lands: {key}"
+                ))]);
+            }
+            _ => {
+                return Err(vec![lint_config_diagnostic(format!(
+                    "unknown lint config key: {key}"
+                ))]);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_rule_table(
+    options: &mut LintOptions,
+    value: &toml::Value,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let Some(table) = value.as_table() else {
+        return Err(vec![lint_config_diagnostic("[lint.rules] must be a table")]);
+    };
+    for (rule, level) in table {
+        require_known_rule(rule)?;
+        options
+            .rule_levels
+            .insert(rule.clone(), as_rule_severity(rule, level)?);
+    }
+    Ok(())
+}
+
+fn apply_per_file_ignores(
+    options: &mut LintOptions,
+    value: &toml::Value,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let Some(table) = value.as_table() else {
+        return Err(vec![lint_config_diagnostic(
+            "[lint.per-file-ignores] must be a table",
+        )]);
+    };
+    for (pattern, rules) in table {
+        let rules = as_string_list(pattern, rules)?;
+        for rule in &rules {
+            require_known_rule(rule)?;
+        }
+        options.per_file_ignores.push(PerFileIgnore {
+            pattern: pattern.clone(),
+            rules,
+        });
+    }
+    Ok(())
+}
+
+fn apply_config_override(
+    config: &mut EffectiveLintConfig,
+    key: &str,
+    raw_value: &str,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let value = raw_value
+        .parse::<toml::Value>()
+        .unwrap_or_else(|_| toml::Value::String(raw_value.trim_matches('"').to_string()));
+    let mut table = toml::map::Map::new();
+    table.insert(key.to_string(), value);
+    apply_lint_table(&mut config.options, &toml::Value::Table(table))
+}
+
+fn apply_overrides(options: &mut LintOptions, overrides: &LintConfigOverrides) {
+    if let Some(select) = &overrides.select {
+        options.select.clone_from(select);
+    }
+    options
+        .extend_select
+        .extend(overrides.extend_select.clone());
+    options.ignore.extend(overrides.ignore.clone());
+    options
+        .per_file_ignores
+        .extend(overrides.per_file_ignores.clone());
+    options
+        .per_file_ignores
+        .extend(overrides.extend_per_file_ignores.clone());
+    options.exclude.extend(overrides.exclude.clone());
+    options.exclude.extend(overrides.extend_exclude.clone());
+    if let Some(respect_gitignore) = overrides.respect_gitignore {
+        options.respect_gitignore = respect_gitignore;
+    }
+    if let Some(force_exclude) = overrides.force_exclude {
+        options.force_exclude = force_exclude;
+    }
+    if let Some(preview) = overrides.preview {
+        options.preview = preview;
+    }
+}
+
+fn validate_rule_selectors(options: &LintOptions) -> Result<(), Vec<RenderedDiagnostic>> {
+    for selector in options
+        .select
+        .iter()
+        .chain(options.extend_select.iter())
+        .chain(options.ignore.iter())
+    {
+        if selector == "default" || selector == "all" {
+            continue;
+        }
+        if RULES
+            .iter()
+            .any(|rule| rule.id == selector || rule.category == selector)
+        {
+            continue;
+        }
+        return Err(vec![lint_config_diagnostic(format!(
+            "unknown Sifr lint rule selector: {selector}"
+        ))]);
+    }
+    Ok(())
+}
+
+fn as_bool(key: &str, value: &toml::Value) -> Result<bool, Vec<RenderedDiagnostic>> {
+    value
+        .as_bool()
+        .ok_or_else(|| vec![lint_config_diagnostic(format!("{key} must be a boolean"))])
+}
+
+fn as_string(key: &str, value: &toml::Value) -> Result<String, Vec<RenderedDiagnostic>> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| vec![lint_config_diagnostic(format!("{key} must be a string"))])
+}
+
+fn as_string_list(key: &str, value: &toml::Value) -> Result<Vec<String>, Vec<RenderedDiagnostic>> {
+    let Some(values) = value.as_array() else {
+        return Err(vec![lint_config_diagnostic(format!(
+            "{key} must be an array"
+        ))]);
+    };
+    values
+        .iter()
+        .map(|value| as_string(key, value))
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn as_rule_severity(
+    key: &str,
+    value: &toml::Value,
+) -> Result<RuleSeverity, Vec<RenderedDiagnostic>> {
+    match as_string(key, value)?.as_str() {
+        "ignore" => Ok(RuleSeverity::Ignore),
+        "warn" => Ok(RuleSeverity::Warn),
+        "error" => Ok(RuleSeverity::Error),
+        _ => Err(vec![lint_config_diagnostic(format!(
+            "{key} severity must be one of ignore, warn, or error"
+        ))]),
+    }
+}
+
+fn require_known_rule(rule: &str) -> Result<(), Vec<RenderedDiagnostic>> {
+    if rule_metadata(rule).is_some() {
+        Ok(())
+    } else {
+        Err(vec![lint_config_diagnostic(format!(
+            "unknown Sifr lint rule id: {rule}"
+        ))])
+    }
+}

--- a/crates/sifr_lint/src/discovery.rs
+++ b/crates/sifr_lint/src/discovery.rs
@@ -1,0 +1,142 @@
+use crate::{diagnostic, LintOptions};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use ignore::WalkBuilder;
+use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub fn collect_sifr_files(
+    path: &Path,
+    options: &LintOptions,
+) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    collect_sifr_files_for_targets(&[path.to_path_buf()], options)
+}
+
+pub fn collect_sifr_files_for_targets(
+    paths: &[PathBuf],
+    options: &LintOptions,
+) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    let targets = if paths.is_empty() {
+        vec![PathBuf::from(".")]
+    } else {
+        paths.to_vec()
+    };
+    let include = globset("include", &options.include)?;
+    let exclude_patterns = options.exclude.clone();
+    let exclude = globset("exclude", &exclude_patterns)?;
+    let mut files = BTreeSet::new();
+    for target in targets {
+        if target.is_file() {
+            if should_include_explicit_file(&target, &include, &exclude, options) {
+                files.insert(target);
+            }
+        } else if target.is_dir() {
+            collect_directory_files(&target, &include, &exclude, options, &mut files)?;
+        } else {
+            return Err(vec![diagnostic(
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+                format!("lint target does not exist: {}", target.display()),
+                [("path", target.display().to_string())],
+                Vec::new(),
+                None,
+            )]);
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
+fn collect_directory_files(
+    root: &Path,
+    include: &GlobSet,
+    exclude: &GlobSet,
+    options: &LintOptions,
+    files: &mut BTreeSet<PathBuf>,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .standard_filters(options.respect_gitignore)
+        .hidden(false)
+        .git_ignore(options.respect_gitignore)
+        .git_global(options.respect_gitignore)
+        .git_exclude(options.respect_gitignore)
+        .parents(options.respect_gitignore);
+    if options.respect_gitignore {
+        builder
+            .add_custom_ignore_filename(".gitignore")
+            .add_custom_ignore_filename(".ignore");
+    }
+    for entry in builder.build() {
+        let entry = entry.map_err(|err| {
+            vec![diagnostic(
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+                format!("could not read lint target under {}: {err}", root.display()),
+                [("path", root.display().to_string())],
+                Vec::new(),
+                None,
+            )]
+        })?;
+        let path = entry.path();
+        if path.is_dir() || is_default_excluded_dir(path) {
+            continue;
+        }
+        if path_matches(root, path, include) && !path_matches(root, path, exclude) {
+            files.insert(path.to_path_buf());
+        }
+    }
+    Ok(())
+}
+
+fn should_include_explicit_file(
+    path: &Path,
+    include: &GlobSet,
+    exclude: &GlobSet,
+    options: &LintOptions,
+) -> bool {
+    if options.force_exclude && path_matches(Path::new("."), path, exclude) {
+        return false;
+    }
+    is_sifr_file(path) || path_matches(Path::new("."), path, include)
+}
+
+fn path_matches(root: &Path, path: &Path, set: &GlobSet) -> bool {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    set.is_match(relative) || set.is_match(path)
+}
+
+fn globset(kind: &str, patterns: &[String]) -> Result<GlobSet, Vec<RenderedDiagnostic>> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        builder.add(Glob::new(pattern).map_err(|err| {
+            vec![diagnostic(
+                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+                format!("invalid lint {kind} glob {pattern:?}: {err}"),
+                [("pattern", pattern.clone())],
+                Vec::new(),
+                None,
+            )]
+        })?);
+    }
+    builder.build().map_err(|err| {
+        vec![diagnostic(
+            DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+            format!("invalid lint {kind} glob set: {err}"),
+            [("kind", kind.to_string())],
+            Vec::new(),
+            None,
+        )]
+    })
+}
+
+fn is_sifr_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension == "sifr")
+}
+
+fn is_default_excluded_dir(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| {
+        matches!(
+            name.to_string_lossy().as_ref(),
+            ".git" | "target" | ".venv" | "venv" | "node_modules" | "sifr_output"
+        )
+    })
+}

--- a/crates/sifr_lint/src/lib.rs
+++ b/crates/sifr_lint/src/lib.rs
@@ -1,16 +1,35 @@
-//! Sifr-owned policy-rule and suppression foundation.
+//! Sifr-owned policy-rule, configuration, discovery, and suppression foundation.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
-use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic};
+use globset::Glob;
+use sifr_diagnostics::{
+    DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+mod config;
+mod discovery;
+
+pub use config::effective_lint_config;
+pub use discovery::{collect_sifr_files, collect_sifr_files_for_targets};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RuleSeverity {
     Ignore,
     Warn,
     Error,
+}
+
+impl RuleSeverity {
+    fn diagnostic_severity(self) -> Severity {
+        match self {
+            Self::Ignore => Severity::Note,
+            Self::Warn => Severity::Warning,
+            Self::Error => Severity::Error,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -21,13 +40,32 @@ pub enum RuleStatus {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FixAvailability {
+    None,
+    Safe,
+    Unsafe,
+    Manual,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SuppressionComplexity {
+    PhysicalLine,
+    SingleNode,
+    StatementRange,
+    SymbolWorkspace,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RuleMetadata {
     pub id: &'static str,
     pub summary: &'static str,
     pub docs_url: &'static str,
     pub default_level: RuleSeverity,
     pub status: RuleStatus,
+    pub category: &'static str,
     pub source: &'static str,
+    pub fix_availability: FixAvailability,
+    pub suppression_complexity: SuppressionComplexity,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -38,12 +76,25 @@ pub enum DiagnosticMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PerFileIgnore {
+    pub pattern: String,
+    pub rules: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LintOptions {
     pub mode: DiagnosticMode,
     pub explicit_target: bool,
     pub include: Vec<String>,
     pub exclude: Vec<String>,
-    pub respect_ignore_files: bool,
+    pub respect_gitignore: bool,
+    pub force_exclude: bool,
+    pub preview: bool,
+    pub select: Vec<String>,
+    pub extend_select: Vec<String>,
+    pub ignore: Vec<String>,
+    pub rule_levels: BTreeMap<String, RuleSeverity>,
+    pub per_file_ignores: Vec<PerFileIgnore>,
 }
 
 impl Default for LintOptions {
@@ -51,11 +102,38 @@ impl Default for LintOptions {
         Self {
             mode: DiagnosticMode::Workspace,
             explicit_target: true,
-            include: Vec::new(),
+            include: vec!["*.sifr".to_string()],
             exclude: Vec::new(),
-            respect_ignore_files: true,
+            respect_gitignore: true,
+            force_exclude: false,
+            preview: false,
+            select: vec!["default".to_string()],
+            extend_select: Vec::new(),
+            ignore: Vec::new(),
+            rule_levels: BTreeMap::new(),
+            per_file_ignores: Vec::new(),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LintConfigOverrides {
+    pub select: Option<Vec<String>>,
+    pub extend_select: Vec<String>,
+    pub ignore: Vec<String>,
+    pub per_file_ignores: Vec<PerFileIgnore>,
+    pub extend_per_file_ignores: Vec<PerFileIgnore>,
+    pub exclude: Vec<String>,
+    pub extend_exclude: Vec<String>,
+    pub respect_gitignore: Option<bool>,
+    pub force_exclude: Option<bool>,
+    pub preview: Option<bool>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EffectiveLintConfig {
+    pub options: LintOptions,
+    pub config_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -77,7 +155,10 @@ pub const RULES: &[RuleMetadata] = &[
         docs_url: "https://sifr.sh/docs/errors/SIFR-LINT-0004",
         default_level: RuleSeverity::Warn,
         status: RuleStatus::Stable,
+        category: "style-policy",
         source: "sifr_lint::rules::trailing_whitespace",
+        fix_availability: FixAvailability::None,
+        suppression_complexity: SuppressionComplexity::PhysicalLine,
     },
     RuleMetadata {
         id: "unknown-suppression",
@@ -85,7 +166,10 @@ pub const RULES: &[RuleMetadata] = &[
         docs_url: "https://sifr.sh/docs/errors/SIFR-LINT-0001",
         default_level: RuleSeverity::Warn,
         status: RuleStatus::Stable,
+        category: "suppression-policy",
         source: "sifr_lint::suppressions",
+        fix_availability: FixAvailability::None,
+        suppression_complexity: SuppressionComplexity::PhysicalLine,
     },
     RuleMetadata {
         id: "unused-suppression",
@@ -93,7 +177,10 @@ pub const RULES: &[RuleMetadata] = &[
         docs_url: "https://sifr.sh/docs/errors/SIFR-LINT-0002",
         default_level: RuleSeverity::Warn,
         status: RuleStatus::Stable,
+        category: "suppression-policy",
         source: "sifr_lint::suppressions",
+        fix_availability: FixAvailability::None,
+        suppression_complexity: SuppressionComplexity::PhysicalLine,
     },
     RuleMetadata {
         id: "blanket-suppression",
@@ -101,7 +188,10 @@ pub const RULES: &[RuleMetadata] = &[
         docs_url: "https://sifr.sh/docs/errors/SIFR-LINT-0003",
         default_level: RuleSeverity::Warn,
         status: RuleStatus::Stable,
+        category: "suppression-policy",
         source: "sifr_lint::suppressions",
+        fix_availability: FixAvailability::None,
+        suppression_complexity: SuppressionComplexity::PhysicalLine,
     },
 ];
 
@@ -116,23 +206,35 @@ pub fn lint_source(source: &str, file: Option<&Path>, options: &LintOptions) -> 
         };
     }
 
-    let mut suppressions = parse_suppressions(source, file);
+    let mut suppressions = parse_suppressions(source);
     let mut diagnostics = Vec::new();
-    diagnostics.extend(suppression_shape_diagnostics(&suppressions, file, source));
+    diagnostics.extend(suppression_shape_diagnostics(
+        &suppressions,
+        file,
+        source,
+        options,
+    ));
 
     for (line_index, line) in source.split_inclusive('\n').enumerate() {
-        if line_has_trailing_whitespace(line) {
-            let rule = "trailing-whitespace";
+        let rule = "trailing-whitespace";
+        if line_has_trailing_whitespace(line) && rule_enabled(rule, file, options) {
             if mark_suppressed(&mut suppressions, line_index, rule) {
                 continue;
             }
-            diagnostics.push(trailing_whitespace_diagnostic(
-                file, source, line_index, line,
+            diagnostics.push(with_rule_severity(
+                trailing_whitespace_diagnostic(file, source, line_index, line),
+                rule,
+                options,
             ));
         }
     }
 
-    diagnostics.extend(unused_suppression_diagnostics(&suppressions, file, source));
+    diagnostics.extend(unused_suppression_diagnostics(
+        &suppressions,
+        file,
+        source,
+        options,
+    ));
     diagnostics.sort_by_key(diagnostic_order_key);
     LintResult { diagnostics }
 }
@@ -141,7 +243,14 @@ pub fn lint_path(
     path: &Path,
     options: &LintOptions,
 ) -> Result<LintResult, Vec<RenderedDiagnostic>> {
-    let files = collect_sifr_files(path, options)?;
+    lint_paths(&[path.to_path_buf()], options)
+}
+
+pub fn lint_paths(
+    paths: &[PathBuf],
+    options: &LintOptions,
+) -> Result<LintResult, Vec<RenderedDiagnostic>> {
+    let files = collect_sifr_files_for_targets(paths, options)?;
     let mut diagnostics = Vec::new();
     for file in files {
         let source = fs::read_to_string(&file).map_err(|err| {
@@ -159,92 +268,56 @@ pub fn lint_path(
     Ok(LintResult { diagnostics })
 }
 
-pub fn collect_sifr_files(
-    path: &Path,
-    options: &LintOptions,
-) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
-    if path.is_file() {
-        return Ok(vec![path.to_path_buf()]);
-    }
-    if !path.is_dir() {
-        return Err(vec![diagnostic(
-            DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
-            format!("lint target does not exist: {}", path.display()),
-            [("path", path.display().to_string())],
-            Vec::new(),
-            None,
-        )]);
-    }
-    let ignore_patterns = if options.respect_ignore_files {
-        read_ignore_patterns(path)
-    } else {
-        Vec::new()
+fn rule_enabled(rule_id: &str, file: Option<&Path>, options: &LintOptions) -> bool {
+    let Some(metadata) = rule_metadata(rule_id) else {
+        return false;
     };
-    let mut files = Vec::new();
-    collect_sifr_files_inner(path, path, options, &ignore_patterns, &mut files)?;
-    files.sort();
-    Ok(files)
-}
-
-fn collect_sifr_files_inner(
-    root: &Path,
-    path: &Path,
-    options: &LintOptions,
-    ignore_patterns: &[String],
-    files: &mut Vec<PathBuf>,
-) -> Result<(), Vec<RenderedDiagnostic>> {
-    for entry in fs::read_dir(path).map_err(|err| {
-        vec![diagnostic(
-            DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
-            format!("could not read directory {}: {err}", path.display()),
-            [("path", path.display().to_string())],
-            Vec::new(),
-            None,
-        )]
-    })? {
-        let entry = entry.map_err(|err| {
-            vec![diagnostic(
-                DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
-                format!(
-                    "could not read directory entry under {}: {err}",
-                    path.display()
-                ),
-                [("path", path.display().to_string())],
-                Vec::new(),
-                None,
-            )]
-        })?;
-        let child = entry.path();
-        if should_exclude(root, &child, options, ignore_patterns) {
-            continue;
-        }
-        if child.is_dir() {
-            collect_sifr_files_inner(root, &child, options, ignore_patterns, files)?;
-        } else if is_sifr_file(&child) {
-            files.push(child);
-        }
-    }
-    Ok(())
-}
-
-fn should_exclude(
-    root: &Path,
-    path: &Path,
-    options: &LintOptions,
-    ignore_patterns: &[String],
-) -> bool {
-    if options.explicit_target && path.is_file() {
+    if per_file_ignored(rule_id, file, options) {
         return false;
     }
-    if is_default_excluded_dir(path) {
-        return true;
+    if options
+        .ignore
+        .iter()
+        .any(|selector| selector_matches(selector, metadata))
+    {
+        return false;
     }
-    let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
-    options.exclude.iter().any(|pattern| rel.contains(pattern))
-        || ignore_patterns.iter().any(|pattern| rel.contains(pattern))
+    let selected = options
+        .select
+        .iter()
+        .chain(options.extend_select.iter())
+        .any(|selector| selector_matches(selector, metadata));
+    let level = options
+        .rule_levels
+        .get(rule_id)
+        .copied()
+        .unwrap_or(metadata.default_level);
+    selected && level != RuleSeverity::Ignore
 }
 
-fn parse_suppressions(source: &str, file: Option<&Path>) -> Vec<Suppression> {
+fn selector_matches(selector: &str, rule: &RuleMetadata) -> bool {
+    match selector {
+        "all" => rule.status != RuleStatus::Deprecated,
+        "default" => {
+            rule.default_level != RuleSeverity::Ignore && rule.status == RuleStatus::Stable
+        }
+        _ => selector == rule.id || selector == rule.category,
+    }
+}
+
+fn per_file_ignored(rule_id: &str, file: Option<&Path>, options: &LintOptions) -> bool {
+    let Some(file) = file else {
+        return false;
+    };
+    options.per_file_ignores.iter().any(|ignore| {
+        ignore.rules.iter().any(|rule| rule == rule_id)
+            && Glob::new(&ignore.pattern)
+                .ok()
+                .is_some_and(|glob| glob.compile_matcher().is_match(file))
+    })
+}
+
+fn parse_suppressions(source: &str) -> Vec<Suppression> {
     let mut suppressions = Vec::new();
     for (line_index, line) in source.lines().enumerate() {
         let Some(comment_start) = line.find('#') else {
@@ -270,7 +343,6 @@ fn parse_suppressions(source: &str, file: Option<&Path>) -> Vec<Suppression> {
         } else {
             Vec::new()
         };
-        let _ = file;
         suppressions.push(Suppression {
             line: line_index,
             rules,
@@ -284,36 +356,61 @@ fn suppression_shape_diagnostics(
     suppressions: &[Suppression],
     file: Option<&Path>,
     source: &str,
+    options: &LintOptions,
 ) -> Vec<RenderedDiagnostic> {
     let mut diagnostics = Vec::new();
     for suppression in suppressions {
         if suppression.rules.is_empty() {
-            diagnostics.push(suppression_diagnostic(
-                DiagnosticCode::LINT_BLANKET_SUPPRESSION,
-                "sifr suppression must list explicit policy rule ids",
+            push_if_enabled(
+                &mut diagnostics,
+                suppression_diagnostic(
+                    DiagnosticCode::LINT_BLANKET_SUPPRESSION,
+                    "sifr suppression must list explicit policy rule ids",
+                    "blanket-suppression",
+                    suppression.line,
+                    file,
+                    source,
+                    Some("use `# sifr: ignore[rule-id]` with a Sifr policy rule id"),
+                ),
                 "blanket-suppression",
-                suppression.line,
                 file,
-                source,
-                Some("use `# sifr: ignore[rule-id]` with a Sifr policy rule id"),
-            ));
+                options,
+            );
             continue;
         }
         for rule in &suppression.rules {
             if rule_metadata(rule).is_none() {
-                diagnostics.push(suppression_diagnostic(
-                    DiagnosticCode::LINT_UNKNOWN_SUPPRESSION,
-                    format!("unknown Sifr policy rule id '{rule}'"),
-                    rule,
-                    suppression.line,
+                push_if_enabled(
+                    &mut diagnostics,
+                    suppression_diagnostic(
+                        DiagnosticCode::LINT_UNKNOWN_SUPPRESSION,
+                        format!("unknown Sifr policy rule id '{rule}'"),
+                        rule,
+                        suppression.line,
+                        file,
+                        source,
+                        Some("remove the suppression or use a known Sifr policy rule id"),
+                    ),
+                    "unknown-suppression",
                     file,
-                    source,
-                    Some("remove the suppression or use a known Sifr policy rule id"),
-                ));
+                    options,
+                );
             }
         }
     }
     diagnostics
+}
+
+fn push_if_enabled(
+    diagnostics: &mut Vec<RenderedDiagnostic>,
+    diagnostic: RenderedDiagnostic,
+    rule: &str,
+    file: Option<&Path>,
+    options: &LintOptions,
+) {
+    if rule_enabled(rule, file, options) {
+        diagnostics.push(with_rule_severity(diagnostic, rule, options));
+    }
 }
 
 fn mark_suppressed(suppressions: &mut [Suppression], line: usize, rule: &str) -> bool {
@@ -330,24 +427,42 @@ fn unused_suppression_diagnostics(
     suppressions: &[Suppression],
     file: Option<&Path>,
     source: &str,
+    options: &LintOptions,
 ) -> Vec<RenderedDiagnostic> {
     let mut diagnostics = Vec::new();
     for suppression in suppressions {
         for rule in &suppression.rules {
             if rule_metadata(rule).is_some() && !suppression.used_rules.contains(rule) {
-                diagnostics.push(suppression_diagnostic(
-                    DiagnosticCode::LINT_UNUSED_SUPPRESSION,
-                    format!("unused Sifr suppression for policy rule '{rule}'"),
-                    rule,
-                    suppression.line,
+                push_if_enabled(
+                    &mut diagnostics,
+                    suppression_diagnostic(
+                        DiagnosticCode::LINT_UNUSED_SUPPRESSION,
+                        format!("unused Sifr suppression for policy rule '{rule}'"),
+                        rule,
+                        suppression.line,
+                        file,
+                        source,
+                        Some("remove the unused suppression"),
+                    ),
+                    "unused-suppression",
                     file,
-                    source,
-                    Some("remove the unused suppression"),
-                ));
+                    options,
+                );
             }
         }
     }
     diagnostics
+}
+
+fn with_rule_severity(
+    mut diagnostic: RenderedDiagnostic,
+    rule: &str,
+    options: &LintOptions,
+) -> RenderedDiagnostic {
+    if let Some(level) = options.rule_levels.get(rule) {
+        diagnostic.severity = level.diagnostic_severity();
+    }
+    diagnostic
 }
 
 fn trailing_whitespace_diagnostic(
@@ -428,7 +543,17 @@ fn suppression_diagnostic(
     diagnostic
 }
 
-fn diagnostic(
+pub(crate) fn lint_config_diagnostic(message: impl Into<String>) -> RenderedDiagnostic {
+    diagnostic(
+        DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
+        message.into(),
+        [],
+        Vec::new(),
+        None,
+    )
+}
+
+pub(crate) fn diagnostic(
     code: DiagnosticCode,
     message: impl Into<String>,
     args: impl IntoIterator<Item = (&'static str, String)>,
@@ -480,38 +605,10 @@ fn byte_offset_for_line(source: &str, line_index: usize) -> u32 {
     u32::try_from(offset).unwrap_or(u32::MAX)
 }
 
-fn read_ignore_patterns(root: &Path) -> Vec<String> {
-    [".gitignore", ".ignore"]
-        .iter()
-        .flat_map(|name| {
-            fs::read_to_string(root.join(name))
-                .unwrap_or_default()
-                .lines()
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .map(|line| line.trim().to_string())
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .collect()
-}
-
-fn is_sifr_file(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|extension| extension == "sifr")
-}
-
-fn is_default_excluded_dir(path: &Path) -> bool {
-    path.file_name().is_some_and(|name| {
-        matches!(
-            name.to_string_lossy().as_ref(),
-            ".git" | "target" | ".venv" | "venv" | "node_modules" | "sifr_output"
-        )
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn suppression_only_suppresses_matching_policy_rule() {
@@ -541,5 +638,69 @@ mod tests {
         let source = "def main(): # sifr: ignore\n    pass\n";
         let result = lint_source(source, None, &LintOptions::default());
         assert_eq!(result.diagnostics[0].code, "SIFR-LINT-0003");
+    }
+
+    #[test]
+    fn config_rule_ignore_disables_rule() {
+        let root = temp_dir("lint_config_rule_ignore");
+        fs::write(
+            root.join("sifr.toml"),
+            "[lint.rules]\ntrailing-whitespace = \"ignore\"\n",
+        )
+        .unwrap();
+        let config =
+            effective_lint_config(&root, &[], false, &LintConfigOverrides::default()).unwrap();
+        let result = lint_source("def main():  \n    pass\n", None, &config.options);
+        assert!(result.diagnostics.is_empty());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovery_respects_gitignore_unless_disabled() {
+        let root = temp_dir("lint_discovery_gitignore");
+        fs::create_dir_all(root.join("ignored")).unwrap();
+        fs::write(root.join(".gitignore"), "ignored/\n").unwrap();
+        fs::write(root.join("main.sifr"), "def main():\n    pass\n").unwrap();
+        fs::write(
+            root.join("ignored").join("skip.sifr"),
+            "def skip():\n    pass\n",
+        )
+        .unwrap();
+        let files = collect_sifr_files(&root, &LintOptions::default()).unwrap();
+        assert_eq!(files.len(), 1);
+        let options = LintOptions {
+            respect_gitignore: false,
+            ..LintOptions::default()
+        };
+        let files = collect_sifr_files(&root, &options).unwrap();
+        assert_eq!(files.len(), 2);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn per_file_ignore_filters_rule() {
+        let options = LintOptions {
+            per_file_ignores: vec![PerFileIgnore {
+                pattern: "*.sifr".to_string(),
+                rules: vec!["trailing-whitespace".to_string()],
+            }],
+            ..LintOptions::default()
+        };
+        let result = lint_source(
+            "def main():  \n    pass\n",
+            Some(Path::new("main.sifr")),
+            &options,
+        );
+        assert!(result.diagnostics.is_empty());
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("sifr_{name}_{nonce}"));
+        fs::create_dir_all(&path).unwrap();
+        path
     }
 }

--- a/docs/cli_command_semantics.md
+++ b/docs/cli_command_semantics.md
@@ -60,6 +60,20 @@ preview, config, path-selection, and cache controls, and formats only `.sifr`
 source. Editor formatting is served through `sifr lsp --stdio`, not through an
 editor-owned formatter implementation.
 
+Lint commands use the Sifr-owned policy-rule engine. `sifr lint [OPTIONS]
+[FILES]...` defaults to the current directory, accepts multiple files or
+directories, supports stdin with `-` and `--stdin-filename`, resolves `[lint]`,
+`[lint.rules]`, and `[lint.per-file-ignores]` from `sifr.toml`, and applies
+CLI/global config overrides after discovered config. The command supports
+Sifr rule selection through `--select`, `--extend-select`, and `--ignore`;
+path filtering through `--exclude`, `--extend-exclude`, gitignore controls, and
+force-exclude controls; and lint-local `--output-format concise|full|json`,
+`--output-file`, `--show-files`, `--show-settings`, and `--exit-zero`.
+
+`sifr lint` emits only suppressible policy diagnostics. It does not run,
+downgrade, suppress, or auto-fix hard compiler diagnostics from `sifr check`.
+Fix-related lint flags are reserved for the production fix-engine milestone.
+
 ## Edge Cases
 
 - A neighboring invalid `scratch.sifr` file must not break `run/build` when `main.sifr` has no local imports.

--- a/internal_docs/tooling_analysis.md
+++ b/internal_docs/tooling_analysis.md
@@ -147,6 +147,15 @@ Sifr lint authority. Milestone 1 locks those decisions in machine-readable
 manifests before config, discovery, parser-aware suppressions, phase-gated
 orchestration, fix support, or editor actions are expanded.
 
+Milestone 2 implements the non-fix `sifr lint [OPTIONS] [FILES]...` surface
+through `crates/sifr/src/lint_cli.rs` and keeps command execution separate from
+package/build/check orchestration. `sifr_lint` now owns `[lint]`,
+`[lint.rules]`, and `[lint.per-file-ignores]` config loading from `sifr.toml`,
+path-relative `extend`, CLI overrides, selector validation, per-file ignores,
+glob-based include/exclude matching, and `ignore`-crate backed gitignore
+discovery. The suppression gate remains `physical_line_only`; non-line rules
+are still blocked until the parser-aware suppression milestone.
+
 ## Generated Rust And Test Metadata
 
 Generated Rust preview uses compiler/codegen APIs and source maps. It must be cancellable, revision-checked, budgeted under `lsp-generated-rust-preview`, and must not return partial generated code after a document change invalidates the request.

--- a/issues/ad-hoc-production-grade-sifr-linter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-linter-execution.md
@@ -11,7 +11,7 @@ Phase contract: `issues/ad-hoc-production-grade-sifr-linter.md`
 - [x] Ruff rule-family and config-surface audit manifest created
 - [x] Linter CLI parity manifest created
 - [x] Forbidden Ruff/Python lint dependency guardrail completed
-- [ ] Lint config and file discovery completed
+- [x] Lint config and file discovery completed
 - [ ] Parser-aware suppression engine completed
 - [ ] Phase-gated lint runner completed
 - [ ] Sifr policy rule families completed
@@ -75,6 +75,7 @@ This phase locks the lint/Ruff reuse decisions before implementation starts. Cha
 - `2026-05-26`: Claude linter CLI review pass 3 verified the final disposition spelling cleanup and confirmed the CLI plan is implementation-ready and elegant enough for implementation.
 - `2026-05-27`: Claude pre-implementation discovery review found no blockers and confirmed M1 can start. It requested precision edits for manifest key population, suppression-gate milestone format, parser-aware API import checks, lint CLI file-size planning, and diagnostic-class code-action guardrails; the phase was updated accordingly.
 - `2026-05-27`: Claude M1 reuse-contract review pass 1 found no blockers and returned `SATISFIED` for M1 closure. Review artifact: `reviews/sifr-linter-m1-reuse-contract-review-pass-1.md`.
+- `2026-05-27`: Claude M2 config/discovery review pass 1 found no blockers and returned `SATISFIED` for M2 closure. Review artifact: `reviews/sifr-linter-m2-config-discovery-review-pass-1.md`.
 
 ## Validation Log
 
@@ -84,6 +85,18 @@ This phase locks the lint/Ruff reuse decisions before implementation starts. Cha
   - `python3 verification/tooling/check_linter_reuse_contract.py` passed.
   - `python3 verification/tooling/check_linter_reuse_contract.py --self-test` passed.
   - `cargo test -p sifr_lint` passed: 3 unit tests and 0 doctests.
+  - `git diff --check` passed.
+  - `python3 scripts/check_file_size_guardrails.py` passed.
+- `2026-05-27` M2 local checks:
+  - `cargo check -p sifr` passed.
+  - `cargo build -p sifr` passed.
+  - `cargo clippy -p sifr_lint -- -D warnings` passed.
+  - `cargo clippy -p sifr_lint -p sifr -- -D warnings` is blocked by pre-existing `clippy::too_many_arguments` in `crates/sifr/src/diagnostic_rendering_and_run.rs:219`, outside the M2 diff.
+  - `cargo test -p sifr_lint` passed: 6 unit tests and 0 doctests.
+  - `cargo test -p sifr -- --skip test_e2e_pass` passed.
+  - `python3 verification/tooling/check_linter_reuse_contract.py` passed.
+  - `python3 verification/tooling/check_linter_reuse_contract.py --self-test` passed.
+  - CLI smoke fixtures passed for concise diagnostics, stdin JSON diagnostics, config severity ignore, `--show-files`, `--show-settings`, `--exit-zero`, and rejected Ruff/Python flag handling.
   - `git diff --check` passed.
   - `python3 scripts/check_file_size_guardrails.py` passed.
 

--- a/reviews/sifr-linter-m2-config-discovery-review-pass-1.md
+++ b/reviews/sifr-linter-m2-config-discovery-review-pass-1.md
@@ -1,0 +1,111 @@
+---
+
+# M2 Review: Production-Grade Sifr Linter
+
+## Final Verdict: SATISFIED
+
+M2 materially implements the locked lint config, file discovery, and non-fix CLI surface through Sifr-owned APIs. No blockers remain.
+
+---
+
+## Blocker Analysis
+
+**None.** No blocker bugs, missing fixtures, or contract gaps were identified.
+
+---
+
+## Review Criteria Results
+
+### 1. Config Implementation ([lint], [lint.rules], [lint.per-file-ignores], extends, CLI overrides, unknown-key diagnostics, selector validation)
+
+**VERIFIED - Full M2 coverage**
+
+| Feature | Location | Implementation |
+|---------|----------|----------------|
+| `[lint]` table | `config.rs:118-169` | `apply_lint_table()` handles all keys |
+| `[lint.rules]` | `config.rs:171-185` | `apply_rule_table()` with known-rule validation |
+| `[lint.per-file-ignores]` | `config.rs:187-207` | `apply_per_file_ignores()` |
+| `extends` | `config.rs:94-116` | `apply_extends()` with cycle detection |
+| CLI overrides | `lint_cli.rs:188-201` | `lint_cli_overrides()` → `LintConfigOverrides` |
+| Unknown-key diagnostics | `config.rs:161-165` | Returns diagnostic for unknown keys |
+| Selector validation | `config.rs:249-270` | `validate_rule_selectors()` validates select/ignore |
+
+### 2. File Discovery (Ruff-inspired/language-neutral)
+
+**VERIFIED** - `discovery.rs` implements:
+- `ignore::WalkBuilder` for directory traversal
+- `.gitignore`, `.git/global`, `.git/exclude` respect
+- Custom `.ignore` file support
+- `force_exclude` applies excludes to explicit file targets (`discovery.rs:89-99`)
+- Explicit-target preservation via `should_include_explicit_file()`
+- Default exclusions: `.git`, `target`, `.venv`, `venv`, `node_modules`, `sifr_output`
+- Globset-based include/exclude via `globset` crate
+
+### 3. Non-fix CLI Surface Coverage
+
+**VERIFIED** - All M2 locked CLI surfaces implemented in `lint_cli.rs`:
+
+| Locked Surface | Implemented |
+|----------------|-------------|
+| Default '.' | `lint_targets()` returns `.` when empty |
+| Multiple targets | `paths: Vec<PathBuf>` |
+| stdin | `reads_stdin()` detects `-` |
+| `--stdin-filename` | `stdin_filename: Option<PathBuf>` |
+| Selectors | `--select`, `--extend-select`, `--ignore` |
+| Per-file ignores | `--per-file-ignores`, `--extend-per-file-ignores` |
+| `--output-format` | `LintOutputFormat::{Concise,Full,Json}` |
+| `--output-file` | `output_file: Option<PathBuf>` |
+| `--show-files` | Implemented |
+| `--show-settings` | Implemented |
+| `--exclude`, `--extend-exclude` | Implemented |
+| `--respect-gitignore`/`--no-respect-gitignore` | Implemented |
+| `--force-exclude`/`--no-force-exclude` | Implemented |
+| `--preview`/`--no-preview` | Implemented |
+| `--exit-zero` | Implemented |
+| `--config` (global) | Implemented |
+| `--isolated` (global) | Implemented |
+
+### 4. Hard Diagnostics Separation
+
+**VERIFIED** - `lint_cli.rs` delegates to `sifr_lint::lint_source` and `sifr_lint::lint_paths`, which only emit policy diagnostics. Hard compiler diagnostics remain untouched.
+
+### 5. Ruff/Python Rejection
+
+**VERIFIED**:
+- `check_linter_reuse_contract.py` passes
+- `ruff_rule_config_audit.json` encodes rejected keys
+- `config.rs:148-165` explicitly rejects Ruff/Python keys (`target-version`, `extension`, `src`, `builtins`, `typing-modules`, fix keys)
+- Forbidden source patterns not found
+
+### 6. Validation
+
+**VERIFIED:**
+- `cargo clippy -p sifr_lint -- -D warnings` passes
+- `cargo test -p sifr_lint` passes: 6 unit tests
+- `python3 verification/tooling/check_linter_reuse_contract.py` passes
+- `python3 verification/tooling/check_linter_reuse_contract.py --self-test` passes
+- File sizes: `lib.rs` (706 lines), `config.rs` (319 lines), `discovery.rs` (142 lines), `lint_cli.rs` (355 lines) — all under 900-line cap
+
+**Pre-existing note:** `cargo clippy -p sifr_lint -p sifr` fails on a pre-existing `too_many_arguments` warning in `diagnostic_rendering_and_run.rs:219`, outside this diff.
+
+### 7. Contract Alignment
+
+**VERIFIED:**
+- `lint_config_schema_placeholder.json` state is `"implemented-m2"`
+- `lint_cli_parity.json` surfaces aligned with M2 implementation
+- `lint_rule_metadata.json` matches `RULES` in `lib.rs`
+- `suppression_gate.json` confirms `physical_line_only` gate holds
+
+---
+
+## Non-Blocking Findings
+
+1. **`lint_config_schema_placeholder.json` path naming**: The file is named "placeholder" but now contains implemented schema. Consider renaming to `lint_config_schema.json` in M3, but this is cosmetic and non-blocking.
+
+2. **Execution tracker update**: The tracker should note the M2 review pass and mark the review artifact link once this review is saved.
+
+---
+
+## Conclusion
+
+M2 satisfies all seven review criteria with no blockers. The implementation correctly implements the non-fix `sifr lint` contract through Sifr-owned APIs, maintains the Ruff/Python reuse boundary, and provides sufficient test coverage for M2 closure.

--- a/verification/tooling/check_linter_reuse_contract.py
+++ b/verification/tooling/check_linter_reuse_contract.py
@@ -57,6 +57,7 @@ SCAN_ROOTS = [
 ]
 IMPLEMENTED_LINT_OPTION_ALIASES = {
     "path": "FILES",
+    "paths": "FILES",
     "files": "FILES",
     "targets": "FILES",
     "config": "--config",
@@ -159,7 +160,13 @@ def validate_cli_manifest(manifest: dict[str, Any]) -> None:
     require(isinstance(surfaces, list) and surfaces, "CLI surfaces must be a non-empty array")
     names = [surface.get("ruff_surface") for surface in surfaces]
     require(len(names) == len(set(names)), "Ruff CLI surfaces must be unique")
-    by_spelling = {surface.get("sifr_spelling"): surface for surface in surfaces if surface.get("sifr_spelling")}
+    by_spelling: dict[str, dict[str, Any]] = {}
+    for surface in surfaces:
+        spelling = surface.get("sifr_spelling")
+        if not spelling:
+            continue
+        for expanded in expand_sifr_spellings(spelling):
+            by_spelling[expanded] = surface
     for surface in surfaces:
         disposition = surface.get("disposition")
         require(disposition in ALLOWED_DISPOSITIONS, f"invalid CLI disposition: {surface}")
@@ -198,17 +205,34 @@ def implemented_lint_options() -> set[str]:
     options: set[str] = {"--config", "--isolated"}
     start = cli_source.find("Lint {")
     end = cli_source.find("Lsp {", start)
-    require(start != -1 and end != -1, "could not locate Commands::Lint clap surface")
-    lint_block = cli_source[start:end]
-    for match in re.finditer(r"#\[arg\([^\]]*long(?:\s*=\s*\"([^\"]+)\")?", lint_block):
-        explicit = match.group(1)
-        if explicit:
-            options.add(f"--{explicit}")
-    for match in re.finditer(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\s*:", lint_block):
-        alias = IMPLEMENTED_LINT_OPTION_ALIASES.get(match.group(1))
+    if start != -1 and end != -1:
+        lint_block = cli_source[start:end]
+    else:
+        lint_block = (REPO_ROOT / "crates" / "sifr" / "src" / "lint_cli.rs").read_text(encoding="utf-8")
+    for match in re.finditer(
+        r"#\[arg\(([^\]]*)\)\]\s*pub\(crate\)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:",
+        lint_block,
+        flags=re.MULTILINE,
+    ):
+        attr, field = match.groups()
+        if "long" in attr:
+            explicit = re.search(r'long\s*=\s*"([^"]+)"', attr)
+            options.add(f"--{explicit.group(1) if explicit else field.replace('_', '-')}")
+        alias = IMPLEMENTED_LINT_OPTION_ALIASES.get(field)
         if alias:
             options.add(alias)
     return options
+
+
+def expand_sifr_spellings(spelling: str) -> list[str]:
+    if "/" not in spelling:
+        return [spelling]
+    expanded: list[str] = []
+    for part in spelling.split("/"):
+        part = part.strip()
+        if part.startswith("--"):
+            expanded.append(part)
+    return expanded or [spelling]
 
 
 def validate_rule_metadata(manifest: dict[str, Any]) -> None:
@@ -233,7 +257,10 @@ def validate_rule_metadata(manifest: dict[str, Any]) -> None:
 def validate_config_schema_placeholder(manifest: dict[str, Any]) -> None:
     require(manifest.get("schema") == 1, "lint config schema placeholder schema must be 1")
     require(manifest.get("authority") == "sifr.toml", "lint config authority must be sifr.toml")
-    require(manifest.get("state") == "placeholder-unimplemented", "M1 config schema must remain a placeholder")
+    require(
+        manifest.get("state") in {"placeholder-unimplemented", "implemented-m2"},
+        "lint config schema state must be a known phase state",
+    )
 
 
 def validate_suppression_gate(manifest: dict[str, Any], rule_metadata: dict[str, Any]) -> None:

--- a/verification/tooling/linter_manifests/lint_config_schema_placeholder.json
+++ b/verification/tooling/linter_manifests/lint_config_schema_placeholder.json
@@ -2,7 +2,12 @@
   "schema": 1,
   "authority": "sifr.toml",
   "table": "lint",
-  "state": "placeholder-unimplemented",
-  "planned_tables": ["lint", "lint.rules", "lint.per-file-ignores"],
-  "notes": "Milestone 2 replaces this placeholder with the implemented Sifr-owned lint config schema."
+  "state": "implemented-m2",
+  "implemented_tables": ["lint", "lint.rules", "lint.per-file-ignores"],
+  "implemented_keys": [
+    "extend", "preview", "select", "extend-select", "ignore", "include", "extend-include",
+    "exclude", "extend-exclude", "respect-gitignore", "force-exclude", "rules",
+    "per-file-ignores"
+  ],
+  "notes": "Milestone 2 implements the non-fix Sifr-owned lint config schema. Fix-related keys remain reserved until M6."
 }

--- a/verification/tooling/linter_manifests/ruff_rule_config_audit.json
+++ b/verification/tooling/linter_manifests/ruff_rule_config_audit.json
@@ -82,6 +82,7 @@
     {"key": "unsafe-fixes", "kind": "config", "disposition": "adapt", "rationale": "Unsafe fix policy concept is reusable.", "sifr_requirement_note": "Use disabled/hint/enabled; never hard diagnostics."},
     {"key": "per-file-ignores", "kind": "config", "disposition": "adapt", "rationale": "Per-file ignore model is language-neutral.", "sifr_requirement_note": "Use Sifr glob matching and rule IDs."},
     {"key": "extend-per-file-ignores", "kind": "config", "disposition": "adapt", "rationale": "Per-file ignore extension is language-neutral.", "sifr_requirement_note": "Use Sifr glob matching and rule IDs."},
+    {"key": "rules", "kind": "config", "disposition": "sifr-native", "rationale": "Per-rule severity override table is a Sifr-owned policy surface.", "sifr_requirement_note": "Only Sifr rule IDs are accepted."},
     {"key": "inline-noqa", "kind": "comment-directive", "disposition": "reject", "rationale": "Sifr suppression syntax is not noqa.", "sifr_requirement_note": "Use # sifr: ignore[rule-id]."},
     {"key": "preview", "kind": "config", "disposition": "adapt", "rationale": "Preview policy concept is reusable.", "sifr_requirement_note": "Use Sifr RuleStatus."},
     {"key": "explicit-preview-rules", "kind": "config", "disposition": "adapt", "rationale": "Explicit preview selection concept is reusable.", "sifr_requirement_note": "Use Sifr RuleStatus only."},
@@ -123,7 +124,11 @@
     {"key": "required-version", "kind": "config", "disposition": "future-phase", "rationale": "Toolchain version guard requires separate policy.", "sifr_requirement_note": "Do not expose now."},
     {"key": "watch", "kind": "cli", "disposition": "future-phase", "rationale": "LSP owns editor watch behavior in this phase.", "sifr_requirement_note": "Do not expose CLI watch now."}
   ],
-  "accepted_sifr_config_keys": [],
+  "accepted_sifr_config_keys": [
+    "extend", "preview", "select", "extend-select", "ignore", "include", "extend-include",
+    "exclude", "extend-exclude", "respect-gitignore", "force-exclude", "rules",
+    "per-file-ignores", "config", "isolated"
+  ],
   "rejected_ruff_config_keys": [
     "extend-ignore", "inline-noqa", "pyproject.toml", "ruff.toml", ".ruff.toml", "tool.ruff",
     "target-version", "per-file-target-version", "extension", "src", "namespace-packages",


### PR DESCRIPTION
## Summary

Implements Milestone 2 for the production-grade Sifr linter phase:

- Adds Sifr-owned `[lint]`, `[lint.rules]`, and `[lint.per-file-ignores]` config loading from `sifr.toml`, including path-relative `extend`, CLI/global overrides, unknown-key diagnostics, and selector validation.
- Adds `ignore` + `globset` based lint file discovery with include/exclude, gitignore controls, force-exclude, explicit-target behavior, and deterministic ordering.
- Splits `sifr lint` command modeling/execution into `crates/sifr/src/lint_cli.rs` and implements the non-fix CLI surface: default `.`, multiple targets, stdin, selectors, per-file ignores, output format/file, show-files/settings, discovery flags, preview flags, exit-zero, global config, and isolated mode.
- Updates lint reuse/config manifests, CLI docs, tooling docs, execution tracker, and Claude review artifact.

## Validation

- `cargo check -p sifr`
- `cargo build -p sifr`
- `cargo test -p sifr_lint`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo clippy -p sifr_lint -- -D warnings`
- `python3 verification/tooling/check_linter_reuse_contract.py`
- `python3 verification/tooling/check_linter_reuse_contract.py --self-test`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- CLI smoke fixtures for concise diagnostics, stdin JSON diagnostics, config ignore, show-files, show-settings, exit-zero, and rejected Ruff/Python flags

Note: `cargo clippy -p sifr_lint -p sifr -- -D warnings` still fails on pre-existing `clippy::too_many_arguments` in `crates/sifr/src/diagnostic_rendering_and_run.rs:219`, outside this diff.

Claude review artifact: `reviews/sifr-linter-m2-config-discovery-review-pass-1.md` returned `SATISFIED` for M2 closure.
