### PR TITLE
Update LeetCode benchmark fix phase docs

### DIFF
--- a/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
+++ b/issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
@@ -1,18 +1,20 @@
-# Ad Hoc Phase: LeetCode Benchmark Slowness Root Cause Analysis
+# Ad Hoc Phase: Fix LeetCode Benchmark Slowness Root Causes
 
-Status: implemented and Claude-reviewed on 2026-05-30
-Context: corrective benchmark-analysis phase for `audits/leetcode` after the first broad Python-vs-Sifr benchmark report exposed several Sifr-slower cases.
+Status: planned and Claude-reviewed as implementation-ready on 2026-05-30
+Context: corrective implementation phase for `audits/leetcode` after the completed benchmark analyzer/report phase identified every measured Sifr-slower, partial, and failed LeetCode benchmark case.
 
 ## Purpose
 
-Explain every benchmarked case where Sifr is slower than Python, separate compiler/runtime work from LeetCode Sifr implementation work, and prevent the benchmark report from driving misleading conclusions.
+Fix the actual root causes behind the LeetCode benchmark slowness, not just classify them. This phase turns the prior diagnostic inventory into an implementation plan that restores apples-to-apples benchmark parity, removes generated-code performance pathologies, and prevents the report from presenting known-divergent implementations as language-performance evidence.
 
-This phase is deliberately diagnostic. It does not assume that "native should always be faster." The benchmark only becomes a language-performance signal when:
+The benchmark only becomes a language-performance signal when:
 
 - the Python and Sifr problem implementations use equivalent algorithms and data structures,
 - generated Rust preserves the intended complexity instead of inserting hidden full-container copies,
 - benchmark harness overhead is symmetric enough to not dominate the result,
 - failed correctness cases are not treated as performance data.
+
+This phase is successful only when the known root-cause families below have either been fixed or explicitly reclassified with fresh emitted-code evidence and benchmark results.
 
 ## Source Inputs
 
@@ -45,7 +47,16 @@ This phase uses the 75 measured-slower problem definition for the slowness table
 
 ## Executive Summary
 
-There are two distinct classes of slowness.
+There are two distinct classes of slowness, and they must be fixed in this order:
+
+1. **Restore benchmark parity first.**
+   If the Python and Sifr solutions use different algorithms or data structures, port the Sifr LeetCode solution to the Python algorithm before treating the result as a compiler-performance problem.
+
+2. **Fix compiler/runtime lowering where parity already exists.**
+   Equivalent Sifr solutions should not emit repeated string scans, full container clones, cloned optional trees/lists, or row-copying matrix updates in hot loops.
+
+3. **Re-run and reclassify after each fix.**
+   A problem only leaves this phase when correctness passes, runtime and memory are refreshed from raw benchmark output, and the registry metadata is updated from the analyzer.
 
 ### Fix in the Sifr compiler/runtime
 
@@ -85,6 +96,127 @@ Primary LeetCode-code causes:
 
 4. **Sifr workaround code is more defensive than the Python source.**
    Many Sifr solutions include `None` guards, wrapper helpers, copied rows, or fallback default values because current language/library support makes direct Python-style code hard. Some of that is necessary today, but it means the benchmark is not comparing equivalent code.
+
+## Implementation Decisions
+
+These decisions are locked for this phase so implementation work can proceed without re-litigating benchmark semantics.
+
+### D1: Apples-To-Apples Means Same Algorithm And Comparable Data Structure
+
+For benchmark purposes, "same problem" is not enough. A Sifr solution is equivalent only when it uses the same algorithmic complexity class and a comparable data structure to the Python implementation selected by the runner.
+
+Implications:
+
+- `heapq` Python solutions must be matched with a Sifr heap/priority-queue implementation, not repeated scans or sorted-vector insertion.
+- Python deque/monotonic-queue solutions must be matched with a Sifr deque/monotonic-queue implementation, not window rescans.
+- Python trie-node solutions must be matched by equivalent Sifr trie-node algorithms for the audited problems, even if a shared Sifr helper also exists.
+- Stateful design problems must compare against the final Python class definition that the runner imports, not an earlier alternate class in the file.
+
+### D2: Fix LeetCode Sifr Code Before Compiler Attribution For Known-Divergent Rows
+
+Rows marked `leetcode_sifr_code` or known-divergent `mixed` are not compiler regressions yet. Their first implementation ticket is a Sifr-code parity repair. Only after the Sifr code uses the equivalent algorithm should remaining slowness be attributed to compiler/runtime lowering.
+
+Primary parity repairs:
+
+- Heap/priority queue: `1985`, `0973`, `0703`, `1046`, `1834`, `0295`, `1631`, `0778`.
+- Trie/correctness: `0208`, `0211`, `0212`.
+- Direct algorithm divergence: `0015`, `0239`, `0496`, `2306`.
+- Stateful parity review before compiler-only work: `0146`, `0355`, `0380`, `1396`, `1472`.
+
+### D3: Add Reusable Audit Helpers Only When They Preserve Parity
+
+Reusable helpers are allowed, but they must not change the benchmarked algorithm.
+
+Decisions:
+
+- Use the existing `lib/sifr/heapq.sifr` API for heap parity unless a specific problem proves a missing operation:
+  - `heapify(heap)`,
+  - `heappush(heap, item)`,
+  - `heappop(heap) -> T | None`,
+  - `heappushpop(heap, item) -> T | None`,
+  - `heapreplace(heap, item) -> T | None`,
+  - `nsmallest(n, items)`,
+  - `nlargest(n, items)`.
+- Use the existing `sifr.collections.deque` API for monotonic queue parity:
+  - `append`,
+  - `appendleft`,
+  - `pop`,
+  - `popleft`,
+  - `len`,
+  - `clear`.
+- Do not use the current shared `helpers.trie.Trie` as the parity implementation for `0208`, `0211`, or `0212` unless the Python benchmark side is changed to the same representation. The default fix is direct Sifr ports that mirror the Python trie algorithms.
+- Helper APIs must have focused fixture tests before broad benchmark use, because a helper bug can contaminate many problem results.
+
+Trie port structure decision:
+
+- `0208`, `0211`, and `0212` should each carry the trie structure needed by the Python source in the Sifr problem file or a problem-local helper under `audits/leetcode/benchmarks/cases/<category>` only if multiple fixtures need it.
+- Do not introduce a new shared benchmark trie helper during M1. Shared trie optimization belongs to M2 after parity is restored.
+- If a shared helper is later used, both Python and Sifr benchmark sides must intentionally use comparable helper semantics.
+
+### D4: Compiler Fixes Must Preserve Safety Semantics
+
+Compiler/runtime work must remove accidental work without weakening Sifr's safety guarantees.
+
+Decisions:
+
+- String indexing fixes use cached `Vec<char>` or equivalent code-point storage for immutable/index-heavy strings. They must not silently switch Python/Sifr character indexing to byte indexing.
+- Repeated `len(s)` in a loop is cached only when the string is loop-invariant.
+- Container membership, length, and index reads lower through borrowed access whenever the source expression is a read, not a move.
+- Mutable list/matrix cell updates lower as place mutations instead of clone-modify-reassign when the ownership model proves the container is uniquely mutable.
+- Optional tree/list traversal uses borrowed child accessors where possible; cloning boxed nodes/subtrees in traversal is a bug unless ownership requires it.
+- No fix may introduce user-triggerable panics or data-dependent unwraps in generated runtime code.
+
+### D5: Every Fix Needs A Generated-Code Regression Test
+
+Benchmark speedups are necessary but not sufficient. Each compiler/root-cause fix needs a generated-code regression that checks the emitted Rust shape.
+
+Test location and runner:
+
+- Compiler emitted-code assertions live in `crates/sifr_codegen/src/lib_codegen_tests/`, following the existing `generate_rust_from_source` / `generate_rust_with_metadata` pattern.
+- Add focused tests near the affected lowering module, or create a dedicated `leetcode_performance_codegen_tests.rs` module if the fixture spans multiple lowering surfaces.
+- Run the focused test with `cargo test -p sifr_codegen -- <test_name>`.
+- Closure for compiler fixes also runs `scripts/run_all_tests.sh --profile quick`.
+- LeetCode parity fixes use benchmark fixtures plus existing stdlib fixtures where relevant:
+  - `crates/sifr/tests/e2e/pass/cpython_heapq*.sifr` for heap behavior,
+  - `crates/sifr/tests/e2e/pass/*deque*.sifr` for deque behavior,
+  - the affected `audits/leetcode` problem fixtures for benchmark parity.
+
+Required negative assertions:
+
+- String hot-loop fixtures should not contain repeated `chars().nth(...)` or loop-invariant `chars().count()`.
+- Field reads such as `self.map.len()` and `self.map.contains_key(...)` should not emit `self.map.clone()`.
+- Trie/table reads should not clone full `_children`, `_terminal`, maps, or rows for lookup-only paths.
+- Tree/list traversal fixtures should not emit subtree/node clones in simple traversal paths.
+- Matrix cell update fixtures should not clone a whole row for each cell mutation.
+
+Representative emitted-code contracts:
+
+| Track | Before | After |
+| --- | --- | --- |
+| C1 string indexing | `s.chars().nth(i as usize)` inside the loop | one loop-scope cached character storage such as `let __s_chars: Vec<char> = s.chars().collect();` followed by indexed reads from `__s_chars` |
+| C1 string length | `s.chars().count()` repeated in loop conditions | one loop-invariant cached length derived from the same cached character storage |
+| C2 field reads | `(self.map.clone()).contains_key(...)` / `(self.map.clone()).len()` | `self.map.contains_key(...)` / `self.map.len()` borrowed reads |
+| C2 container index reads | `self.rows.clone()[i as usize].clone()` for lookup-only paths | borrowed row/item access where the result is not moved |
+| C3 optional tree/list traversal | `root.as_deref().cloned()` in traversal/comparison paths | borrowed `root.as_deref()` access with cloning only at ownership boundaries |
+| C4 matrix mutation | clone row, mutate clone, assign whole row back per cell | direct mutable place update such as `grid[r as usize][c as usize] = value` when the matrix is uniquely mutable |
+
+### D6: Benchmark Reclassification Is Data-Driven
+
+Manual intuition does not close a fix.
+
+Decisions:
+
+- Re-run the affected subset after each fix, then the full category if the subset passes.
+- Run the analyzer after every benchmark run and update metadata from the analyzer output.
+- A runtime fix with a Peak RSS regression greater than 10% at the same fixture size remains open with a memory-specific tag unless the PR documents why the memory tradeoff is intentional and bounded.
+- A fixed failed problem that becomes benchmarkable may enter the slower inventory and must be handled by this phase.
+
+Benchmark commands:
+
+- Subset: `python3 benchmarks/bench.py run --runs 2 --warmup 1 --memory-runs 1 <problem_id> ...`
+- Report: `python3 benchmarks/bench.py report-html`
+- Analyzer: `python3 benchmarks/analyze_slowness.py --check-metadata`
+- Full closure benchmark uses the same command shape without explicit problem ids.
 
 ## Classification Rule
 
@@ -375,9 +507,7 @@ Current issue:
 
 Required direction:
 
-- Decide whether benchmark parity means:
-  - port the Python trie node algorithms directly to Sifr, or
-  - port the Sifr shared helper algorithm to Python and benchmark that too.
+- Port the Python trie node algorithms directly to Sifr for `0208`, `0211`, and `0212` unless the benchmark intentionally changes both languages to the same shared-helper representation.
 - Fix `0212` uniqueness semantics.
 - After parity is restored, address compiler clone-elision in `helpers.trie`.
 
@@ -396,6 +526,7 @@ Required direction:
   - `same_algorithm: true`
   - `known_divergence: heap_missing`, `trie_helper`, `stateful_helper`, etc.
 - Report UI should distinguish "Sifr slower on equivalent implementation" from "Sifr slower on known-divergent implementation."
+- Code parity changes must land before compiler attribution changes for the same problem unless emitted Rust already proves a compiler-only issue.
 
 ## Benchmark/Report Contract Updates
 
@@ -416,7 +547,7 @@ python3 benchmarks/bench.py report-html
 python3 benchmarks/analyze_slowness.py --output issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
 ```
 
-The second command does not exist yet. It is an implementation prerequisite, not a current capability. M0 below must add it before this phase is used to drive implementation tickets.
+The analyzer was added by the predecessor reporting phase and is now the authoritative way to refresh this phase's generated snapshot. If analyzer output and hand-written phase text disagree, treat the analyzer output as the benchmark-data source and update the hand-written implementation plan accordingly.
 
 Concrete metadata path:
 
@@ -457,7 +588,7 @@ Reclassification thresholds:
 - `python.mean / sifr.mean < 0.8`: still materially slower; keep the current owner or reclassify based on the new emitted code and parity review.
 - Any correctness/build failure after a fix overrides runtime data and sets `benchmark_status` to the corresponding failed state.
 
-Memory must be rechecked with the same status discipline. A runtime win with a large Peak RSS regression is not considered fully fixed; it remains a benchmark concern with a memory-specific tag.
+Memory must be rechecked with the same status discipline. A runtime win with a Peak RSS regression greater than 10% at the same fixture size is not considered fully fixed unless the PR explicitly documents an intentional and bounded memory tradeoff; otherwise it remains a benchmark concern with a memory-specific tag.
 
 ## Failed-To-Benchmarkable Conversion
 
@@ -532,77 +663,96 @@ These problems are not part of the 75 measured-slower table unless they have at 
 
 ## Milestones
 
-Dependency order: **M0 -> M1 -> M2/M3 -> M4**. M2 and M3 can proceed in parallel after M1, but M4 depends on seeded metadata from M0/M1.
+Dependency order: **M0 -> M1 -> M2/M3 -> M4 -> M5**. M2 and M3 can proceed in parallel only for disjoint problem families. Any problem marked `known_divergent` must go through M1 before compiler performance work is credited as a fix.
 
-### M0: Reproducible Analyzer And Metadata Bootstrap
+Track ownership matrix:
 
-- Add `audits/leetcode/benchmarks/analyze_slowness.py`.
-- Read raw hyperfine and memory output from `audits/leetcode/benchmarks/results/.raw`.
-- Emit:
-  - complete problem count,
-  - measured-slower problem inventory,
-  - partial benchmark inventory,
-  - no-pair/failed inventory,
-  - worst Python/Sifr ratio per problem,
-  - slower fixture sizes,
-  - failure excerpts.
-- Seed registry metadata for all 75 measured-slower problems and all 53 incomplete/failed problems:
-  - `benchmark_status`,
-  - `parity_status`,
-  - `primary_slowness_owner`,
-  - `slowness_tags`.
-- Make analyzer output deterministic so future benchmark runs can diff slowness classification changes.
+| Track | Primary scope | Must wait for |
+| --- | --- | --- |
+| M1 heap/deque/trie/direct parity | `1985`, `0973`, `0703`, `1046`, `1834`, `0295`, `1631`, `0778`, `0208`, `0211`, `0212`, `0015`, `0239`, `0496`, `2306`, `0146`, `0355`, `0380`, `1396`, `1472` | baseline metadata only |
+| M2 string/container/stateful codegen | C1/C2 families after any known-divergent row is ported | M1 for overlapping known-divergent or mixed rows |
+| M3 recursive/matrix codegen | C3/C4 tree/list/grid families | M1 only for overlapping mixed rows |
+| M4 report/analyzer gates | all benchmark metadata and report summaries | M1/M2/M3 metadata updates |
+| M5 closure | full suite and residual tickets | M1-M4 |
 
-### M1: Slowness Taxonomy Lock
+### M0: Baseline Lock And Ticket Slicing
 
-- Review analyzer output against this phase and lock the initial metadata.
-- Split classifications into compiler/runtime, LeetCode Sifr code, mixed, and low-priority/noise.
-- Record failed-but-relevant cases such as `0212_word_search_ii`.
-- Gate report language so it cannot imply apples-to-apples parity for known-divergent solutions.
+- Confirm the generated analyzer snapshot still matches the raw benchmark results before implementation starts.
+- Cut implementation tickets from the decisions in this phase:
+  - LeetCode Sifr parity repairs,
+  - compiler string lowering,
+  - compiler container/field clone elision,
+  - tree/list optional traversal borrowing,
+  - matrix/list cell mutation lowering,
+  - report/analyzer reclassification gates.
+- Each ticket must name the affected problem set, expected emitted-code change, benchmark subset, and acceptance gate.
+- Do not start broad compiler work from a known-divergent benchmark row until the parity ticket for that row is complete.
 
-### M2: LeetCode Sifr Parity Repairs
+### M1: LeetCode Sifr Parity Repairs
 
-- Fix heap/priority-queue problem ports or add a reusable heap helper.
-- Fix trie parity and `0212` duplicate output semantics.
-- Fix known hand-port divergences: `2306`, `1472`, `0239`, and stateful data structures.
-- Re-run benchmark subset after each parity repair.
+- Add Sifr heap/priority-queue support or use an existing equivalent helper.
+- Port heap/priority-queue problems to match Python algorithms: `1985`, `0973`, `0703`, `1046`, `1834`, `0295`, `1631`, `0778`.
+- Port trie problems to parity with Python problem-local trie algorithms: `0208`, `0211`, `0212`.
+- Fix `0212_word_search_ii` duplicate-result semantics.
+- Fix direct hand-port divergences: `0015`, `0239`, `0496`, `2306`.
+- Review and repair stateful problem parity before compiler attribution: `0146`, `0355`, `0380`, `1396`, `1472`.
+- Re-run each repaired subset and update registry metadata from the analyzer.
 
-### M3: Compiler Codegen Performance Repairs
+### M2: High-Impact Compiler Codegen Repairs
 
-- String index/iteration lowering.
-- Collection and class-field clone elision.
-- Tree/list optional traversal borrow preservation.
-- Matrix/list cell mutation lowering.
-- Dict/set borrowed access and update lowering.
-- Generated-code regression tests for each repaired class.
+- Fix string index/iteration lowering for equivalent string-heavy problems.
+- Fix collection and class-field clone elision for dictionary, set, list, trie, and object-state reads.
+- Add generated-code regression tests for every fixed lowering pattern.
+- Re-run affected string/container/stateful benchmark subsets and update metadata.
 
-### M4: Benchmark Report Semantics
+### M3: Recursive And Matrix Compiler Repairs
 
-- Depends on M0/M1 metadata being present in the problem registry.
-- Add UI badges or filters for:
+- Fix tree/list optional traversal borrow preservation.
+- Fix moved-value and optional-node failure classes that currently block linked-list/tree benchmarks where feasible in this phase.
+- Fix matrix/list cell mutation lowering.
+- Add generated-code regression tests for traversal and matrix mutation.
+- Re-run affected tree/list/graph/DP benchmark subsets and update metadata.
+
+### M4: Benchmark Report And Analyzer Enforcement
+
+- Ensure report summaries include only `complete` + `equivalent` comparisons by default.
+- Ensure known-divergent, unknown, partial, and failed cases remain visible as coverage/work items.
+- Add or maintain UI badges and filters for:
   - equivalent implementation,
   - known divergent Sifr code,
   - suspected compiler/codegen bottleneck,
-  - failed correctness/build.
-- Keep runtime and memory graphs, but let engineers filter to apples-to-apples results only.
+  - failed correctness/build,
+  - partial benchmark.
+- Make analyzer checks fail when a problem is missing required metadata after it becomes benchmarkable.
 - Add category summaries that ignore known-divergent solutions unless explicitly requested.
+
+### M5: Full Re-Benchmark And Closure
+
+- Run the full LeetCode benchmark suite with the production benchmark command.
+- Regenerate the HTML report and analyzer snapshot.
+- Confirm every formerly known-divergent row is either:
+  - fixed and reclassified,
+  - still divergent with a follow-up ticket,
+  - or moved to failed/partial with a concrete blocker.
+- Confirm compiler-fixed families no longer emit the targeted pathological Rust in regression fixtures.
+- Confirm runtime and memory outcomes are both acceptable; runtime fixes with material Peak RSS regressions stay open.
+- Record final PR links, validation commands, and residual follow-up tickets in this document.
 
 ## Acceptance Criteria
 
-- Every current Sifr-slower complete benchmark is listed in this phase.
-- Partial measured benchmarks, currently `0234_palindrome_linked_list`, are explicitly marked and excluded from apples-to-apples summaries until complete.
-- Every listed problem has a primary owner and root-cause rationale.
-- `0212_word_search_ii` is tracked as a failed Tries case, not a slower benchmark.
-- `benchmarks/analyze_slowness.py` or an equivalent reproducible analyzer exists before implementation work depends on this inventory.
-- Registry metadata is seeded and validated for the 75 measured-slower problems and the 53 incomplete/failed problems.
-- Fixed problems follow the post-fix re-benchmark protocol before being reclassified.
-- Claude review has approved the taxonomy after at least two rounds.
-- The benchmark report no longer encourages treating known-divergent implementations as direct language-performance evidence.
-- Follow-up implementation tickets can be cut directly from the compiler and LeetCode-code tracks.
+- Known-divergent LeetCode Sifr implementations named in M1 are either ported to equivalent algorithms/data structures or explicitly deferred with linked follow-up tickets and report metadata that keeps them out of apples-to-apples summaries.
+- Compiler fixes in M2/M3 include generated-code regression tests that prove the targeted pathological lowering is gone.
+- Each fixed problem follows the post-fix re-benchmark protocol before metadata is reclassified.
+- Runtime and Peak RSS both remain visible in the report; a runtime improvement with a Peak RSS regression greater than 10% at the same fixture size does not close the ticket unless the PR documents an intentional bounded tradeoff.
+- `0212_word_search_ii` passes correctness before any Tries runtime comparison is treated as benchmark evidence.
+- Partial measured benchmarks, currently `0234_palindrome_linked_list`, are excluded from apples-to-apples summaries until every fixture builds, passes correctness, and produces runtime plus memory rows.
+- The analyzer snapshot and report agree on complete, partial, failed, known-divergent, unknown, and equivalent counts.
+- The final phase closure records implementation PRs, validation commands, benchmark command, refreshed analyzer counts, and any residual follow-up tickets.
+- Claude review has approved this fix-oriented phase as implementation-ready after iterative review.
 
-## Phase Closure
+## Predecessor Baseline Work
 
-Implemented on 2026-05-30:
+Completed on 2026-05-30 by the prior benchmark-analysis/report phase:
 
 - Added `audits/leetcode/benchmarks/analyze_slowness.py` for deterministic `.raw` result analysis.
 - Added `audits/leetcode/benchmarks/slowness_seed.py` and seeded registry metadata for the 75 measured-slower problems plus the 53 incomplete/failed entries.
@@ -627,10 +777,15 @@ Validation run:
 - `scripts/run_all_tests.sh --profile quick` (exit 0; wall-time/skew advisories only)
 - touched source files checked under the 900-line guardrail
 
-Claude review rounds:
+Prior Claude review rounds for the predecessor analysis/report phase:
 
 - `reviews/leetcode-slowness-phase-review-pass-1.md`: satisfied, no blocking issues.
 - `reviews/leetcode-slowness-phase-review-pass-2.md`: satisfied, no blocking or important issues remain.
+
+Fix-phase Claude review rounds:
+
+- `reviews/leetcode-slowness-fix-phase-review-pass-1.md`: confirmed the phase was fix-oriented; requested concrete helper APIs, trie structure, emitted-code contracts, regression-test location, parallelism grounding, and memory threshold.
+- `reviews/leetcode-slowness-fix-phase-review-pass-2.md`: confirmed those gaps were resolved and no blocking issues remain.
 
 <!-- analyze_slowness:start -->
 ## Generated Analyzer Snapshot

--- a/issues/ad-hoc-leetcode-incomplete-failed-benchmark-fixes.md
+++ b/issues/ad-hoc-leetcode-incomplete-failed-benchmark-fixes.md
@@ -1,0 +1,469 @@
+# Ad Hoc Phase: LeetCode Incomplete And Failed Benchmark Fixes
+
+Status: planned on 2026-05-30
+Context: follow-up phase for the `Incomplete And Failed Problem Appendix` in `issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md`.
+
+## Purpose
+
+Turn every currently incomplete or failed LeetCode benchmark into a complete, correctness-passing Python/Sifr benchmark case, without hiding failures behind benchmark skips or weakening Sifr's safety model.
+
+This phase is intentionally separate from the slowness phase. A problem that does not build, times out, or fails correctness is not performance evidence yet. The goal here is to make those problems benchmarkable first, then hand newly slower cases back to the slowness-analysis workflow.
+
+## Source Inputs
+
+- Failure appendix: `issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md`
+- Raw run logs: `audits/leetcode/benchmarks/results/.raw/*.run.log`
+- Sifr sources: `audits/leetcode/src/*.sifr`
+- Python oracle sources: `audits/leetcode/src/*.py`
+- Benchmark registry: `audits/leetcode/benchmarks/problems/*.json`
+- Generic benchmark harness: `audits/leetcode/benchmarks/harnesses/generic.py`
+- Helpers: `audits/leetcode/src/helpers/list_node.sifr`, `audits/leetcode/src/helpers/tree_node.sifr`
+- Proposed safe-math helper: `audits/leetcode/src/helpers/safe_math.sifr`
+
+Inventory from the source appendix:
+
+- **53 incomplete/failed entries**
+- **52 no-complete-pair failures**
+- **1 partial benchmark**: `0234_palindrome_linked_list`
+
+The table in this phase is the authoritative working copy for all 53 rows copied from the slowness phase failure appendix. The 52 no-complete-pair failures are all rows except `0234_palindrome_linked_list`, which remains partial because at least one fixture produced complete Python/Sifr timing rows while another fixture failed.
+
+## Executive Summary
+
+The failures split into three implementation tracks.
+
+### Track H: Benchmark Harness / Helper Fixes
+
+Most linked-list and tree failures are benchmark infrastructure problems, not problem-solution failures.
+
+Primary causes:
+
+1. **Owned list/tree results are consumed while validating expected output.**
+   The generated runner calls `listNodeToString(result)` or `treeToString(result)` and then also uses `result` in the wrong-result print path or checksum path. Because the helper signatures consume owned values, the runner triggers `use of moved value`.
+
+2. **Owned tree inputs are built once and reused across validation and benchmark loops.**
+   Runners for tree problems bind `root` once, call an `own root` solution, then call the solution again inside loops with the moved value.
+
+3. **Tree result wrong-result printing uses `str(result)` instead of `treeToString(result)`.**
+   Several generated runners compile the expected check with `treeToString(result)`, but the failure print still emits `str(result)`. Generated Rust then tries to format `TreeNode` with `Display` and fails to compile.
+
+These are generated-runner fixes in `audits/leetcode/benchmarks/harnesses/generic.py`. They should be fixed before touching the compiler or rewriting many LeetCode solutions.
+
+### Track L: LeetCode Sifr Code Fixes
+
+Several Sifr ports are not valid Sifr under current language rules.
+
+Primary causes:
+
+1. **Division and modulo return `Result[int, DivisionError]`.**
+   Many ports use Python-style `/`, `//`, or `%` directly in comparisons, indexing, assignments, or returns. Sifr is correct to require explicit handling when the divisor may be zero or overflow-sensitive.
+
+2. **Nullable APIs are too narrow.**
+   Some LeetCode functions accept `TreeNode` or `ListNode` when the benchmark harness correctly models the input as `TreeNode | None` or `ListNode | None`.
+
+3. **Empty stack/list literals need explicit element types.**
+   Stack problems that start with `stack = []` and later store tuples currently infer `Any | None` on `pop()` or indexing paths.
+
+4. **A few ports have actual correctness or parity issues.**
+   `0212_word_search_ii` returns duplicates for duplicate input words. `0269_alien_dictionary` returns a valid but non-canonical topological order that does not match the Python-generated expected fixture. `0707_design_linked_list` uses recursive singly-linked-list operations while Python uses a sentinel doubly-linked list.
+
+### Track C: Compiler / Runtime Follow-Ups
+
+Compiler work should not be used to bypass safe error handling, but the repeated failure patterns point to useful ergonomics and precision improvements:
+
+- better diagnostics and refinement around non-zero divisors,
+- bidirectional inference for empty list literals populated by tuple appends,
+- clearer ownership diagnostics for generated harness code,
+- borrowed string operations so `len(s)` / `for c in s` patterns do not force unnecessary ownership in ordinary code.
+
+These compiler improvements should come after the immediate harness and Sifr-code unblocking work, except when a compiler bug is proven by a minimal reproduction outside the benchmark harness.
+
+## Fix Tracks
+
+### H1: Owned Result Rendering In Generated Runners
+
+Problems:
+
+- `0206_reverse_linked_list`
+- `0021_merge_two_sorted_lists`
+- `0203_remove_linked_list_elements`
+- `0083_remove_duplicates_from_sorted_list`
+- `0876_middle_of_the_linked_list`
+- `0019_remove_nth_node_from_end_of_list`
+- `1721_swapping_nodes_in_a_linked_list`
+- `0002_add_two_numbers`
+- `0024_swap_nodes_in_pairs`
+- `0148_sort_list`
+- `0086_partition_list`
+- `0061_rotate_list`
+- `0147_insertion_sort_list`
+- `0025_reverse_nodes_in_k_group`
+
+Evidence:
+
+```sifr
+result: ListNode | None = reverseList(_build_list_node(_bench_tokens, 0, len(_bench_tokens)))
+if listNodeToString(result) != expected_text.strip():
+    print("wrong result: " + str(result))
+```
+
+Best fix:
+
+- Change `single_sifr_runner_body` and related generated-runner paths in `audits/leetcode/benchmarks/harnesses/generic.py` so structured outputs are rendered into a local string exactly once before comparison.
+- Use that same local rendered string for wrong-result printing.
+- Keep checksum generation consistent with the same formatter.
+- Do not fix H1 by changing helper signatures or adding clones to `ListNode` / `TreeNode`; those would hide ownership problems and affect solution semantics.
+
+Do not fix this by rewriting all linked-list problem solutions. The failure is at the runner/helper boundary.
+
+### H2: Owned Tree Inputs Reused Across Validation And Loops
+
+Problems:
+
+- `0144_binary_tree_preorder_traversal`
+- `0145_binary_tree_postorder_traversal`
+- `0617_merge_two_binary_trees`
+- `0701_insert_into_a_binary_search_tree`
+- `0450_delete_node_in_a_bst`
+- `0103_binary_tree_zigzag_level_order_traversal`
+- `0662_maximum_width_of_binary_tree`
+- `0513_find_bottom_left_tree_value`
+- `0669_trim_a_binary_search_tree`
+
+Evidence:
+
+```sifr
+root: TreeNode | None = _build_balanced_tree(root_values, 0, len(root_values) - 1)
+result: list[int] = preorderTraversal(root)
+...
+loop_result: list[int] = preorderTraversal(root)
+```
+
+Best fix:
+
+- Teach the Sifr runner generator to rebuild owned `tree_node[int]` inputs for every validation and loop call, matching how list-node inputs are rebuilt from tokens.
+- Alternatively, generate a fresh tree binding expression instead of a reusable `root` variable for owned tree arguments.
+- Keep borrowed/non-mutating tree calls efficient only after the correctness path is fixed.
+
+### H3: Tree Wrong-Result Formatting Uses `str(TreeNode)`
+
+Problems:
+
+- `0226_invert_binary_tree`
+- `0108_convert_sorted_array_to_binary_search_tree`
+- `0106_construct_binary_tree_from_inorder_and_postorder_traversal`
+- `0105_construct_binary_tree_from_preorder_and_inorder_traversal`
+
+Evidence:
+
+```text
+error[E0277]: `TreeNode` doesn't implement `std::fmt::Display`
+println!("{}", format!("{}{}", "wrong result: ", ... format!("{}", __v)))
+```
+
+Best fix:
+
+- Update `sifr_expected_check` / runner generation so `tree_node_int` wrong-result paths use `treeToString(result)` instead of `str(result)`.
+- Apply the same rule for `list_node_int`.
+- Add a generated-runner test that compiles a failing tree result path without requiring `Display` on `TreeNode`.
+
+### L1: Explicit Division / Modulo Result Handling
+
+Problems:
+
+- `0853_car_fleet`
+- `1209_remove_all_adjacent_duplicates_in_string_ii`
+- `0441_arranging_coins`
+- `0875_koko_eating_bananas`
+- `0622_design_circular_queue`
+- `1383_maximum_performance_of_a_team`
+- `0502_ipo`
+- `0698_partition_to_k_equal_sum_subsets`
+- `0909_snakes_and_ladders`
+- `0743_network_delay_time`
+- `0062_unique_paths`
+- `1220_count_vowels_permutation`
+- `0846_hand_of_straights`
+- `0263_ugly_number`
+- `1260_shift_2d_grid`
+- `0007_reverse_integer`
+
+Representative failures:
+
+```text
+cannot compare 'Result[int, DivisionError]' and 'int' with !=
+unsupported operand type(s) for +: 'int' and 'Result[int, DivisionError]'
+return type mismatch: expected 'int', got 'Result[int, DivisionError]'
+exact integer to float conversion requires handling possible overflow or precision loss
+```
+
+Best fix:
+
+- Add a small LeetCode-audit helper surface for safe integer math in `audits/leetcode/src/helpers/safe_math.sifr`. This helper is for audit solutions only; it is not a compiler prelude and should not change language semantics.
+- Initial helper API:
+  - `def div_or_zero(a: int, b: int) -> int`
+  - `def mod_or_zero(a: int, b: int) -> int`
+  - `def ceil_div_positive_or_zero(a: int, b: int) -> int`
+  - `def trunc_div_toward_zero_or_zero(a: int, b: int) -> int`
+  - `def ratio_or_zero(a: int, b: int) -> float`
+- Helper behavior:
+  - if `b == 0`, return `0` as a safe fallback;
+  - otherwise use Sifr `try` / `except DivisionError` locally and return `0` on the impossible error path;
+  - callers must still guard invalid problem inputs when LeetCode semantics require another result such as `False`, `-1`, or early return.
+- Update each Sifr solution to call these helpers only after documenting or guarding the divisor constraints.
+- Preserve the compiler guarantee: do not add a compiler fallback that silently unwraps division or modulo.
+- Add comments only where the divisor safety comes from LeetCode constraints and is not obvious locally.
+
+Compiler follow-up:
+
+- Improve non-zero divisor refinement for constants, loop counters with positive ranges, and branches like `if k <= 0: return ...`.
+- Improve diagnostics to point at the divisor proof obligation and suggested local handling pattern.
+
+### L2: Nullable Function Signatures
+
+Problems:
+
+- `0234_palindrome_linked_list`
+- `0141_linked_list_cycle`
+- `1448_count_good_nodes_in_binary_tree`
+- `0230_kth_smallest_element_in_a_bst`
+
+Representative failures:
+
+```text
+argument 1 ('head') of function 'hasCycle': expected 'ListNode', got 'None | ListNode'
+argument 1 ('root') of function 'goodNodes': expected 'TreeNode', got 'None | TreeNode'
+```
+
+Best fix:
+
+- Match LeetCode API shapes in Sifr: public linked-list/tree entrypoints should accept `ListNode | None` or `TreeNode | None` unless the registry marks the input as non-nullable.
+- For problems where the fixture generator guarantees non-empty input, encode that in the registry with `nullable: false` and keep the function signature non-null only if the LeetCode API also allows that assumption.
+- For `0234_palindrome_linked_list`, prefer changing `isPalindrome(own head: ListNode)` to accept `ListNode | None`; empty input should return `True` or follow the generated oracle.
+
+### L3: Typed Stack / Tuple Collections
+
+Problems:
+
+- `0739_daily_temperatures`
+- `0084_largest_rectangle_in_histogram`
+
+Representative failures:
+
+```text
+cannot index type 'Any | None' with 'int'
+'>' not supported between instances of 'int' and 'Any'
+```
+
+Best fix:
+
+- Add explicit stack element types in the Sifr ports, e.g. `stack: list[tuple[int, int]] = []`.
+- Handle `pop()` as optional if Sifr returns `tuple[int, int] | None`, even when guarded by `while stack`.
+
+Compiler follow-up:
+
+- Improve empty-list inference from later `append((...))`.
+- Narrow `pop()` return type under a preceding non-empty guard when the guard and pop are in the same control-flow region.
+
+### L4: Correctness And Fixture Semantics
+
+Problems:
+
+- `0212_word_search_ii`
+- `0269_alien_dictionary`
+
+Best fixes:
+
+- `0212_word_search_ii`: return unique found words. The current Sifr code records `found[word] = True`, then appends once per input word, so duplicate words in the fixture produce duplicate output. Iterate over `found` keys or track an emitted set.
+- `0269_alien_dictionary`: this is primarily a benchmark expected-shape problem. The current fixture expects the Python DFS order `cba` for repeated `abc`, while Sifr's Kahn-style implementation returns `abc`, which is also valid when there are no ordering edges. Preferred fix: add a problem-specific expected shape that validates topological-order correctness instead of exact string equality. Fallback only if problem-specific validators are rejected: intentionally port Sifr to match the Python DFS order and mark the registry as exact-order parity.
+
+Reclassification note for `0269`: the slowness phase listed it as correctness because the generated fixture rejected Sifr's output. This phase assigns the primary fix to the benchmark harness/expected-shape layer because the fixture encodes an arbitrary valid topological order as the only accepted answer.
+
+### L5: Stateful Object Implementation Parity / Timeout
+
+Problem:
+
+- `0707_design_linked_list`
+
+Evidence:
+
+- Raw log shows two fixture sizes pass, then the full benchmark is terminated.
+- Python uses sentinel doubly-linked-list pointer updates.
+- Sifr uses recursive singly-linked-list rebuilds for add/delete operations.
+
+Best fix:
+
+- Port the Python data-structure shape more directly, or use a vector-backed representation with equivalent semantics and predictable update cost.
+- Avoid recursive whole-list reconstruction on every operation.
+- After correctness passes all sizes, re-run as a performance case because this may become a slowness problem rather than merely an incomplete benchmark.
+
+### L6: String Ownership In `0006_zigzag_conversion`
+
+Problem:
+
+- `0006_zigzag_conversion`
+
+Failure:
+
+```text
+use of moved value: 's'
+```
+
+Best fix:
+
+- Remove unnecessary ownership from the public signature: `def convert(s: str, numRows: int) -> str`.
+- Keep the early return path and loop over `s` borrow-like.
+
+Compiler follow-up:
+
+- Verify whether `len(s)` or `for c in s` is forcing a move where a borrow should be enough. If so, reduce to a compiler test outside the benchmark harness.
+
+## Every Failed / Incomplete Problem
+
+| Problem | Current failure | Primary track | Best first fix |
+| --- | --- | --- | --- |
+| `0739_daily_temperatures` | tuple stack inferred as `Any | None` | LeetCode Sifr code | Add `list[tuple[int, int]]` stack annotation and optional-safe `pop()` handling. |
+| `0853_car_fleet` | int division to float requires explicit handling | LeetCode Sifr code | Use explicit checked conversion/division helper for travel time. |
+| `1209_remove_all_adjacent_duplicates_in_string_ii` | `%` returns `Result[int, DivisionError]` | LeetCode Sifr code | Handle modulo result explicitly after proving `k > 0`. |
+| `0084_largest_rectangle_in_histogram` | tuple stack inferred as `Any | None` | LeetCode Sifr code | Add typed stack annotation and optional-safe pop handling. |
+| `0441_arranging_coins` | `/` exact integer-to-float conversion rejected | LeetCode Sifr code | Rewrite as integer arithmetic with checked `//`, avoiding float division. |
+| `0875_koko_eating_bananas` | `//` result used as int | LeetCode Sifr code | Guard `k > 0`, unwrap checked ceil-division helper. |
+| `0206_reverse_linked_list` | moved `result` in runner validation | Benchmark harness | Render list-node result into one local string in the generated runner. |
+| `0021_merge_two_sorted_lists` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0234_palindrome_linked_list` | partial; nullable input mismatch | LeetCode Sifr code | Accept `ListNode | None` or mark registry non-null only if fixtures guarantee it. |
+| `0203_remove_linked_list_elements` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0083_remove_duplicates_from_sorted_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0876_middle_of_the_linked_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0019_remove_nth_node_from_end_of_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `1721_swapping_nodes_in_a_linked_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0002_add_two_numbers` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0141_linked_list_cycle` | public API rejects nullable head | LeetCode Sifr code | Accept `ListNode | None` and preserve no-cycle fixture semantics. |
+| `0024_swap_nodes_in_pairs` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0148_sort_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0086_partition_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0061_rotate_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0147_insertion_sort_list` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0025_reverse_nodes_in_k_group` | moved `result` in runner validation | Benchmark harness | Same list-node result-rendering fix as H1. |
+| `0707_design_linked_list` | terminated after partial success | LeetCode Sifr code | Replace recursive singly-linked-list rebuilds with pointer-parity or vector-backed object state. |
+| `0622_design_circular_queue` | modulo result used as list index | LeetCode Sifr code | Explicitly handle modulo result after proving capacity is positive. |
+| `0144_binary_tree_preorder_traversal` | moved `root` reused by runner | Benchmark harness | Rebuild owned tree input for each validation/loop call. |
+| `0145_binary_tree_postorder_traversal` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0226_invert_binary_tree` | generated Rust tries `Display` on `TreeNode` | Benchmark harness | Use `treeToString` in wrong-result rendering. |
+| `0108_convert_sorted_array_to_binary_search_tree` | generated Rust tries `Display` on `TreeNode` | Benchmark harness | Use `treeToString` in wrong-result rendering. |
+| `0617_merge_two_binary_trees` | moved tree inputs reused by runner | Benchmark harness | Rebuild both owned tree inputs per call. |
+| `0701_insert_into_a_binary_search_tree` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0450_delete_node_in_a_bst` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0103_binary_tree_zigzag_level_order_traversal` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0106_construct_binary_tree_from_inorder_and_postorder_traversal` | generated Rust tries `Display` on `TreeNode` | Benchmark harness | Use `treeToString` in wrong-result rendering. |
+| `0662_maximum_width_of_binary_tree` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `1448_count_good_nodes_in_binary_tree` | public API rejects nullable root | LeetCode Sifr code | Accept `TreeNode | None` and return `0` for empty root. |
+| `0230_kth_smallest_element_in_a_bst` | public API rejects nullable root | LeetCode Sifr code | Either mark fixture non-null in registry or accept `TreeNode | None` with explicit empty handling. |
+| `0105_construct_binary_tree_from_preorder_and_inorder_traversal` | generated Rust tries `Display` on `TreeNode` | Benchmark harness | Use `treeToString` in wrong-result rendering. |
+| `0513_find_bottom_left_tree_value` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0669_trim_a_binary_search_tree` | moved `root` reused by runner | Benchmark harness | Same owned-tree rebuild fix as H2. |
+| `0212_word_search_ii` | duplicate words in Sifr output | LeetCode Sifr code | Emit unique found words, not one output per duplicate input word. |
+| `1383_maximum_performance_of_a_team` | modulo result returned as int | LeetCode Sifr code | Explicitly handle `% mod`; `mod` is positive constant. |
+| `0502_ipo` | encoded heap division/mod results used as ints | LeetCode Sifr code | Use checked `//` and `%` helpers for positive base. |
+| `0698_partition_to_k_equal_sum_subsets` | modulo/division results used in comparisons | LeetCode Sifr code | Guard `k > 0`, handle `%` and `//` explicitly. |
+| `0909_snakes_and_ladders` | division/mod results flow into list indexes | LeetCode Sifr code | Use checked board-coordinate helper returning plain ints after bounds proof. |
+| `0743_network_delay_time` | division/mod results and moved heap item | LeetCode Sifr code | Decode heap entries through checked helper and avoid reusing moved encoded values. |
+| `0269_alien_dictionary` | exact expected string rejects valid alternate order | Benchmark harness | Add topological-order validity expected shape; fallback is matching Python DFS order intentionally. |
+| `0062_unique_paths` | checked division result assigned to int | LeetCode Sifr code | Use exact combinatorics helper with explicit checked division. |
+| `1220_count_vowels_permutation` | `% MOD` result assigned to int variables | LeetCode Sifr code | Handle modulo result for positive constant `MOD`. |
+| `0846_hand_of_straights` | modulo result compared to int | LeetCode Sifr code | Handle `len(hand) % groupSize` after guarding `groupSize > 0`. |
+| `0263_ugly_number` | modulo/division results used directly | LeetCode Sifr code | Handle `% p` and `// p` explicitly for constant positive divisors. |
+| `1260_shift_2d_grid` | division/mod results returned as list ints | LeetCode Sifr code | Use checked index conversion helper after proving matrix dimensions positive. |
+| `0006_zigzag_conversion` | moved string parameter | LeetCode Sifr code | Remove unnecessary `own` from string parameter; reduce compiler repro if still failing. |
+| `0007_reverse_integer` | exact int-to-float conversion rejected | LeetCode Sifr code | Avoid float division; use integer truncation helper that models Python behavior explicitly. |
+
+## Analyzer Schema
+
+The machine-readable analyzer output is a superset of the slowness phase M0 output. It should keep the slowness phase fields unchanged and add failure-specific fields under a stable schema version.
+
+Required top-level metadata:
+
+- `schema_version`: `leetcode_failed_benchmark_inventory_v1`
+- `source_raw_dir`: path to the raw result directory analyzed
+- `generated_at`: ISO timestamp
+- `problem_count`: total rows emitted
+
+Required row fields:
+
+- `problem_id`: registry problem id, for example `0206_reverse_linked_list`
+- `benchmark_status`: `partial`, `failed_build`, `failed_typecheck`, `failed_correctness`, or `failed_timeout`
+- `primary_track`: `benchmark_harness`, `leetcode_sifr_code`, `mixed_harness_and_code`, or `compiler_followup`
+- `failure_mode`: one stable tag from the vocabulary below
+- `failure_excerpt`: short excerpt from the raw log or generated runner evidence
+- `first_fix`: short machine-readable summary matching the table's best first fix
+- `related_slowness_phase`: boolean indicating whether this problem also has complete timing rows in the slowness phase
+
+The table above is a human-readable rendering. The analyzer should emit snake_case identifiers, not the prose labels shown in the table.
+
+Failure mode vocabulary:
+
+- `moved_result_rendering`
+- `moved_owned_tree_input`
+- `structured_result_display`
+- `division_result_unhandled`
+- `float_conversion_unhandled`
+- `nullable_signature_mismatch`
+- `typed_stack_inference`
+- `correctness_duplicate_output`
+- `correctness_expected_shape`
+- `timeout_stateful_object`
+- `moved_string_parameter`
+
+## Milestones
+
+Dependency order: **M0 -> M1 -> M2 -> M3 -> M4**.
+
+### M0: Failure Inventory Lock
+
+- Extend `audits/leetcode/benchmarks/analyze_slowness.py`, introduced by the slowness phase M0, so it emits these 53 incomplete/failed rows deterministically as JSON.
+- Validate analyzer output against the slowness phase M0 registry metadata.
+- Use `schema_version: "leetcode_failed_benchmark_inventory_v1"` and the `Analyzer Schema` section above.
+- Include `problem_id`, `benchmark_status`, `primary_track`, `failure_mode`, `failure_excerpt`, and `first_fix` for each row.
+- Record the primary track for each row: `benchmark_harness`, `leetcode_sifr_code`, `mixed_harness_and_code`, or `compiler_followup`.
+- Preserve `0234_palindrome_linked_list` as `benchmark_status: "partial"` until every configured fixture passes.
+
+### M1: Benchmark Harness Unblockers
+
+- Fix list/tree structured-result rendering without consuming result values.
+- Rebuild owned tree inputs for each validation and benchmark loop call.
+- Fix `tree_node_int` and `list_node_int` wrong-result formatting.
+- Re-run the H1/H2/H3 problem subset and verify those failures disappear without changing problem solutions.
+
+### M2: LeetCode Sifr Code Unblockers
+
+- Add explicit safe math helper usage for division/modulo failures.
+- Fix nullable public signatures for linked-list/tree APIs.
+- Add typed stack annotations for tuple stack problems.
+- Fix `0212`, `0269`, `0707`, and `0006` as problem-specific ports.
+- Re-run the full incomplete subset after each small batch.
+
+### M3: Compiler Ergonomics Follow-Ups
+
+- Only after M1/M2 are complete, reduce recurring patterns into compiler tests.
+- Candidate compiler work:
+  - non-zero divisor refinement,
+  - empty-list tuple inference,
+  - `pop()` optional narrowing under non-empty guards,
+  - borrowed string iteration/length behavior,
+  - clearer ownership diagnostics for generated runner shapes.
+
+### M4: Reintegrate With Performance Analysis
+
+- Use the post-fix re-benchmark protocol from `issues/ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md` as the authoritative procedure.
+- Every newly complete problem must be benchmarked for runtime and memory.
+- The engineer completing an M1/M2 fix owns the subset re-run and metadata update for affected problems.
+- Newly slower problems should be added to the slowness phase metadata and reviewed there instead of being treated as unrelated regressions.
+- Report UI should show formerly failed problems as complete only after all fixture sizes have Python/Sifr timing and memory rows.
+
+## Acceptance Criteria
+
+- All 53 appendix entries are listed with a primary fix track and first fix.
+- Harness fixes unblock harness-owned failures without requiring LeetCode solution rewrites.
+- LeetCode Sifr code fixes preserve Sifr safety semantics and do not rely on implicit division/modulo unwraps.
+- Correctness fixes for `0212` and `0269` are validated against fixture semantics, not just one expected string.
+- `0707_design_linked_list` either completes all configured sizes or is reclassified with a concrete residual performance blocker.
+- Claude review confirms the phase is implementation-ready and has no unresolved ownership-boundary gaps.

--- a/reviews/leetcode-incomplete-failed-fixes-review-pass-1.md
+++ b/reviews/leetcode-incomplete-failed-fixes-review-pass-1.md
@@ -1,0 +1,92 @@
+## Review: ad-hoc-leetcode-incomplete-failed-benchmark-fixes.md
+
+### Overall Assessment
+
+The phase doc is structurally sound with correct root-cause analysis (confirmed against raw logs), proper 3-track separation, and a logical milestone dependency order. However, there are **4 material blockers** and several non-blocking gaps before engineers can implement from it.
+
+---
+
+### Material Blockers
+
+**1. M0 is ambiguous (line 369)**
+
+"Add or extend the slowness analyzer" does not specify whether this means:
+- Modifying existing `benchmarks/analyze_slowness.py`
+- Creating new inventory tooling
+- Locking down the existing 53 entries that the slowness phase M0 already seeds
+
+The slowness phase M0 explicitly states it "seeds registry metadata for all 53 incomplete/failed problems." This phase doc M0 appears to duplicate or build on that work, but the relationship is unclear.
+
+**Requested edit**: Clarify M0 scope: "Extend `analyze_slowness.py` to emit the 53 rows deterministically as JSON with `primary_track` and `benchmark_status` fields. Validate against the slowness phase M0's seeded registry metadata."
+
+**2. L1 helper surface is undefined (line 198)**
+
+"A small LeetCode-audit helper surface for guaranteed-safe integer math" is never specified:
+- Where does it live? (`audits/leetcode/src/helpers/`? Compiler prelude? Inline in each solution?)
+- What's the API? `checked_div(a: int, b: int) -> int`? `ceil_div(a: int, b: int) -> int`?
+- Error behavior? "Return early" vs "default" are different (line 198 says "return early OR default")
+
+Without this, engineers implementing L1 fixes don't know what to call or where to put it.
+
+**Requested edit**: Add a concrete L1 helper proposal with API, location, and error-handling semantics. E.g.: "Add `checked_div(a: int, b: int) -> int` and `checked_mod(a: int, b: int) -> int` to `audits/leetcode/src/helpers/math.sifr`. Both return early with a sentinel (-1) when the divisor is proven zero by the solver, otherwise unwrap the Result. These are used only in benchmark audit code, not the compiler."
+
+**3. H1 implementation strategy is ambiguous (line 107)**
+
+"render list/tree rendering does not consume the result" has three plausible interpretations:
+- Borrow-based helpers: change `listNodeToString(own result: ...)` to borrow
+- One-shot rendering: generated runner renders once, stores string, reuses it
+- Clone-based: add `Clone` to TreeNode/ListNode, clone before rendering
+
+The right answer is probably option 2 (one-shot rendering in the runner generator), but this needs to be explicit.
+
+**Requested edit**: Specify the approach: "Fix H1 by changing `single_sifr_runner_body` in `generic.py` to render structured results into a local string before comparison, then use the same string in wrong-result printing. Do not modify helper signatures."
+
+**4. "no-complete-pair failures" category is never enumerated (lines 23-26, 40)**
+
+The doc mentions "52 no-complete-pair failures" but:
+- Doesn't list which 52 problems are in this category
+- Doesn't explain whether these are the same 52 as the slowness doc's failure appendix
+- Doesn't clarify whether ALL 53 table entries are "no-complete-pair" failures, or if some are partial/complete
+
+This matters for correctness validation: a "correctness fix" for a problem without a passing Python baseline is meaningless unless you first establish the Python baseline is valid.
+
+**Requested edit**: Either (a) enumerate the 52 "no-complete-pair" problems explicitly, or (b) clarify that all 53 table entries appear in the slowness doc's failure appendix and reference that as the authoritative list.
+
+---
+
+### Non-Blocking Issues
+
+**5. H3 is generated-Sifr-code work, not harness work (lines 146-164)**
+
+The H3 fix changes the wrong-result path in `single_sifr_runner_body` from `str(result)` to `treeToString(result)`. This is correctly in `generic.py`, but it's a generated-runner concern, not a runtime-harness concern. This is fine — just note it in the track description to avoid confusion.
+
+**6. 0269_alien_dictionary "Best fix" changes fixture semantics (line 264)**
+
+"Use topological-order validity expected shape" means changing the expected fixture, which is a benchmark infrastructure change. This should be tracked as either a harness/registry change (for fixture shape) or a code change (if making Sifr match Python DFS order). The doc says "LeetCode Sifr code" but the fix is at the fixture layer.
+
+**7. M4 is underspecified (lines 398-402)**
+
+"Reintegrate with Performance Analysis" needs:
+- Who runs the post-fix re-benchmark protocol (this phase's engineers? slowness phase engineers?)
+- How newly complete problems are added to slowness phase metadata
+- Whether M4 requires a separate review/approval step
+
+**8. M0/M1/M2/M3 don't reference the slowness phase's post-fix protocol (lines 364-397)**
+
+The slowness doc's "Post-Fix Re-Benchmark Protocol" (lines 446-451) is the authoritative procedure for re-running benchmarks after fixes. This phase should explicitly reference it, or state that it owns that protocol for these 53 problems.
+
+---
+
+### What's Solid
+
+- **Table count**: 53 rows matches the slowness doc's 53 incomplete problems. ✓
+- **Root-cause analysis**: Confirmed correct against raw logs (H1: "use of moved value: 'result'" in 0206, H3: `Display` error in 0226, L2: "expected 'ListNode', got 'None | ListNode'" in 0141). ✓
+- **Track separation**: Harness fixes (H1/H2/H3) don't require solution rewrites. LeetCode code fixes (L1-L6) are scoped to specific ports. Compiler work (Track C) is deferred. ✓
+- **Dependency order**: M0 → M1 → M2 → M3 → M4 is correct. ✓
+- **Acceptance criteria**: Tests are concrete enough (all 53 entries listed, harness fixes don't require rewrites, correctness fixes validated against fixtures). ✓
+
+---
+
+### Summary
+
+The phase doc is close to implementation-ready. The material blockers (M0 ambiguity, undefined L1 helper surface, ambiguous H1 strategy, unenumerated failure category) are all specification gaps, not fundamental design problems. Fix these 4 items and it's ready for implementation.

--- a/reviews/leetcode-incomplete-failed-fixes-review-pass-2.md
+++ b/reviews/leetcode-incomplete-failed-fixes-review-pass-2.md
@@ -1,0 +1,73 @@
+
+
+## Pass 2 Review: Ad Hoc LeetCode Incomplete/Failed Benchmark Fixes
+
+### Blocker Status: **MATERIAL BLOCKERS REMAIN**
+
+The document has made genuine progress — M0 relationship to slowness phase is now explicit, L1 surfaces are defined, H1 approach is constrained, and L4 (0269) correctly names both the harness and code dimensions. But three blockers block implementation readiness.
+
+---
+
+### Blocker 1: M0 — Slowness Phase Schema Extension Is Ambiguous
+
+**Pass 1 finding:** M0 ambiguity with slowness phase analyzer/metadata.
+
+**Current state:** Partially addressed. The document correctly references "Extend `audits/leetcode/benchmarks/analyze_slowness.py`" and specifies JSON output fields. But:
+
+1. **Schema alignment is unstated.** M0 inherits from slowness phase M0 but does not define how the new output extends or overrides the existing schema. What happens to fields from slowness phase M0 that this phase doesn't need? Are `primary_track` values identical between phases?
+
+2. **Table does not match machine-readable format.** M0 specifies `primary_track` values like `benchmark_harness`, `leetcode_sifr_code`, `mixed_harness_and_code`, `compiler_followup`. The working table (lines 320–375) uses prose like "Benchmark harness", "LeetCode Sifr code", "Benchmark harness / LeetCode Sifr code". This is editorial presentation, not the JSON that M0 should emit. The disconnect between prose table and machine-readable schema is unresolved.
+
+3. **`failure_mode` and `failure_excerpt` are underspecified.** M0 names these as required fields but doesn't define their value set or content expectations. "moved `result` in runner validation" is prose; should it be a tagged failure type like `ownership_consumed_post_validation`?
+
+**Required edit:** Define explicit schema relationship — either this phase's JSON is a superset of slowness phase M0, a fork with a version marker, or extends with additional fields. Clarify that the prose table is a human-readable rendering and that the machine-readable output uses snake_case identifiers. Define a small tag vocabulary for `failure_mode`.
+
+---
+
+### Blocker 2: L1 — Helper Surface Location and File Naming Are Undefined
+
+**Pass 1 finding:** undefined L1 safe math helper surface.
+
+**Current state:** Function signatures are defined (lines 202–207) and behavioral rules are specified (lines 208–214). But:
+
+1. **Path is ambiguous.** The text references "a small LeetCode-audit helper surface for safe integer math in `audits/leetcode/src/helpers/math.sifr`." The source inputs section (lines 13–20) lists `audits/leetcode/src/helpers/list_node.sifr` and `audits/leetcode/src/helpers/tree_node.sifr` but does not mention `math.sifr`. If the intent is to place the file alongside existing helpers, it should be listed in source inputs.
+
+2. **Naming convention is ambiguous.** The existing helpers are named after their data structure (`list_node`, `tree_node`). The proposed name `math` is generic and could conflict with standard library modules. `safe_math.sifr` or `math_helpers.sifr` would be more precise.
+
+**Required edit:** Add `audits/leetcode/src/helpers/math.sifr` (or renamed alternative) to source inputs. Either change the L1 text to reference the renamed file or rename the file to match the existing helper naming convention.
+
+---
+
+### Blocker 3: L4 (0269) — Classification Changed but Not Resolved
+
+**Pass 1 finding:** unclear 0269 classification after it was changed to benchmark harness / LeetCode Sifr code.
+
+**Current state:** Pass 1 correctly flagged that 0269 was reclassified from correctness-only to mixed harness/code. The document now (line 367) shows "Benchmark harness / LeetCode Sifr code" as primary track. But:
+
+1. **Both tracks remain ambiguous.** The L4 text (lines 273–277) names two options — "prefer topological-order validity expected shape" OR "intentionally port Sifr to match the Python DFS order." Neither is chosen. The "Preferred fix" language suggests the first option, but "If the benchmark framework should avoid problem-specific validators" is a conditional that doesn't resolve.
+
+2. **Table entry for 0269 is dual-classified.** Line 367 shows "Benchmark harness / LeetCode Sifr code" — both tracks. If the preferred fix is topological-order validity in the harness, then `benchmark_harness` is the primary track and the code change is secondary. If the preferred fix is matching Python order in the Sifr code, then `leetcode_sifr_code` is primary. The table cannot have two primary tracks.
+
+3. **The 0269 problem was changed from correctness-only.** Looking at the slowness phase, this problem's failure was classified as correctness. The reclassification to "benchmark harness" as a co-track is correct because the expected fixture itself is the constraint. But the document doesn't explain the reclassification rationale — an engineer picking up this task would not know why 0269 now has a harness track.
+
+**Required edit:** Choose one preferred fix in L4 and make the alternative explicit as "fallback if framework design prohibits problem-specific validators." Align the table entry for 0269 to one primary track. Add a one-line reclassification note explaining why 0269 now has a harness track (fixture itself is the constraint, not just code correctness).
+
+---
+
+### Remaining Polish (Not Blockers)
+
+- **H1 implementation strategy** is well-constrained (no helper signature changes, no solution rewrites) but doesn't specify which functions beyond `single_sifr_runner_body` need updating, or whether to inline the rendered-string logic or factor into a shared helper.
+- **M2 "small batch"** is vague on re-run intervals. Suggest: "re-run after every 5–10 problems" or "after each track's problems are exhausted."
+- **0269 Python DFS order detail** — the L4 text says "Python DFS order cba" but doesn't explain why. A one-sentence note on why Kahn vs. DFS produces different output for repeated-constraint fixtures would help implementers.
+
+---
+
+### Verdict
+
+**Not implementation-ready.** Three material blockers (M0 schema alignment, L1 location/naming, L4 resolution/classification) prevent a clean handoff. Polish items are non-blocking but would improve handoff quality.
+
+**Exact required edits:**
+
+1. M0: State schema relationship to slowness phase M0; clarify prose table vs. machine-readable output; define `failure_mode` tag vocabulary.
+2. L1: Add `audits/leetcode/src/helpers/math.sifr` (or renamed) to source inputs; rename to match existing helper convention.
+3. L4: Choose preferred fix with explicit fallback; update table entry to single primary track; add reclassification note for the harness track.

--- a/reviews/leetcode-incomplete-failed-fixes-review-pass-3.md
+++ b/reviews/leetcode-incomplete-failed-fixes-review-pass-3.md
@@ -1,0 +1,13 @@
+
+
+Pass 2 blockers are resolved:
+
+**M0 schema alignment and failure_mode vocabulary:** Lines 379–415 define the full schema with `schema_version: "leetcode_failed_benchmark_inventory_v1"`, all required top-level and row fields, and the 11-tag vocabulary (`moved_result_rendering`, `moved_owned_tree_input`, `structured_result_display`, `division_result_unhandled`, etc.).
+
+**L1 helper location/naming:** Lines 201–215 specify `audits/leetcode/src/helpers/safe_math.sifr` with the exact API (`div_or_zero`, `mod_or_zero`, `ceil_div_positive_or_zero`, `trunc_div_toward_zero_or_zero`, `ratio_or_zero`) and behavior (zero divisor fallback, try/except locally, caller-guards for problem inputs). Audit-only, not compiler prelude.
+
+**L4/0269 primary classification and preferred fix:** Lines 270–278 address `0269_alien_dictionary` with primary fix in the benchmark harness/expected-shape layer (topological-order validity validator), explicit fallback to DFS-order parity if needed, and a clear reclassification note explaining why it was correctness in slowness phase but harness here.
+
+One note: the working table (lines 323–377) uses prose "Best first fix" descriptions rather than the formal `failure_mode` vocabulary tags. The schema section correctly defines the machine-readable codes, and the table has `first_fix` (a fix summary) as distinct from `failure_mode` (a vocabulary tag). These are consistent but the table is human-readable rendering, not the JSON output. No change needed.
+
+The document is **implementation-ready**.

--- a/reviews/leetcode-slowness-fix-phase-review-pass-1.md
+++ b/reviews/leetcode-slowness-fix-phase-review-pass-1.md
@@ -1,0 +1,88 @@
+
+
+Looking at this document as an implementation plan against your six criteria.
+
+---
+
+## Review: ad-hoc-leetcode-benchmark-slowness-root-cause-analysis.md
+
+###1. Fix-focused vs. analysis-only? ✓The phase is clearly implementation-oriented. Purpose, D1-D6, M1-M5, and the Compiler/LeetCode Work Tracks all describe actual fix work. The generated analyzer snapshot validates the inventory. No issues here.
+
+### 2. Implementation decisions captured clearly? Partial
+
+**Good:**
+- D1-D6 are concrete and lock decisions for execution- M0-M5 dependency chain is explicit- Post-fix re-benchmark protocol is defined**Gaps:**
+
+| Gap | Location | What's missing |
+|---|---|---|
+| Heap helper API | L1, D3 | The document says "add or use a Sifr heap/priority-queue helper" but never defines the helper's API shape, placement (which module), or what the benchmark ports call |
+| Trie port structure | L2 | "Port the Python trie node algorithms directly to Sifr" is underspecified — does it mean one file per problem, a shared local trie module, or inline implementations? |
+| String lowering strategy | C1 | "Introduce an indexed string view or cached character vector lowering" — the document doesn't say which HIR/codegen phase implements this, or what the exact emitted-Rust contract is |
+| Container clone elision | C2 | "Distinguish borrowed field reads from owned field moves in HIR/codegen" — no before/after emitted-code example showing the transition from `self.map.clone().contains_key(...)` to borrowed access |
+| Tree/list traversal | C3 | "Add borrow-preserving accessors" — no API shape defined |
+| Regression test infrastructure | D5, M2, M3 | Every fix needs generated-code regression tests, but the document never says where these live, what tool runs them, or what the assertion language is |
+
+### 3. Hidden gaps, circular dependencies, ownership, acceptance gates
+
+**Circular dependency:**
+- M1 L2 (trie parity) must complete before M2 trie clone work is credited — correctly documented ✓
+- M1 L1 (heap parity) depends on a heap helper that doesn't exist yet — correctly documented as an L1 deliverable ✓
+
+**Ownership gap:**
+- D3 says helpers need "focused fixture tests before broad benchmark use" but doesn't assign test authorship or define "focused"
+- M2 and M3 can run in parallel "only for disjoint problem families" — but the document never enumerates which problems are in which track, leaving the parallelism claim unsubstantiated for mixed cases like `0208`/`0211` (trie in both M1 and M2)
+
+**Acceptance gates:**
+- Runtime + Peak RSS both visible in report ✓
+- Correctness before runtime comparison ✓- Partial benchmarks excluded from apples-to-apples ✓
+- Analyzer snapshot agrees with report ✓**Missing gate:** D5 regression tests have no runner, no location, and no pass/fail criterion. A fix can close without proving the pathological lowering is gone.
+
+### 4. Compiler vs. LeetCode Sifr code separation? ✓
+
+M1 = LeetCode Sifr code parity (L1-L3). M2/M3 = compiler lowering (C1-C4). Clean separation. D2 enforces ordering: known-divergent rows don't get compiler credit until Sifr code is fixed.
+
+### 5. Milestones executable without re-litigating decisions? Partial
+
+**Executable:**
+- M0 (baseline lock + ticket slicing) is clear
+- M1 problem lists are specific (e.g., `1985`, `0973`, `0703`...)
+- M5 closure record fields are defined
+
+**Requires re-litigation:**
+- M2 C1/C2: "required compiler/runtime direction" is architectural intent, not a commit. An engineer picking this up needs to make decisions about indexed string view API, HIR representation, and codegen lowering strategy before writing a line of code.
+- M3 C3/C4: same issue — "borrow-preserving accessors" and "mutable indexed place updates" are descriptions of the goal, not the implementation plan.
+
+###6. Generated-code regression tests, benchmark reruns, memory checks, report metadata gates sufficient? Partial
+
+**Benchmark reruns:** Post-fix protocol (lines 526-543) is data-driven and well-specified.
+
+**Memory checks:** Mentioned in the re-benchmark protocol and acceptance criteria, but no concrete threshold. "Material Peak RSS regression" is not quantified.
+
+**Report metadata:** D6 and M4 fully specify the metadata fields and analyzer enforcement. ✓
+
+**Regression tests:** D5 lists negative assertions (no `chars().nth`, no `self.map.clone()`, no subtree clones) but:
+- No test location- No runner command
+- No pass/fail definition
+- No existing test infrastructure referenced
+
+---
+
+## Summary
+
+**No blocking issues.** The phase is fix-oriented, properly sequenced, and cleanly separated between compiler and LeetCode code work.
+
+**Polishing required before implementation:**
+
+1. **M2/M3 need concrete before/after emitted-code examples** for at least one representative problem per C1-C4. Without this, engineers must invent the codegen contract during implementation, which defeats the purpose of pre-litigating decisions.
+
+2. **Heap helper API must be defined** in L1 or D3 before M1 can execute — even a minimal stub API (e.g., `Heap[T]`, `push`, `pop`, `heapify`) is enough to unblock the ports.
+
+3. **Trie port structure** (inline per problem vs. local module) must be decided in L2.
+
+4. **Regression test infrastructure** needs a location and a runner command. This is a small addition — even pointing to an existing codegen test pattern in the codebase would suffice.
+
+5. **M2/M3 parallelism** is claimed but not grounded — specify which problems are in M2 vs. M3, or remove the parallelism claim.
+
+6. **Memory threshold** for "material Peak RSS regression" should be quantified (e.g., >10% delta at same fixture size).
+
+None of these are blockers. All are resolvable with targeted edits before M0 ticket slicing.

--- a/reviews/leetcode-slowness-fix-phase-review-pass-2.md
+++ b/reviews/leetcode-slowness-fix-phase-review-pass-2.md
@@ -1,0 +1,19 @@
+
+
+Reviewing the document against the six targeted edits requested in Pass 1.
+
+**Pass 1 checklist — all resolved:**
+
+1. **Heap helper API and placement** — D3 (lines 127-148) defines the full `heapq.sifr` API: `heapify`, `heappush`, `heappop`, `heappushpop`, `heapreplace`, `nsmallest`, `nlargest`. Deque parity operations also listed. Explicitly forbids shared trie helper for M1.
+
+2. **Trie port structure** — Lines 150-154 specify problem-local trie structures for 0208, 0211, 0212. Shared helper deferred to M2. Explicit rule: both Python and Sifr must use comparable helper semantics if a shared helper is later introduced.
+
+3. **Emitted-code contracts** — D5 (lines 192-202) has the contracts table with five categories: C1 string indexing/length, C2 field/container reads, C3 optional tree/list traversal, C4 matrix mutation. Each has a concrete before/after Rust shape.
+
+4. **Generated-code regression test location and runner** — D5 (lines 172-178) specifies `crates/sifr_codegen/src/lib_codegen_tests/` with the `generate_rust_from_source` / `generate_rust_with_metadata` pattern, optional `leetcode_performance_codegen_tests.rs` module, and `cargo test -p sifr_codegen -- <test_name>` as the runner. Negative assertions enumerated (lines 184-190) covering all five contract categories.
+
+5. **M2/M3 parallelism grounded** — Dependency matrix (lines 668-676) is explicit: M2 and M3 run in parallel only for disjoint problem families. Any `known_divergent` problem blocks M2/M3 credit until M1 parity is restored. Track table shows M3 only waits for M1 on overlapping mixed rows, not M2.
+
+6. **Memory regression threshold quantified** — D6 (line 211) and Post-Fix Protocol (line 588) both state: Peak RSS regression >10% at the same fixture size keeps the ticket open with a memory-specific tag unless the PR documents an intentional and bounded tradeoff.
+
+**No blocking issues remain.** The document is implementation-ready. Only polish remains: registry metadata seeding for the 75 measured-slower problems, ticket cutting, and the milestone execution itself.

--- a/reviews/leetcode-slowness-fix-phase-review-pass-3.md
+++ b/reviews/leetcode-slowness-fix-phase-review-pass-3.md
@@ -1,0 +1,11 @@
+
+
+**Ready.**
+
+The phase passes all three checks:
+
+1. **Implementation-ready** — D1-D6 are locked with concrete direction. The two-class fix ordering (benchmark parity first, then compiler attribution) is explicit. The 75 measured-slower table is paired with a generated analyzer snapshot that confirms the counts. C1-C4 and L1-L3 tracks are each grounded in representative emitted Rust evidence, not intuition.
+
+2. **No material gaps or contradictions** — Trie structure decision (problem-local, not shared), heap/deque API surface, emitted-code contracts (table with before/after), regression test location and negative assertions, memory regression threshold (10%), reclassification thresholds, milestone dependency order, and failure-mode tracking are all specified. The 75-row table and generated snapshot agree on counts and parity assignments.
+
+3. **Tickets can be cut without unresolved design decisions** — M0 locks baseline and ticket slicing. M1/M2/M3 have scoped problem lists and explicit wait conditions. D2 enforces the ordering constraint: known-divergent rows cannot be compiler-attributed until the parity repair lands. No open questions remain that would stall an engineer picking up C1 string lowering, C2 field clones, or the L1 heap parity work.


### PR DESCRIPTION
## Summary
- Reframes the LeetCode benchmark slowness phase around fixing root causes instead of only analysis.
- Adds the incomplete/failed benchmark fixes phase document.
- Includes Claude review artifacts for both phase docs.

## Validation
- Documentation-only change; no tests run.