### PR TITLE
Optimize self-field collection access

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -30,12 +30,12 @@ impl RustEmitter {
             return true;
         }
 
-        if !crate::helpers::MUTATING_METHODS.contains(&method) {
-            return false;
-        }
-
         if matches!(parent.as_ref(), HirExpr::Name { name, .. } if name == "self") {
             return true;
+        }
+
+        if !crate::helpers::MUTATING_METHODS.contains(&method) {
+            return false;
         }
 
         let parent_class_name = match crate::resolve_alias_type_for_plain_call(parent.ty()) {

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -188,6 +188,12 @@ impl RustEmitter {
             if requires_shared_borrow || requires_mut_borrow {
                 lowered_arg = Self::clone_moved_names_in_borrowed_aggregate(arg, lowered_arg);
             }
+            if (requires_shared_borrow || requires_mut_borrow)
+                && matches!(arg, HirExpr::FieldAccess { object, .. }
+                    if matches!(object.as_ref(), HirExpr::Name { name, .. } if name == "self"))
+            {
+                lowered_arg = Self::strip_redundant_borrowed_self_field_clone(lowered_arg);
+            }
 
             if requires_shared_borrow
                 && !self.arg_is_already_borrowed_for_registry_call(arg, &lowered_arg)

--- a/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
@@ -1,4 +1,36 @@
 use super::*;
+
+#[test]
+fn method_calls_on_self_collection_fields_do_not_clone_for_read_only_receivers() {
+    let generated = generate_rust_from_source(
+        r#"
+def head(values: list[int]) -> int:
+    value: int | None = values[0]
+    if value is not None:
+        return value
+    return 0
+
+class Store:
+    items: list[int]
+    lookup: dict[int, int]
+
+    def __init__(self):
+        self.items = [1, 2, 3]
+        self.lookup = {1: 10}
+
+    def total(self, key: int) -> int:
+        return len(self.items) + self.lookup.get(key, 0) + head(self.items)
+"#,
+    );
+
+    assert!(generated.contains("self.items.len() as i64"));
+    assert!(generated.contains("self.lookup.get(&key)"));
+    assert!(generated.contains("head(&self.items)"));
+    assert!(!generated.contains("self.items.clone().len()"));
+    assert!(!generated.contains("self.lookup.clone().get"));
+    assert!(!generated.contains("head(&self.items.clone())"));
+}
+
 #[test]
 fn test_structured_stmt_path_lowers_collection_truthiness_inside_boolop_condition() {
     let tuple_ty = Type::Tuple(vec![Type::Int, Type::Int]);

--- a/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/structured_lowering_codegen_tests.rs
@@ -681,6 +681,61 @@ fn test_structured_stmt_path_handles_nested_subscript_augassign_inside_loop_if()
 }
 
 #[test]
+fn test_structured_stmt_path_handles_attribute_list_subscript_assign_inside_if() {
+    let stmt = HirStmt::If {
+        condition: HirExpr::BoolLiteral(true),
+        then_body: vec![HirStmt::AttributeSubscriptAssign {
+            object: "self".to_string(),
+            field: "history".to_string(),
+            index: HirExpr::BinOp {
+                left: Box::new(HirExpr::Name {
+                    name: "i".to_string(),
+                    ty: Type::Int,
+                }),
+                op: "+".to_string(),
+                right: Box::new(HirExpr::IntLiteral(1)),
+                ty: Type::Int,
+            },
+            value: HirExpr::Call {
+                func: "str".to_string(),
+                args: vec![HirExpr::Name {
+                    name: "url".to_string(),
+                    ty: Type::Str,
+                }],
+                ty: Type::Str,
+            },
+            field_ty: Type::List(Box::new(Type::Str)),
+        }],
+        elif_clauses: vec![],
+        else_body: None,
+    };
+
+    let mut emitter = RustEmitter::new();
+    let captured = emitter.capture_structured_stmts(|inner| inner.emit_stmt(&stmt));
+
+    assert!(matches!(captured.first(), Some(RustStmt::If { .. })));
+}
+
+#[test]
+fn test_structured_stmt_path_handles_top_level_attribute_list_subscript_assign() {
+    let stmt = HirStmt::AttributeSubscriptAssign {
+        object: "self".to_string(),
+        field: "history".to_string(),
+        index: HirExpr::Name {
+            name: "i".to_string(),
+            ty: Type::Int,
+        },
+        value: HirExpr::StringLiteral("page".to_string()),
+        field_ty: Type::List(Box::new(Type::Str)),
+    };
+
+    let mut emitter = RustEmitter::new();
+    let captured = emitter.capture_structured_stmts(|inner| inner.emit_stmt(&stmt));
+
+    assert!(matches!(captured.first(), Some(RustStmt::Block(_))));
+}
+
+#[test]
 fn test_structured_stmt_path_handles_delete_with_name_key_inside_loop_if() {
     let stmt = HirStmt::For {
         target: "ch".to_string(),

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -156,6 +156,12 @@ impl RustEmitter {
             if needs_shared_borrow || needs_mut_borrow {
                 lowered_arg = Self::clone_moved_names_in_borrowed_aggregate(hir_arg, lowered_arg);
             }
+            if (needs_shared_borrow || needs_mut_borrow)
+                && matches!(hir_arg, HirExpr::FieldAccess { object, .. }
+                    if matches!(object.as_ref(), HirExpr::Name { name, .. } if name == "self"))
+            {
+                lowered_arg = Self::strip_redundant_borrowed_self_field_clone(lowered_arg);
+            }
 
             if needs_shared_borrow && !already_borrowed {
                 lowered_arg = crate::RustExpr::Ref {
@@ -172,6 +178,19 @@ impl RustEmitter {
             adapted.push(lowered_arg);
         }
         adapted
+    }
+
+    pub(crate) fn strip_redundant_borrowed_self_field_clone(
+        expr: crate::RustExpr,
+    ) -> crate::RustExpr {
+        match expr {
+            crate::RustExpr::MethodCall {
+                receiver,
+                method,
+                args,
+            } if method == "clone" && args.is_empty() => *receiver,
+            other => other,
+        }
     }
 
     pub(crate) fn lower_recursive_capture_arg_for_ir(

--- a/crates/sifr_codegen/src/stmt_support_emitter/field_assignment.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/field_assignment.rs
@@ -291,25 +291,6 @@ impl RustEmitter {
         else {
             return Ok(false);
         };
-        let Type::Dict(key_ty, _) = field_ty else {
-            return Ok(false);
-        };
-
-        let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_))
-            && matches!(index, HirExpr::Name { name, .. }
-                if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()));
-        let key_is_non_copy_name = matches!(index, HirExpr::Name { .. })
-            && matches!(
-                crate::resolve_alias_type_for_plain_call(index.ty()),
-                Type::Str | Type::LiteralStr(_)
-            );
-
-        let Some(mut index_expr) = self.lower_stmt_expr_for_ir(index)? else {
-            return Ok(false);
-        };
-        if key_needs_clone || key_is_non_copy_name {
-            index_expr = crate::RustExpr::Clone(Box::new(index_expr));
-        }
         let Some(value_expr) = self.lower_stmt_expr_for_ir(value)? else {
             return Ok(false);
         };
@@ -318,11 +299,37 @@ impl RustEmitter {
             expr: Box::new(Self::object_name_expr_for_ir(object)),
             field: field.clone(),
         };
-        let lowered = crate::RustStmt::Expr(crate::RustExpr::MethodCall {
-            receiver: Box::new(receiver),
-            method: "insert".to_string(),
-            args: vec![index_expr, value_expr],
-        });
+        let lowered = match field_ty {
+            Type::List(_) => {
+                let Some(index_expr) = self.lower_stmt_expr_for_ir(index)? else {
+                    return Ok(false);
+                };
+                crate::build_list_subscript_assign_stmt(receiver, index_expr, value_expr)
+            }
+            Type::Dict(key_ty, _) => {
+                let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_))
+                    && matches!(index, HirExpr::Name { name, .. }
+                        if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()));
+                let key_is_non_copy_name = matches!(index, HirExpr::Name { .. })
+                    && matches!(
+                        crate::resolve_alias_type_for_plain_call(index.ty()),
+                        Type::Str | Type::LiteralStr(_)
+                    );
+
+                let Some(mut index_expr) = self.lower_stmt_expr_for_ir(index)? else {
+                    return Ok(false);
+                };
+                if key_needs_clone || key_is_non_copy_name {
+                    index_expr = crate::RustExpr::Clone(Box::new(index_expr));
+                }
+                crate::RustStmt::Expr(crate::RustExpr::MethodCall {
+                    receiver: Box::new(receiver),
+                    method: "insert".to_string(),
+                    args: vec![index_expr, value_expr],
+                })
+            }
+            _ => return Ok(false),
+        };
         self.emit_lowered_stmts(std::slice::from_ref(&lowered));
         Ok(true)
     }

--- a/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/stmt_block.rs
@@ -358,25 +358,6 @@ impl RustEmitter {
                 field_ty,
             } = stmt
             {
-                let Type::Dict(key_ty, _) = field_ty else {
-                    return Ok(None);
-                };
-
-                let key_needs_clone = matches!(key_ty.as_ref(), Type::Str | Type::TypeVar(_))
-                    && matches!(index, HirExpr::Name { name, .. }
-                            if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()));
-                let key_is_non_copy_name = matches!(index, HirExpr::Name { .. })
-                    && matches!(
-                        crate::resolve_alias_type_for_plain_call(index.ty()),
-                        Type::Str | Type::LiteralStr(_)
-                    );
-
-                let Some(mut index_expr) = self.lower_rendered_expr_for_ir(index)? else {
-                    return Ok(None);
-                };
-                if key_needs_clone || key_is_non_copy_name {
-                    index_expr = crate::RustExpr::Clone(Box::new(index_expr));
-                }
                 let Some(value_expr) = self.lower_rendered_expr_for_ir(value)? else {
                     return Ok(None);
                 };
@@ -385,14 +366,40 @@ impl RustEmitter {
                     expr: Box::new(Self::object_name_expr_for_ir(object)),
                     field: field.clone(),
                 };
-                (
-                    vec![crate::RustStmt::Expr(crate::RustExpr::MethodCall {
-                        receiver: Box::new(receiver),
-                        method: "insert".to_string(),
-                        args: vec![index_expr, value_expr],
-                    })],
-                    true,
-                )
+                let lowered_stmt = match field_ty {
+                    Type::List(_) => {
+                        let Some(index_expr) = self.lower_rendered_expr_for_ir(index)? else {
+                            return Ok(None);
+                        };
+                        crate::build_list_subscript_assign_stmt(receiver, index_expr, value_expr)
+                    }
+                    Type::Dict(key_ty, _) => {
+                        let key_needs_clone = matches!(
+                            key_ty.as_ref(),
+                            Type::Str | Type::TypeVar(_)
+                        ) && matches!(index, HirExpr::Name { name, .. }
+                                    if self.borrowed_params.contains(name.as_str()) || self.mut_borrowed_params.contains(name.as_str()));
+                        let key_is_non_copy_name = matches!(index, HirExpr::Name { .. })
+                            && matches!(
+                                crate::resolve_alias_type_for_plain_call(index.ty()),
+                                Type::Str | Type::LiteralStr(_)
+                            );
+
+                        let Some(mut index_expr) = self.lower_rendered_expr_for_ir(index)? else {
+                            return Ok(None);
+                        };
+                        if key_needs_clone || key_is_non_copy_name {
+                            index_expr = crate::RustExpr::Clone(Box::new(index_expr));
+                        }
+                        crate::RustStmt::Expr(crate::RustExpr::MethodCall {
+                            receiver: Box::new(receiver),
+                            method: "insert".to_string(),
+                            args: vec![index_expr, value_expr],
+                        })
+                    }
+                    _ => return Ok(None),
+                };
+                (vec![lowered_stmt], true)
             } else if let HirStmt::FieldAssign {
                 object,
                 field,


### PR DESCRIPTION
## Summary
- suppress redundant direct self.field clones for read-only collection method receivers and borrowed helper arguments
- add structured lowering for attribute-list subscript assignment in both direct and nested statement paths
- add focused codegen regressions for self-field read access and self.field[index] mutation lowering

## Validation
- cargo test -p sifr_codegen test_structured_stmt_path_handles_attribute_list_subscript_assign_inside_if
- cargo test -p sifr_codegen test_structured_stmt_path_handles_top_level_attribute_list_subscript_assign
- cargo test -p sifr_codegen method_calls_on_self_collection_fields_do_not_clone_for_read_only_receivers
- cargo build -p sifr
- cargo run -q -p sifr -- emit audits/leetcode/src/1472_design_browser_history.sifr
- cargo run -q -p sifr -- emit audits/leetcode/benchmarks/generated/sifr/1472_design_browser_history_runner.sifr
- scripts/run_all_tests.sh --profile quick (exit 0; wall-time/cache/skew advisories only)

## Review
- Claude Opus pass 1: APPROVED WITH NITS
- Claude Opus pass 2: APPROVED