### PR TITLE
Normalize LeetCode slowness subrepo pointer

### DIFF
--- a/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
+++ b/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
@@ -610,6 +610,11 @@ Implemented on 2026-05-30:
 - Updated the HTML report so summary metrics only include `complete` + `equivalent` comparisons, while divergent, unknown, partial, and failed cases remain visible through metadata badges and the coverage inventory.
 - Generated analyzer snapshot below confirms the phase inventory counts.
 
+Merged PRs:
+
+- `sifr-lang/leetcode#7`: benchmark analyzer, metadata seeding, and report filtering.
+- `sifr-lang/sifr#2201`: phase closure docs, review artifacts, validation note, and subrepo pointer update.
+
 Validation run:
 
 - `python3 -m py_compile benchmarks/analyze_slowness.py benchmarks/report_metadata.py benchmarks/report.py benchmarks/specs.py benchmarks/slowness_seed.py`


### PR DESCRIPTION
## Summary
- move audits/leetcode from the PR branch commit to the squash-merged sifr-lang/leetcode main commit for #7
- record merged phase PR links in the slowness analysis issue

## Validation
- git -C audits/leetcode diff --quiet c8676e06d08cbbb4b3d1864b143fe10a9b64481b origin/main
- git diff --check

The subrepo tree is identical to the already reviewed and validated LeetCode implementation; this PR only normalizes the parent pointer to the commit now reachable from leetcode main.