### PR TITLE
[codex] Normalize diagnostic display paths

### DIFF
--- a/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-compact.stderr.txt
@@ -1,2 +1,2 @@
 1 error, 0 warnings, 0 notes
-E SIFR-DECIMAL-0001 <WORKSPACE>/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30 Decimal() received invalid exact literal '12.34.56'
+E SIFR-DECIMAL-0001 crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30 Decimal() received invalid exact literal '12.34.56'

--- a/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/baselines/check-human.stderr.txt
@@ -1,5 +1,5 @@
 error[SIFR-DECIMAL-0001]: Decimal() received invalid exact literal '12.34.56'
-  --> <WORKSPACE>/crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30
+  --> crates/sifr/tests/verification/diagnostics/decimal_invalid_literal/main.sifr:3:30
      |
    3 |     value: decimal = Decimal("12.34.56")
      |                              ^^^^^^^^^^

--- a/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/baselines/check-compact.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/baselines/check-compact.stderr.txt
@@ -1,2 +1,2 @@
 1 error, 0 warnings, 0 notes
-E SIFR-FLOW-0007 <WORKSPACE>/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/main.sifr:3:5 invalid assignment target: attribute assignment target must be a simple name
+E SIFR-FLOW-0007 crates/sifr/tests/verification/diagnostics/multiline_span_rendering/main.sifr:3:5 invalid assignment target: attribute assignment target must be a simple name

--- a/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/baselines/check-human.stderr.txt
+++ b/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/baselines/check-human.stderr.txt
@@ -1,5 +1,5 @@
 error[SIFR-FLOW-0007]: invalid assignment target: attribute assignment target must be a simple name
-  --> <WORKSPACE>/crates/sifr/tests/verification/diagnostics/multiline_span_rendering/main.sifr:3:5
+  --> crates/sifr/tests/verification/diagnostics/multiline_span_rendering/main.sifr:3:5
      |
    3 |     (
      |     ^

--- a/crates/sifr_diagnostics/src/render/presentation.rs
+++ b/crates/sifr_diagnostics/src/render/presentation.rs
@@ -3,6 +3,7 @@ use crate::model::Severity;
 use crate::source_map::{SourceMap, SourceMapError};
 use crate::DiagnosticSink;
 use std::fmt::Write as _;
+use std::path::Path;
 
 #[derive(Debug)]
 pub enum PresentationRenderError {
@@ -240,13 +241,34 @@ impl SpanRole {
 
 fn location_label(span: &DiagnosticSpan) -> String {
     match (&span.file, span.line, span.column) {
-        (Some(file), Some(line), Some(column)) => format!("{file}:{line}:{column}"),
-        (Some(file), Some(line), None) => format!("{file}:{line}"),
-        (Some(file), None, _) => file.clone(),
+        (Some(file), Some(line), Some(column)) => {
+            format!("{}:{line}:{column}", display_file_path(file))
+        }
+        (Some(file), Some(line), None) => format!("{}:{line}", display_file_path(file)),
+        (Some(file), None, _) => display_file_path(file),
         (None, Some(line), Some(column)) => format!("<unknown>:{line}:{column}"),
         (None, Some(line), None) => format!("<unknown>:{line}"),
         (None, None, Some(column)) => format!("<unknown>:0:{column}"),
         (None, None, None) => "<unknown>".to_string(),
+    }
+}
+
+fn display_file_path(file: &str) -> String {
+    let path = Path::new(file);
+    if !path.is_absolute() {
+        return file.to_string();
+    }
+
+    let Ok(current_dir) = std::env::current_dir() else {
+        return file.to_string();
+    };
+    let Ok(relative) = path.strip_prefix(current_dir) else {
+        return file.to_string();
+    };
+    if relative.as_os_str().is_empty() {
+        file.to_string()
+    } else {
+        relative.display().to_string()
     }
 }
 

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -1,6 +1,6 @@
 # Ad Hoc Phase Execution: Production-Grade Diagnostic Presentation
 
-Status: planned on 2026-05-27
+Status: completed on 2026-05-27
 
 Phase contract: `issues/ad-hoc-production-grade-diagnostic-presentation.md`
 
@@ -14,8 +14,8 @@ Phase contract: `issues/ad-hoc-production-grade-diagnostic-presentation.md`
 - [x] M3 compact stable output completed
 - [x] Diagnostic presentation verification gate completed
 - [x] M4 docs and closeout completed
-- [ ] Full local validation recorded
-- [ ] Final production-readiness review approved
+- [x] Full local validation recorded
+- [x] Final production-readiness review approved
 
 ## Planning Lock Addendum
 
@@ -71,8 +71,7 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test` -> passed, including negative checks for missing fixture, missing baseline, missing schema field, and missing run-all wiring.
 - `scripts/run_all_tests.sh --profile quick` -> completed through quick-lane guardrails, diagnostic presentation contract check/self-test, tooling checks, representative validation contracts, and quick e2e pass suite (`67 passed, 0 failed`). The latest validation report was written to `target/validation_lane_reports/quick.latest.json`.
 - Phase-owned fixtures are `decimal_invalid_literal`, `multiline_span_rendering`, and `presentation_contract_cases`; the checker enforces severity-only compact summaries and one-line-per-retained-diagnostic output against those baselines.
-- Phase-owned fixtures are `decimal_invalid_literal`, `multiline_span_rendering`, and `presentation_contract_cases`; the checker enforces severity-only compact summaries and one-line-per-retained-diagnostic output against those baselines.
 
 ## PR Log
 
-- Implementation PR links will be recorded per milestone after they are opened and merged.
+- M1-M4 implementation and closeout merged in PR [#2193](https://github.com/sifr-lang/sifr/pull/2193) (`2c3fd50a807d1bb8664439a22c9e3051efc01491`).

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -78,4 +78,4 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 ## PR Log
 
 - M1-M4 implementation and closeout merged in PR [#2193](https://github.com/sifr-lang/sifr/pull/2193) (`2c3fd50a807d1bb8664439a22c9e3051efc01491`).
-- Post-gate path-display follow-up: pending.
+- Post-gate path-display follow-up opened in PR [#2195](https://github.com/sifr-lang/sifr/pull/2195) (`f2d0814ff0f99d563b345d2a96a961549d38b7cd`).

--- a/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
+++ b/issues/ad-hoc-production-grade-diagnostic-presentation-execution.md
@@ -59,6 +59,7 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `2026-05-27`: Claude verification-contract review pass 2 verified the pass-1 precision edits and returned `SATISFIED` with no blockers, no required precision edits, and no remaining verification or discovery gaps. Review artifact: `reviews/diagnostic-presentation-verification-contract-review-pass-2.md`.
 - `2026-05-27`: Implementation wave 1 moved CLI diagnostic formatting onto `sifr_diagnostics` presentation helpers after recovery limiting; added source-aware human rendering, stable compact one-line rendering, multiline and synthetic presentation contract fixtures, JSON schema lock evidence, and the phase-owned contract checker with negative self-tests.
 - `2026-05-27`: Claude implementation review pass 4 returned `SATISFIED` with no blockers. It verified CLI delegation, human/compact/JSON contracts, fixtures, checker/self-test wiring, docs, and execution tracker evidence. Review artifact: `reviews/diagnostic-presentation-implementation-review-pass-4.md`.
+- `2026-05-27`: Quick-gate validation exposed a post-merge human/compact path-display mismatch between `check` and `run`. The follow-up fix normalizes absolute source paths under the current workspace to relative display paths in human/compact renderers only, preserving JSON transport paths. Claude implementation review pass 5 returned `SATISFIED` with no blockers. Review artifact: `reviews/diagnostic-presentation-implementation-review-pass-5.md`.
 
 ## Validation Log
 
@@ -69,9 +70,12 @@ This phase locks the diagnostic output-mode responsibilities before implementati
 - `python3 scripts/check_diagnostic_baseline_hygiene.py && python3 scripts/check_diagnostic_schema_sync.py && python3 scripts/check_diagnostic_docs_sync.py && python3 scripts/check_diagnostic_code_coverage.py` -> passed.
 - `python3 verification/tooling/check_diagnostic_presentation_contract.py` -> passed.
 - `python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test` -> passed, including negative checks for missing fixture, missing baseline, missing schema field, and missing run-all wiring.
-- `scripts/run_all_tests.sh --profile quick` -> completed through quick-lane guardrails, diagnostic presentation contract check/self-test, tooling checks, representative validation contracts, and quick e2e pass suite (`67 passed, 0 failed`). The latest validation report was written to `target/validation_lane_reports/quick.latest.json`.
+- `CARGO_INCREMENTAL=0 bash scripts/run_validation_contract_matrix.sh` -> passed after updating legacy validation-contract expected text to the new code-bearing human diagnostic header.
+- `CARGO_INCREMENTAL=0 python3 verification/performance/run_benchmarks.py --sample-scale smoke --case formatter-corpus-001-project-check --case formatter-large-file-001-check --case incremental-local-loop-001-unchanged-file-update --case interactive-tooling-foundation-002-warm-diagnostics-query` -> passed after warming the frontend query benchmark helper.
+- `CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile quick` -> passed through quick-lane guardrails, diagnostic presentation contract check/self-test, tooling checks, performance smoke checks, diagnostics/unit tests, representative validation contracts, and quick e2e pass suite (`67 passed, 0 failed`). The run reported a wall-time advisory from cold caches, but exited successfully and wrote `target/validation_lane_reports/quick.latest.json`.
 - Phase-owned fixtures are `decimal_invalid_literal`, `multiline_span_rendering`, and `presentation_contract_cases`; the checker enforces severity-only compact summaries and one-line-per-retained-diagnostic output against those baselines.
 
 ## PR Log
 
 - M1-M4 implementation and closeout merged in PR [#2193](https://github.com/sifr-lang/sifr/pull/2193) (`2c3fd50a807d1bb8664439a22c9e3051efc01491`).
+- Post-gate path-display follow-up: pending.

--- a/reviews/diagnostic-presentation-implementation-review-pass-5.md
+++ b/reviews/diagnostic-presentation-implementation-review-pass-5.md
@@ -1,0 +1,17 @@
+
+
+**SATISFIED** — no blockers found.
+
+**Review summary:**
+
+The post-gate diagnostic presentation fix is focused and correct across all three change categories:
+
+1. **presentation.rs** (`crates/sifr_diagnostics/src/render/presentation.rs:242-273`): Introduces `display_file_path()` which normalizes absolute paths to relative under cwd only in `location_label()` — used exclusively by human/compact modes. JSON path (`render_json_envelope`, line 128-130) bypasses `location_label` entirely via direct `serde_json::to_string_pretty`, so transport unchanged.
+
+2. **Baselines** (4 files): Updated from `<WORKSPACE>/crates/...` to `crates/...` for human/compact modes only. Correct per diagnostic type (multiline_span_rendering, decimal_invalid_literal).
+
+3. **manifest.json** (3 occurrences): Updated expected substrings from legacy `"type error: [module] return type mismatch..."` to new `"error[SIFR-TYPE-0002]: return type mismatch..."` — consistent with the stripped module context in human/compact messages (see `strip_leading_module_context`, line 283-298).
+
+The `display_file_path()` helper is defensive with proper fallbacks:
+- Returns original string for relative paths, unresolvable cwd, or non-prefixable absolute paths
+- Edge case `relative.as_os_str().is_empty()` (path == cwd) returns original unchanged

--- a/verification/validation_contracts/manifest.json
+++ b/verification/validation_contracts/manifest.json
@@ -85,13 +85,13 @@
               "kind": "contains",
               "command_id": "negative_check",
               "stream": "stderr",
-              "text": "type error: [helper] return type mismatch: expected 'int', got 'str'"
+              "text": "error[SIFR-TYPE-0002]: return type mismatch: expected 'int', got 'str'"
             },
             {
               "kind": "contains",
               "command_id": "negative_test",
               "stream": "stderr",
-              "text": "type error: [helper] return type mismatch: expected 'int', got 'str'"
+              "text": "error[SIFR-TYPE-0002]: return type mismatch: expected 'int', got 'str'"
             }
           ]
         }
@@ -390,7 +390,7 @@
               "kind": "contains",
               "command_id": "m24_5_neg_check",
               "stream": "stderr",
-              "text": "type error: [main] return type mismatch: expected 'int', got 'str'"
+              "text": "error[SIFR-TYPE-0002]: return type mismatch: expected 'int', got 'str'"
             }
           ]
         },
@@ -521,7 +521,7 @@
               "kind": "contains",
               "command_id": "m25_5_neg_check",
               "stream": "stderr",
-              "text": "type error: [main] return type mismatch: expected 'int', got 'str'"
+              "text": "error[SIFR-TYPE-0002]: return type mismatch: expected 'int', got 'str'"
             }
           ]
         },


### PR DESCRIPTION
## Summary

- Normalize absolute source paths under the current workspace to relative paths for human and compact diagnostic rendering.
- Preserve JSON diagnostic transport paths unchanged.
- Update diagnostics baselines and validation-contract expected strings to match the production diagnostic presentation.

## Validation

- `cargo fmt --check`
- `cargo test -p sifr_diagnostics --lib presentation -- --nocapture`
- `CARGO_INCREMENTAL=0 bash scripts/run_validation_contract_matrix.sh`
- `python3 verification/tooling/check_diagnostic_presentation_contract.py`
- `python3 verification/tooling/check_diagnostic_presentation_contract.py --self-test`
- `python3 scripts/run_verification_hardening.py --suite diagnostics`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- `CARGO_INCREMENTAL=0 scripts/run_all_tests.sh --profile quick`

Quick completed successfully; it reported a wall-time advisory from cold caches, but exited 0.
