### PR TITLE
Use take for recursive option field moves

### DIFF
--- a/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
+++ b/crates/sifr_codegen/src/expr_render_helpers/field_and_stdlib_rewrites.rs
@@ -179,8 +179,13 @@ impl RustEmitter {
             }
             if crate::helpers::is_option_type(ty) {
                 if self.recursive_option_field_can_move(object) {
+                    let moved_field = crate::RustExpr::MethodCall {
+                        receiver: Box::new(lowered_field),
+                        method: "take".to_string(),
+                        args: vec![],
+                    };
                     return crate::RustExpr::MethodCall {
-                        receiver: Box::new(crate::RustExpr::Paren(Box::new(lowered_field))),
+                        receiver: Box::new(moved_field),
                         method: "map".to_string(),
                         args: vec![crate::RustExpr::Closure {
                             params: vec![crate::RustParam::Named {

--- a/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
@@ -133,8 +133,8 @@ def reverseInto(own mut cur: ListNode | None, own prev: ListNode | None) -> List
     );
 
     assert!(
-        rust_code.contains("(cur.next).map(|__sifr_boxed_recursive_value|"),
-        "owned recursive field read should move the boxed child instead of cloning it:\n{rust_code}"
+        rust_code.contains("cur.next.take().map(|__sifr_boxed_recursive_value|"),
+        "owned recursive field read should take and move the boxed child instead of cloning it:\n{rust_code}"
     );
     assert!(
         !rust_code.contains("(cur.next).as_deref().cloned()"),
@@ -143,6 +143,44 @@ def reverseInto(own mut cur: ListNode | None, own prev: ListNode | None) -> List
     assert!(
         !rust_code.contains("Some((cur).clone())"),
         "owned optional parameter wrapping should move cur instead of cloning it:\n{rust_code}"
+    );
+}
+
+#[test]
+fn test_owned_recursive_option_field_take_preserves_parent_use() {
+    let rust_code = generate_rust_from_source(
+        r#"class ListNode:
+    val: int
+    next: ListNode | None
+
+    def __init__(self, val: int = 0, next: ListNode | None = None):
+        self.val = val
+        self.next = next
+
+def swapPairs(own mut head: ListNode | None) -> ListNode | None:
+    if head is None:
+        return None
+    second: ListNode | None = head.next
+    if second is None:
+        return head
+    rest: ListNode | None = second.next
+    head.next = rest
+    second.next = head
+    return second
+"#,
+    );
+
+    assert!(
+        rust_code.contains("head.next.take().map(|__sifr_boxed_recursive_value|"),
+        "owned recursive field read should leave the parent usable after an empty child:\n{rust_code}"
+    );
+    assert!(
+        rust_code.contains("return Some(head);"),
+        "regression should keep returning the parent after taking an empty child:\n{rust_code}"
+    );
+    assert!(
+        !rust_code.contains("(head.next).map(|__sifr_boxed_recursive_value|"),
+        "owned recursive field read must not partially move the parent field:\n{rust_code}"
     );
 }
 


### PR DESCRIPTION
## Summary
- lower owned recursive optional field reads through `.take().map(...)` so parent structs remain usable after extracting an optional child
- keep borrowed/self recursive field reads on `as_deref().cloned()`
- add a swap-pairs regression test for returning the parent when the child is absent

## Validation
- cargo test -p sifr_codegen recursive_option_field
- cargo fmt --check
- ./target/debug/sifr emit audits/leetcode/benchmarks/generated/sifr/0024_swap_nodes_in_pairs_runner.sifr | rg -n 'fn swapPairs|head\.next|second\.next|return Some\(head\)' -C 2
- ./target/debug/sifr check audits/leetcode/benchmarks/generated/sifr/0024_swap_nodes_in_pairs_runner.sifr
- ./target/debug/sifr run audits/leetcode/src/0024_swap_nodes_in_pairs.sifr
- ./target/debug/sifr run audits/leetcode/src/0206_reverse_linked_list.sifr
- (audits/leetcode) SIFR_BIN=/Users/yaseralnajjar/work/sifr/codebase/target/debug/sifr python3 benchmarks/bench.py run --runs 2 --warmup 1 --memory-runs 1 0024_swap_nodes_in_pairs
- git diff --check
- python3 scripts/check_hir_maintainability_guardrails.py
- python3 scripts/check_file_size_guardrails.py
- scripts/run_all_tests.sh --profile quick

## Review
- Claude Opus reviewer: APPROVED (reviews/leetcode-recursive-option-take-m6-review-pass-1.md)
