### PR TITLE
Optimize owned recursive option field moves

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -178,6 +178,22 @@ impl RustEmitter {
                 return lowered_field;
             }
             if crate::helpers::is_option_type(ty) {
+                if self.recursive_option_field_can_move(object) {
+                    return crate::RustExpr::MethodCall {
+                        receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_field))),
+                        method: "map".to_string(),
+                        args: vec![crate::RustExpr::Closure {
+                            params: vec![crate::RustParam::Named {
+                                name: "__sifr_boxed_recursive_value".to_string(),
+                                ty: crate::RustType::Named("_".to_string()),
+                            }],
+                            body: Box::new(crate::RustExpr::Deref(Box::new(
+                                crate::RustExpr::Ident("__sifr_boxed_recursive_value".to_string()),
+                            ))),
+                            is_move: false,
+                        }],
+                    };
+                }
                 return crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::MethodCall {
                         receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_field))),
@@ -208,6 +224,15 @@ impl RustEmitter {
         }
 
         lowered_field
+    }
+
+    fn recursive_option_field_can_move(&self, object: &HirExpr) -> bool {
+        let HirExpr::Name { name, .. } = object else {
+            return false;
+        };
+        name != "self"
+            && !self.borrowed_params.contains(name)
+            && !self.mut_borrowed_params.contains(name)
     }
 }
 

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/plain_call_args.rs
@@ -22,6 +22,10 @@ impl RustEmitter {
             let effective_arg_ty = self.effective_registry_expr_ty(arg);
             let arg_is_option = crate::helpers::is_option_type(&effective_arg_ty);
             let mut lowered_arg = self.try_lower_registry_expr_strict(arg)?;
+            let borrowed_name_arg = matches!(arg, HirExpr::Name { name, ty }
+                if self.borrowed_params.contains(name)
+                    || self.mut_borrowed_params.contains(name)
+                    || ty.rust_type().starts_with('&'));
             if let Some(aligned_callable) = self
                 .try_build_registry_callable_convention_alignment_expr(
                     arg,
@@ -72,7 +76,11 @@ impl RustEmitter {
                 let needs_box_inner =
                     param_ty.rust_type().starts_with("Option<Box<") || is_recursive_ctor_param;
                 if !arg_is_option && !matches!(arg, HirExpr::NoneLiteral) {
-                    if !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty) {
+                    let param_rust_type = param_ty.rust_type();
+                    let param_is_owned_rust_value = !param_rust_type.starts_with('&');
+                    if (!param_is_owned_rust_value || borrowed_name_arg)
+                        && !crate::helpers::is_copy_type_for_codegen(&effective_arg_ty)
+                    {
                         lowered_arg = crate::RustExpr::MethodCall {
                             receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),
                             method: "clone".to_string(),
@@ -161,10 +169,6 @@ impl RustEmitter {
                 }
             }
 
-            let borrowed_name_arg = matches!(arg, HirExpr::Name { name, ty }
-                if self.borrowed_params.contains(name)
-                    || self.mut_borrowed_params.contains(name)
-                    || ty.rust_type().starts_with('&'));
             if convention.is_owned() && borrowed_name_arg {
                 lowered_arg = crate::RustExpr::MethodCall {
                     receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_arg))),

--- a/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
@@ -113,6 +113,64 @@ fn test_guarded_non_option_compare_does_not_emit_some_wrapping() {
 }
 
 #[test]
+fn test_owned_recursive_option_field_moves_without_tail_clone() {
+    let rust_code = generate_rust_from_source(
+        r#"class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+def reverseInto(own mut cur: ListNode | None, own prev: ListNode | None) -> ListNode | None:
+    if cur is None:
+        return prev
+    next_node: ListNode | None = cur.next
+    cur.next = prev
+    return reverseInto(next_node, cur)
+"#,
+    );
+
+    assert!(
+        rust_code.contains("(cur.next).map(|__sifr_boxed_recursive_value|"),
+        "owned recursive field read should move the boxed child instead of cloning it:\n{rust_code}"
+    );
+    assert!(
+        !rust_code.contains("(cur.next).as_deref().cloned()"),
+        "owned recursive field read should not clone the remaining list tail:\n{rust_code}"
+    );
+    assert!(
+        !rust_code.contains("Some((cur).clone())"),
+        "owned optional parameter wrapping should move cur instead of cloning it:\n{rust_code}"
+    );
+}
+
+#[test]
+fn test_borrowed_recursive_option_field_still_clones() {
+    let rust_code = generate_rust_from_source(
+        r#"class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+def nodeNext(node: ListNode | None) -> ListNode | None:
+    if node is None:
+        return None
+    return node.next
+"#,
+    );
+
+    assert!(
+        rust_code.contains("(node.next).as_deref().cloned()"),
+        "borrowed recursive field read must keep cloning semantics:\n{rust_code}"
+    );
+}
+
+#[test]
 fn test_empty_print() {
     // print() should emit println!() not println!("{}", "")
     let module = HirModule {

--- a/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
+++ b/crates/sifr_codegen/src/stmt_support_emitter/call_args_and_returns.rs
@@ -64,7 +64,13 @@ impl RustEmitter {
                 let needs_box_inner =
                     param_ty.rust_type().starts_with("Option<Box<") || is_recursive_ctor_param;
                 if !arg_is_option && !matches!(hir_arg, HirExpr::NoneLiteral) {
-                    let wrapped_inner = Self::clone_non_copy_name_expr_for_ir(hir_arg, lowered_arg);
+                    let param_rust_type = param_ty.rust_type();
+                    let param_is_owned_rust_value = !param_rust_type.starts_with('&');
+                    let wrapped_inner = if param_is_owned_rust_value && !borrowed_name_arg {
+                        lowered_arg
+                    } else {
+                        Self::clone_non_copy_name_expr_for_ir(hir_arg, lowered_arg)
+                    };
                     lowered_arg = if needs_box_inner {
                         Self::ensure_some_box_inner_for_ir(wrapped_inner)
                     } else {


### PR DESCRIPTION
## Summary
- lower owned recursive optional field reads as moves instead of `as_deref().cloned()` when the base is a non-borrowed local name
- avoid cloning non-copy names when wrapping them for owned optional parameters
- add emitted-code coverage for owned linked-list reversal and borrowed helper traversal

## Validation
- `cargo test -p sifr_codegen recursive_option_field`
- `cargo run -q -p sifr -- run audits/leetcode/src/0206_reverse_linked_list.sifr`
- `SIFR_BIN=target/debug/sifr python3 benchmarks/bench.py run --runs 2 --warmup 1 --memory-runs 1 0206_reverse_linked_list`
- `python3 benchmarks/analyze_slowness.py --check-metadata`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile quick` (exit 0; wall-time/cache/skew advisories only)

Review: Claude Opus approved in `reviews/leetcode-recursive-option-move-m4-review-pass-1.md`.
