### PR TITLE
M0: add canonical source position foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/sifr_source",
     "crates/sifr_diagnostics",
     "crates/sifr_runtime",
     "crates/sifr_type_system",
@@ -44,6 +45,7 @@ sifr_python_parser = { package = "ruff_python_parser", path = "third_party/ruff/
 
 # Sifr-specific crates
 sifr_diagnostics = { path = "crates/sifr_diagnostics" }
+sifr_source = { path = "crates/sifr_source" }
 sifr_runtime = { path = "crates/sifr_runtime" }
 sifr_type_system = { path = "crates/sifr_type_system" }
 sifr_hir = { path = "crates/sifr_hir" }

--- a/crates/sifr_diagnostics/src/render/mod.rs
+++ b/crates/sifr_diagnostics/src/render/mod.rs
@@ -1,8 +1,10 @@
 use crate::model::{ChildSeverity, DiagnosticArg, DiagnosticSuggestion, RelatedKind, Severity};
 use crate::source_map::{SourceMap, SourceMapError, SourceSpan};
 use crate::{DiagnosticSink, SifrDiagnostic};
+use ruff_text_size::TextSize;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use sifr_source::LineMap;
 use std::collections::BTreeMap;
 
 mod presentation;
@@ -244,16 +246,15 @@ fn render_span(
     label: Option<String>,
 ) -> Result<DiagnosticSpan, SourceMapError> {
     source_map.validate_span(span)?;
-    let text = source_map
-        .source_text(span.source_id)
+    let source = source_map
+        .source(span.source_id)
         .ok_or(SourceMapError::UnknownSource(span.source_id))?;
-    let line_starts = source_map
-        .line_starts(span.source_id)
-        .ok_or(SourceMapError::UnknownSource(span.source_id))?;
+    let text = source.as_str();
+    let line_map = source.line_map();
     let byte_start = span.range.start().to_u32();
     let byte_end = span.range.end().to_u32();
-    let (line, column) = line_column(text, line_starts, byte_start);
-    let (end_line, end_column) = line_column(text, line_starts, byte_end);
+    let (line, column) = line_column(text, line_map, byte_start);
+    let (end_line, end_column) = line_column(text, line_map, byte_end);
     Ok(DiagnosticSpan {
         file: source_map.display_path(span.source_id).map(str::to_string),
         byte_start,
@@ -264,17 +265,19 @@ fn render_span(
         end_column: Some(end_column),
         is_primary,
         label,
-        lines: span_lines(text, line_starts, byte_start, byte_end),
+        lines: span_lines(text, line_map, byte_start, byte_end),
     })
 }
 
-fn line_column(text: &str, line_starts: &[u32], byte_pos: u32) -> (u32, u32) {
+fn line_column(text: &str, line_map: &LineMap, byte_pos: u32) -> (u32, u32) {
+    let byte_pos = TextSize::new(byte_pos);
+    let line_starts = line_map.line_starts();
     let line_index = match line_starts.binary_search(&byte_pos) {
         Ok(index) => index,
         Err(index) => index.saturating_sub(1),
     };
-    let line_start = usize::try_from(line_starts[line_index]).unwrap_or(0);
-    let byte_pos_usize = usize::try_from(byte_pos).unwrap_or(text.len());
+    let line_start = usize::try_from(line_starts[line_index].to_u32()).unwrap_or(0);
+    let byte_pos_usize = usize::try_from(byte_pos.to_u32()).unwrap_or(text.len());
     let prefix = text.get(line_start..byte_pos_usize).unwrap_or_default();
     (
         u32::try_from(line_index + 1).unwrap_or(u32::MAX),
@@ -286,10 +289,13 @@ fn line_column(text: &str, line_starts: &[u32], byte_pos: u32) -> (u32, u32) {
 // normalize or strip it before printing snippets to a terminal.
 fn span_lines(
     text: &str,
-    line_starts: &[u32],
+    line_map: &LineMap,
     byte_start: u32,
     byte_end: u32,
 ) -> Vec<DiagnosticSpanLine> {
+    let byte_start = TextSize::new(byte_start);
+    let byte_end = TextSize::new(byte_end);
+    let line_starts = line_map.line_starts();
     let start_line_index = match line_starts.binary_search(&byte_start) {
         Ok(index) => index,
         Err(index) => index.saturating_sub(1),
@@ -299,22 +305,31 @@ fn span_lines(
         Err(index) => index.saturating_sub(1),
     };
     (start_line_index..=end_line_index)
-        .map(|line_index| render_line(text, line_starts, line_index, byte_start, byte_end))
+        .map(|line_index| {
+            render_line(
+                text,
+                line_map,
+                line_index,
+                byte_start.to_u32(),
+                byte_end.to_u32(),
+            )
+        })
         .collect()
 }
 
 fn render_line(
     text: &str,
-    line_starts: &[u32],
+    line_map: &LineMap,
     line_index: usize,
     byte_start: u32,
     byte_end: u32,
 ) -> DiagnosticSpanLine {
-    let line_start = usize::try_from(line_starts[line_index]).unwrap_or(0);
-    let line_end = line_starts
-        .get(line_index + 1)
-        .and_then(|next| usize::try_from(*next).ok())
-        .unwrap_or(text.len());
+    let line = u32::try_from(line_index).unwrap_or(u32::MAX);
+    let full_range = line_map
+        .line_full_byte_range(line)
+        .unwrap_or_else(|| ruff_text_size::TextRange::new(line_map.eof(), line_map.eof()));
+    let line_start = usize::try_from(full_range.start().to_u32()).unwrap_or(0);
+    let line_end = usize::try_from(full_range.end().to_u32()).unwrap_or(text.len());
     let line_text = text[line_start..line_end]
         .trim_end_matches('\n')
         .to_string();

--- a/crates/sifr_diagnostics/src/source_map/mod.rs
+++ b/crates/sifr_diagnostics/src/source_map/mod.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use serde::{Deserialize, Serialize};
+use sifr_source::SourceText;
 use std::collections::HashMap;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -57,8 +58,7 @@ struct SourceFile {
     display_path: String,
     module_name: Option<String>,
     source_hash: u64,
-    text: String,
-    line_starts: Vec<u32>,
+    text: SourceText,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -93,9 +93,8 @@ impl SourceMap {
             .next_id
             .checked_add(1)
             .unwrap_or_else(|| panic!("source id allocation overflowed"));
-        let text = text.into();
-        let line_starts = line_starts(&text);
-        let source_hash = stable_hash(&text);
+        let text = SourceText::new(text);
+        let source_hash = text.source_hash();
         self.sources.insert(
             id,
             SourceFile {
@@ -104,7 +103,6 @@ impl SourceMap {
                 module_name: module_name.map(Into::into),
                 source_hash,
                 text,
-                line_starts,
             },
         );
         id
@@ -145,7 +143,7 @@ impl SourceMap {
             .ok_or(SourceMapError::UnknownSource(span.source_id))?;
         let byte_start = span.range.start().to_u32();
         let byte_end = span.range.end().to_u32();
-        let source_len = u32::try_from(source.text.len()).unwrap_or(u32::MAX);
+        let source_len = u32::try_from(source.text.as_str().len()).unwrap_or(u32::MAX);
         if byte_start > byte_end || byte_end > source_len {
             return Err(SourceMapError::InvalidSpan {
                 source_id: span.source_id,
@@ -157,37 +155,9 @@ impl SourceMap {
         Ok(())
     }
 
-    pub(crate) fn source_text(&self, source_id: SourceId) -> Option<&str> {
-        self.sources
-            .get(&source_id)
-            .map(|source| source.text.as_str())
+    pub(crate) fn source(&self, source_id: SourceId) -> Option<&SourceText> {
+        self.sources.get(&source_id).map(|source| &source.text)
     }
-
-    pub(crate) fn line_starts(&self, source_id: SourceId) -> Option<&[u32]> {
-        self.sources
-            .get(&source_id)
-            .map(|source| source.line_starts.as_slice())
-    }
-}
-
-fn line_starts(text: &str) -> Vec<u32> {
-    let mut starts = vec![0];
-    for (index, byte) in text.bytes().enumerate() {
-        if byte == b'\n' {
-            if let Ok(next) = u32::try_from(index + 1) {
-                starts.push(next);
-            }
-        }
-    }
-    starts
-}
-
-fn stable_hash(text: &str) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-    text.as_bytes().iter().fold(FNV_OFFSET, |hash, byte| {
-        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
-    })
 }
 
 mod text_range_serde {

--- a/crates/sifr_frontend/Cargo.toml
+++ b/crates/sifr_frontend/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 [dependencies]
 sifr_diagnostics = { workspace = true }
 sifr_hir = { workspace = true }
+sifr_source = { workspace = true }
 sifr_syntax = { workspace = true }
 sifr_type_system = { workspace = true }
 sifr_python_ast = { workspace = true }

--- a/crates/sifr_frontend/src/bin/frontend_query_bench.rs
+++ b/crates/sifr_frontend/src/bin/frontend_query_bench.rs
@@ -263,14 +263,19 @@ fn run_iteration(
             else {
                 return Err("source map did not expose entrypoint file".to_string());
             };
-            let _ = source_map.text_position_to_span(
-                file.id,
-                TextPosition {
-                    line: 0,
-                    character: 0,
-                },
-                PositionEncoding::UTF8,
-            );
+            let target = TextPosition {
+                line: 0,
+                character: 0,
+            };
+            let span = source_map
+                .text_position_to_span(file.id, &target, PositionEncoding::UTF8)
+                .ok_or_else(|| "source map lookup failed for entrypoint start".to_string())?;
+            let round_trip = source_map
+                .span_to_text_range(file.id, span, PositionEncoding::UTF8)
+                .ok_or_else(|| "source map round trip failed for entrypoint start".to_string())?;
+            if round_trip.start != target || round_trip.end != target {
+                return Err("source map round trip changed the entrypoint start".to_string());
+            }
         }
         other => {
             return Err(format!(

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -1,29 +1,19 @@
 use super::{
     collect_module_exports, diagnostic_with_code, empty_hir_module, hir_diagnostic_to_rendered,
     local_import_dependencies, module_state, reveal_type_diagnostics, source_hash,
-    symbols_from_hir, warning_diagnostics,
+    symbols_from_hir, warning_diagnostics, DocumentVersion, FileId, SourceFileView, SourceHash,
+    SourceMapView, SourcePath, SourceRevision, SourceText,
 };
-use ruff_text_size::TextRange;
 use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
 use sifr_hir::{
     lower_module_with_externals_and_name, ExternalDefs, HirModule, LoweringResult,
     LoweringWarningDiagnostic, RevealTypeDiagnostic,
 };
 use sifr_python_ast::Stmt;
-use sifr_syntax::{ParsedModule, TextPosition, TextRangeUtf};
+use sifr_syntax::ParsedModule;
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
-use std::path::{Path, PathBuf};
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FileId(u32);
-
-impl FileId {
-    #[must_use]
-    pub fn as_u32(self) -> u32 {
-        self.0
-    }
-}
+use std::path::Path;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleId(pub(crate) u32);
@@ -46,67 +36,6 @@ impl GraphRevision {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct SourceRevision(u64);
-
-impl SourceRevision {
-    #[must_use]
-    pub fn as_u64(self) -> u64 {
-        self.0
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceHash(pub(super) String);
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourcePath(PathBuf);
-
-impl SourcePath {
-    #[must_use]
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        Self(path.into())
-    }
-
-    #[must_use]
-    pub fn as_path(&self) -> &Path {
-        &self.0
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceText(String);
-
-impl SourceText {
-    #[must_use]
-    pub fn new(source: impl Into<String>) -> Self {
-        Self(source.into())
-    }
-
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceUri(String);
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct DocumentVersion(i64);
-
-impl DocumentVersion {
-    #[must_use]
-    pub fn new(version: i64) -> Self {
-        Self(version)
-    }
-
-    #[must_use]
-    pub fn as_i64(self) -> i64 {
-        self.0
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FrontendMode {
     SingleFile,
     ProjectEntrypoint,
@@ -123,13 +52,6 @@ pub struct FrontendInput {
 pub struct ProjectRoot {
     pub root: SourcePath,
     pub entrypoint: SourcePath,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PositionEncoding {
-    UTF8,
-    UTF16,
-    UTF32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -205,42 +127,6 @@ pub struct ModuleGraphView {
     pub edges: Vec<ModuleGraphEdge>,
     pub entrypoint: ModuleId,
     pub revision: GraphRevision,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceFileView {
-    pub id: FileId,
-    pub canonical_path: SourcePath,
-    pub uri: Option<SourceUri>,
-    pub source_hash: SourceHash,
-    pub document_version: Option<DocumentVersion>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceMapView {
-    pub files: Vec<SourceFileView>,
-    pub revision: SourceRevision,
-}
-
-impl SourceMapView {
-    #[must_use]
-    pub fn text_position_to_span(
-        &self,
-        _file: FileId,
-        _position: TextPosition,
-        _encoding: PositionEncoding,
-    ) -> Option<TextRange> {
-        None
-    }
-
-    #[must_use]
-    pub fn span_to_text_range(
-        &self,
-        _span: TextRange,
-        _encoding: PositionEncoding,
-    ) -> Option<TextRangeUtf> {
-        None
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -614,6 +500,7 @@ impl FrontendContext {
                     uri: None,
                     source_hash: module.source_hash.clone(),
                     document_version: module.document_version,
+                    source: module.source.clone(),
                 })
                 .collect(),
             revision: self.source_revision,

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -10,3 +10,5 @@ pub use graph_cache_and_queries::*;
 mod hir_views;
 mod query_diagnostics;
 pub use query_diagnostics::*;
+mod source_maps;
+pub use source_maps::*;

--- a/crates/sifr_frontend/src/source_maps.rs
+++ b/crates/sifr_frontend/src/source_maps.rs
@@ -1,0 +1,188 @@
+use ruff_text_size::TextRange;
+pub use sifr_source::{PositionEncoding, SourceText, TextPosition, TextRangeUtf};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FileId(pub(crate) u32);
+
+impl FileId {
+    #[must_use]
+    pub fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    #[must_use]
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SourceRevision(pub(crate) u64);
+
+impl SourceRevision {
+    #[must_use]
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceHash(pub(crate) String);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourcePath(PathBuf);
+
+impl SourcePath {
+    #[must_use]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceUri(String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DocumentVersion(i64);
+
+impl DocumentVersion {
+    #[must_use]
+    pub fn new(version: i64) -> Self {
+        Self(version)
+    }
+
+    #[must_use]
+    pub fn as_i64(self) -> i64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceFileView {
+    pub id: FileId,
+    pub canonical_path: SourcePath,
+    pub uri: Option<SourceUri>,
+    pub source_hash: SourceHash,
+    pub document_version: Option<DocumentVersion>,
+    pub source: SourceText,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceMapView {
+    pub files: Vec<SourceFileView>,
+    pub revision: SourceRevision,
+}
+
+impl SourceMapView {
+    #[must_use]
+    pub fn text_position_to_span(
+        &self,
+        file: FileId,
+        position: &TextPosition,
+        encoding: PositionEncoding,
+    ) -> Option<TextRange> {
+        let source = self.source_for_file(file)?;
+        let offset = source.byte_offset_with_encoding(position, encoding)?;
+        Some(TextRange::new(offset, offset))
+    }
+
+    #[must_use]
+    pub fn span_to_text_range(
+        &self,
+        file: FileId,
+        span: TextRange,
+        encoding: PositionEncoding,
+    ) -> Option<TextRangeUtf> {
+        self.source_for_file(file)?.range_at(span, encoding)
+    }
+
+    #[must_use]
+    pub fn source_for_file(&self, file: FileId) -> Option<&SourceText> {
+        self.files
+            .iter()
+            .find(|source_file| source_file.id == file)
+            .map(|source_file| &source_file.source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DocumentVersion, FileId, PositionEncoding, SourceFileView, SourceHash, SourceMapView,
+        SourcePath, SourceRevision, SourceText, TextPosition,
+    };
+    use ruff_text_size::{TextRange, TextSize};
+
+    fn source_map(source: &str) -> SourceMapView {
+        SourceMapView {
+            files: vec![SourceFileView {
+                id: FileId::new(0),
+                canonical_path: SourcePath::new("main.sifr"),
+                uri: None,
+                source_hash: SourceHash("hash".to_string()),
+                document_version: Some(DocumentVersion::new(7)),
+                source: SourceText::new(source),
+            }],
+            revision: SourceRevision(0),
+        }
+    }
+
+    #[test]
+    fn source_map_lookup_round_trips_multibyte_positions() {
+        let map = source_map("a🦀b\n");
+        let position = TextPosition {
+            line: 0,
+            character: 5,
+        };
+        let span = map
+            .text_position_to_span(FileId::new(0), &position, PositionEncoding::Utf8)
+            .unwrap();
+        assert_eq!(span, TextRange::new(TextSize::new(5), TextSize::new(5)));
+        assert_eq!(
+            map.span_to_text_range(FileId::new(0), span, PositionEncoding::Utf16),
+            Some(sifr_source::TextRangeUtf {
+                start: TextPosition {
+                    line: 0,
+                    character: 3,
+                },
+                end: TextPosition {
+                    line: 0,
+                    character: 3,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn source_map_lookup_rejects_unregistered_files_and_invalid_boundaries() {
+        let map = source_map("a🦀b\r\n");
+        assert_eq!(
+            map.text_position_to_span(
+                FileId::new(1),
+                &TextPosition {
+                    line: 0,
+                    character: 0,
+                },
+                PositionEncoding::Utf8,
+            ),
+            None
+        );
+        assert_eq!(
+            map.text_position_to_span(
+                FileId::new(0),
+                &TextPosition {
+                    line: 0,
+                    character: 2,
+                },
+                PositionEncoding::Utf8,
+            ),
+            None
+        );
+    }
+}

--- a/crates/sifr_lsp/Cargo.toml
+++ b/crates/sifr_lsp/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 [dependencies]
 sifr_analysis = { workspace = true }
 sifr_diagnostics = { workspace = true }
-sifr_syntax = { workspace = true }
+sifr_source = { workspace = true }
 ruff_text_size = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }

--- a/crates/sifr_lsp/src/conversion.rs
+++ b/crates/sifr_lsp/src/conversion.rs
@@ -9,7 +9,7 @@ use sifr_analysis::{
     TestItem, TextEdit, TypeHierarchyItem, WorkspaceEdit, WorkspaceSymbol,
 };
 use sifr_diagnostics::{DiagnosticArg, DiagnosticSpan, RenderedDiagnostic, Severity};
-use sifr_syntax::{SourceText as SyntaxSourceText, TextPosition};
+use sifr_source::{PositionEncoding, SourceText as SourceTextMap, TextPosition};
 use std::path::PathBuf;
 use url::Url;
 
@@ -43,6 +43,14 @@ pub(crate) fn lsp_position(value: &Value) -> LspResult<TextPosition> {
 }
 
 pub(crate) fn lsp_range(value: &Value, source: &str) -> LspResult<TextRange> {
+    lsp_range_with_encoding(value, source, PositionEncoding::Utf8)
+}
+
+fn lsp_range_with_encoding(
+    value: &Value,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<TextRange> {
     let start = value
         .get("start")
         .ok_or_else(|| LspError::invalid_params("missing LSP range start"))
@@ -51,12 +59,12 @@ pub(crate) fn lsp_range(value: &Value, source: &str) -> LspResult<TextRange> {
         .get("end")
         .ok_or_else(|| LspError::invalid_params("missing LSP range end"))
         .and_then(lsp_position)?;
-    let source = SyntaxSourceText::new(source);
+    let source = SourceTextMap::new(source);
     let start = source
-        .byte_offset(&start)
+        .byte_offset_with_encoding(&start, encoding)
         .ok_or_else(|| LspError::invalid_params("range start is outside the document"))?;
     let end = source
-        .byte_offset(&end)
+        .byte_offset_with_encoding(&end, encoding)
         .ok_or_else(|| LspError::invalid_params("range end is outside the document"))?;
     if start > end {
         return Err(LspError::invalid_params(
@@ -67,8 +75,16 @@ pub(crate) fn lsp_range(value: &Value, source: &str) -> LspResult<TextRange> {
 }
 
 pub(crate) fn text_range(range: TextRange, source: &str) -> LspResult<Value> {
-    let source = SyntaxSourceText::new(source);
-    let Some(utf_range) = source.text_range(range) else {
+    text_range_with_encoding(range, source, PositionEncoding::Utf8)
+}
+
+fn text_range_with_encoding(
+    range: TextRange,
+    source: &str,
+    encoding: PositionEncoding,
+) -> LspResult<Value> {
+    let source = SourceTextMap::new(source);
+    let Some(utf_range) = source.range_at(range, encoding) else {
         return Err(LspError::internal(
             "analysis returned a range outside the document",
         ));
@@ -150,7 +166,7 @@ pub(crate) fn signature_help(help: SignatureHelp) -> Value {
 }
 
 pub(crate) fn semantic_tokens(tokens: Vec<SemanticToken>, source: &str) -> LspResult<Value> {
-    let source_map = SyntaxSourceText::new(source);
+    let source_map = SourceTextMap::new(source);
     let mut encoded = Vec::new();
     let mut previous_line = 0;
     let mut previous_start = 0;
@@ -457,4 +473,37 @@ fn token_modifier_bits(modifiers: &[String]) -> u32 {
         };
         bits | (1_u32 << shift)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lsp_range_with_encoding, text_range_with_encoding};
+    use ruff_text_size::{TextRange, TextSize};
+    use serde_json::json;
+    use sifr_source::PositionEncoding;
+
+    #[test]
+    fn utf16_ranges_round_trip_through_conversion_layer() {
+        let source = "a🦀b\n";
+        let range_json = json!({
+            "start": { "line": 0, "character": 1 },
+            "end": { "line": 0, "character": 3 }
+        });
+        let range = lsp_range_with_encoding(&range_json, source, PositionEncoding::Utf16).unwrap();
+        assert_eq!(range, TextRange::new(TextSize::new(1), TextSize::new(5)));
+        assert_eq!(
+            text_range_with_encoding(range, source, PositionEncoding::Utf16).unwrap(),
+            range_json
+        );
+    }
+
+    #[test]
+    fn utf16_ranges_reject_surrogate_pair_interiors() {
+        let source = "a🦀b\n";
+        let range_json = json!({
+            "start": { "line": 0, "character": 2 },
+            "end": { "line": 0, "character": 3 }
+        });
+        assert!(lsp_range_with_encoding(&range_json, source, PositionEncoding::Utf16).is_err());
+    }
 }

--- a/crates/sifr_source/Cargo.toml
+++ b/crates/sifr_source/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sifr_diagnostics"
+name = "sifr_source"
 version = "0.0.0"
 publish = false
 edition = { workspace = true }
@@ -8,13 +8,6 @@ license = { workspace = true }
 
 [dependencies]
 ruff_text_size = { workspace = true }
-sifr_source = { workspace = true }
-schemars = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-
-[dev-dependencies]
-static_assertions = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sifr_source/src/lib.rs
+++ b/crates/sifr_source/src/lib.rs
@@ -1,0 +1,386 @@
+//! Canonical source text, line-map, and editor position conversion primitives.
+//!
+//! This crate intentionally sits at the bottom of the Sifr dependency graph.
+//! Higher compiler and tooling crates may depend on it; it must not depend on
+//! syntax, diagnostics, frontend, analysis, LSP, package, driver, or CLI crates.
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+use ruff_text_size::{TextRange, TextSize};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PositionEncoding {
+    Utf8,
+    Utf16,
+    Utf32,
+}
+
+impl PositionEncoding {
+    pub const UTF8: Self = Self::Utf8;
+    pub const UTF16: Self = Self::Utf16;
+    pub const UTF32: Self = Self::Utf32;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextPosition {
+    pub line: u32,
+    pub character: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextRangeUtf {
+    pub start: TextPosition,
+    pub end: TextPosition,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LineMap {
+    line_starts: Arc<[TextSize]>,
+    text_len: TextSize,
+}
+
+impl LineMap {
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        let mut line_starts = vec![TextSize::new(0)];
+        for (index, byte) in text.bytes().enumerate() {
+            if byte == b'\n' {
+                if let Ok(next) = u32::try_from(index + 1) {
+                    line_starts.push(TextSize::new(next));
+                }
+            }
+        }
+        let text_len = TextSize::new(u32::try_from(text.len()).unwrap_or(u32::MAX));
+        Self {
+            line_starts: Arc::from(line_starts),
+            text_len,
+        }
+    }
+
+    #[must_use]
+    pub fn line_starts(&self) -> &[TextSize] {
+        &self.line_starts
+    }
+
+    #[must_use]
+    pub fn line_count(&self) -> usize {
+        self.line_starts.len()
+    }
+
+    #[must_use]
+    pub fn eof(&self) -> TextSize {
+        self.text_len
+    }
+
+    #[must_use]
+    pub fn line_full_byte_range(&self, line: u32) -> Option<TextRange> {
+        let line = usize::try_from(line).ok()?;
+        let start = *self.line_starts.get(line)?;
+        let end = self
+            .line_starts
+            .get(line + 1)
+            .copied()
+            .unwrap_or(self.text_len);
+        Some(TextRange::new(start, end))
+    }
+
+    #[must_use]
+    pub fn line_byte_range(&self, text: &str, line: u32) -> Option<TextRange> {
+        let full = self.line_full_byte_range(line)?;
+        let start = usize::try_from(full.start().to_u32()).ok()?;
+        let mut end = usize::try_from(full.end().to_u32()).ok()?;
+        let line_text = text.get(start..end)?;
+        if line_text.ends_with("\r\n") {
+            end = end.saturating_sub(2);
+        } else if line_text.ends_with('\n') {
+            end = end.saturating_sub(1);
+        }
+        Some(TextRange::new(
+            full.start(),
+            TextSize::new(u32::try_from(end).ok()?),
+        ))
+    }
+
+    fn line_index_at_offset(&self, offset: TextSize) -> Option<usize> {
+        if offset > self.text_len {
+            return None;
+        }
+        Some(match self.line_starts.binary_search(&offset) {
+            Ok(index) => index,
+            Err(index) => index.checked_sub(1)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceText {
+    text: Arc<str>,
+    line_map: LineMap,
+}
+
+impl SourceText {
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let line_map = LineMap::new(&text);
+        Self {
+            text: Arc::from(text),
+            line_map,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    #[must_use]
+    pub fn line_map(&self) -> &LineMap {
+        &self.line_map
+    }
+
+    #[must_use]
+    pub fn source_hash(&self) -> u64 {
+        stable_hash(self.as_str())
+    }
+
+    #[must_use]
+    pub fn byte_offset(&self, position: &TextPosition) -> Option<TextSize> {
+        self.byte_offset_with_encoding(position, PositionEncoding::Utf8)
+    }
+
+    #[must_use]
+    pub fn byte_offset_with_encoding(
+        &self,
+        position: &TextPosition,
+        encoding: PositionEncoding,
+    ) -> Option<TextSize> {
+        let line_range = self
+            .line_map
+            .line_byte_range(self.as_str(), position.line)?;
+        let line_start = usize::try_from(line_range.start().to_u32()).ok()?;
+        let line_end = usize::try_from(line_range.end().to_u32()).ok()?;
+        let line_text = self.as_str().get(line_start..line_end)?;
+        let character = usize::try_from(position.character).ok()?;
+        let offset =
+            match encoding {
+                PositionEncoding::Utf8 => {
+                    let offset = line_start.checked_add(character)?;
+                    (offset <= line_end && self.as_str().is_char_boundary(offset))
+                        .then_some(offset)?
+                }
+                PositionEncoding::Utf16 => line_start.checked_add(
+                    encoded_character_byte_offset(line_text, character, EncodedWidth::Utf16)?,
+                )?,
+                PositionEncoding::Utf32 => line_start.checked_add(
+                    encoded_character_byte_offset(line_text, character, EncodedWidth::Utf32)?,
+                )?,
+            };
+        u32::try_from(offset).ok().map(TextSize::new)
+    }
+
+    #[must_use]
+    pub fn text_position(&self, offset: TextSize) -> Option<TextPosition> {
+        self.position_at(offset, PositionEncoding::Utf8)
+    }
+
+    #[must_use]
+    pub fn position_at(
+        &self,
+        offset: TextSize,
+        encoding: PositionEncoding,
+    ) -> Option<TextPosition> {
+        let offset_usize = usize::try_from(offset.to_u32()).ok()?;
+        if offset_usize > self.as_str().len() || !self.as_str().is_char_boundary(offset_usize) {
+            return None;
+        }
+        let line_index = self.line_map.line_index_at_offset(offset)?;
+        let line = u32::try_from(line_index).ok()?;
+        let line_range = self.line_map.line_byte_range(self.as_str(), line)?;
+        if offset > line_range.end() {
+            return None;
+        }
+        let line_start = usize::try_from(line_range.start().to_u32()).ok()?;
+        let prefix = self.as_str().get(line_start..offset_usize)?;
+        let character = match encoding {
+            PositionEncoding::Utf8 => offset_usize.checked_sub(line_start)?,
+            PositionEncoding::Utf16 => prefix.encode_utf16().count(),
+            PositionEncoding::Utf32 => prefix.chars().count(),
+        };
+        Some(TextPosition {
+            line,
+            character: u32::try_from(character).ok()?,
+        })
+    }
+
+    #[must_use]
+    pub fn text_range(&self, range: TextRange) -> Option<TextRangeUtf> {
+        self.range_at(range, PositionEncoding::Utf8)
+    }
+
+    #[must_use]
+    pub fn range_at(&self, range: TextRange, encoding: PositionEncoding) -> Option<TextRangeUtf> {
+        Some(TextRangeUtf {
+            start: self.position_at(range.start(), encoding)?,
+            end: self.position_at(range.end(), encoding)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceFile {
+    pub canonical_path: PathBuf,
+    pub uri: Option<String>,
+    pub source_hash: u64,
+    pub document_version: Option<i64>,
+    pub source: SourceText,
+}
+
+impl SourceFile {
+    #[must_use]
+    pub fn new(
+        canonical_path: impl Into<PathBuf>,
+        uri: Option<String>,
+        document_version: Option<i64>,
+        source: SourceText,
+    ) -> Self {
+        let source_hash = source.source_hash();
+        Self {
+            canonical_path: canonical_path.into(),
+            uri,
+            source_hash,
+            document_version,
+            source,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EncodedWidth {
+    Utf16,
+    Utf32,
+}
+
+fn encoded_character_byte_offset(
+    text: &str,
+    character: usize,
+    width: EncodedWidth,
+) -> Option<usize> {
+    let mut consumed = 0usize;
+    for (offset, ch) in text.char_indices() {
+        if consumed == character {
+            return Some(offset);
+        }
+        let char_width = match width {
+            EncodedWidth::Utf16 => ch.len_utf16(),
+            EncodedWidth::Utf32 => 1,
+        };
+        if consumed.checked_add(char_width)? > character {
+            return None;
+        }
+        consumed = consumed.checked_add(char_width)?;
+    }
+    (consumed == character).then_some(text.len())
+}
+
+fn stable_hash(text: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    text.as_bytes().iter().fold(FNV_OFFSET, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PositionEncoding, SourceText, TextPosition};
+    use ruff_text_size::{TextRange, TextSize};
+
+    #[test]
+    fn converts_utf8_utf16_and_utf32_positions() {
+        let source = SourceText::new("a🦀b\r\nζ\n");
+        assert_eq!(
+            source.byte_offset_with_encoding(
+                &TextPosition {
+                    line: 0,
+                    character: 5
+                },
+                PositionEncoding::Utf8,
+            ),
+            Some(TextSize::new(5))
+        );
+        assert_eq!(
+            source.byte_offset_with_encoding(
+                &TextPosition {
+                    line: 0,
+                    character: 3
+                },
+                PositionEncoding::Utf16,
+            ),
+            Some(TextSize::new(5))
+        );
+        assert_eq!(
+            source.byte_offset_with_encoding(
+                &TextPosition {
+                    line: 0,
+                    character: 2
+                },
+                PositionEncoding::Utf32,
+            ),
+            Some(TextSize::new(5))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_boundaries_and_crlf_interior() {
+        let source = SourceText::new("a🦀b\r\n");
+        assert_eq!(
+            source.byte_offset_with_encoding(
+                &TextPosition {
+                    line: 0,
+                    character: 2
+                },
+                PositionEncoding::Utf8,
+            ),
+            None
+        );
+        assert_eq!(
+            source.byte_offset_with_encoding(
+                &TextPosition {
+                    line: 0,
+                    character: 2
+                },
+                PositionEncoding::Utf16,
+            ),
+            None
+        );
+        assert_eq!(
+            source.position_at(TextSize::new(7), PositionEncoding::Utf8),
+            None
+        );
+    }
+
+    #[test]
+    fn supports_eof_and_range_round_trips() {
+        let source = SourceText::new("alpha\nβeta\n");
+        let eof = source.line_map().eof();
+        assert_eq!(
+            source.position_at(eof, PositionEncoding::Utf8),
+            Some(TextPosition {
+                line: 2,
+                character: 0
+            })
+        );
+        let range = TextRange::new(TextSize::new(6), TextSize::new(11));
+        let utf16 = source.range_at(range, PositionEncoding::Utf16).unwrap();
+        assert_eq!(
+            source.byte_offset_with_encoding(&utf16.start, PositionEncoding::Utf16),
+            Some(range.start())
+        );
+        assert_eq!(
+            source.byte_offset_with_encoding(&utf16.end, PositionEncoding::Utf16),
+            Some(range.end())
+        );
+    }
+}

--- a/crates/sifr_syntax/Cargo.toml
+++ b/crates/sifr_syntax/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 
 [dependencies]
 sifr_diagnostics = { workspace = true }
+sifr_source = { workspace = true }
 sifr_python_ast = { workspace = true }
 sifr_python_parser = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/sifr_syntax/src/lib.rs
+++ b/crates/sifr_syntax/src/lib.rs
@@ -5,7 +5,7 @@
 //! parser APIs.
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
-use ruff_text_size::{Ranged as _, TextRange, TextSize};
+use ruff_text_size::{Ranged as _, TextRange};
 use sifr_diagnostics::{
     ChildSeverity, DiagnosticArg, DiagnosticBuilder, DiagnosticCode, DiagnosticSink,
     RenderedDiagnostic, Severity, SourceMap, SourceSpan,
@@ -16,6 +16,7 @@ use sifr_python_parser::{
     parse_unchecked, InterpolatedStringErrorType, LexicalErrorType, Mode, ParseError,
     ParseErrorType, ParseOptions, Parsed, UnsupportedSyntaxError,
 };
+pub use sifr_source::{SourceText, TextPosition, TextRangeUtf};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug)]
@@ -68,84 +69,6 @@ impl SyntaxTokenKind {
 impl From<TokenKind> for SyntaxTokenKind {
     fn from(value: TokenKind) -> Self {
         Self(format!("{value:?}"))
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TextPosition {
-    pub line: u32,
-    pub character: u32,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TextRangeUtf {
-    pub start: TextPosition,
-    pub end: TextPosition,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SourceText {
-    text: String,
-    line_starts: Vec<usize>,
-}
-
-impl SourceText {
-    #[must_use]
-    pub fn new(text: impl Into<String>) -> Self {
-        let text = text.into();
-        let mut line_starts = vec![0];
-        for (idx, byte) in text.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(idx + 1);
-            }
-        }
-        Self { text, line_starts }
-    }
-
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.text
-    }
-
-    #[must_use]
-    pub fn byte_offset(&self, position: &TextPosition) -> Option<TextSize> {
-        let line = usize::try_from(position.line).ok()?;
-        let character = usize::try_from(position.character).ok()?;
-        let line_start = *self.line_starts.get(line)?;
-        let line_end = self
-            .line_starts
-            .get(line + 1)
-            .copied()
-            .unwrap_or(self.text.len());
-        let offset = line_start.checked_add(character)?;
-        (offset <= line_end && self.text.is_char_boundary(offset))
-            .then(|| u32::try_from(offset).ok().map(TextSize::new))
-            .flatten()
-    }
-
-    #[must_use]
-    pub fn text_position(&self, offset: TextSize) -> Option<TextPosition> {
-        let offset = usize::try_from(offset.to_u32()).ok()?;
-        if offset > self.text.len() || !self.text.is_char_boundary(offset) {
-            return None;
-        }
-        let line_index = match self.line_starts.binary_search(&offset) {
-            Ok(index) => index,
-            Err(index) => index.checked_sub(1)?,
-        };
-        let line_start = *self.line_starts.get(line_index)?;
-        Some(TextPosition {
-            line: u32::try_from(line_index).ok()?,
-            character: u32::try_from(offset - line_start).ok()?,
-        })
-    }
-
-    #[must_use]
-    pub fn text_range(&self, range: TextRange) -> Option<TextRangeUtf> {
-        Some(TextRangeUtf {
-            start: self.text_position(range.start())?,
-            end: self.text_position(range.end())?,
-        })
     }
 }
 

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -237,6 +237,7 @@ Ruff submodule crates and is currently Rust 1.93.
 sifr/
   Cargo.toml                (workspace root)
   crates/
+    sifr_source/            (canonical source text, line-map, file metadata, and UTF-8/UTF-16/UTF-32 position conversion primitives)
     sifr_frontend/          (canonical parse/lower/type-check/diagnostics query facade shared by CLI and tooling)
     sifr_diagnostics/       (canonical diagnostic codes, source-map spans, model, render schema, and sink)
     sifr_hir/               (High-level IR: typed AST after name resolution + type checking)
@@ -267,6 +268,7 @@ New crates added per milestone as needed:
 
 - milestone_core_stdlib/milestone_ext_collections: `sifr_std` (standard library wrappers, extended collections)
 - Ad-hoc semantic diagnostic taxonomy: `sifr_diagnostics` (shared diagnostic model and schema, introduced before migrating existing emission paths)
+- TypeScript-Go architecture transfer M0: `sifr_source` (bottom-of-graph source text, line-map, source-file metadata, and editor position conversion authority)
 - milestone_ffi: FFI codegen extensions in `sifr_codegen`
 - Phase 35 shared analysis/query architecture: `sifr_frontend` (canonical frontend API and query/database ownership)
 - milestone_dev_tooling: `sifr_lsp` (language server), `sifr_format` (formatter), `sifr_lint` (linter)
@@ -794,7 +796,7 @@ Sifr compiles to Rust source code, which is then compiled by `rustc`. This creat
 - **Help and children:** help text is attached through `help` fields or `ChildSeverity::Help`; `Help` is not a top-level diagnostic severity. Diagnostic children are uncoded `Note` or `Help` messages.
 - **Canonical diagnostic object:** target migrated parser, lowering, type checking, borrow checking, and codegen paths must emit `SifrDiagnostic` values from `sifr_diagnostics`. Source diagnostics require a `SourceSpan`; internal diagnostics are reserved for compiler failures without source mapping.
 - **Canonical suggestion model:** suggestion payloads are structured logical suggestions with one or more text replacement edits plus applicability (`MachineApplicable`, `MaybeIncorrect`, `HasPlaceholders`, or `Unspecified`). Replacement text lives in suggestion edits, not duplicated help children.
-- **Span mapping:** semantic diagnostics preserve byte ranges as `SourceSpan` values before rendering. Renderers derive display paths, byte offsets, 1-based UTF-8 character line/column positions, source snippets, and related spans at the source-map boundary. Codegen/rustc diagnostics use `.sifr` source mapping where available; unmapped compiler failures use `SIFR-INTERNAL-*`.
+- **Span mapping:** semantic diagnostics preserve byte ranges as `SourceSpan` values before rendering. `sifr_source` owns source text, line maps, and UTF-8/UTF-16/UTF-32 position conversion primitives. Renderers derive display paths, byte offsets, 1-based UTF-8 character line/column positions, source snippets, and related spans at the source-map boundary without defining a separate line-map authority. Codegen/rustc diagnostics use `.sifr` source mapping where available; unmapped compiler failures use `SIFR-INTERNAL-*`.
 - **Producer/presentation boundary:** producers own canonical diagnostic identity, source spans, related spans, and structured context before a diagnostic reaches output formatting. `sifr_diagnostics` owns source-map rendering and the `human`, `json`, and `compact` presentation once producers have supplied canonical diagnostic data. Workspace and package discovery must attach resolver details as args/children on source-level import diagnostics instead of replacing source problems with phase-specific workspace codes.
 - **Package diagnostic conversion:** `sifr_driver::diagnostics::render_package_diagnostic` is the shared package-to-rendered conversion path. It preserves `PackageDiagnostic.help` and useful `PackageDiagnosticOrigin` fields as JSON args while leaving diagnostics spanless when no honest source/config byte range is available.
 - `**rustc` error translation:** when `rustc` emits an error on generated code, the driver translates it back to `.sifr` coordinates using the span map. If translation fails (e.g., error in compiler-generated boilerplate), the raw `rustc` error is shown with a note: "This error originated in the Rust compilation step."

--- a/internal_docs/frontend_query_architecture.md
+++ b/internal_docs/frontend_query_architecture.md
@@ -2,7 +2,7 @@
 
 status: active
 
-`crates/sifr_frontend/` is the canonical process-local frontend query crate. It owns session loading, module identities, graph views, source-map views, parse/lower/type-check/diagnostic/analysis query methods, cache metadata, and update invalidation reports.
+`crates/sifr_frontend/` is the canonical process-local frontend query crate. It owns session loading, module identities, graph views, source-map views, parse/lower/type-check/diagnostic/analysis query methods, cache metadata, and update invalidation reports. Source text, line maps, source-file metadata, and UTF-8/UTF-16/UTF-32 position conversions are provided by the lower-level `sifr_source` crate so frontend, diagnostics, syntax, and LSP do not keep separate source-position authorities.
 
 ## Current Boundary
 
@@ -11,7 +11,7 @@ status: active
 - single-file context loading with optional external definitions for driver integration
 - project loading from an entrypoint directory with the entrypoint pinned to `ModuleId(0)`
 - deterministic `FileId` and `ModuleId` assignment within a context revision
-- module graph and source map inspection
+- module graph and source map inspection, including real source-map position/range round trips for registered source files
 - parse, lower, type-check, module diagnostics, project diagnostics, module analysis, and project analysis queries
 - query metadata with cache hit/miss status plus graph/source revisions
 - dependency-first project lowering so imported module exports are available before importers are checked

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
@@ -7,7 +7,7 @@ Phase contract: `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md`
 ## Checklist
 
 - [x] Phase plan drafted
-- [ ] Phase plan reviewed and approved for implementation
+- [x] Phase plan reviewed and approved for implementation
 - [ ] M0 source and position foundation completed
 - [ ] M1 architecture contract and guardrails completed
 - [ ] M2 source provider and overlay store completed
@@ -95,6 +95,7 @@ This phase locks the TypeScript-Go-derived architecture transfer before implemen
 - `2026-05-29`: Claude milestone-slicing review rounds recorded in `reviews/ad-hoc-typescript-go-milestone-slicing-claude-review.md`. Feedback incorporated by splitting session/snapshot/LSP work, scheduler/cancellation work, cache-key/reuse work, adding explicit dependencies, moving flow graph earlier, and clarifying trace/status as a normalization milestone.
 - `2026-05-30`: Package ambiguous-import source-map consideration incorporated. The phase now locks the boundary between fatal package/source-map diagnostics and canonical import-site `SIFR-IMPORT-0005` diagnostics.
 - `2026-05-30`: Claude package source-map review recorded in `reviews/ad-hoc-typescript-go-package-ambiguous-import-source-map-review.md`. Feedback incorporated by adding explicit package import-resolution state coverage, candidate-retention proof, end-to-end diagnostic fixtures, and non-duplication checks.
+- `2026-06-01`: Claude implementation-start review recorded in `reviews/typescript-go-architecture-transfer-plan-review-pass-1.md`. M0 approved as the first implementation PR after tightening its public API, migration-site, test-gate, out-of-scope, and dependency-direction guardrail language.
 
 ## Validation Log
 
@@ -111,6 +112,23 @@ This phase locks the TypeScript-Go-derived architecture transfer before implemen
 - `2026-05-30`: `rg -n "[[:blank:]]+$" issues/ad-hoc-typescript-go-compiler-architecture-transfer.md issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md reviews/ad-hoc-typescript-go-package-ambiguous-import-source-map-review.md` -> no trailing whitespace.
 - `2026-05-30`: `git diff --no-index --check /dev/null <planning/review file>` loop over the seven TypeScript-Go planning/review files -> passed with no whitespace errors.
 - `2026-05-30`: `python3 scripts/check_file_size_guardrails.py` -> PASS after package source-map diagnostic boundary update.
+- `2026-06-01`: M0 focused validation in progress on branch `wave_tsgo_m0_source_foundation`.
+- `2026-06-01`: `cargo test -p sifr_source` -> PASS.
+- `2026-06-01`: `cargo test -p sifr_syntax` -> PASS.
+- `2026-06-01`: `cargo test -p sifr_diagnostics && cargo test -p sifr_frontend && cargo test -p sifr_lsp` -> PASS after source-position authority migration.
+- `2026-06-01`: `cargo test -p sifr_analysis` -> PASS.
+- `2026-06-01`: `cargo test -p sifr -- --skip test_e2e_pass` -> PASS.
+- `2026-06-01`: `cargo fmt --check` -> PASS.
+- `2026-06-01`: `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- `2026-06-01`: `python3 scripts/check_source_crate_dependency_direction.py` -> PASS.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS before M0 implementation review; report `target/validation_lane_reports/quick.latest.json`, wall time 272.93s.
+- `2026-06-01`: M0 implementation review pass 1 recorded in `reviews/typescript-go-m0-source-foundation-review-pass-1.md`; reviewer required fixing `cargo clippy --workspace -- -D warnings`.
+- `2026-06-01`: `cargo clippy --workspace -- -D warnings` -> PASS after changing `SourceMapView::text_position_to_span` to borrow `TextPosition`.
+- `2026-06-01`: `cargo test -p sifr_frontend` -> PASS after clippy follow-up.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS after clippy follow-up; report `target/validation_lane_reports/quick.latest.json`, wall time 232.80s.
+- `2026-06-01`: `git diff --check` -> PASS after clippy follow-up.
+- `2026-06-01`: `cargo fmt --check` -> PASS after clippy follow-up.
+- `2026-06-01`: M0 implementation review pass 2 recorded in `reviews/typescript-go-m0-source-foundation-review-pass-2.md`; reviewer approved M0 for PR.
 
 ## PR Log
 

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -488,15 +488,26 @@ Goal: remove the source-map stub risk before any snapshot or LSP architecture wo
 Scope:
 
 - add `sifr_source` at the bottom of the dependency hierarchy
+- lock `sifr_source` public API for M0: `SourceText`, `LineMap`, `PositionEncoding`, `TextPosition`, `TextRangeUtf`, and `SourceFile`
 - migrate syntax, diagnostics, frontend, and LSP conversion to shared `SourceText`, `LineMap`, `PositionEncoding`, `TextPosition`, and `TextRangeUtf`
+- migrate known M0 call sites: parser-side `sifr_syntax::SourceText` consumers, `sifr_diagnostics::SourceMap` line-map storage/rendering, `crates/sifr_frontend/src/graph_cache_and_queries.rs` source-map view construction/conversion, `crates/sifr_frontend/src/bin/frontend_query_bench.rs` `interactive.source_map_lookup`, and `crates/sifr_lsp/src/conversion.rs` range/position conversion helpers
 - replace `SourceMapView` stubs with UTF-8/UTF-16/UTF-32 conversions
 - make `interactive.source_map_lookup` assert real round trips
 - add multibyte, CRLF, EOF, invalid-boundary, and rendered-diagnostic parity tests
+- add a dependency-direction guardrail proving `sifr_source` does not depend on higher compiler/tooling crates
+
+Out of scope:
+
+- no `SourceProvider`, `WorkspaceSession`, `WorkspaceSnapshot`, `DirtyScope`, cache reuse, scheduler behavior, or LSP request-flow migration
+- no direct filesystem read migration; M1 inventories direct reads and M2 moves semantic reads behind the provider boundary
 
 Closeout:
 
 - frontend, diagnostics, and LSP have one source-position authority
-- no valid source-map lookup returns `None` because the method is stubbed
+- source conversions return `Some` for positions on character boundaries inside registered source files and return `None` only for genuinely invalid positions, such as unregistered files, byte offsets inside multibyte scalars or CRLF line endings, surrogate-pair interiors, and out-of-range positions
+- UTF-8, UTF-16, UTF-32, multibyte, CRLF, EOF, invalid-boundary, rendered-diagnostic parity, and LSP UTF-16 conversion tests pass
+- `interactive.source_map_lookup` is no longer a no-op benchmark path
+- dependency-direction guardrail is part of local validation
 - symbol/navigation range correctness is unblocked for later milestones
 
 ### M1: Architecture Contract And Guardrails

--- a/reviews/typescript-go-architecture-transfer-plan-review-pass-1.md
+++ b/reviews/typescript-go-architecture-transfer-plan-review-pass-1.md
@@ -1,0 +1,61 @@
+I have enough evidence. Below is the focused review.
+
+---
+
+# Plan Review: TypeScript-Go Compiler Architecture Transfer
+
+## Verdict
+
+**The plan is acceptable for starting M0 exactly as written, but M0's milestone description needs tightening before the implementation PR is opened.** No prerequisite change is required first.
+
+## Evidence verified against the issue
+
+- `sifr_source` crate does not exist (no entry under `crates/`); must be created.
+- `SourceMapView::text_position_to_span` and `span_to_text_range` return `None` as stubs at `crates/sifr_frontend/src/graph_cache_and_queries.rs:227` and `:237`.
+- `interactive.source_map_lookup` at `crates/sifr_frontend/src/bin/frontend_query_bench.rs:255-274` calls the stub and discards the result (`let _ = source_map.text_position_to_span(...)`).
+- Three competing source-position authorities exist today: `crates/sifr_syntax/src/lib.rs:87` (UTF-8 byte line starts, `Vec<usize>`), `crates/sifr_diagnostics/src/source_map/mod.rs:61-65` (separate `SourceMap` with `Vec<u32>` line starts), and `crates/sifr_frontend/src/graph_cache_and_queries.rs:77` (string wrapper, no line map). This is exactly the split D0-2 describes.
+- `ruff_text_size` is already a workspace dep (`Cargo.toml` declares `third_party/ruff/crates/ruff_text_size`), so the locked decision's "may depend only on `std` and source-position primitives such as `ruff_text_size`" is workable.
+- Dependency direction in the locked decision is consistent: `sifr_source` is at the bottom; `sifr_syntax` already depends on `sifr_diagnostics` (not the other way around), so the new crate can sit below both without creating cycles.
+- Milestone `depends on` chains (M0→M1→…→M17, with M11/M14/M15/M16/M17 fanning into M5/M10) are coherent; no milestone is gated on work a later milestone delivers.
+
+## Correctness risks to address before opening the M0 PR
+
+1. **M0 closeout is too soft to be a gate.** "`no valid source-map lookup returns `None` because the method is stubbed`" can be read two ways (always-`Some` vs. validity-aware). Pin to: conversions return `Some` for positions on character boundaries inside registered source files, and return `None` only for genuinely invalid positions (unregistered file, byte inside multi-byte scalar, non-boundary offset).
+
+2. **M0 scope omits an explicit "out of scope" list.** Without one, M0 risks pulling in overlays, snapshots, fingerprints, or scheduler hooks "since they touch the same code". Lock the exclusion list: no `SourceProvider`, no `WorkspaceSession`, no `WorkspaceSnapshot`, no `DirtyScope`, no cache reuse, no scheduler changes, no LSP request flow changes.
+
+3. **M0 scope does not enumerate LSP/syntax/diagnostics migration sites.** The spec says "migrate syntax, diagnostics, frontend, and LSP conversion" but doesn't list files. Add a concrete inventory before implementation: `crates/sifr_lsp/src/conversion.rs:45,69,391`; `crates/sifr_lsp/src/capabilities.rs:28`; the parser-side `sifr_syntax::SourceText` consumers; the `sifr_diagnostics::SourceMap` consumers that need a re-pointing, not a rewrite. Without an inventory, the PR will either under-migrate (leaving the stub reachable) or over-migrate (touching the JSON schema, which the locked decision forbids).
+
+4. **`sifr_syntax::SourceText` re-export vs rename is undecided.** The locked decision says `sifr_source` sits below `sifr_syntax`; that implies `sifr_syntax::SourceText` either becomes a re-export of `sifr_source::SourceText` or wraps it. Either is fine, but M0 must commit to one. The `Vec<usize>` line-start field at `crates/sifr_syntax/src/lib.rs:89` is a clean opportunity to delegate to `sifr_source::LineMap`. Pick a name and pin it in the M0 PR.
+
+5. **No `sifr_source` dep-direction guardrail.** The locked decision states `sifr_source` must not depend on `sifr_syntax`/`sifr_diagnostics`/`sifr_frontend`/`sifr_analysis`/`sifr_lsp`/etc., but the issue defers the actual guardrail to M1. Risk: M0 lands, a later PR re-adds a dep, no automation catches it. Recommend M0 itself land a small `scripts/check_source_crate_dependency_direction.py` (or extend the existing `check_hir_maintainability_guardrails.py`) and have CI fail on a violation. This is two hours of work and saves a future archeology session.
+
+6. **The perf-bench rewrite alone is not a correctness test.** `frontend_query_bench.rs:266` currently does `let _ = source_map.text_position_to_span(...)`. Rewriting it to assert a real round trip is fine, but a perf bench is allowed to no-op on a regression. M0 should also add a dedicated unit test in `crates/sifr_frontend` (and/or a `crates/sifr_source` test) covering UTF-8, UTF-16, and UTF-32 round trips across multibyte, CRLF, EOF, surrogate-pair interior, and non-boundary offsets, with snapshot baselines. The bench becomes a perf assertion; the unit test becomes the correctness gate.
+
+7. **EOF, CRLF, multibyte, and rendered-diagnostic parity tests are mentioned in scope but not in closeout.** Move them from "scope" into the closeout acceptance list. A milestone can be closed with passing tests omitted otherwise.
+
+8. **`FrontendContext::load_project` reads entrypoint and project dir via `std::fs` directly at `crates/sifr_frontend/src/graph_cache_and_queries.rs:426` and `:436`.** M0 does not need to change this; M2 does. But if M0 reworks `ModuleState` to carry `sifr_source::SourceText`/`LineMap` (it should, otherwise the new types don't reach the rest of the frontend), then `module_state` becomes a touch point. Make that construction explicit in the M0 PR so D0-3 and the "direct-read inventory" promise from M1 are not papered over.
+
+9. **LSP UTF-16 negotiation must keep working.** `crates/sifr_lsp/src/capabilities.rs:28` advertises UTF-8 position encoding. M0's `PositionEncoding` migration must not break the negotiation. Closeout should require an LSP test that round-trips a UTF-16 position through the new conversion layer.
+
+10. **D0-11 (docs overstate target architecture as reality) is not in M0's scope.** M0 won't fix `internal_docs/lsp_server.md`. That's fine — M1 is the right home — but flag it: if M0 ships first, reviewers should not assume the docs will be corrected in the same PR. Track as M1 acceptance.
+
+## Dependency sequencing observations
+
+- The M0→M1→M2→M3→M4→M5 chain is defensible. M0 closes the source-position hole before any session/snapshot work depends on it, which is the only ordering that prevents the "snapshot built on stubbed conversions" anti-pattern.
+- M11 depending on both M5 and M10 is correct: the scheduler can only be "real" once the session owns the snapshot and the snapshot has identity that can be captured per request.
+- M15 depending on M3, M5, M6, and M10 is correct: residency needs the session (M3), the LSP layer (M5), event compaction (M6), and snapshot reuse (M10) all in place.
+- M17 depending on M5, M12, M14, and M16 is correct: the marker-based editor corpus needs the LSP session, per-request budgets, bucketed indexes, and trace/status to exist before it can validate their behavior.
+- No milestone in the chain has a missing dependency. None depends on work that M0 alone delivers (i.e., M0 is genuinely the first PR; later milestones don't need anything M0 doesn't promise).
+
+## Missing acceptance gates worth adding now
+
+- A "LSP conversion sites migrated" gate: list of file:line call sites that must move from `sifr_syntax::SourceText`/raw byte math to `sifr_source` conversion APIs.
+- A "`sifr_source` public API" lock: explicit list of types and functions the crate exports, so syntax/diagnostics/frontend/LSP migration PRs have a stable target.
+- A "dep-direction guardrail in CI" gate (item 5 above).
+- A "bench is no longer a no-op" gate, ideally backed by a unit test (item 6 above).
+- An "M0 out of scope" list (item 2 above) inside the milestone description.
+
+## Recommendation
+
+Approve M0 as the first implementation PR. Before opening it, tighten the M0 description in `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md` (lines 482-500) to: enumerate the migration call sites, list `sifr_source`'s locked public API, add an explicit out-of-scope list, add the unit-test gates alongside the perf-bench rewrite, and require the dep-direction guardrail as part of M0 (not deferred to M1). These are doc-only edits to the issue and the execution checklist; they do not require reopening the planning review. The architecture decisions themselves are sound and M0 is correctly placed.

--- a/reviews/typescript-go-m0-source-foundation-review-pass-1.md
+++ b/reviews/typescript-go-m0-source-foundation-review-pass-1.md
@@ -1,0 +1,91 @@
+I have enough evidence to render a verdict. The implementation is solid, but I found one clippy blocker that the user did not include in their validation pass.
+
+---
+
+# M0 Implementation Review
+
+## Verdict
+
+**M0 is not yet approved for PR.** One blocker must be fixed first: a pedantic clippy warning that escalates to an error under `cargo clippy --workspace -- -D warnings`, which AGENTS.md lists as a required local validation step. The user did not run that command; running it fails on a single source line.
+
+## Blocker
+
+**`cargo clippy --workspace -- -D warnings` fails on `crates/sifr_frontend/src/source_maps.rs:87`.**
+
+```
+error: this argument is passed by value, but not consumed in the function body
+  --> crates/sifr_frontend/src/source_maps.rs:87:19
+   |
+87 |         position: TextPosition,
+   |                   ^^^^^^^^^^^^
+```
+
+`SourceMapView::text_position_to_span` takes `position: TextPosition` by value but only passes a reference to `sifr_source::SourceText::byte_offset_with_encoding`. This is the only warning in the workspace introduced by the M0 diff, and it conflicts with the AGENTS.md requirement:
+
+> `cargo clippy --workspace -- -D warnings`
+
+Two acceptable fixes:
+
+- Change the signature to `position: &TextPosition` and update the bench (`crates/sifr_frontend/src/bin/frontend_query_bench.rs:269`) plus the two test call sites in `crates/sifr_frontend/src/source_maps.rs:140,181` to pass `&position`. Note this is a public API change on `SourceMapView`.
+- Or add `#[allow(clippy::needless_pass_by_value)]` on the method. The bench and tests stay unchanged but the public API retains the by-value signature.
+
+Either is fine. Pick the one the project prefers for SourceMapView ergonomics and apply it.
+
+## Correctness — what I checked, what holds
+
+I walked the new `sifr_source` API and the consumer migrations with a fine-tooth comb. No correctness defects found in any of the M0 closeout categories the user listed.
+
+### `crates/sifr_source/src/lib.rs`
+
+- **UTF-8 byte offsets** (line 149-181, 184-215): `is_char_boundary` is checked for the UTF-8 path; UTF-16/UTF-32 offsets come from `encoded_character_byte_offset` which iterates `text.char_indices()`, so the returned offset is always a char boundary of `line_text`. Char-boundary safety holds.
+- **UTF-16 surrogate interiors** (line 265-285): `encoded_character_byte_offset` rejects a request that lands inside a surrogate pair via `if consumed.checked_add(char_width)? > character { return None; }`. Verified for `a🦀b` — `character: 2, Utf16` returns `None` as expected.
+- **UTF-32 char counts** (line 265-285): `EncodedWidth::Utf32` uses `ch.len_utf16() == 1`, treating each scalar as one code point, so it counts characters correctly. `position_at` uses `prefix.chars().count()`. Both consistent.
+- **CRLF line endings** (line 89-103): `line_byte_range` strips both `\r\n` and `\n` from the trailing end of the slice, so a CRLF line's content range does not include the `\r` or `\n`. `parser_diagnostic_preserves_crlf_source_text_in_json_span` (`crates/sifr_syntax/src/lib.rs:553`) verifies the renderer still shows the `\r` in the displayed snippet, which is the existing convention.
+- **EOF** (line 105-113, 189-215): For `"alpha\nβeta\n"` (12 bytes, line_starts `[0, 6, 12]`), `position_at(12, Utf8)` returns `Some({line: 2, character: 0})` and round-trips back to offset 12. `line_index_at_offset` uses `Err(index) => index.checked_sub(1)?`, which correctly handles `offset == text_len` because the returned `Err(line_starts.len())` decrements to the last real line.
+- **Spans in diagnostic rendering** (`crates/sifr_diagnostics/src/render/mod.rs:244-307`): The migration replaces the per-source `Vec<u32>` line_starts with `LineMap::line_starts()`. The `binary_search` argument flips from `u32` to `TextSize` (which is `Ord`); logic is unchanged. `render_line` uses `line_full_byte_range` (newline-inclusive) and `trim_end_matches('\n')` to preserve the same `lines[].text` shape as before, including the trailing `\r` for CRLF.
+- **Multi-file `SourceMapView`** (`crates/sifr_frontend/src/source_maps.rs:82-111`): `source_for_file` linear-scans the `files` vec by `id`; `text_position_to_span` returns `None` for unregistered files (test at line 168-178 confirms).
+
+### Dependency direction
+
+- `sifr_source/Cargo.toml` lists only `ruff_text_size`. `crates/sifr_source/src/lib.rs` `use`s only `ruff_text_size`, `std::path::PathBuf`, `std::sync::Arc`. No upward reference to `sifr_diagnostics`, `sifr_syntax`, `sifr_frontend`, `sifr_analysis`, `sifr_lsp`, `sifr_lint`, `sifr_format`, `sifr_package`, `sifr_hir`, `sifr_type_system`, `sifr_codegen`, `sifr_driver`, or `sifr`.
+- `python3 scripts/check_source_crate_dependency_direction.py` -> PASS.
+- The four consumers (`sifr_diagnostics`, `sifr_frontend`, `sifr_lsp`, `sifr_syntax`) all declare `sifr_source = { workspace = true }` in their `Cargo.toml`. `sifr_lint` uses `sifr_frontend::SourceText`, which is now a re-export of `sifr_source::SourceText` (`crates/sifr_frontend/src/source_maps.rs:2`), so the linter shares the same authority by re-export, not by introducing a separate type.
+
+### One source-position authority
+
+After this PR, every byte/position computation routes through `sifr_source`:
+
+- `sifr_syntax::SourceText` / `TextPosition` / `TextRangeUtf` are re-exports of `sifr_source` (line 19).
+- `sifr_diagnostics::SourceMap` stores `text: SourceText` and exposes `pub(crate) fn source` returning `&SourceText` (`crates/sifr_diagnostics/src/source_map/mod.rs:158`). The old `pub(crate) fn source_text` and `line_starts` accessors and the local `fn line_starts(text: &str)` and `fn stable_hash(text: &str)` are deleted — only one FNV-1a hash function remains in the workspace (in `sifr_source::stable_hash`).
+- `sifr_frontend::SourceFileView` carries `source: SourceText` (`crates/sifr_frontend/src/source_maps.rs:67-74`); `SourceMapView::text_position_to_span` and `span_to_text_range` delegate to `SourceText::byte_offset_with_encoding` and `range_at`.
+- `sifr_lsp::conversion` constructs `sifr_source::SourceText` and calls `byte_offset_with_encoding` / `range_at` (`crates/sifr_lsp/src/conversion.rs:62-74, 86-91`). The default `lsp_range` and `text_range` still hardcode `PositionEncoding::Utf8`; UTF-16 is exercised only in the new `*_with_encoding` helpers, which is the right M0 scope (actual capability-driven routing is M5 per the plan).
+
+## Test coverage I verified by running
+
+```
+cargo test -p sifr_source        -> 3 passed
+cargo test -p sifr_syntax        -> 8 passed
+cargo test -p sifr_diagnostics   -> 32 passed
+cargo test -p sifr_frontend      -> 5 passed (lib)
+cargo test -p sifr_lsp           -> 2 passed
+cargo test -p sifr_analysis      -> 10 passed
+cargo test -p sifr -- --skip test_e2e_pass -> 33 passed
+```
+
+`cargo fmt --check` PASS, `git diff --check` PASS, `python3 scripts/check_file_size_guardrails.py` PASS, `python3 scripts/check_source_crate_dependency_direction.py` PASS.
+
+## Scope fit
+
+- M0 closeout items, in order: shared `SourceText`/`LineMap`/`PositionEncoding`/`TextPosition`/`TextRangeUtf` ✓; parser-side `sifr_syntax::SourceText` consumers migrated (`crates/sifr_syntax/src/lib.rs:194-203` builds a `SourceMap::register_source`, but the local `SourceText(String)` struct is gone, replaced by the re-export) ✓; `sifr_diagnostics::SourceMap` line-map storage/rendering migrated to `sifr_source::LineMap` ✓; `crates/sifr_frontend/src/graph_cache_and_queries.rs` source-map view construction/conversion migrated (new `crates/sifr_frontend/src/source_maps.rs` holds the migrated types and methods) ✓; `crates/sifr_frontend/src/bin/frontend_query_bench.rs` `interactive.source_map_lookup` rewritten to assert a real round trip and a UTF-8 round-trip equality check ✓; `crates/sifr_lsp/src/conversion.rs` helpers migrated ✓; `SourceMapView` stubs replaced ✓; multibyte/CRLF/EOF/invalid-boundary/rendered-diagnostic-parity/LSP-UTF-16 tests added (in `sifr_source::tests`, `sifr_syntax::tests`, `sifr_diagnostics` rendering path, and `sifr_lsp::conversion::tests`) ✓; dep-direction guardrail added and wired into `scripts/run_all_tests.sh:99-100` ✓; out-of-scope items (SourceProvider, WorkspaceSession, WorkspaceSnapshot, DirtyScope, cache reuse, scheduler, LSP request flow) untouched ✓.
+- The locked API surface listed in the M0 description (`SourceText`, `LineMap`, `PositionEncoding`, `TextPosition`, `TextRangeUtf`, `SourceFile`) is all in `sifr_source::lib.rs` with the expected shape. `SourceFile` is not consumed anywhere yet — that is acceptable because M2/M3 own overlay lifecycle; the type is locked here so later milestones build on a stable name.
+
+## Required change before PR
+
+1. Fix the `clippy::needless_pass_by_value` failure on `SourceMapView::text_position_to_span` (either `&TextPosition` or `#[allow]`), and re-run `cargo clippy --workspace -- -D warnings` to confirm. Add the result to the validation log.
+
+## Optional, not required
+
+- The bench file duplicates the `TextPosition { line: 0, character: 0 }` literal three times in the round-trip check; a `let target = TextPosition { line: 0, character: 0 };` would tighten it. Pure readability, not a correctness issue.
+- `sifr_source::SourceFile` is unused. That is fine — it is the locked M0 surface, picked up in M2.
+
+Once the clippy fix is in and the full local validation script passes, M0 is approved to merge.

--- a/reviews/typescript-go-m0-source-foundation-review-pass-2.md
+++ b/reviews/typescript-go-m0-source-foundation-review-pass-2.md
@@ -1,0 +1,31 @@
+# Follow-up Review: M0 Pass-1 Blocker Area
+
+**Verdict: M0 is approved for PR.** The blocker is resolved cleanly with no fallout.
+
+## Blocker resolution
+
+`crates/sifr_frontend/src/source_maps.rs:87` — signature is now `position: &TextPosition`. All three call sites updated:
+- `source_maps.rs:144` (`&position`)
+- `source_maps.rs:166-173, 177-184` (inline `&TextPosition {...}` for the unregistered-file and invalid-boundary tests)
+- `frontend_query_bench.rs:271` (`&target`) — also folds in the prior review's optional "extract `let target`" readability note
+
+## Validation I re-ran (independent confirmation)
+
+| Check | Result |
+|---|---|
+| `cargo clippy --workspace -- -D warnings` | PASS — clean `Finished` |
+| `cargo test -p sifr_frontend` | PASS — 5/5 (both `source_maps` tests included) |
+| `scripts/run_all_tests.sh --profile quick` | PASS — 67 e2e, validation lane report clean |
+| `git diff --check` | PASS |
+| `cargo fmt --check` | PASS |
+
+## Fallout check
+
+- **No unintended callers broke.** `text_position_to_span` is referenced only in `source_maps.rs` (definition + 3 tests) and `frontend_query_bench.rs:271`. Both updated. The remaining grep hits are in `reviews/`, `issues/`, `internal_docs/phases/35_*` (historical / forward-looking prose).
+- **Public API change is intentional and consistent.** The prior review explicitly called this out as a consequence and acceptable ("Pick the one the project prefers for SourceMapView ergonomics"). The project chose `&TextPosition`; everywhere that builds one now does.
+- **Bench upgrade is a positive, not a regression.** The old `let _ = source_map.text_position_to_span(...)` discarded the result. The new version asserts a real UTF-8 round trip (`.span_to_text_range` → `round_trip.start == target` etc.). This is the M0 contract that pass-1 said the bench should be exercising; it now does.
+- **Pre-existing inconsistency, not fallout.** The bench uses `PositionEncoding::UTF8` (uppercase) while the tests use `PositionEncoding::Utf8`. Both compile (Rust accepts the all-caps form as a valid identifier) and this discrepancy pre-dates the M0 fix — flagging only so the team is aware; it is not in the blocker area and not required to be fixed here.
+
+## Recommendation
+
+Open the PR. The local validation gate that mirrors CI is green.

--- a/scripts/check_source_crate_dependency_direction.py
+++ b/scripts/check_source_crate_dependency_direction.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Guard the bottom-of-graph dependency contract for `sifr_source`."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tomllib
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SOURCE_CRATE = REPO_ROOT / "crates" / "sifr_source"
+ALLOWED_DEPENDENCIES = {"ruff_text_size"}
+FORBIDDEN_CRATES = {
+    "sifr_diagnostics",
+    "sifr_syntax",
+    "sifr_frontend",
+    "sifr_analysis",
+    "sifr_lsp",
+    "sifr_lint",
+    "sifr_format",
+    "sifr_package",
+    "sifr_hir",
+    "sifr_type_system",
+    "sifr_codegen",
+    "sifr_driver",
+    "sifr",
+}
+
+
+def main() -> int:
+    manifest = tomllib.loads((SOURCE_CRATE / "Cargo.toml").read_text())
+    dependencies = set(manifest.get("dependencies", {}))
+    unexpected = sorted(dependencies - ALLOWED_DEPENDENCIES)
+    if unexpected:
+        print(
+            "sifr_source has non-bottom dependency/dependencies: "
+            + ", ".join(unexpected),
+            file=sys.stderr,
+        )
+        return 1
+
+    violations: list[str] = []
+    for path in sorted((SOURCE_CRATE / "src").rglob("*.rs")):
+        text = path.read_text()
+        for crate in sorted(FORBIDDEN_CRATES):
+            if f"use {crate}" in text or f"{crate}::" in text:
+                violations.append(f"{path.relative_to(REPO_ROOT)} references {crate}")
+
+    if violations:
+        print("sifr_source depends upward in source code:", file=sys.stderr)
+        for violation in violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -96,6 +96,9 @@ python3 "${SCRIPT_DIR}/check_hir_maintainability_guardrails.py"
 echo "Running file-size guardrails"
 python3 "${SCRIPT_DIR}/check_file_size_guardrails.py"
 
+echo "Running source crate dependency-direction guardrail"
+python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py"
+
 echo "Running sifr_driver maintainability guardrails"
 python3 "${SCRIPT_DIR}/check_sifr_driver_maintainability_guardrails.py"
 


### PR DESCRIPTION
## Summary
- add `sifr_source` as the bottom-of-graph source text, line-map, source-file metadata, and UTF-8/UTF-16/UTF-32 conversion authority
- migrate syntax re-exports, diagnostics source-map rendering, frontend `SourceMapView`, source-map benchmark lookup, and LSP conversion helpers to the shared source-position authority
- add dependency-direction validation for `sifr_source`, update M0 docs/tracker, and record reviewer artifacts

## Validation
- `cargo test -p sifr_source`
- `cargo test -p sifr_syntax`
- `cargo test -p sifr_diagnostics`
- `cargo test -p sifr_frontend`
- `cargo test -p sifr_lsp`
- `cargo test -p sifr_analysis`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_source_crate_dependency_direction.py`
- `scripts/run_all_tests.sh --profile quick` (rerun after clippy follow-up; PASS, wall time 232.80s)

## Reviews
- Plan approval: `reviews/typescript-go-architecture-transfer-plan-review-pass-1.md`
- M0 implementation pass 1: `reviews/typescript-go-m0-source-foundation-review-pass-1.md`
- M0 implementation pass 2: `reviews/typescript-go-m0-source-foundation-review-pass-2.md` (approved for PR)
