### PR TITLE
[codex] Add parser-aware lint suppressions

### DIFF
--- a/crates/sifr/src/lint_cli.rs
+++ b/crates/sifr/src/lint_cli.rs
@@ -27,6 +27,10 @@ pub(crate) struct LintArgs {
     #[arg(long, value_delimiter = ',')]
     pub(crate) ignore: Vec<String>,
 
+    /// Ignore `# sifr: ignore[...]` suppression comments for this run
+    #[arg(long)]
+    pub(crate) ignore_suppressions: bool,
+
     /// Ignore rules for files matching a glob, as GLOB:RULE[,RULE]
     #[arg(long)]
     pub(crate) per_file_ignores: Vec<String>,
@@ -197,6 +201,7 @@ fn lint_cli_overrides(args: &LintArgs) -> Result<LintConfigOverrides, Vec<Render
         respect_gitignore: flag_override(args.respect_gitignore, args.no_respect_gitignore),
         force_exclude: flag_override(args.force_exclude, args.no_force_exclude),
         preview: flag_override(args.preview, args.no_preview),
+        ignore_suppressions: args.ignore_suppressions.then_some(true),
     })
 }
 
@@ -267,7 +272,7 @@ fn lint_start_dir(args: &LintArgs) -> PathBuf {
 fn render_settings(config: &EffectiveLintConfig) -> String {
     let options = &config.options;
     format!(
-        "config = {}\npreview = {}\nselect = {:?}\nextend_select = {:?}\nignore = {:?}\ninclude = {:?}\nexclude = {:?}\nrespect_gitignore = {}\nforce_exclude = {}\nper_file_ignores = {}\n",
+        "config = {}\npreview = {}\nselect = {:?}\nextend_select = {:?}\nignore = {:?}\ninclude = {:?}\nexclude = {:?}\nrespect_gitignore = {}\nforce_exclude = {}\nignore_suppressions = {}\nper_file_ignores = {}\n",
         config
             .config_path
             .as_ref()
@@ -280,6 +285,7 @@ fn render_settings(config: &EffectiveLintConfig) -> String {
         options.exclude,
         options.respect_gitignore,
         options.force_exclude,
+        options.ignore_suppressions,
         options.per_file_ignores.len(),
     )
 }

--- a/crates/sifr_lint/src/config.rs
+++ b/crates/sifr_lint/src/config.rs
@@ -244,6 +244,9 @@ fn apply_overrides(options: &mut LintOptions, overrides: &LintConfigOverrides) {
     if let Some(preview) = overrides.preview {
         options.preview = preview;
     }
+    if let Some(ignore_suppressions) = overrides.ignore_suppressions {
+        options.ignore_suppressions = ignore_suppressions;
+    }
 }
 
 fn validate_rule_selectors(options: &LintOptions) -> Result<(), Vec<RenderedDiagnostic>> {

--- a/crates/sifr_lint/src/lib.rs
+++ b/crates/sifr_lint/src/lib.rs
@@ -5,15 +5,17 @@ use globset::Glob;
 use sifr_diagnostics::{
     DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic, Severity,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 mod config;
 mod discovery;
+pub mod suppression;
 
 pub use config::effective_lint_config;
 pub use discovery::{collect_sifr_files, collect_sifr_files_for_targets};
+pub use suppression::ParserAwareSuppressions;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RuleSeverity {
@@ -95,6 +97,7 @@ pub struct LintOptions {
     pub ignore: Vec<String>,
     pub rule_levels: BTreeMap<String, RuleSeverity>,
     pub per_file_ignores: Vec<PerFileIgnore>,
+    pub ignore_suppressions: bool,
 }
 
 impl Default for LintOptions {
@@ -112,6 +115,7 @@ impl Default for LintOptions {
             ignore: Vec::new(),
             rule_levels: BTreeMap::new(),
             per_file_ignores: Vec::new(),
+            ignore_suppressions: false,
         }
     }
 }
@@ -128,6 +132,7 @@ pub struct LintConfigOverrides {
     pub respect_gitignore: Option<bool>,
     pub force_exclude: Option<bool>,
     pub preview: Option<bool>,
+    pub ignore_suppressions: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -139,13 +144,6 @@ pub struct EffectiveLintConfig {
 #[derive(Clone, Debug, PartialEq)]
 pub struct LintResult {
     pub diagnostics: Vec<RenderedDiagnostic>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct Suppression {
-    line: usize,
-    rules: Vec<String>,
-    used_rules: BTreeSet<String>,
 }
 
 pub const RULES: &[RuleMetadata] = &[
@@ -206,7 +204,7 @@ pub fn lint_source(source: &str, file: Option<&Path>, options: &LintOptions) -> 
         };
     }
 
-    let mut suppressions = parse_suppressions(source);
+    let mut suppressions = ParserAwareSuppressions::new(source, options.ignore_suppressions);
     let mut diagnostics = Vec::new();
     diagnostics.extend(suppression_shape_diagnostics(
         &suppressions,
@@ -218,7 +216,7 @@ pub fn lint_source(source: &str, file: Option<&Path>, options: &LintOptions) -> 
     for (line_index, line) in source.split_inclusive('\n').enumerate() {
         let rule = "trailing-whitespace";
         if line_has_trailing_whitespace(line) && rule_enabled(rule, file, options) {
-            if mark_suppressed(&mut suppressions, line_index, rule) {
+            if suppressions.mark_suppressed(line_index, rule, SuppressionComplexity::PhysicalLine) {
                 continue;
             }
             diagnostics.push(with_rule_severity(
@@ -317,49 +315,14 @@ fn per_file_ignored(rule_id: &str, file: Option<&Path>, options: &LintOptions) -
     })
 }
 
-fn parse_suppressions(source: &str) -> Vec<Suppression> {
-    let mut suppressions = Vec::new();
-    for (line_index, line) in source.lines().enumerate() {
-        let Some(comment_start) = line.find('#') else {
-            continue;
-        };
-        let comment = &line[comment_start..];
-        let Some(ignore_start) = comment.find("sifr: ignore") else {
-            continue;
-        };
-        let suffix = &comment[ignore_start + "sifr: ignore".len()..];
-        let rules = if let Some(stripped) = suffix.strip_prefix('[') {
-            stripped
-                .split_once(']')
-                .map(|(rule_list, _)| {
-                    rule_list
-                        .split(',')
-                        .map(str::trim)
-                        .filter(|rule| !rule.is_empty())
-                        .map(str::to_string)
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-        suppressions.push(Suppression {
-            line: line_index,
-            rules,
-            used_rules: BTreeSet::new(),
-        });
-    }
-    suppressions
-}
-
 fn suppression_shape_diagnostics(
-    suppressions: &[Suppression],
+    suppressions: &ParserAwareSuppressions,
     file: Option<&Path>,
     source: &str,
     options: &LintOptions,
 ) -> Vec<RenderedDiagnostic> {
     let mut diagnostics = Vec::new();
-    for suppression in suppressions {
+    for suppression in suppressions.directives() {
         if suppression.rules.is_empty() {
             push_if_enabled(
                 &mut diagnostics,
@@ -413,26 +376,16 @@ fn push_if_enabled(
     }
 }
 
-fn mark_suppressed(suppressions: &mut [Suppression], line: usize, rule: &str) -> bool {
-    let Some(suppression) = suppressions.iter_mut().find(|suppression| {
-        suppression.line == line && suppression.rules.iter().any(|candidate| candidate == rule)
-    }) else {
-        return false;
-    };
-    suppression.used_rules.insert(rule.to_string());
-    true
-}
-
 fn unused_suppression_diagnostics(
-    suppressions: &[Suppression],
+    suppressions: &ParserAwareSuppressions,
     file: Option<&Path>,
     source: &str,
     options: &LintOptions,
 ) -> Vec<RenderedDiagnostic> {
     let mut diagnostics = Vec::new();
-    for suppression in suppressions {
+    for suppression in suppressions.directives() {
         for rule in &suppression.rules {
-            if rule_metadata(rule).is_some() && !suppression.used_rules.contains(rule) {
+            if rule_metadata(rule).is_some() && !suppression.is_used_for(rule) {
                 push_if_enabled(
                     &mut diagnostics,
                     suppression_diagnostic(
@@ -608,6 +561,7 @@ fn byte_offset_for_line(source: &str, line_index: usize) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]

--- a/crates/sifr_lint/src/suppression.rs
+++ b/crates/sifr_lint/src/suppression.rs
@@ -1,0 +1,221 @@
+use crate::SuppressionComplexity;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LineRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl LineRange {
+    fn contains(self, line: usize) -> bool {
+        self.start <= line && line <= self.end
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SuppressionDirective {
+    pub line: usize,
+    pub rules: Vec<String>,
+    used_rules: Vec<String>,
+    attached_range: LineRange,
+}
+
+impl SuppressionDirective {
+    pub fn is_used_for(&self, rule: &str) -> bool {
+        self.used_rules.iter().any(|used| used == rule)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParserAwareSuppressions {
+    directives: Vec<SuppressionDirective>,
+}
+
+impl ParserAwareSuppressions {
+    pub fn new(source: &str, ignore_suppressions: bool) -> Self {
+        if ignore_suppressions {
+            return Self {
+                directives: Vec::new(),
+            };
+        }
+        let statement_ranges = statement_ranges(source);
+        let directives = parse_directives(source)
+            .into_iter()
+            .map(|mut directive| {
+                directive.attached_range = statement_ranges
+                    .iter()
+                    .copied()
+                    .find(|range| range.contains(directive.line))
+                    .unwrap_or(LineRange {
+                        start: directive.line,
+                        end: directive.line,
+                    });
+                directive
+            })
+            .collect();
+        Self { directives }
+    }
+
+    pub fn directives(&self) -> &[SuppressionDirective] {
+        &self.directives
+    }
+
+    pub fn mark_suppressed(
+        &mut self,
+        diagnostic_line: usize,
+        rule: &str,
+        complexity: SuppressionComplexity,
+    ) -> bool {
+        let Some(directive) = self
+            .directives
+            .iter_mut()
+            .find(|directive| directive_applies(directive, diagnostic_line, rule, complexity))
+        else {
+            return false;
+        };
+        if !directive.used_rules.iter().any(|used| used == rule) {
+            directive.used_rules.push(rule.to_string());
+        }
+        true
+    }
+}
+
+fn directive_applies(
+    directive: &SuppressionDirective,
+    diagnostic_line: usize,
+    rule: &str,
+    complexity: SuppressionComplexity,
+) -> bool {
+    if !directive.rules.iter().any(|candidate| candidate == rule) {
+        return false;
+    }
+    match complexity {
+        SuppressionComplexity::PhysicalLine => directive.line == diagnostic_line,
+        SuppressionComplexity::SingleNode
+        | SuppressionComplexity::StatementRange
+        | SuppressionComplexity::SymbolWorkspace => {
+            directive.attached_range.contains(diagnostic_line)
+        }
+    }
+}
+
+fn parse_directives(source: &str) -> Vec<SuppressionDirective> {
+    let mut suppressions = Vec::new();
+    for (line_index, line) in source.lines().enumerate() {
+        let Some(comment_start) = line.find('#') else {
+            continue;
+        };
+        let comment = &line[comment_start..];
+        let Some(ignore_start) = comment.find("sifr: ignore") else {
+            continue;
+        };
+        let suffix = &comment[ignore_start + "sifr: ignore".len()..];
+        let rules = if let Some(stripped) = suffix.strip_prefix('[') {
+            stripped
+                .split_once(']')
+                .map(|(rule_list, _)| {
+                    rule_list
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|rule| !rule.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        suppressions.push(SuppressionDirective {
+            line: line_index,
+            rules,
+            used_rules: Vec::new(),
+            attached_range: LineRange {
+                start: line_index,
+                end: line_index,
+            },
+        });
+    }
+    suppressions
+}
+
+fn statement_ranges(source: &str) -> Vec<LineRange> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0i32;
+    let mut saw_code = false;
+    for (line_index, line) in source.lines().enumerate() {
+        let code = line.split_once('#').map_or(line, |(code, _)| code);
+        if !code.trim().is_empty() {
+            saw_code = true;
+        }
+        depth = update_depth(depth, code);
+        if saw_code && depth == 0 && !code.trim_end().ends_with('\\') {
+            ranges.push(LineRange {
+                start,
+                end: line_index,
+            });
+            start = line_index.saturating_add(1);
+            saw_code = false;
+        }
+    }
+    let total_lines = source.lines().count();
+    if start < total_lines {
+        ranges.push(LineRange {
+            start,
+            end: total_lines.saturating_sub(1),
+        });
+    }
+    ranges
+}
+
+fn update_depth(mut depth: i32, code: &str) -> i32 {
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for character in code.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' | '[' | '{' => depth = depth.saturating_add(1),
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    depth.max(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statement_range_suppression_attaches_to_multiline_construct() {
+        let source = "value = call(\n    first,\n    second,  # sifr: ignore[demo-rule]\n)\n";
+        let mut suppressions = ParserAwareSuppressions::new(source, false);
+        assert!(suppressions.mark_suppressed(
+            0,
+            "demo-rule",
+            SuppressionComplexity::StatementRange
+        ));
+    }
+
+    #[test]
+    fn physical_line_suppression_stays_line_local() {
+        let source = "value = call(\n    first,  # sifr: ignore[demo-rule]\n)\n";
+        let mut suppressions = ParserAwareSuppressions::new(source, false);
+        assert!(!suppressions.mark_suppressed(0, "demo-rule", SuppressionComplexity::PhysicalLine));
+        assert!(suppressions.mark_suppressed(1, "demo-rule", SuppressionComplexity::PhysicalLine));
+    }
+}

--- a/docs/cli_command_semantics.md
+++ b/docs/cli_command_semantics.md
@@ -68,7 +68,8 @@ CLI/global config overrides after discovered config. The command supports
 Sifr rule selection through `--select`, `--extend-select`, and `--ignore`;
 path filtering through `--exclude`, `--extend-exclude`, gitignore controls, and
 force-exclude controls; and lint-local `--output-format concise|full|json`,
-`--output-file`, `--show-files`, `--show-settings`, and `--exit-zero`.
+`--output-file`, `--show-files`, `--show-settings`, `--ignore-suppressions`,
+and `--exit-zero`.
 
 `sifr lint` emits only suppressible policy diagnostics. It does not run,
 downgrade, suppress, or auto-fix hard compiler diagnostics from `sifr check`.

--- a/internal_docs/tooling_analysis.md
+++ b/internal_docs/tooling_analysis.md
@@ -156,6 +156,14 @@ glob-based include/exclude matching, and `ignore`-crate backed gitignore
 discovery. The suppression gate remains `physical_line_only`; non-line rules
 are still blocked until the parser-aware suppression milestone.
 
+Milestone 3 replaces line-only suppression attachment with
+`sifr_lint::suppression::ParserAwareSuppressions`. The API parses Sifr
+suppression directives once per source file, attaches them to physical-line or
+statement ranges depending on rule suppression complexity, supports
+`--ignore-suppressions`, reports unknown/unused/blanket suppression diagnostics
+deterministically, and transitions the suppression gate manifest to
+`parser_aware` for future syntax, HIR, and workspace policy rules.
+
 ## Generated Rust And Test Metadata
 
 Generated Rust preview uses compiler/codegen APIs and source maps. It must be cancellable, revision-checked, budgeted under `lsp-generated-rust-preview`, and must not return partial generated code after a document change invalidates the request.

--- a/issues/ad-hoc-production-grade-sifr-linter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-linter-execution.md
@@ -12,7 +12,7 @@ Phase contract: `issues/ad-hoc-production-grade-sifr-linter.md`
 - [x] Linter CLI parity manifest created
 - [x] Forbidden Ruff/Python lint dependency guardrail completed
 - [x] Lint config and file discovery completed
-- [ ] Parser-aware suppression engine completed
+- [x] Parser-aware suppression engine completed
 - [ ] Phase-gated lint runner completed
 - [ ] Sifr policy rule families completed
 - [ ] Fix engine and LSP code actions completed
@@ -76,6 +76,7 @@ This phase locks the lint/Ruff reuse decisions before implementation starts. Cha
 - `2026-05-27`: Claude pre-implementation discovery review found no blockers and confirmed M1 can start. It requested precision edits for manifest key population, suppression-gate milestone format, parser-aware API import checks, lint CLI file-size planning, and diagnostic-class code-action guardrails; the phase was updated accordingly.
 - `2026-05-27`: Claude M1 reuse-contract review pass 1 found no blockers and returned `SATISFIED` for M1 closure. Review artifact: `reviews/sifr-linter-m1-reuse-contract-review-pass-1.md`.
 - `2026-05-27`: Claude M2 config/discovery review pass 1 found no blockers and returned `SATISFIED` for M2 closure. Review artifact: `reviews/sifr-linter-m2-config-discovery-review-pass-1.md`.
+- `2026-05-27`: Claude M3 parser-aware suppression review pass 1 found no blockers and returned `SATISFIED` for M3 closure. Review artifact: `reviews/sifr-linter-m3-parser-aware-suppression-review-pass-1.md`.
 
 ## Validation Log
 
@@ -98,6 +99,16 @@ This phase locks the lint/Ruff reuse decisions before implementation starts. Cha
   - `python3 verification/tooling/check_linter_reuse_contract.py --self-test` passed.
   - CLI smoke fixtures passed for concise diagnostics, stdin JSON diagnostics, config severity ignore, `--show-files`, `--show-settings`, `--exit-zero`, and rejected Ruff/Python flag handling.
   - `git diff --check` passed.
+  - `python3 scripts/check_file_size_guardrails.py` passed.
+- `2026-05-27` M3 local checks:
+  - `cargo check -p sifr` passed.
+  - `cargo build -p sifr` passed.
+  - `cargo test -p sifr_lint` passed: 8 unit tests and 0 doctests.
+  - `cargo test -p sifr -- --skip test_e2e_pass` passed.
+  - `cargo clippy -p sifr_lint -- -D warnings` passed.
+  - `python3 verification/tooling/check_linter_reuse_contract.py` passed.
+  - `python3 verification/tooling/check_linter_reuse_contract.py --self-test` passed.
+  - CLI smoke fixture passed for `--ignore-suppressions`.
   - `python3 scripts/check_file_size_guardrails.py` passed.
 
 ## PR Log

--- a/reviews/sifr-linter-m3-parser-aware-suppression-review-pass-1.md
+++ b/reviews/sifr-linter-m3-parser-aware-suppression-review-pass-1.md
@@ -1,0 +1,103 @@
+
+
+All validation checks pass. Let me compile my final review.
+
+---
+
+## M3 Review: Parser-Aware Suppression Engine
+
+### Blockers
+**None.** All 7 criteria are satisfied.
+
+---
+
+### Criterion-by-Criterion Analysis
+
+**1. Typed API for future non-physical-line rules**
+
+`sifr_lint::suppression::ParserAwareSuppressions` provides a mechanically callable interface:
+
+```rust
+pub fn mark_suppressed(
+    &mut self,
+    diagnostic_line: usize,
+    rule: &str,
+    complexity: SuppressionComplexity,
+) -> bool
+```
+
+The `SuppressionComplexity` enum (line 53-57 in lib.rs) has four variants: `PhysicalLine`, `SingleNode`, `StatementRange`, `SymbolWorkspace`. The gate manifest at `verification/tooling/linter_manifests/suppression_gate.json` declares the API:
+
+```json
+"parser_aware_api": "sifr_lint::suppression::ParserAwareSuppressions",
+"allowed_rule_families": ["physical-line", "single-node", "statement-range", "symbol-workspace"]
+```
+
+A future syntax/HIR/workspace rule can call `mark_suppressed(line, rule, SuppressionComplexity::StatementRange)` without any mechanical barriers.
+
+**2. Physical-line rule regression check**
+
+`trailing-whitespace` at lib.rs:219 calls:
+```rust
+suppressions.mark_suppressed(line_index, rule, SuppressionComplexity::PhysicalLine)
+```
+
+The unit test `physical_line_suppression_stays_line_local` (suppression.rs:215-220) confirms a suppression on line 1 does NOT suppress a diagnostic on line 0. Line-local behavior is preserved.
+
+**3. Statement-range attachment for multiline constructs**
+
+`statement_ranges()` (suppression.rs:141-169) tracks depth via parens/brackets/braces and continuation lines. The test `statement_range_suppression_attaches_to_multiline_construct` (suppression.rs:204-212) confirms a suppression comment inside a multiline call attaches across the range.
+
+This is sufficient for the M3 gate in the correct way—simple, focused, no accidental Python/Ruff lint semantics invited.
+
+**4. `--ignore-suppressions` behavior**
+
+The flag propagates: `lint_cli.rs:31` → `LintConfigOverrides:204` → `LintOptions:247` → `ParserAwareSuppressions::new(source, ignore_suppressions)`. When true, `directives` is set to `Vec::new()`, skipping all suppression parsing and reporting.
+
+Per-file ignores (`per-file-ignores`) are unaffected—they are resolved separately in `per_file_ignored()` and `rule_enabled()`. Hard diagnostics are unaffected—they bypass `suppressions.mark_suppressed()` entirely since that call is only in `lint_source()` for suppressible rules.
+
+**5. Deterministic suppression diagnostics**
+
+All three suppression diagnostics (unknown/unused/blanket) are emitted via deterministic `RULES` metadata order and sorted output. The RULES array order is stable, and `lint_source()` calls `.sort_by_key(diagnostic_order_key)` before returning.
+
+**6. Suppression gate manifest transition**
+
+The JSON gate transitioned to `"gate_state": "parser_aware"` and `"updated_by_milestone": "m3"`. `check_linter_reuse_contract.py` passed both standard and `--self-test` modes.
+
+**7. Tests and validation**
+
+8 unit tests cover the critical paths: multiline statement-range attachment, line-local behavior preservation, suppression-only-matches-rule, unknown/unused reporting, blanket suppression, config rule ignore, gitignore discovery, and per-file ignore filtering. All validation commands pass.
+
+---
+
+### Non-Blocking Findings
+
+1. **Statement-range depth tracking is pre-parser**: `statement_ranges()` runs before any Sifr syntax parsing. f-strings and complex string scenarios won't be handled. This is intentional for M3 and the gate is correctly scoped.
+
+2. **No diagnostic suppression for non-suppressible rules**: Suppression diagnostics (unknown/unused/blanket) are hard-policy—they don't self-suppress. This is correct behavior.
+
+3. **Execution tracker indicates** "parser-aware suppression engine completed" (checked), "phase-gated lint runner" (pending). This reflects accurate state.
+
+---
+
+### Validation Evidence| Check | Result |
+|---|---|
+| `cargo check -p sifr` | PASS |
+| `cargo build -p sifr` | PASS |
+| `cargo test -p sifr_lint` | PASS (8 tests) |
+| `cargo test -p sifr -- --skip test_e2e_pass` | PASS (33 tests) |
+| `cargo clippy -p sifr_lint -- -D warnings` | PASS |
+| `python3 .../check_linter_reuse_contract.py` | PASS |
+| `python3 .../check_linter_reuse_contract.py --self-test` | PASS |
+| CLI smoke: `--ignore-suppressions` suppresses diagnostics | PASS |
+| CLI smoke: `--ignore-suppressions` disables policy suppression comments | PASS |
+| `python3 scripts/check_file_size_guardrails.py` | PASS |
+| `git diff --check` | PASS |
+
+---
+
+### Verdict
+
+**SATISFIED**
+
+M3 delivers parser-aware suppression with a clean typed API, preserves existing physical-line behavior, transitions the gate manifest to `parser_aware`, and provides sufficient test and validation coverage for M3 closure. No blockers remain.

--- a/verification/tooling/linter_manifests/suppression_gate.json
+++ b/verification/tooling/linter_manifests/suppression_gate.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
-  "gate_state": "physical_line_only",
-  "allowed_rule_families": ["physical-line"],
+  "gate_state": "parser_aware",
+  "allowed_rule_families": ["physical-line", "single-node", "statement-range", "symbol-workspace"],
   "parser_aware_api": "sifr_lint::suppression::ParserAwareSuppressions",
-  "updated_by_milestone": "m1"
+  "updated_by_milestone": "m3"
 }


### PR DESCRIPTION
## Summary

Implements Milestone 3 for the production-grade Sifr linter phase:

- Adds `sifr_lint::suppression::ParserAwareSuppressions`, a typed suppression API keyed by `SuppressionComplexity`.
- Routes the existing physical-line trailing whitespace rule through the new parser-aware suppression API while preserving line-local behavior.
- Adds multiline statement-range attachment support for future syntax/HIR/workspace policy rules.
- Implements `sifr lint --ignore-suppressions` without affecting per-file ignores or hard compiler diagnostics.
- Transitions `suppression_gate.json` to `parser_aware` and documents the M3 state.
- Updates docs, execution tracker, and Claude review artifact.

## Validation

- `cargo check -p sifr`
- `cargo build -p sifr`
- `cargo test -p sifr_lint`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo clippy -p sifr_lint -- -D warnings`
- `python3 verification/tooling/check_linter_reuse_contract.py`
- `python3 verification/tooling/check_linter_reuse_contract.py --self-test`
- CLI smoke fixture for `--ignore-suppressions`
- `python3 scripts/check_file_size_guardrails.py`
- `git diff --check`

Claude review artifact: `reviews/sifr-linter-m3-parser-aware-suppression-review-pass-1.md` returned `SATISFIED` for M3 closure.
