### PR TITLE
Record linter closure PR link

### DIFF
--- a/issues/ad-hoc-production-grade-sifr-linter-execution.md
+++ b/issues/ad-hoc-production-grade-sifr-linter-execution.md
@@ -200,3 +200,4 @@ Implementation PR links will be recorded here as each milestone closes.
 - M4 `phase_gated_lint_engine`: https://github.com/sifr-lang/sifr/pull/2187
 - M5 `policy_rule_families`: https://github.com/sifr-lang/sifr/pull/2188
 - M6 `lint_fixes_and_code_actions`: https://github.com/sifr-lang/sifr/pull/2189
+- M7 `lsp_editor_docs_and_closeout`: https://github.com/sifr-lang/sifr/pull/2190


### PR DESCRIPTION
## Summary
- record the merged M7 closeout PR link in the production-grade linter execution tracker

## Validation
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`

The full phase validation and final production-readiness review are recorded in the already-merged M7 closeout PR #2190.
