### PR TITLE
[codex] Add diagnostic presentation phase plan

### DIFF
--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -1,0 +1,57 @@
+# Ad Hoc Phase Execution: Production-Grade Diagnostic Presentation
+
+Status: planned on 2026-05-27
+
+Phase contract: `issues/ad-hoc-production-grade-diagnostic-presentation.md`
+
+## Checklist
+
+- [x] Phase plan drafted
+- [x] Phase plan reviewed and approved for implementation
+- [ ] M1 renderer contract lock completed
+- [ ] M2 human source-aware output completed
+- [ ] M3 compact stable output completed
+- [ ] M4 docs and closeout completed
+- [ ] Full local validation recorded
+- [ ] Final production-readiness review approved
+
+## Planning Lock Addendum
+
+This phase locks the diagnostic output-mode responsibilities before implementation starts. Changing the `human`, `compact`, or `json` mode contract requires a reviewed planning update.
+
+### Required Implementation Work
+
+| ID | Work item | Required closeout |
+| --- | --- | --- |
+| W-1 | Default human output drops primary source locations. | M2 renders file, line, column, source snippet, highlight, notes, help, suggestions, and docs URL for span-backed diagnostics. |
+| W-2 | Compact output is verbose grouped text rather than stable one-line diagnostics. | M3 emits summary plus one physical line per retained diagnostic with stable fields. |
+| W-3 | JSON is structurally useful but needs schema stability protected while CLI text formats change. | M1 and M4 confirm JSON schema compatibility and update only intentional text baselines. |
+| W-4 | Renderer behavior is split between CLI-local rendering and `sifr_diagnostics` source-aware rendering. | M1 locks canonical `sifr_diagnostics` presentation ownership and tests CLI delegation after recovery limiting. |
+| W-5 | Spanless internal diagnostics need a deliberate display contract. | M2 and M3 add spanless internal diagnostic fixtures for human and compact modes. |
+| W-6 | Human target output requires visual highlight markers that the current canonical renderer does not print. | M2 adds a highlight renderer for single-line, multiline, and CRLF source snippets. |
+| W-7 | Compact summary changes current help-count behavior. | M1 records severity-only compact summary counts as an intentional contract change and keeps help details in human/JSON. |
+| W-8 | Snapshot path normalization affects portable baselines. | M1 documents `<WORKSPACE>` normalization for verification baselines while preserving live diagnostic display paths. |
+| W-9 | Command-level format routing can drift across CLI entrypoints. | M1/M2/M3 add format-selection coverage for `check`, `build`, `run`, and `emit` diagnostics. |
+
+### Locked Mode Decisions
+
+| Mode | Locked decision |
+| --- | --- |
+| `human` | Default developer-facing view with source snippets and caret-style highlights. |
+| `compact` | Terse line-oriented output for agents, CI, and scanning; no snippets or default URLs. |
+| `json` | Canonical structured transport; preserve existing rendered diagnostic schema unless separately reviewed. |
+
+## Review Log
+
+- `2026-05-27`: Initial phase plan drafted from current CLI output inspection and desired output-mode responsibilities.
+- `2026-05-27`: Claude phase review pass 1 found two planning blockers: unresolved CLI-vs-`sifr_diagnostics` delegation ownership and missing highlight-rendering infrastructure in the plan. The phase was updated to make `sifr_diagnostics` the canonical presentation owner after CLI recovery limiting, require caret/highlight rendering, require CRLF-safe snippet rendering, document severity-only compact summaries, add multiline fixtures, add command-level format routing tests, and document `<WORKSPACE>` baseline normalization.
+- `2026-05-27`: Claude phase review pass 2 returned `SATISFIED` with no remaining blockers. One non-blocking precision edit was applied: M1 now requires a JSON schema-lock fixture enumerating the required `RenderedDiagnostic` fields. Review artifact: `reviews/diagnostic-presentation-phase-review-pass-2.md`.
+
+## Validation Log
+
+- Validation evidence will be recorded per implementation milestone.
+- Planning PR validation starts with `git diff --check` and review artifact checks.
+
+## PR Log
+
+- Implementation PR links will be recorded per milestone after they are opened and merged.

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -12,6 +12,7 @@ Phase contract: `issues/ad-hoc-production-grade-diagnostic-presentation.md`
 - [ ] M1 renderer contract lock completed
 - [ ] M2 human source-aware output completed
 - [ ] M3 compact stable output completed
+- [ ] Diagnostic presentation verification gate completed
 - [ ] M4 docs and closeout completed
 - [ ] Full local validation recorded
 - [ ] Final production-readiness review approved
@@ -36,6 +37,7 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 | W-10 | Multiline diagnostics need explicit verification coverage. | M1 creates a multiline diagnostic verification fixture with locked `human`, `compact`, and `json` baselines. |
 | W-11 | Compact mode must not inherit the old grouped `CompactKey` behavior. | M1 locks one-line-per-retained-diagnostic compact rendering after recovery limiting; M3 implements that contract. |
 | W-12 | Related spans are present in the canonical diagnostic model but not rendered by current human presentation. | M2 renders related spans with labels/kinds after the primary span. |
+| W-13 | The phase lacks a named mechanical verification gate. | M1 adds `verification/tooling/check_diagnostic_presentation_contract.py`, its `--self-test`, and `scripts/run_all_tests.sh --profile quick` wiring; M2/M3/M4 close all checker obligations. |
 
 ### Locked Mode Decisions
 
@@ -52,11 +54,15 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `2026-05-27`: Claude phase review pass 2 returned `SATISFIED` with no remaining blockers. One non-blocking precision edit was applied: M1 now requires a JSON schema-lock fixture enumerating the required `RenderedDiagnostic` fields. Review artifact: `reviews/diagnostic-presentation-phase-review-pass-2.md`.
 - `2026-05-27`: Claude implementation-readiness review pass 1 returned `SATISFIED` with no blockers and four required precision edits. The phase was updated to require a new multiline verification fixture, clarify that command-format tests lock existing routing behavior, forbid inheriting old compact grouping behavior, and explicitly scope related-span rendering into M2. Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-1.md`.
 - `2026-05-27`: Claude implementation-readiness review pass 2 verified all pass-1 precision edits and returned `SATISFIED` with no blockers, unresolved decisions, or discovery gaps. Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md`.
+- `2026-05-27`: User review found the phase did not make verification a first-class deliverable. The phase was updated to require `verification/tooling/check_diagnostic_presentation_contract.py`, negative self-tests, quick-lane wiring, and per-mode fixture/baseline enforcement.
+- `2026-05-27`: Claude verification-contract review pass 1 returned `SATISFIED` with no blockers and two required precision edits. The phase was updated to name `decimal_invalid_literal` as the existing locked single-line fixture and to clarify that `check_diagnostic_presentation_contract.py` is an M1 deliverable, not a pre-existing guardrail. Review artifact: `reviews/diagnostic-presentation-verification-contract-review-pass-1.md`.
 
 ## Validation Log
 
 - Validation evidence will be recorded per implementation milestone.
 - Planning PR validation starts with `git diff --check` and review artifact checks.
+- `check_diagnostic_presentation_contract.py` does not exist yet. It is an M1 deliverable, not a pre-existing guardrail; M1 must author the tool, prove it fails against missing obligations in negative self-tests, and then wire it into the quick lane.
+- M1 validation must include `python3 verification/tooling/check_diagnostic_presentation_contract.py`, `python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test`, and proof that both are wired into `scripts/run_all_tests.sh --profile quick`.
 
 ## PR Log
 

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -56,6 +56,7 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `2026-05-27`: Claude implementation-readiness review pass 2 verified all pass-1 precision edits and returned `SATISFIED` with no blockers, unresolved decisions, or discovery gaps. Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md`.
 - `2026-05-27`: User review found the phase did not make verification a first-class deliverable. The phase was updated to require `verification/tooling/check_diagnostic_presentation_contract.py`, negative self-tests, quick-lane wiring, and per-mode fixture/baseline enforcement.
 - `2026-05-27`: Claude verification-contract review pass 1 returned `SATISFIED` with no blockers and two required precision edits. The phase was updated to name `decimal_invalid_literal` as the existing locked single-line fixture and to clarify that `check_diagnostic_presentation_contract.py` is an M1 deliverable, not a pre-existing guardrail. Review artifact: `reviews/diagnostic-presentation-verification-contract-review-pass-1.md`.
+- `2026-05-27`: Claude verification-contract review pass 2 verified the pass-1 precision edits and returned `SATISFIED` with no blockers, no required precision edits, and no remaining verification or discovery gaps. Review artifact: `reviews/diagnostic-presentation-verification-contract-review-pass-2.md`.
 
 ## Validation Log
 

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -8,6 +8,7 @@ Phase contract: `issues/ad-hoc-production-grade-diagnostic-presentation.md`
 
 - [x] Phase plan drafted
 - [x] Phase plan reviewed and approved for implementation
+- [x] Implementation-readiness review approved
 - [ ] M1 renderer contract lock completed
 - [ ] M2 human source-aware output completed
 - [ ] M3 compact stable output completed
@@ -31,7 +32,10 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 | W-6 | Human target output requires visual highlight markers that the current canonical renderer does not print. | M2 adds a highlight renderer for single-line, multiline, and CRLF source snippets. |
 | W-7 | Compact summary changes current help-count behavior. | M1 records severity-only compact summary counts as an intentional contract change and keeps help details in human/JSON. |
 | W-8 | Snapshot path normalization affects portable baselines. | M1 documents `<WORKSPACE>` normalization for verification baselines while preserving live diagnostic display paths. |
-| W-9 | Command-level format routing can drift across CLI entrypoints. | M1/M2/M3 add format-selection coverage for `check`, `build`, `run`, and `emit` diagnostics. |
+| W-9 | Command-level format routing can drift across CLI entrypoints. | M1/M2/M3 add regression coverage proving `check`, `build`, `run`, and `emit` diagnostics keep respecting selected formats. |
+| W-10 | Multiline diagnostics need explicit verification coverage. | M1 creates a multiline diagnostic verification fixture with locked `human`, `compact`, and `json` baselines. |
+| W-11 | Compact mode must not inherit the old grouped `CompactKey` behavior. | M1 locks one-line-per-retained-diagnostic compact rendering after recovery limiting; M3 implements that contract. |
+| W-12 | Related spans are present in the canonical diagnostic model but not rendered by current human presentation. | M2 renders related spans with labels/kinds after the primary span. |
 
 ### Locked Mode Decisions
 
@@ -46,6 +50,8 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `2026-05-27`: Initial phase plan drafted from current CLI output inspection and desired output-mode responsibilities.
 - `2026-05-27`: Claude phase review pass 1 found two planning blockers: unresolved CLI-vs-`sifr_diagnostics` delegation ownership and missing highlight-rendering infrastructure in the plan. The phase was updated to make `sifr_diagnostics` the canonical presentation owner after CLI recovery limiting, require caret/highlight rendering, require CRLF-safe snippet rendering, document severity-only compact summaries, add multiline fixtures, add command-level format routing tests, and document `<WORKSPACE>` baseline normalization.
 - `2026-05-27`: Claude phase review pass 2 returned `SATISFIED` with no remaining blockers. One non-blocking precision edit was applied: M1 now requires a JSON schema-lock fixture enumerating the required `RenderedDiagnostic` fields. Review artifact: `reviews/diagnostic-presentation-phase-review-pass-2.md`.
+- `2026-05-27`: Claude implementation-readiness review pass 1 returned `SATISFIED` with no blockers and four required precision edits. The phase was updated to require a new multiline verification fixture, clarify that command-format tests lock existing routing behavior, forbid inheriting old compact grouping behavior, and explicitly scope related-span rendering into M2. Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-1.md`.
+- `2026-05-27`: Claude implementation-readiness review pass 2 verified all pass-1 precision edits and returned `SATISFIED` with no blockers, unresolved decisions, or discovery gaps. Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md`.
 
 ## Validation Log
 

--- a/issues/ad-hoc-production-grade-diagnostic-presentation.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation.md
@@ -177,6 +177,7 @@ In scope:
 7. Update docs for `--diagnostic-format`.
 8. Ensure LSP/editor diagnostic behavior is not regressed by CLI presentation changes.
 9. Ensure generated docs URLs and diagnostic code identities remain unchanged.
+10. Add a phase-owned verification gate that mechanically enforces the diagnostic presentation contract before closure.
 
 Out of scope:
 
@@ -191,16 +192,20 @@ Out of scope:
 
 ### M1: Renderer Contract Lock
 
+- Add `verification/tooling/check_diagnostic_presentation_contract.py` with positive and negative self-tests.
+- Wire `check_diagnostic_presentation_contract.py` and its `--self-test` mode into `scripts/run_all_tests.sh --profile quick`.
 - Add focused renderer contract tests for current canonical span data.
 - Lock target human and compact output fixtures.
 - Confirm JSON schema remains unchanged.
 - Add a JSON schema-lock fixture that enumerates the required `RenderedDiagnostic` fields: `code`, `severity`, `message`, `message_template`, `args`, `url`, `spans`, `children`, `help`, and `suggestions`.
+- Treat `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal` as the existing locked single-line span fixture for `human`, `compact`, and `json`.
 - Add a new multiline diagnostic verification fixture, for example `crates/sifr/tests/verification/diagnostics/multiline_span_rendering`, with locked `human`, `compact`, and `json` baselines.
 - Lock snapshot path normalization behavior: verification baselines may use `<WORKSPACE>` for repository-root-relative portability, while live CLI output preserves the display path passed through the diagnostic span.
 - Document and test that CLI diagnostic rendering delegates to `sifr_diagnostics` after recovery limiting, while CLI success/status messages remain CLI-owned.
 - Record the compact summary format change from `summary: ... help item(s)` to severity-only counts as intentional.
 - Record the compact grouping decision as intentional: compact renders one line for each retained diagnostic after recovery limiting and must not reuse the old grouped `CompactKey` behavior.
 - Add regression tests proving `check`, `build`, `run`, and `emit` respect the selected diagnostic format; these tests lock existing routing behavior rather than adding new command routing.
+- The verification gate must fail until required fixtures, baselines, and renderer contract tests exist.
 
 ### M2: Human Source-Aware Output
 
@@ -211,6 +216,7 @@ Out of scope:
 - Preserve child notes, help, suggestions, and docs URL.
 - Add spanless diagnostic coverage.
 - Regenerate affected verification baselines.
+- Extend `check_diagnostic_presentation_contract.py` to enforce human-mode source location, snippet highlight, related-span, CRLF, suggestion, and spanless-diagnostic fixture coverage.
 
 ### M3: Compact Stable Output
 
@@ -218,13 +224,39 @@ Out of scope:
 - Preserve deterministic ordering and recovery-limit summaries.
 - Add tests covering paths, unknown locations, repeated diagnostics, and omitted diagnostics.
 - Regenerate affected verification baselines.
+- Extend `check_diagnostic_presentation_contract.py` to enforce compact severity-only summary, one-line-per-retained-diagnostic output, no default URLs/snippets, and no old grouped `CompactKey` behavior.
 
 ### M4: Docs And Closeout
 
 - Update public CLI docs and internal diagnostic architecture notes.
+- Close all `check_diagnostic_presentation_contract.py` obligations and keep the guardrail wired into `scripts/run_all_tests.sh`.
 - Run local validation.
 - Record validation evidence in the execution tracker.
 - Complete final review before closure.
+
+## Verification Contract
+
+This phase owns a new mechanical verification gate:
+
+```bash
+python3 verification/tooling/check_diagnostic_presentation_contract.py
+python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test
+```
+
+The gate must be wired into `scripts/run_all_tests.sh --profile quick` in M1 and remain active through phase closure.
+
+The checker must verify:
+
+- The existing `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal` fixture continues to provide locked single-line span baselines for `human`, `compact`, and `json`.
+- Required verification fixture directories exist for single-line and multiline diagnostics.
+- Required `human`, `compact`, and `json` baselines exist for each diagnostic-presentation fixture.
+- JSON schema-lock coverage enumerates `RenderedDiagnostic` fields: `code`, `severity`, `message`, `message_template`, `args`, `url`, `spans`, `children`, `help`, and `suggestions`.
+- Human-mode baselines include file/line/column, source snippet, visual highlight marker, docs URL, spanless diagnostic fallback, related-span rendering, child note/help rendering, suggestion rendering, and CRLF-safe output coverage.
+- Compact-mode baselines use severity-only summaries, one retained diagnostic per line, stable first fields, and no default snippets or URLs.
+- CLI regression coverage exists for `check`, `build`, `run`, and `emit` format selection.
+- The phase docs and execution tracker mention every required fixture and guardrail.
+
+The checker must include negative self-tests that prove it fails when a required fixture, baseline, field, or run-all wiring entry is missing.
 
 ## Acceptance Criteria
 
@@ -235,6 +267,7 @@ Out of scope:
 - Verification baselines prove the three modes have distinct, intentional responsibilities.
 - Verification baselines include both single-line and multiline source-span diagnostics.
 - CLI tests prove `check`, `build`, `run`, and `emit` respect `--diagnostic-format` for diagnostics.
+- `verification/tooling/check_diagnostic_presentation_contract.py` and `--self-test` pass and are wired into `scripts/run_all_tests.sh --profile quick`.
 - No user-facing diagnostic loses code identity, severity, docs URL, or source span data.
 - No fallback renderer path hides source-map rendering failures.
 
@@ -246,6 +279,8 @@ Minimum validation for implementation PRs:
 cargo fmt --check
 cargo test -p sifr_diagnostics
 cargo test -p sifr -- --skip test_e2e_pass
+python3 verification/tooling/check_diagnostic_presentation_contract.py
+python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test
 python3 scripts/check_file_size_guardrails.py
 scripts/run_all_tests.sh --profile quick
 ```

--- a/issues/ad-hoc-production-grade-diagnostic-presentation.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation.md
@@ -1,0 +1,255 @@
+# Ad Hoc Phase: Production-Grade Diagnostic Presentation
+
+Status: planned on 2026-05-27
+
+## Purpose
+
+Make Sifr diagnostic output modes match their intended audiences:
+
+- `human`: the primary developer-facing diagnostic view, optimized for fixing source problems quickly.
+- `compact`: a terse, stable, line-oriented view for agents, CI summaries, and quick terminal scanning.
+- `json`: the canonical structured diagnostic transport for tools and editor integrations.
+
+The current compiler already carries source span data through diagnostics. The gap is presentation: default human output drops file, line, column, and snippet context, while compact and JSON expose the useful location data.
+
+## Source Inputs
+
+This phase is based on:
+
+- Current diagnostic renderer implementation in `crates/sifr/src/diagnostic_rendering_and_run.rs`
+- Canonical diagnostic model and source-map renderer in `crates/sifr_diagnostics`
+- HIR diagnostic source ranges in `crates/sifr_hir/src/lower/diagnostic_types.rs`
+- Frontend diagnostic source-range rendering in `crates/sifr_frontend/src/query_diagnostics.rs`
+- Existing verification baselines under `crates/sifr/tests/verification/diagnostics`
+- Public diagnostic code docs under `docs/errors`
+- Project diagnostic architecture notes in `internal_docs/architecture.md`
+
+## Current Behavior
+
+For `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr`, the current modes behave as follows.
+
+Human mode omits the source location:
+
+```text
+type error: [main] Decimal() received invalid exact literal '12.34.56'
+```
+
+Compact mode includes a source location:
+
+```text
+summary: 1 error(s), 0 warning(s), 0 note(s), 0 help item(s)
+error [SIFR-DECIMAL-0001] [main] Decimal() received invalid exact literal '12.34.56' (x1)
+  at crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30
+  url: https://sifr.sh/docs/errors/SIFR-DECIMAL-0001
+```
+
+JSON mode includes canonical structured span data:
+
+```json
+{
+  "code": "SIFR-DECIMAL-0001",
+  "spans": [
+    {
+      "file": "crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr",
+      "line": 3,
+      "column": 30,
+      "end_line": 3,
+      "end_column": 40,
+      "lines": [
+        {
+          "text": "    value: decimal = Decimal(\"12.34.56\")",
+          "highlight_start": 30,
+          "highlight_end": 40
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Product Decision
+
+Sifr will keep three diagnostic modes, but their contracts must be explicit and mechanically tested.
+
+The canonical presentation boundary is:
+
+- `sifr_diagnostics` owns diagnostic presentation for `human`, `compact`, and `json` once diagnostics have been reduced to canonical `RenderedDiagnostic` values.
+- The CLI may apply recovery limits, select the requested format, write to stdout/stderr, and choose command exit status.
+- The CLI must not keep a second span-dropping diagnostic renderer for user-facing compiler diagnostics.
+- CLI-only status messages such as successful build paths may remain in the CLI, but diagnostic formatting must flow through the canonical presentation renderer.
+
+Implementation must converge the existing CLI-local renderer and the `sifr_diagnostics` presentation renderer into one source-aware path. If a future command needs CLI-specific diagnostic presentation, it must document why the canonical renderer cannot serve it and add a regression test proving no source span is dropped.
+
+### Human mode
+
+Human mode is the default and must be the most readable source-fixing experience.
+
+Target shape:
+
+```text
+error[SIFR-DECIMAL-0001]: Decimal() received invalid exact literal '12.34.56'
+  --> crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30
+   |
+ 3 |     value: decimal = Decimal("12.34.56")
+   |                              ^^^^^^^^^^
+   |
+   = docs: https://sifr.sh/docs/errors/SIFR-DECIMAL-0001
+```
+
+Required behavior:
+
+- Show severity, diagnostic code, and message on the first line.
+- Show primary file, line, and column for every diagnostic with a primary span.
+- Show source snippets and highlight ranges for primary spans.
+- Render visual highlight markers from `DiagnosticSpanLine.highlight_start` and `DiagnosticSpanLine.highlight_end`.
+- Handle multiline spans with clear per-line highlighting.
+- Normalize or strip CRLF carriage returns before printing snippets to terminals while preserving JSON span text semantics.
+- Show related spans when present, without hiding the primary source location.
+- Show child notes, help, suggestions, and docs URL in a stable, readable format.
+- Preserve spanless internal diagnostics with a clear fallback layout that does not pretend a source location exists.
+- Avoid module-prefix noise when the file path already identifies the source context, unless multi-module ambiguity requires it.
+
+### Compact mode
+
+Compact mode is for terse scanning and agent/CI consumption. It should be stable, line-oriented, and easy to parse without being JSON.
+
+Target shape for one diagnostic:
+
+```text
+1 error, 0 warnings, 0 notes
+E SIFR-DECIMAL-0001 crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30 Decimal() received invalid exact literal '12.34.56'
+```
+
+Target shape for multiple diagnostics:
+
+```text
+3 errors, 1 warning
+E SIFR-NAME-0001 src/main.sifr:8:12 undefined variable `user_id`
+E SIFR-TYPE-0002 src/main.sifr:14:20 expected `int`, found `str`
+E SIFR-DECIMAL-0001 src/main.sifr:22:30 Decimal() received invalid exact literal '12.34.56'
+W SIFR-FLOW-0001 src/main.sifr:31:5 unreachable statement ignored
+```
+
+Required behavior:
+
+- Emit a single summary line.
+- Emit one physical line per retained diagnostic.
+- Use stable fields: severity abbreviation, code, location or `<unknown>`, message.
+- Do not emit snippets.
+- Do not emit URLs by default unless a future reviewed flag requests verbose compact output.
+- Count only diagnostics by severity in the summary. Help items remain visible in `human` and `json`, but are not counted separately in compact mode.
+- Preserve deterministic diagnostic ordering and recovery-limit summaries.
+- Keep output parseable under spaces in messages by making the first four fields stable.
+
+### JSON mode
+
+JSON mode remains the canonical structured output and should not be optimized for human aesthetics.
+
+Required behavior:
+
+- Preserve the existing `RenderedDiagnostic` schema unless a schema migration is explicitly reviewed.
+- Preserve code, severity, message, template, args, URL, spans, children, help, and suggestions.
+- Preserve byte ranges and 1-based UTF-8 character line/column positions.
+- Preserve source snippets and highlight ranges.
+- Continue to serve as the authoritative mode for editor/tool integration tests.
+
+## Scope
+
+In scope:
+
+1. Replace the CLI-local human renderer with a source-aware human renderer.
+2. Align CLI human output with `sifr_diagnostics` source-span rendering instead of dropping spans.
+3. Redesign compact output into a stable one-line-per-diagnostic format.
+4. Keep JSON output structurally stable.
+5. Update verification baselines for `human`, `compact`, and `json` where output changes are intentional.
+6. Add renderer tests for:
+   - primary source span
+   - multiline source span
+   - related span
+   - spanless internal diagnostic
+   - help and child notes
+   - suggestions
+   - CRLF source snippets in human mode
+   - compact deterministic ordering
+   - compact recovery-limit summaries
+   - command-level format selection for `check`, `build`, `run`, and `emit`
+7. Update docs for `--diagnostic-format`.
+8. Ensure LSP/editor diagnostic behavior is not regressed by CLI presentation changes.
+9. Ensure generated docs URLs and diagnostic code identities remain unchanged.
+
+Out of scope:
+
+- Changing diagnostic codes or diagnostic family taxonomy.
+- Changing type checker, HIR lowering, parser, ownership, or codegen diagnostic semantics.
+- Changing the JSON schema except for a separately reviewed schema migration.
+- Adding color output. Color can be a later terminal-UX phase.
+- Adding machine-readable non-JSON formats.
+- Reworking source-map storage or byte-range semantics.
+
+## Milestones
+
+### M1: Renderer Contract Lock
+
+- Add focused renderer contract tests for current canonical span data.
+- Lock target human and compact output fixtures.
+- Confirm JSON schema remains unchanged.
+- Add a JSON schema-lock fixture that enumerates the required `RenderedDiagnostic` fields: `code`, `severity`, `message`, `message_template`, `args`, `url`, `spans`, `children`, `help`, and `suggestions`.
+- Add fixture coverage for multiline diagnostics in all three modes.
+- Lock snapshot path normalization behavior: verification baselines may use `<WORKSPACE>` for repository-root-relative portability, while live CLI output preserves the display path passed through the diagnostic span.
+- Document and test that CLI diagnostic rendering delegates to `sifr_diagnostics` after recovery limiting, while CLI success/status messages remain CLI-owned.
+- Record the compact summary format change from `summary: ... help item(s)` to severity-only counts as intentional.
+
+### M2: Human Source-Aware Output
+
+- Implement default human output with file, line, column, snippet, and highlight.
+- Add a highlight renderer for `DiagnosticSpanLine.highlight_start` and `DiagnosticSpanLine.highlight_end`.
+- Add CRLF-safe snippet rendering for terminals.
+- Preserve child notes, help, suggestions, and docs URL.
+- Add spanless diagnostic coverage.
+- Regenerate affected verification baselines.
+
+### M3: Compact Stable Output
+
+- Replace grouped verbose compact output with stable summary plus one-line diagnostics.
+- Preserve deterministic ordering and recovery-limit summaries.
+- Add tests covering paths, unknown locations, repeated diagnostics, and omitted diagnostics.
+- Regenerate affected verification baselines.
+
+### M4: Docs And Closeout
+
+- Update public CLI docs and internal diagnostic architecture notes.
+- Run local validation.
+- Record validation evidence in the execution tracker.
+- Complete final review before closure.
+
+## Acceptance Criteria
+
+- `sifr check <file>` in default human mode shows a usable source location for span-backed diagnostics.
+- Human output includes a highlighted source snippet for primary spans.
+- Compact output is line-oriented and stable enough for agent/CI scanning.
+- JSON output remains schema-compatible and keeps full span data.
+- Verification baselines prove the three modes have distinct, intentional responsibilities.
+- Verification baselines include both single-line and multiline source-span diagnostics.
+- CLI tests prove `check`, `build`, `run`, and `emit` respect `--diagnostic-format` for diagnostics.
+- No user-facing diagnostic loses code identity, severity, docs URL, or source span data.
+- No fallback renderer path hides source-map rendering failures.
+
+## Validation
+
+Minimum validation for implementation PRs:
+
+```bash
+cargo fmt --check
+cargo test -p sifr_diagnostics
+cargo test -p sifr -- --skip test_e2e_pass
+python3 scripts/check_file_size_guardrails.py
+scripts/run_all_tests.sh --profile quick
+```
+
+Full phase closure validation:
+
+```bash
+scripts/run_all_tests.sh
+```
+
+If full validation is blocked by an unrelated inherited failure, the execution tracker must record the exact command, failure, and why this phase did not cause it.

--- a/issues/ad-hoc-production-grade-diagnostic-presentation.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation.md
@@ -135,6 +135,7 @@ Required behavior:
 - Emit a single summary line.
 - Emit one physical line per retained diagnostic.
 - Use stable fields: severity abbreviation, code, location or `<unknown>`, message.
+- Do not group retained diagnostics by message template, rendered message, or primary file. Recovery limiting may still add explicit omission-summary diagnostics before compact rendering.
 - Do not emit snippets.
 - Do not emit URLs by default unless a future reviewed flag requests verbose compact output.
 - Count only diagnostics by severity in the summary. Help items remain visible in `human` and `json`, but are not counted separately in compact mode.
@@ -172,7 +173,7 @@ In scope:
    - CRLF source snippets in human mode
    - compact deterministic ordering
    - compact recovery-limit summaries
-   - command-level format selection for `check`, `build`, `run`, and `emit`
+   - command-level format-selection regression coverage for `check`, `build`, `run`, and `emit`
 7. Update docs for `--diagnostic-format`.
 8. Ensure LSP/editor diagnostic behavior is not regressed by CLI presentation changes.
 9. Ensure generated docs URLs and diagnostic code identities remain unchanged.
@@ -194,16 +195,19 @@ Out of scope:
 - Lock target human and compact output fixtures.
 - Confirm JSON schema remains unchanged.
 - Add a JSON schema-lock fixture that enumerates the required `RenderedDiagnostic` fields: `code`, `severity`, `message`, `message_template`, `args`, `url`, `spans`, `children`, `help`, and `suggestions`.
-- Add fixture coverage for multiline diagnostics in all three modes.
+- Add a new multiline diagnostic verification fixture, for example `crates/sifr/tests/verification/diagnostics/multiline_span_rendering`, with locked `human`, `compact`, and `json` baselines.
 - Lock snapshot path normalization behavior: verification baselines may use `<WORKSPACE>` for repository-root-relative portability, while live CLI output preserves the display path passed through the diagnostic span.
 - Document and test that CLI diagnostic rendering delegates to `sifr_diagnostics` after recovery limiting, while CLI success/status messages remain CLI-owned.
 - Record the compact summary format change from `summary: ... help item(s)` to severity-only counts as intentional.
+- Record the compact grouping decision as intentional: compact renders one line for each retained diagnostic after recovery limiting and must not reuse the old grouped `CompactKey` behavior.
+- Add regression tests proving `check`, `build`, `run`, and `emit` respect the selected diagnostic format; these tests lock existing routing behavior rather than adding new command routing.
 
 ### M2: Human Source-Aware Output
 
 - Implement default human output with file, line, column, snippet, and highlight.
 - Add a highlight renderer for `DiagnosticSpanLine.highlight_start` and `DiagnosticSpanLine.highlight_end`.
 - Add CRLF-safe snippet rendering for terminals.
+- Render related spans in human mode with their labels/kinds while keeping the primary span first.
 - Preserve child notes, help, suggestions, and docs URL.
 - Add spanless diagnostic coverage.
 - Regenerate affected verification baselines.

--- a/reviews/diagnostic-presentation-implementation-readiness-review-pass-1.md
+++ b/reviews/diagnostic-presentation-implementation-readiness-review-pass-1.md
@@ -1,0 +1,72 @@
+
+
+Let me write the final review directly since I've gathered sufficient evidence.
+
+---
+
+## Diagnostic Presentation Phase Implementation-Readiness Review
+
+**SATISFIED**
+
+### Rationale
+
+Cross-referencing the phase docs against the actual code reveals the plan accurately describes implementation state, correctly identifies required work, and correctly identifies what does NOT need to change. There are no remaining implementation-time product decision holes. All required contracts are explicit and backed by concrete code.
+
+### Precision Edits Required
+
+No blockers, but four precision edits are needed before implementation:
+
+**1. EDIT: Phase plan — M1 renderer contract lock (multiline fixtures)**
+
+The plan says "Add fixture coverage for multiline diagnostics in all three modes." The existing fixture (`decimal_invalid_literal`) is single-line only. M1 must either create a new multiline fixture or annotate which existing fixture to update.
+
+Line count in plan: The plan documents fixtures exist but does not call out the single-line gap.
+
+**2. EDIT: Execution tracker — W-9 wording (command coverage tests)**
+
+W-9 says "M1/M2/M3 add format-selection coverage for `check`, `build`, `run`, and `emit` diagnostics." All four commands already correctly pass `diagnostic_format` through the call chain. The actual scope is "add regression/contract tests proving format selection is not regressed," not "add format selection."
+
+**3. EDIT: Phase plan — compact grouping key (stability note)**
+
+M3 states "Replace grouped verbose compact output with stable summary plus one-line diagnostics." The plan's target shape key is `(severity abbreviation, code, location or<unknown>, message)`, but the canonical renderer in `presentation.rs` groups by `(severity_rank, code, message_template, primary_display_file)`. This produces different grouping than the target. Either:
+- (a) M3 must document that grouping adopts the canonical key, or
+- (b) update the target shape to reflect `(severity abbreviation, code, message template, file or<unknown>)`.
+
+Current code (`presentation.rs:146-161`): `CompactKey { severity_rank, code, message_template, primary_display_file }` — does not include rendered message or `<unknown>` location.
+
+Target shape in plan: "severity abbreviation, code, location or `<unknown>`, message" — includes rendered message and explicit location.
+
+**4. EDIT: Phase plan — related spans clarification**
+
+The plan says "Show related spans when present, without hiding the primary source location." The canonical `presentation.rs` human renderer does not currently render related spans (only primary spans and children). The plan correctly identifies this as a gap to be implemented. No change needed in the plan, but M2 must confirm: is rendering related spans in human mode also in scope, or is only primary span rendering in scope for M2?
+
+### Blockers: None
+
+All prior-review blockers are resolved:
+1. `sifr_diagnostics` ownership is confirmed in both plan and code (`presentation.rs` routes all three modes)
+2. Highlight rendering is correctly attributed to M2 as implementation work
+3. JSON schema stability is protected via `deny_unknown_fields` and `#[schemars(required)]` annotations
+4. `<WORKSPACE>` normalization is documented and operative in baselines
+5. CRLF handling is documented: sources retain `\r` in serialized text, human renderers strip it
+
+### Key Findings
+
+**Renderer boundary** (`presentation.rs`): Confirmed correct. `render_human_envelope`, `render_compact_envelope`, `render_json_envelope` all operate on `RenderedDiagnostic` values. CLI routes through `render_diagnostics` which applies recovery limits then delegates.
+
+**Missing highlight renderer**: Confirmed gap. `presentation.rs` prints line text but no caret-style highlights. `DiagnosticSpanLine.highlight_start` and `highlight_end` exist in schema but are not consumed by `render_human_envelope`.
+
+**Suggested output**: Confirmed gap. `presentation.rs` human mode does not render suggestions. Schema stores suggestions; M2 likely needs to add suggestion rendering.
+
+**CRLF handling**: Correctly documented — sources carry `\r` in serialized text, `render_line` trims only trailing `\n`, so `\r` persists to JSON. Human output is responsible for normalizing.
+
+**Compact help-count change**: Correctly documented in W-7. Current `presentation.rs:164-176` counts only severity, but CLI `cli_model_and_entrypoint.rs:853-871` counts help items. Phase changes CLI to drop help counts.
+
+**Format routing**: All four commands (`check`, `build`, `run`, `emit`) pass `diagnostic_format` through the call chain correctly.
+
+### M1 Contract-Lock Prerequisites Before M2/M3
+
+M1 must produce before M2/M3:
+1. A multiline `RenderedDiagnostic` fixture locked for human/compact/json
+2. A JSON schema-lock test enumerating required fields
+3. A test proving `presentation.rs` canonical renderers do not drop span data4. Documentation of compact grouping key (current code vs. target, choose one)
+5. A test proving CLI `check`, `build`, `run`, `emit` format selection worksThese are contract items that do not require M2 implementation work.

--- a/reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md
+++ b/reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md
@@ -1,0 +1,48 @@
+
+
+**SATISFIED**
+
+### Pass-1 Precision Edits: All Applied
+
+**1. Multiline verification fixture — ADDRESSED**
+
+Phase plan, line 198:
+> Add a new multiline diagnostic verification fixture, for example `crates/sifr/tests/verification/diagnostics/multiline_span_rendering`, with locked `human`, `compact`, and `json` baselines.
+
+Concrete fixture path specified, not generic coverage. ✓
+
+**2. Command-format tests as regression coverage — ADDRESSED**
+
+Phase plan, line 203:
+> Add regression tests proving `check`, `build`, `run`, and `emit` respect the selected diagnostic format; these tests lock existing routing behavior rather than adding new command routing.
+
+Execution tracker, W-9 (line 34):
+> M1/M2/M3 add regression coverage proving `check`, `build`, `run`, and `emit` diagnostics keep respecting selected formats.
+
+Explicitly locks existing routing, not adding routing. ✓
+
+**3. Lock compact to avoid old `CompactKey` grouping — ADDRESSED**
+
+Phase plan, line 202:
+> Record the compact grouping decision as intentional: compact renders one line for each retained diagnostic after recovery limiting and must not reuse the old grouped `CompactKey` behavior.
+
+Execution tracker, W-11 (line 36):
+> Compact mode must not inherit the old grouped `CompactKey` behavior. | M1 locks one-line-per-retained-diagnostic compact rendering after recovery limiting; M3 implements that contract.
+
+Explicitly forbids old grouping behavior. ✓
+
+**4. Related-span rendering scoped into M2 — ADDRESSED**
+
+Phase plan, line 210 (M2):
+> Render related spans in human mode with their labels/kinds while keeping the primary span first.
+
+Execution tracker, W-12 (line 37):
+> Related spans are present in the canonical diagnostic model but not rendered by current human presentation. | M2 renders related spans with labels/kinds after the primary span.
+
+Explicitly scoped to M2 with labels/kinds. ✓
+
+### Blockers: None
+
+All implementation-readiness gaps are closed. No remaining unresolved decisions or discovery items.
+
+Review artifact: `reviews/diagnostic-presentation-implementation-readiness-review-pass-2.md`

--- a/reviews/diagnostic-presentation-phase-review-pass-1.md
+++ b/reviews/diagnostic-presentation-phase-review-pass-1.md
@@ -1,0 +1,87 @@
+
+
+Based on my review of both planning documents, source implementation files, current baselines, and renderer code, here is my assessment:
+
+---
+
+## SATISFIED (with two blocking issues)
+
+The phase plan is well-structured with correct problem diagnosis and appropriate scope. However, two blocking issues must be resolved before implementation can begin.
+
+---
+
+## Blocking Issues
+
+### B1: Delegation Architecture Is Unresolved (W-4)
+
+The plan states the goal is to "align CLI human output with `sifr_diagnostics` source-span rendering instead of dropping spans" (Scope item 2), but M1 requires "documenting where CLI rendering should delegate to `sifr_diagnostics`."
+
+**Problem**: Two distinct human renderer implementations already exist with diverging behavior:
+
+- **CLI renderer** (`crates/sifr/src/diagnostic_rendering_and_run.rs:101-113`): Drops span data entirely. Current `human` baseline outputs `type error: [main] Decimal() received invalid exact literal '12.34.56'` with no location.
+- **Canonical renderer** (`crates/sifr_diagnostics/src/render/presentation.rs:52-83`): Shows file:line:column and source snippet, but lacks caret-style highlights, places `url:` in internal position, and omits child notes/help indentation.
+
+The plan never specifies which renderer wins in each CLI code path, whether CLI should delegate to `sifr_diagnostics` for all rendering, or whether they should converge into one path.
+
+**Required resolution**: Decide and document the delegation boundary before M1 begins:
+1. Should `render_diagnostic_stream` delegate to `render_sink_human` from `sifr_diagnostics`?
+2. If yes, is the canonical renderer's output acceptable as the target human shape, or does CLI need additional formatting?
+3. If no, what is CLI-specific logging, output, or CLI-only diagnostic categories that justify a separate path?
+
+### B2: Human Mode Target Shape Lacks Visual Highlight Indication
+
+The plan's target human shape includes a caret-style highlight:
+```
+ | ^^^^^^^^^^
+```
+
+**Problem**: The canonical `render_human_envelope` (`presentation.rs:63-67`) outputs only:
+```rust
+for line in &primary.lines {
+    let _ = writeln!(output, "   | {}", line.text);
+}
+```
+
+No highlight rendering exists—no carets, underscores, or visual indicators of the error position within the snippet.
+
+**Missing work**: `presentation.rs` will need a highlight rendering function before M2 can be implemented. This is currently unimplemented infrastructure, and the plan does not allocate time for it.
+
+**Note**: The architecture doc correctly calls out CRLF normalization as a human renderer concern, but this is not mentioned in the phase plan at all—even though the canonical renderer (`presentation.rs`) will need it for any Sifr source with `\r\n`.
+
+---
+
+## Non-Blocking Precision Edits
+
+### E1: Compact Summary Format Regression Is Not Tracked
+
+The plan's target compact shape uses `"1 error, 0 warnings, 0 notes"` but the existing `compact_severity_summary` (presentation.rs:164-175) outputs `"summary:1 error(s), 0 warning(s), 0 note(s), 0 help item(s)"`.
+
+This is a **regression** from the current help-count behavior if intentional. The plan should explicitly acknowledge or document this format change rather than assuming the format is unchanged.
+
+### E2: Multiline Span Rendering Not Covered in M1/M2 Test List
+
+The plan lists test cases for M1 (primary span, multiline span, related span, spanless internal, help, suggestions, compact ordering, compact recovery) but multiline spans are only tested in `presentation.rs` unit tests—not in CLI integration verification.
+
+The only existing verification fixture (`decimal_invalid_literal`) is single-line. No multiline fixture exists. Adding one for all three modes should be in-scope before M2 is complete.
+
+### E3: JSON Help Count Not Mentioned in Mode Contracts
+
+In `DiagnosticFormat::Compact` mode, the CLI produces `summary:1 error(s), 0 warning(s), 0 note(s), 0 help item(s)` including a separate help count. The plan's compact target does not mention help counts at all, so it's unclear whether compact should omit help counts or align with the current behavior.
+
+The `sifr_diagnostics::render_compact_envelope` omits help count and help items by default. This is a potential behavioral gap if implementing compact does not address the current help-item reporting.
+
+### E4: `DiagnosticFormat` Exit Code Handling Is Not Tested
+
+The plan validates LSP/editor regression (scope item8) but no test covers what `DiagnosticFormat` value the CLI sends to `render_diagnostics` for each invocation path (`run`, `build`, `check`). Current tests (`diagnostics_and_packages_tests.rs`) exercise `DiagnosticFormat::Human` but not `Compact` or `Json` for all commands.
+
+### E5: `<WORKSPACE>` Token Handling Is Not Documented
+
+The JSON baseline uses `<WORKSPACE>/crates/...` for the file path, while the current CLI compact output also uses the same token (`at<WORKSPACE>/crates/...`). This substitution is not documented in the plan.
+
+The plan correctly states that generated docs URLs and diagnostic code identities must remain unchanged, but `<WORKSPACE>` substitution affects path comparison and snapshot portability. The plan should document this as an implementation constraint.
+
+---
+
+## Concise Rationale
+
+**SATISFIED** because the plan correctly diagnoses the gap (human mode drops span data; compact is verbose; JSON is canonical), establishes appropriate in/out of scope boundaries, and provides measurable acceptance criteria. The two blocking issues are not architectural dead-ends—they are resolvable by deciding the delegation boundary in M1 and adding highlight rendering to `presentation.rs` before M2. The precision edits are refinements that do not block implementation but should be addressed during M1/M4.

--- a/reviews/diagnostic-presentation-phase-review-pass-2.md
+++ b/reviews/diagnostic-presentation-phase-review-pass-2.md
@@ -1,0 +1,35 @@
+
+
+Based on my review of the updated plan and codebase:
+
+**SATISFIED**
+
+## Blockers Resolved
+
+1. **CLI-vs-`sifr_diagnostics` delegation ownership** — The plan now explicitly establishes ownership:
+   - `sifr_diagnostics` owns presentation after diagnostics are reduced to `RenderedDiagnostic` values
+   - CLI owns recovery limiting, format selection, stdout/stderr, and exit status only
+   - Plan prohibits a second span-dropping renderer for user-facing diagnostics
+   - Code in `presentation.rs` confirms the delegation path (`render_sink_human`/`render_sink_compact`/`render_sink_json`)
+
+2. **Missing highlight-rendering infrastructure** — Plan now properly identifies the gap:
+   - Required behavior lists "Render visual highlight markers from `DiagnosticSpanLine.highlight_start` and `DiagnosticSpanLine.highlight_end`"
+   - M2 explicitly tasks "Add a highlight renderer for `DiagnosticSpanLine.highlight_start` and `DiagnosticSpanLine.highlight_end`"
+   - W-6 locks the work item for single-line, multiline, and CRLF source snippets
+   - Target shape shows the expected caret-style marker output   - Plan is accurate about current `presentation.rs` not printing highlights — this is correctly scoped as M2 implementation work
+
+## Precision Issues (Non-Blocking)
+
+1. **M1 vs M2 boundary** — The W-1/Locked Decision row says human output improvement closes W-1, but the actual closeout column attributes it to M2. M1 should only lock contracts; M2 does the implementation. Minor—M1/M2 are ordered correctly in the milestone sequence.
+
+2. **M3 compact format is type-changing** — The plan correctly shows the old grouped format vs. new one-line format and M3 owns the redesign, but `presentation.rs` currently implements the old grouped format. This is correct—the plan accurately reflects that M3 changes this behavior.
+
+3. **JSON schema stability** — The JSON mode spec says "preserve the existing `RenderedDiagnostic` schema unless schema migration is explicitly reviewed." This is the right posture, but there's no explicit schema-lock test in M1. Consider adding a M1 task to enumerate the exact fields that must not change.
+
+## Rationale
+
+The plan is implementation-ready. Both pass-1 blockers are addressed with clear contracts:
+
+- **Delegation ownership** is explicit in the Product Decision section and backed by the `sifr_diagnostics` presentation API- **Highlight rendering** is spec'd where the gap exists and correctly attributed to M2 implementation work
+
+The plan correctly describes the current code state, locks all three mode contracts, identifies all required work items, covers testing scope comprehensively, and provides unambiguous acceptance criteria. The non-blocking items above are refinements, not obstacles.

--- a/reviews/diagnostic-presentation-verification-contract-review-pass-1.md
+++ b/reviews/diagnostic-presentation-verification-contract-review-pass-1.md
@@ -1,0 +1,55 @@
+
+
+## Verification Contract Review
+
+**SATISFIED** (with required precision edits)
+
+---
+
+### Blockers: None
+
+The user correctly addressed the earlier gap: the phase now makes verification a first-class deliverable with a named mechanical gate. The verification contract is coherent and appropriate.
+
+---
+
+### Required Precision Edits
+
+**1. Phase plan, Verification Contract section — mention existing baseline and its mode coverage**
+
+The verification gate lists all required coverage elements, but the phase plan only references `decimal_invalid_literal` once (in Current Behavior). The plan does not enumerate that this existing fixture covers single-line span diagnostics in all three modes. This matters because implementers need to know what's already there vs. what M1 must create.
+
+Add to the Verification Contract section or the M1 list:
+
+> The existing `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal` fixture provides locked single-line span baselines for `human`, `compact`, and `json`. M1 must create a new multiline span fixture and a JSON schema-lock fixture on top of this foundation.
+
+**2. Execution tracker, Validation Log — add a forward reference for the tool's future existence**
+
+The M1 validation entry says:
+> M1 validation must include `python3 verification/tooling/check_diagnostic_presentation_contract.py`, ...
+
+This is correct but doesn't record that the tool does not yet exist and is part of M1's deliverable. Add to the Validation Log:
+
+> The `check_diagnostic_presentation_contract.py` tool does not exist yet. It is a M1 deliverable, not a pre-existing guardrail. M1 must author the tool, prove it fails in its initial state, and then wire it into the quick lane.
+
+---
+
+### Rationale
+
+The verification contract is well-structured:
+
+1. **Concrete enough**: Names the exact tool, command-line interface, and `--self-test` mode. Establishes negative self-tests as required.
+
+2. **Enforceable**: Lists concrete checks: fixture existence, baseline per-mode coverage, JSON schema field enumeration, CLI regression coverage, and docs linkage. None of these are ambiguous.
+
+3. **Appropriately wired**: Requires wiring into `scripts/run_all_tests.sh --profile quick` in M1. The quick lane already runs all tooling checks; adding the new tool there is a single-line addition.
+
+4. **Covers important contracts**:
+   - **human**: file/line/column, snippet, highlight marker, docs URL, spanless fallback, related spans, child notes/help, suggestions, CRLF safety
+   - **compact**: severity-only summary, one line per retained diagnostic, stable first fields, no snippets/URLs by default, no old `CompactKey` grouping
+   - **json**: exact field enumeration: `code`, `severity`, `message`, `message_template`, `args`, `url`, `spans`, `children`, `help`, `suggestions`
+   - **CLI**: regression coverage for `check`, `build`, `run`, `emit` format selection
+   - **negative self-tests**: proves the checker fails when requirements are missing
+
+5. **Integration**: Execution tracker W-13 maps correctly to the gate. Review log records the user's verification request and the response. The gate remains active through phase closure per the plan.
+
+The two precision edits above are not blockers—they are documentation hygiene so future readers understand that the tool and multiline fixture are *part of* M1 deliverables, not pre-existing scaffolding.

--- a/reviews/diagnostic-presentation-verification-contract-review-pass-2.md
+++ b/reviews/diagnostic-presentation-verification-contract-review-pass-2.md
@@ -1,0 +1,38 @@
+
+
+## Verification Contract Review — Pass 2
+
+**SATISFIED**
+
+---
+
+### Blockers: None
+
+---
+
+### Required Precision Edits: None
+
+Both pass-1 required precision edits have been applied and verified:
+
+**Precision edit 1 — existing fixture coverage now stated in two places:**
+
+- Line 201: "Treat `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal` as the existing locked single-line span fixture for `human`, `compact`, and `json`."
+- Line 250: "The existing `crates/sifr/tests/verification/diagnostics/decimal_invalid_literal` fixture continues to provide locked single-line span baselines for `human`, `compact`, and `json`."
+
+**Precision edit 2 — tool's future existence documented in execution tracker:**
+
+- Line 64: "`check_diagnostic_presentation_contract.py` does not exist yet. It is an M1 deliverable, not a pre-existing guardrail; M1 must author the tool, prove it fails against missing obligations in negative self-tests, and then wire it into the quick lane."
+
+---
+
+### Rationale
+
+The verification contract is fully specified and both precision-edit clarifications are in place:
+
+1. **Implementation readiness is sound**: The phase correctly distinguishes between existing infrastructure (the `decimal_invalid_literal` fixture with its three-mode baselines) and M1 deliverables (the new multiline fixture, JSON schema-lock fixture, and the `check_diagnostic_presentation_contract.py` tool itself). An implementer reading the Verification Contract section can immediately tell what exists vs. what must be created.
+
+2. **Verification gate is concrete**: The exact commands, required checks, and negative self-test expectation are enumerated without ambiguity. The gate covers all important contracts: fixture existence, per-mode baseline coverage, JSON field enumeration, human/compact contract specifics, CLI regression coverage, and phase-docs linkage.
+
+3. **No remaining gaps**: The verification contract, implementation checklist, review log, and validation log are internally consistent. All required W-IDs map to specific milestones and deliverables. No required fixture, baseline, tool, or wiring entry is missing from the documentation.
+
+4. **Ready for M1 kickoff**: Implementation can begin with confidence that the verification gate will fail until M1 obligations are met, then pass once all deliverables are in place and wired correctly.


### PR DESCRIPTION
## Summary

- Adds an ad hoc phase contract for production-grade diagnostic presentation across `human`, `compact`, and `json` modes.
- Adds an execution tracker that records locked mode decisions, implementation work items, validation expectations, planning review status, implementation-readiness approval, and the phase-owned verification gate.
- Includes Claude Opus planning, readiness, and verification review artifacts. Planning pass 1 found two blockers, planning pass 2 returned `SATISFIED`, readiness pass 1 requested precision edits, readiness pass 2 returned `SATISFIED`, verification-contract pass 1 returned `SATISFIED` with precision edits, and verification-contract pass 2 returned `SATISFIED` with no blockers or required edits.

## Why

The current compiler already carries source span data, but default human diagnostics drop file, line, column, and snippet context. This phase locks the product, implementation, and mechanical verification contract before code changes begin.

## Validation

- `git diff --cached --check` passed before each commit.
- Whitespace checks passed for the issue and review artifacts.
- No full test suite was run because this PR only adds planning and review documents.
