### PR TITLE
Restore LeetCode slowness review artifacts

### DIFF
--- a/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
+++ b/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
@@ -615,6 +615,7 @@ Merged PRs:
 - `sifr-lang/leetcode#7`: benchmark analyzer, metadata seeding, and report filtering.
 - `sifr-lang/sifr#2201`: phase closure docs, review artifacts, validation note, and initial subrepo pointer update.
 - `sifr-lang/sifr#2202`: normalized `audits/leetcode` to the squash-merged `leetcode` main commit.
+- `sifr-lang/sifr#2204`: restored the phase review artifacts referenced by this document.
 
 Validation run:
 

--- a/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
+++ b/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
@@ -610,6 +610,12 @@ Implemented on 2026-05-30:
 - Updated the HTML report so summary metrics only include `complete` + `equivalent` comparisons, while divergent, unknown, partial, and failed cases remain visible through metadata badges and the coverage inventory.
 - Generated analyzer snapshot below confirms the phase inventory counts.
 
+Merged PRs:
+
+- `sifr-lang/leetcode#7`: benchmark analyzer, metadata seeding, and report filtering.
+- `sifr-lang/sifr#2201`: phase closure docs, review artifacts, validation note, and initial subrepo pointer update.
+- `sifr-lang/sifr#2202`: normalized `audits/leetcode` to the squash-merged `leetcode` main commit.
+
 Validation run:
 
 - `python3 -m py_compile benchmarks/analyze_slowness.py benchmarks/report_metadata.py benchmarks/report.py benchmarks/specs.py benchmarks/slowness_seed.py`

--- a/reviews/leetcode-slowness-phase-review-pass-1.md
+++ b/reviews/leetcode-slowness-phase-review-pass-1.md
@@ -1,0 +1,70 @@
+## Review Summary: LeetCode Benchmark Slowness Root-Cause Analysis Phase
+
+### Count Verification: ALL PASSING
+
+| Metric | Claimed | Verified |
+|--------|---------|----------|
+| Registry problems | 325 | 325 ✓ |
+| Fully complete problems | 272 | 272 ✓ |
+| Complete fixture pairs | 814 | 814 ✓ |
+| Measured-slower problems | 75 | 75 ✓ |
+| Partial benchmark problems | 1 | 1 ✓ |
+| No-pair failed problems | 52 | 52 ✓ |
+
+### Metadata Coverage: PASSING
+
+- All 75 measured-slower problems seeded with `benchmark_status`, `parity_status`, `primary_slowness_owner`, `slowness_tags` ✓
+- All 53 incomplete/failed problems seeded (52 no-pair + 1 partial) ✓
+- Metadata validation: 0 diagnostics ✓
+
+### Special Cases: CORRECTLY HANDLED
+
+- `0234_palindrome_linked_list`: marked as `benchmark_status: partial` ✓
+- `0212_word_search_ii`: marked as `failed_correctness`, 0 pairs, NOT in measured-slower table ✓
+
+### Report Semantics: CORRECTLY FILTERS
+
+- `include_in_apples_to_apples_summary()` correctly excludes `known_divergent` ✓
+- Report summary shows 44 problems / 130 comparisons (apples-to-apples only) vs 272 problems / 814 pairs (raw) ✓
+- Known divergent problems (13) are excluded from runtime comparisons ✓
+
+### File Sizes: ALL UNDER 900-LINE LIMIT
+
+| File | Lines |
+|------|-------|
+| `analyze_slowness.py` | 440 |
+| `report.py` | 896 |
+| `slowness_seed.py` | 195 |
+| `report_metadata.py` | 174 |
+| `specs.py` | 101 |
+
+### Commands: ALL PASSING
+
+- `analyze_slowness.py --check-metadata` ✓
+- `py_compile` on all modules ✓
+- `bench.py report-html` ✓
+- HIR maintainability guardrails ✓
+
+### Acceptance Criteria Status
+
+| Criterion | Status |
+|-----------|--------|
+| 1. All Sifr-slower benchmarks listed | ✓ |
+| 2. Partial marked and excluded | ✓ |
+| 3. Primary owner + root cause per problem | ✓ |
+| 4. 0212 tracked as failed, not slower | ✓ |
+| 5. Reproducible analyzer exists | ✓ |
+| 6. Metadata seeded and validated | ✓ |
+| 7. Post-fix re-benchmark protocol documented | ✓ |
+| 8. Claude review (this review) | ✓ |
+| 9. Report avoids treating divergent as language evidence | ✓ |
+| 10. Implementation tracks defined | ✓ |
+
+### No Blocking Issues Found
+
+The implementation correctly:
+- Reproduces all claimed counts
+- Seeds metadata for 75 measured-slower + 53 incomplete/failed
+- Excludes known-divergent from apples-to-apples comparisons
+- Handles partial (`0234`) and failed (`0212`) special cases
+- Produces deterministic, diffable analyzer output

--- a/reviews/leetcode-slowness-phase-review-pass-2.md
+++ b/reviews/leetcode-slowness-phase-review-pass-2.md
@@ -1,0 +1,92 @@
+## Review Summary: LeetCode Benchmark Slowness Root-Cause Analysis Phase — Pass 2
+
+### Count Verification: ALL PASSING
+
+| Metric | Claimed | Verified |
+|--------|---------|----------|
+| Registry problems | 325 | 325 ✓ |
+| Fully complete problems | 272 | 272 ✓ |
+| Complete fixture pairs | 814 | 814 ✓ |
+| Measured-slower problems | 75 | 75 ✓ |
+| Partial benchmark problems | 1 | 1 ✓ |
+| No-pair failed problems | 52 | 52 ✓ |
+
+### Metadata Coverage: PASSING
+
+- All 75 measured-slower problems seeded with `benchmark_status`, `parity_status`, `primary_slowness_owner`, `slowness_tags` ✓
+- All 53 incomplete/failed problems seeded (52 no-pair + 1 partial `0234`) ✓
+- `0234_palindrome_linked_list` correctly appears in `SLOWNESS_SEED` with `benchmark_status: partial` ✓
+- Validation exit code: 0 (zero diagnostics) ✓
+
+### Analyzer Determinism: CONFIRMED
+
+- Running `analyze_slowness.py` twice produces identical output ✓
+- `diff <(python3 benchmarks/analyze_slowness.py) <(python3 benchmarks/analyze_slowness.py)` returns zero differences ✓
+- Output is deterministic across runs, enabling diffable snapshots ✓
+
+### Report Semantics: CORRECTLY IMPLEMENTED
+
+- `include_in_apples_to_apples_summary()` filters to `benchmark_status == "complete"` AND `parity_status == "equivalent"` only ✓
+- `report_stats()` uses `include_in_apples_to_apples_summary()` per-pair, excluding `known_divergent`, `unknown`, and `failed_*` ✓
+- HTML report shows: 44 problems, 130 comparisons (apples-to-apples only) vs 272 / 814 (raw) ✓
+- `stable_pairs: 117/130` reflects filtered stable comparisons only ✓
+- Report hero text explicitly states: "Summary metrics include only complete, equivalent-implementation comparisons" ✓
+
+### Seed Completeness: CORRECT
+
+- `SLOWNESS_SEED`: 75 entries, all measured-slower problems covered ✓
+- `FAILED_SEED`: 53 entries, all incomplete/failed problems covered ✓
+- `validate_metadata()` cross-checks via set difference:
+  - `missing_slower = slower_ids - set(SLOWNESS_SEED)` → 0 missing ✓
+  - `missing_failed = incomplete_ids - set(FAILED_SEED) - set(SLOWNESS_SEED)` → 0 missing ✓
+- `merged_seed()` correctly handles `0234` as partial via observed_status override ✓
+
+### File Sizes: ALL UNDER 900-LINE LIMIT
+
+| File | Lines |
+|------|-------|
+| `analyze_slowness.py` | 440 |
+| `report.py` | 896 |
+| `slowness_seed.py` | 195 |
+| `report_metadata.py` | 174 |
+| `specs.py` | 101 |
+
+### Commands: ALL PASSING
+
+- `analyze_slowness.py --check-metadata` → exit 0, zero diagnostics ✓
+- `py_compile` on all modules → OK ✓
+- `bench.py report-html` → wrote /tmp/sifr-leetcode-report.html ✓
+- HIR maintainability guardrails → PASS ✓
+
+### Phase Issue Snapshot: CONSISTENT
+
+- Analyzer snapshot embedded in `issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md` matches live output ✓
+- All counts, problem lists, and failure excerpts match ✓
+
+### Pass-1 Review Follow-Up
+
+Pass-1 identified no blocking issues. This pass verifies:
+
+1. **Determinism**: Confirmed via diff of two consecutive runs. The analyzer produces stable output.
+2. **`0234` cross-check**: Correctly in `SLOWNESS_SEED` with `benchmark_status: "partial"`. Validation does not flag it as missing because the set difference excludes `SLOWNESS_SEED` entries. The `merged_seed()` function overrides to `partial` based on observed benchmark state.
+3. **Report filter correctness**: `report_stats()` calls `include_in_apples_to_apples_summary()` per-pair, so summary metrics (44 problems, 130 comparisons) reflect only equivalent implementations. Known-divergent entries remain visible in the report with metadata badges but do not inflate the summary.
+4. **Seed cross-reference**: 53 entries in `FAILED_SEED` (52 no-pair + `0234`), correctly excluding `0234` from "missing failed" check since it is already in `SLOWNESS_SEED`.
+
+### Acceptance Criteria Status
+
+| Criterion | Status |
+|-----------|--------|
+| 1. All Sifr-slower benchmarks listed | ✓ |
+| 2. Partial marked and excluded | ✓ |
+| 3. Primary owner + root cause per problem | ✓ |
+| 4. 0212 tracked as failed, not slower | ✓ |
+| 5. Reproducible analyzer exists | ✓ |
+| 6. Metadata seeded and validated | ✓ |
+| 7. Post-fix re-benchmark protocol documented | ✓ |
+| 8. Claude review pass 1 | ✓ (pass-1 satisfied) |
+| 9. Claude review pass 2 | ✓ (this review) |
+| 10. Report avoids treating divergent as language evidence | ✓ |
+
+### Reviewer Satisfied
+
+**No blocking issues remain.** All acceptance criteria are met. The implementation correctly reproduces counts, seeds metadata, excludes divergent implementations from report summaries, handles the `0234` partial case, and produces deterministic analyzer output suitable for diffing across re-benchmarks.


### PR DESCRIPTION
## Summary
- restore the Claude Opus phase review artifacts referenced by the slowness phase document
- add the merged PR ledger entries for sifr-lang/leetcode#7, sifr-lang/sifr#2201, and sifr-lang/sifr#2202

## Validation
- git diff --check
- review artifacts restored from the reviewed phase-closure commit

This keeps the phase document, review evidence, and merged PR ledger consistent after the subrepo pointer normalization cleanup.