### PR TITLE
M1: add architecture transfer guardrails

### DIFF
--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -269,6 +269,7 @@ New crates added per milestone as needed:
 - milestone_core_stdlib/milestone_ext_collections: `sifr_std` (standard library wrappers, extended collections)
 - Ad-hoc semantic diagnostic taxonomy: `sifr_diagnostics` (shared diagnostic model and schema, introduced before migrating existing emission paths)
 - TypeScript-Go architecture transfer M0: `sifr_source` (bottom-of-graph source text, line-map, source-file metadata, and editor position conversion authority)
+- TypeScript-Go architecture transfer M1: `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md` records the pre-session direct-read inventory, current LSP single-file rebuild caveat, aggregate LSP budget caveat, and guardrail automation before M2-M5 behavior migration.
 - milestone_ffi: FFI codegen extensions in `sifr_codegen`
 - Phase 35 shared analysis/query architecture: `sifr_frontend` (canonical frontend API and query/database ownership)
 - milestone_dev_tooling: `sifr_lsp` (language server), `sifr_format` (formatter), `sifr_lint` (linter)

--- a/internal_docs/frontend_cache_invalidation.md
+++ b/internal_docs/frontend_cache_invalidation.md
@@ -4,6 +4,12 @@ status: active
 
 Phase 35 v1 frontend caching is process-local and module-granular.
 
+TypeScript-Go architecture transfer M1 note: this document describes the
+pre-session cache behavior. Dependency-sensitive invalidation, dirty-scope
+classification, module signatures, structural replacement, and snapshot-scoped
+cache reuse are planned in M6-M10 and are not implemented by the current
+`FrontendContext::update_module_source` path.
+
 ## Cache State
 
 Each `FrontendContext` module owns cached parse, lower, diagnostics, and analysis entries. Query results include metadata with:

--- a/internal_docs/frontend_query_architecture.md
+++ b/internal_docs/frontend_query_architecture.md
@@ -19,6 +19,11 @@ status: active
 
 `sifr_frontend` consumes `sifr_syntax` for parsing and `sifr_hir` for lowering and semantic diagnostics. It does not invoke codegen, rustc, cargo, CLI policy, or build artifact creation.
 
+TypeScript-Go architecture transfer M1 note: the `FrontendContext` API described
+here is the pre-session, process-local query facade. M3/M4 own re-expressing
+this surface around `WorkspaceSession` and immutable `WorkspaceSnapshot`
+handles; M2 owns moving semantic file reads behind `SourceProvider` first.
+
 ## Driver Consumption
 
 Phase 35 m35.4b routes `check`, `build`, `run`, `emit`, project compilation, and test-runner frontend flows through `sifr_frontend` without preserving duplicate semantics-bearing driver frontend paths. The driver remains responsible for stdlib bootstrap/cache plumbing, build planning, codegen invocation, Cargo/rustc execution, and renderer/CLI presentation.

--- a/internal_docs/lsp_server.md
+++ b/internal_docs/lsp_server.md
@@ -1,6 +1,6 @@
 # Sifr LSP Server Architecture
 
-status: phase36-m36.5-implemented
+status: phase36-m36.5-implemented; TypeScript-Go architecture transfer M1 current-state caveats recorded
 
 ## Protocol Target
 
@@ -28,7 +28,7 @@ It does not own parser logic, lowering, type checking, HIR construction, symbol-
 
 ## Internal Layers
 
-The LSP implementation must expose these layers:
+The LSP implementation is being migrated toward these compiler-service layers:
 
 - `CapabilityRegistry`: resolves position encoding, workspace configuration, pull diagnostics, dynamic registration, related information, semantic tokens, signature label offsets, hierarchical document symbols, completion details/documentation, work-done progress, file watching, and code-action resolve support.
 - `DocumentStore`: tracks open `.sifr` documents by URI, version, language id, source text, line index, canonical `FileId`, edit application, and UTF-8/UTF-16/UTF-32 conversion.
@@ -57,6 +57,27 @@ The concrete m36.5 modules are:
 The stdio server terminates explicitly on `exit` after a successful `shutdown`
 response. This avoids retaining protocol IO threads after the client completes
 the required LSP shutdown sequence.
+
+## Current M1 Compiler-Service Caveats
+
+The TypeScript-Go architecture transfer keeps M1-M4 serialized until captured
+workspace snapshots and publication identity are mechanical. Current
+implementation reality:
+
+- `DocumentStore` still owns per-document `AnalysisHost` values.
+- `DocumentState::rebuild` calls `AnalysisHost::open_single_file` with
+  `FrontendMode::SingleFile` on open/change/save.
+- `RequestQueue` tracks pending request ids and shutdown state; it is not yet a
+  cancellation-token registry.
+- `Scheduler` maps methods to lane labels only; it does not yet run priority
+  queues, debounce, background workers, delayed progress, or cancellation.
+- Stale-result rejection uses current analysis revision checks inside
+  `DocumentState::with_host`, not immutable `WorkspaceSnapshot` and document
+  version publication identity.
+
+M5 owns persistent LSP session integration on `WorkspaceSession` snapshots.
+M11 owns priority queues/debounce. M13 owns cancellation, progress, and
+parent-process watchdog behavior.
 
 ## Capability Matrix
 

--- a/internal_docs/performance_budgets.md
+++ b/internal_docs/performance_budgets.md
@@ -75,6 +75,9 @@ Frontend-query and local edit-loop benchmarks use stricter latency thresholds:
 - m36.5 adds `lsp-query-001-request-families` with budget id
   `perf.lsp.request_families`; it is executed by `lsp_query_bench.py` through
   `sifr lsp --stdio` and is validated by the same manifest/budget gate.
+  TypeScript-Go architecture transfer M1 records this as aggregate smoke
+  coverage only. M12 owns splitting this into per-request protocol-level editor
+  latency budgets.
 
 Timeouts are hard failures. Missing results, unknown ids, malformed metric payloads, and cache-miss regressions are hard failures.
 

--- a/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
+++ b/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
@@ -1,0 +1,151 @@
+# TypeScript-Go Architecture Transfer M1 Guardrails
+
+status: M1 pre-flight gate
+
+This document is the implementation guardrail for
+`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md` M1. It records
+the actual pre-session state after M0 and before M2-M5 behavior migration. Later
+milestones may update this file and its checker when they intentionally replace
+one of these current limitations.
+
+## Locked Terms
+
+M1 locks the following terms before behavior migration starts:
+
+- `sifr_source`: bottom-of-graph source text, line-map, source-file metadata,
+  source hash, and UTF-8/UTF-16/UTF-32 position conversion authority.
+- `SourceProvider`: future semantic file-system boundary in `sifr_frontend` for
+  disk, overlay, tracking, package, directory, canonicalization, and failed
+  lookup reads. Not implemented in M1.
+- `WorkspaceSession`: future mutable owner of workspace compiler-service state.
+  Not implemented in M1.
+- `WorkspaceSnapshot`: future immutable captured state shared by analysis, LSP,
+  lint, format, diagnostics, package tooling, and future API handles. Not
+  implemented in M1.
+- `DirtyScope`, `DirtyReason`, `ImportSignature`, `ExportSignature`,
+  `ModuleSignature`, `CompilerFingerprint`, `CacheKeyFingerprint`,
+  `FlowGraph`, `QueryReadiness`, and `.sifrbuildinfo`: locked architecture terms
+  for later milestones, not M1 behavior.
+
+## Current Direct-Read, Probe, And Documented Effect Inventory
+
+These production filesystem reads and path probes are semantic inputs, tooling
+inputs, package identity inputs, or command-surface inputs. M2 must route
+semantic entries through a typed source provider or explicitly reclassify a row
+as a non-semantic exception. Path probes are listed alongside content and
+directory reads so M2 can track successful and failed lookup dependencies
+without treating probes as source content reads.
+
+| Area | Current site | Current behavior | M2 expectation |
+| --- | --- | --- | --- |
+| Frontend project entrypoint read | `crates/sifr_frontend/src/graph_cache_and_queries.rs:312` | `FrontendContext::load_project` reads the entrypoint from disk. | Provider-tracked file read. |
+| Frontend project directory read | `crates/sifr_frontend/src/graph_cache_and_queries.rs:322` | `load_project` enumerates sibling `.sifr` files directly. | Provider-tracked directory read. |
+| Frontend project module read | `crates/sifr_frontend/src/graph_cache_and_queries.rs:359` | `load_project` reads non-entry modules directly. | Provider-tracked file read. |
+| Driver module resolution | `crates/sifr_driver/src/project/discovery.rs:90`, `crates/sifr_driver/src/project/discovery.rs:118`, `crates/sifr_driver/src/project/discovery.rs:180` | Resolution probes physical paths with `is_file`. | Provider-tracked successful and failed lookup dependencies. |
+| Driver project discovery | `crates/sifr_driver/src/project/discovery.rs:332`, `crates/sifr_driver/src/project/discovery.rs:574` | Project discovery enumerates `.sifr` files and reads selected modules. | Provider-tracked directory and file reads. |
+| Driver workspace manifest discovery | `crates/sifr_driver/src/workspace/mod.rs:32`, `crates/sifr_driver/src/workspace/mod.rs:49`, `crates/sifr_driver/src/workspace/mod.rs:156` | Workspace root discovery probes `sifr.toml`, reads it, and checks configured source roots. | Provider-tracked config reads and directory probes. |
+| Driver package module materialization | `crates/sifr_driver/src/project/package_discovery.rs:53` | Package build/check reads resolved package module source directly. | Provider-tracked package file read. |
+| Linter standalone input | `crates/sifr_lint/src/engine.rs:134` | Lint engine reads each target file directly. | Short-lived provider with shared source-map authority. |
+| Linter config and discovery | `crates/sifr_lint/src/config.rs:48`, `crates/sifr_lint/src/config.rs:72`, `crates/sifr_lint/src/discovery.rs:29`, `crates/sifr_lint/src/discovery.rs:33`, `crates/sifr_lint/src/discovery.rs:79` | Linter config lookup and target discovery probe files/directories and read `sifr.toml`. | Short-lived provider with tracked config and discovery reads. |
+| Formatter standalone input | `crates/sifr_format/src/lib.rs:177`, `crates/sifr_format/src/lib.rs:180`, `crates/sifr_format/src/lib.rs:197`, `crates/sifr_format/src/lib.rs:215`, `crates/sifr_format/src/lib.rs:446`, `crates/sifr_format/src/lib.rs:456` | Formatter checks path shape, walks directories, reads source, and writes formatted files. | Short-lived provider for reads; writes remain command-output effects. |
+| Formatter config | `crates/sifr_format/src/config.rs:85`, `crates/sifr_format/src/config.rs:109` | Formatter config lookup probes candidate files and reads `sifr.toml`. | Short-lived provider with tracked config reads. |
+| Package offline availability | `crates/sifr_package/src/cargo/lock_modes.rs:46` | Offline dependency validation probes whether package roots are available. | Provider-tracked package metadata probe or reviewed package-management exception. |
+| Package manifest read | `crates/sifr_package/src/manifest/sifr.rs:55` | Package identity reads `sifr.toml` directly. | Provider-tracked package/config identity input. |
+| Package manifest validation | `crates/sifr_package/src/manifest/validate.rs:14`, `crates/sifr_package/src/manifest/validate.rs:43`, `crates/sifr_package/src/manifest/validate.rs:44` | Package manifest validation probes source roots and exported source files. | Provider-tracked directory/file probes. |
+| Package source-map traversal | `crates/sifr_package/src/imports/source_map.rs:240`, `crates/sifr_package/src/imports/source_map.rs:254` | Package source-map construction recursively reads package source-root directories and probes child directories. | Provider-tracked directory reads and path probes. |
+| Package namespace API | `crates/sifr_package/src/imports/namespace_api.rs:32`, `crates/sifr_package/src/imports/namespace_api.rs:264` | Package public API extraction reads `__init__.sifr` and probes child namespaces. | Provider-tracked package source reads and probes. |
+| Package source layout | `crates/sifr_package/src/source/layout.rs:30` | Pure-marker validation reads generated package source files. | Reviewed provider-backed package tooling read or non-semantic generated-output exception. |
+| Package session discovery and targets | `crates/sifr_package/src/ops/session_discovery.rs:6`, `crates/sifr_package/src/ops/session_discovery.rs:13`, `crates/sifr_package/src/ops/session_discovery.rs:25`, `crates/sifr_package/src/ops/session_targets.rs:17`, `crates/sifr_package/src/ops/session_targets.rs:34`, `crates/sifr_package/src/ops/session_targets.rs:42` | Package CLI/session discovery probes manifests and source roots. | Provider-tracked package session reads and probes where they affect compilation. |
+| CLI lint command reads | `crates/sifr/src/lint_cli.rs:308`, `crates/sifr/src/lint_cli.rs:496` | CLI lint command reads individual files for linting and probes path exclusion. | Provider-backed for semantic source reads; CLI target filtering remains a documented command-surface probe until M2 classifies it. |
+| CLI check/package command reads | `crates/sifr/src/check_and_package_commands.rs:409`, `crates/sifr/src/check_and_package_commands.rs:415`, `crates/sifr/src/check_and_package_commands.rs:427`, `crates/sifr/src/check_and_package_commands.rs:551`, `crates/sifr/src/check_and_package_commands.rs:554`, `crates/sifr/src/check_and_package_commands.rs:583`, `crates/sifr/src/check_and_package_commands.rs:590`, `crates/sifr/src/check_and_package_commands.rs:601` | CLI package/check command surfaces probe targets and cache paths and read package sources for command output. | Provider-backed for semantic source reads; command-output/cache probes remain documented exceptions where non-semantic. |
+| CLI entrypoint probing | `crates/sifr/src/cli_model_and_entrypoint.rs:634`, `crates/sifr/src/cli_model_and_entrypoint.rs:690`, `crates/sifr/src/cli_model_and_entrypoint.rs:716`, `crates/sifr/src/cli_model_and_entrypoint.rs:721` | CLI mode resolution reads manifests/source files and probes sibling modules. | Provider-backed for semantic source reads; CLI mode-selection probes remain tracked lookup dependencies. |
+
+Permitted M1 exceptions:
+
+- CLI stdin reads are not workspace identity until later explicitly modeled.
+- Generated-output and test-harness reads under tests, verification, and
+  generated artifact checks are outside the M2 semantic source-provider scope.
+- Codegen intrinsics that emit `std::fs::*` for user programs are not compiler
+  service reads.
+- Build artifact cache metadata in `crates/sifr_driver/src/build/workspace.rs:219`,
+  `crates/sifr_driver/src/build/workspace.rs:282`, and
+  `crates/sifr_driver/src/build/workspace.rs:296` is M15
+  `.sifrbuildinfo`/build-metadata territory, not M2 source-provider correctness.
+- Package projection writes and repair probes in
+  `crates/sifr_package/src/projection.rs:100`,
+  `crates/sifr_package/src/projection.rs:109`,
+  `crates/sifr_package/src/projection.rs:127`,
+  `crates/sifr_package/src/projection.rs:129`,
+  `crates/sifr_package/src/projection.rs:169`, and
+  `crates/sifr_package/src/projection.rs:187` are package-management output and
+  repair-state effects unless a later package-aware snapshot milestone promotes
+  a specific read into package identity.
+
+## Current Source-Map Guardrail
+
+M0 replaced the old `SourceMapView` stubs. Current guardrail:
+
+- `SourceMapView::text_position_to_span` delegates to
+  `sifr_source::SourceText::byte_offset_with_encoding`.
+- `SourceMapView::span_to_text_range` delegates to
+  `sifr_source::SourceText::range_at`.
+- Valid registered source-file conversions return `Some`; invalid files,
+  non-boundary positions, and out-of-range spans return `None`.
+
+## Current LSP Reality
+
+`internal_docs/lsp_server.md` describes both implemented Phase 36 behavior and
+future compiler-service layers. As of M1:
+
+- `DocumentStore` still owns per-document analysis hosts.
+- `DocumentState::rebuild` calls `AnalysisHost::open_single_file` with
+  `FrontendMode::SingleFile` on open/change/save.
+- The current `RequestQueue` tracks pending request ids and shutdown state only.
+- The current `Scheduler` maps request methods to lane labels only; it does not
+  yet provide priority queues, cancellation tokens, debounce, background lanes,
+  progress, or worker execution.
+- Stale-result rejection is revision-token based inside per-document
+  `AnalysisHost` use, not `WorkspaceSnapshot`/document-version publication
+  identity.
+
+M1-M4 remain serialized. M5 is the first milestone allowed to remove the
+request-local LSP host shape by making LSP consume captured workspace snapshots.
+M11/M13 own priority queues, cancellation, progress, debounce, and operational
+hardening.
+
+## Current LSP Budget Reality
+
+The enforced protocol-level LSP performance gate is still the aggregate
+`lsp.request_families` scenario with budget id `perf.lsp.request_families`.
+M12 must split this into per-request cases for cold start, diagnostics,
+completion, hover, signature help, navigation, references, rename, semantic
+tokens, inlay hints, selection range, type hierarchy, code actions, formatting,
+generated Rust preview, and workspace diagnostics. Until M12, aggregate LSP
+coverage is smoke coverage only.
+
+## Automation
+
+`verification/tooling/check_typescript_go_m1_guardrails.py` validates:
+
+- M1 documentation contains the locked terms, direct-read inventory, current LSP
+  limitations, serialized M1-M4 rule, and aggregate LSP budget status.
+- `sifr_source` still has bottom-of-graph dependency direction.
+- `SourceMapView` no longer has no-op conversion stubs.
+- Current LSP single-file rebuild and shallow scheduler/request queue reality is
+  visible in code while M1 is active.
+- The performance manifest still has the aggregate-only LSP request-family
+  budget, so M12 cannot be accidentally claimed early.
+
+### Future Milestone Update Obligations
+
+- M2 must either route every non-exempt inventory row through `SourceProvider`
+  or update this inventory with a reviewed exception before closure.
+- M5 must update the current LSP single-file rebuild caveat and the matching
+  script checks when `DocumentStore` stops owning request-local
+  `AnalysisHost::open_single_file` rebuilds.
+- M12 must update the aggregate-only LSP budget caveat and the matching script
+  checks when `lsp.request_families` is split into per-request scenarios.
+- M13 must update the scheduler/request-queue caveats if cancellation tokens,
+  progress, or background queues land in the scheduler modules.
+- M15 must update the build-metadata exception when `.sifrbuildinfo` or
+  equivalent persistent metadata becomes an explicit compiler-service input.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
@@ -8,8 +8,8 @@ Phase contract: `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md`
 
 - [x] Phase plan drafted
 - [x] Phase plan reviewed and approved for implementation
-- [ ] M0 source and position foundation completed
-- [ ] M1 architecture contract and guardrails completed
+- [x] M0 source and position foundation completed
+- [x] M1 architecture contract and guardrails completed
 - [ ] M2 source provider and overlay store completed
 - [ ] M3 workspace session data model completed
 - [ ] M4 analysis snapshot migration completed
@@ -129,8 +129,37 @@ This phase locks the TypeScript-Go-derived architecture transfer before implemen
 - `2026-06-01`: `git diff --check` -> PASS after clippy follow-up.
 - `2026-06-01`: `cargo fmt --check` -> PASS after clippy follow-up.
 - `2026-06-01`: M0 implementation review pass 2 recorded in `reviews/typescript-go-m0-source-foundation-review-pass-2.md`; reviewer approved M0 for PR.
+- `2026-06-01`: M0 merged via PR [#2229](https://github.com/sifr-lang/sifr/pull/2229), merge commit `e548c11310690553d614dc859a86177217a4c958`.
+- `2026-06-01`: M1 validation in progress on branch `wave_tsgo_m1_architecture_guardrails`.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS.
+- `2026-06-01`: `cargo clippy --workspace -- -D warnings` -> PASS.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS with new M1 guardrail wired into local validation; report `target/validation_lane_reports/quick.latest.json`, wall time 242.39s.
+- `2026-06-01`: `git diff --check` -> PASS.
+- `2026-06-01`: `cargo fmt --check` -> PASS.
+- `2026-06-01`: M1 focused validation in progress on branch `wave_tsgo_m1_architecture_guardrails`.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS.
+- `2026-06-01`: `cargo fmt --check` -> PASS for M1.
+- `2026-06-01`: `git diff --check` -> PASS for M1.
+- `2026-06-01`: `python3 scripts/check_file_size_guardrails.py && python3 scripts/check_source_crate_dependency_direction.py` -> PASS for M1.
+- `2026-06-01`: `cargo test -p sifr_frontend && cargo test -p sifr_lsp` -> PASS for M1.
+- `2026-06-01`: `cargo test -p sifr_analysis` -> PASS for M1.
+- `2026-06-01`: `cargo test -p sifr -- --skip test_e2e_pass` -> PASS for M1.
+- `2026-06-01`: M1 implementation review pass 1 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-1.md`; reviewer requested direct-read inventory corrections and completeness/drift checking before PR.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS after M1 review remediation.
+- `2026-06-01`: M1 implementation review pass 2 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-2.md`; reviewer found the probe regex missed `.is_file()`/`.is_dir()` and one package lock-mode probe.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS after M1 review pass 2 remediation.
+- `2026-06-01`: M1 implementation review pass 3 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-3.md`; reviewer approved M1 for PR.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS for M1 (`target/validation_lane_reports/quick.latest.json`, wall time 282.00s).
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` initially failed after M1 review remediation because the guardrail doc omitted `crates/sifr_driver/src/build/workspace.rs:296`; the inventory and script were corrected.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS after build-metadata inventory correction.
+- `2026-06-01`: `git diff --check`, `cargo fmt --check`, and `python3 scripts/check_file_size_guardrails.py` -> PASS after build-metadata inventory correction.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS after M1 review remediation; report `target/validation_lane_reports/quick.latest.json`, wall time 221.14s.
+- `2026-06-01`: M1 implementation review pass 2 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-2.md`; reviewer requested fixing the direct-read/probe regex and adding `crates/sifr_package/src/cargo/lock_modes.rs:46`.
+- `2026-06-01`: M1 implementation review pass 3 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-3.md`; reviewer approved M1 for PR after focused validation.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS after final M1 reviewer fixes; report `target/validation_lane_reports/quick.latest.json`, wall time 233.87s.
 
 ## PR Log
 
 - `2026-05-30`: Phase planning/review PR [#2206](https://github.com/sifr-lang/sifr/pull/2206) records the architecture transfer contract, execution tracker, and incorporated review artifacts.
-- Implementation PR links will be recorded per milestone after they are opened and merged.
+- `2026-06-01`: M0 source and position foundation merged in [#2229](https://github.com/sifr-lang/sifr/pull/2229).
+- Additional implementation PR links will be recorded per milestone after they are opened and merged.

--- a/reviews/typescript-go-architecture-transfer-m1-review-pass-1.md
+++ b/reviews/typescript-go-architecture-transfer-m1-review-pass-1.md
@@ -1,0 +1,68 @@
+Based on my comprehensive review of the M1 implementation, here are my findings ordered by severity.
+
+## Critical (block M1 PR)
+
+### 1. Stale direct-read line number in inventory
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:47`
+
+`crates/sifr_package/src/imports/source_map.rs:254` is documented as a "directory and source-root read" but the actual line 254 in that file is `if path.is_dir() {` — a path-type check, not a direct filesystem read. The only direct read in `discover_modules_recursive` is at line 240 (`std::fs::read_dir(directory)`). The M1 checker at `verification/tooling/check_typescript_go_m1_guardrails.py:48` enforces this stale line number, so the guardrail will permanently embed the wrong reference.
+
+### 2. Inventory misses four production direct reads
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:35-46`
+
+The inventory is incomplete and the checker does not enforce inventory completeness. The following production direct reads are missing:
+
+- `crates/sifr_format/src/lib.rs:197` — `fs::read_dir` in `collect_sifr_files_inner`
+- `crates/sifr_format/src/config.rs:109` — `fs::read_to_string` for canonical config read
+- `crates/sifr_package/src/source/layout.rs:30` — `std::fs::read_to_string` in `validate_pure_marker_file`
+- `crates/sifr_package/src/imports/namespace_api.rs:32` — `std::fs::read_to_string(init_path)` in `parse_init_sifr_reexports`
+
+Without these entries, M2 cannot fully route semantic reads through the typed provider. Consider extending the checker to require that no new `std::fs::` / `fs::read_*` calls appear in these crates without a corresponding inventory row.
+
+### 3. Execution tracker M1 status not updated
+**File:** `issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md:12`
+
+The M1 checklist row is still `[ ] M1 architecture contract and guardrails completed` while the validation log shows M1 has passed all required gates. M0 was already flipped to `[x]` after merge (line 11). Flip M1 to `[x]` before opening the PR, and add an M1 PR log entry mirroring the M0 entry at line 145.
+
+## Major (should fix before merge)
+
+### 4. `is_file()` calls characterized as "lookup dependencies" without a clear schema
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:40`
+
+`crates/sifr_driver/src/project/discovery.rs:90`, `:118`, `:180` are `is_file()` metadata probes, not content reads. The "Provider-tracked successful and failed lookup dependencies" framing is acceptable, but the inventory should make explicit that these are *probe* operations so M2 does not accidentally migrate them under a content-read path. Same applies to `is_file()` / `is_dir()` checks in sifr_format at `:177` and `:180`.
+
+### 5. No negative-coverage assertion for the inventory
+**File:** `verification/tooling/check_typescript_go_m1_guardrails.py`
+
+The checker only asserts the inventory lists the entries it knows about. It does not assert "no new production `std::fs::` call appears outside this list" or "no inventory line drifted from the actual code." Both failures (item 1 and item 2 above) would have been caught by even a simple grep of `std::fs::|fs::read_to_string|fs::read_dir` over the affected crates compared to the listed line numbers.
+
+## Minor (acceptable but worth noting)
+
+### 6. Brittle stub pattern check
+**File:** `verification/tooling/check_typescript_go_m1_guardrails.py:83-86`
+
+The check `"-> Option<TextRange> {\n        None" not in text` requires exact whitespace. It would not catch a function that returns `None` on the first statement with a different indent, nor would it catch a future stub with a different return type. Acceptable for now, but consider evolving to a structural AST/regex check that any `Option<TextRange>`/`Option<TextRangeUtf>` function must contain real logic before its first `None`/`Some` return.
+
+### 7. `DocumentState::rebuild` claim in M1 doc wording
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:73-75` and `internal_docs/lsp_server.md:68-69`
+
+Both files say `DocumentState::rebuild` "calls `AnalysisHost::open_single_file` with `FrontendMode::SingleFile` on open/change/save." Verified accurate: `document_store.rs:86` (new), `:101` (change_full), `:126` (change_incremental), `:136` (save). No correction needed.
+
+## Verifications confirmed accurate
+
+- Locked terms (`sifr_source`, `SourceProvider`, `WorkspaceSession`, `WorkspaceSnapshot`, `DirtyScope`, `DirtyReason`, `ModuleSignature`, `CompilerFingerprint`, `CacheKeyFingerprint`, `FlowGraph`, `.sifrbuildinfo`, `QueryReadiness`) are present in the M1 doc.
+- Source-map guardrail snippets are real: `source_maps.rs:91` calls `byte_offset_with_encoding` and `:102` calls `range_at`.
+- M1-M4 serialization language ("M1-M4 remain serialized") is recorded in the M1 doc and the lsp doc.
+- `perf.lsp.request_families` is the only `lsp-query` case in `verification/performance/manifest.json`; budget id matches.
+- `sifr_source` dependency direction guard passes (only `ruff_text_size`).
+- No M2+ terms (`WorkspaceSession`, `WorkspaceSnapshot`, `SourceProvider`, `DirtyScope`, `can_replace_module_in_project`, `ModuleSignature`, `CompilerFingerprint`, `CacheKeyFingerprint`, `FlowGraph`, `sifrbuildinfo`) appear in any implementation under `crates/`. No behavior overreach.
+- `scripts/run_all_tests.sh` now invokes the M1 guardrail; regressions would block PRs.
+- `rustfmt --check` and `git diff --check` pass; LSP doc status header and "is being migrated" language are correct.
+
+## M1 closeout assessment
+
+The M1 closeout criteria are largely met (locked terms, direct-read inventory, four guardrails, M1-M4 serialization, aggregate-only LSP budget, target-vs-actual docs). The two inventory problems (stale line + missing entries) are factual defects in the artifact that M2 will use; they should be corrected before the M1 closeout gates M2.
+
+---
+
+**Not approved for PR as-is.** Address items 1-3 (stale `source_map.rs:254` line, four missing inventory entries, M1 tracker/PR log updates) and consider adding a completeness check to the M1 guardrail (item 5) before opening the M1 PR.

--- a/reviews/typescript-go-architecture-transfer-m1-review-pass-2.md
+++ b/reviews/typescript-go-architecture-transfer-m1-review-pass-2.md
@@ -1,0 +1,78 @@
+Now I have a clear picture. Let me write the review.
+
+# M1 Implementation Review — Pass 2
+
+## Validation status
+All five gates the user reported pass. I independently re-ran them on the working tree:
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` → PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` → PASS
+- `git diff --check` → exit 0
+- `cargo fmt --check` → exit 0
+- `python3 scripts/check_file_size_guardrails.py` → PASS
+- `cargo clippy --workspace -- -D warnings` → exit 0
+- `python3 scripts/check_source_crate_dependency_direction.py` → exit 0
+
+I also spot-checked inventory line numbers (`validate.rs:14, :43, :44`; `source_map.rs:240, :254`; `layout.rs:30`; `build/workspace.rs:219, :282, :296`; `source_maps.rs:91, :102`) — all match real code. Pass-1 items 1 (stale `source_map.rs:254`) and the four missing entries are fixed. The M1 doc updates in `lsp_server.md`, `frontend_cache_invalidation.md`, `frontend_query_architecture.md`, `architecture.md`, and `performance_budgets.md` are all well-targeted and consistent with the parallel M0 mention at `architecture.md:271`. The execution tracker correctly flips M1 and records validation.
+
+## Findings, ordered by severity
+
+### Major (block PR)
+
+**1. Guardrail regex is broken — `is_file()` / `is_dir()` probes are not caught.**
+
+`verification/tooling/check_typescript_go_m1_guardrails.py:24`
+
+```python
+r"(?:std::fs::|fs::)(?:read_to_string|read_dir)|\\.is_file\\(\\)|\\.is_dir\\(\\)"
+```
+
+In a Python raw string, `\\` is two literal characters (backslash + backslash). The compiled regex therefore looks for `\\.is_file\\(\\)` in source lines, which never matches `.is_file()` or `.is_dir()`. I confirmed by importing the module and inspecting `mod.DIRECT_FS_PATTERN.pattern` — it reads `(?:std::fs::|fs::)(?:read_to_string|read_dir)|\\.is_file\\(\\)|\\.is_dir\\(\\)`. A `re.search(".is_file()")` against this pattern returns `False`.
+
+The effect: `direct_fs_sites()` only enumerates `read_to_string` and `read_dir` sites. The script reports 30 sites and 0 missing — but the true production count is ~50 sites once you count `is_file()` / `is_dir()` probes. The script is silently missing every probe site, which is exactly the negative-coverage check the pass-1 review's item 5 asked for. Without this fix, M2 can land with a new `is_file()` probe in any inventoried crate and the guardrail will not catch it.
+
+Fix is one character per pattern alternative: change `\\.` to `\.` and `\\(` to `\(` and `\\)` to `\)` in the raw string. After the fix, the script becomes a true negative-coverage check.
+
+**2. `crates/sifr_package/src/cargo/lock_modes.rs:46` is not in the inventory.**
+
+```rust
+// crates/sifr_package/src/cargo/lock_modes.rs:46
+if package_root.is_dir() {
+    None
+} else {
+    Some(PackageDiagnostic::source_unavailable_offline(...))
+}
+```
+
+This is a real production probe in the offline lock-mode diagnostic path — a `.sifrbuildinfo`/package-identity adjacent read. It's not enumerated in the inventory table and not named in the permitted-exceptions block. Because the regex is broken (item 1), the script can't catch it. Once the regex is fixed, item 2 will be caught automatically and the doc will need a new row such as "Package offline lock-mode probe" pointing at M15 deferred territory (or a permitted exception with a rationale).
+
+This is the same class of miss pass-1 item 2 flagged. The author added most of the missing entries (and the build-metadata exception at `workspace.rs:296`), but this one slipped through.
+
+### Minor (worth noting, not blocking)
+
+**3. Inventory line `crates/sifr_format/src/lib.rs:456` documents a write.** Line 456 is `fs::write(path, source)` in the formatter. The M1 doc correctly classifies writes as "command-output effects" rather than semantic reads. The script's `read_to_string`/`read_dir` regex never matched it, and the doc names it in the "Formatter standalone input" row alongside reads. Acceptable, but worth a one-line note in the doc clarifying the read/write split so M2 doesn't accidentally try to route a write through a read-only provider.
+
+**4. The `-> Option<TextRange> {\n        None` literal-string check is brittle.** It depends on exact whitespace. If `source_maps.rs` ever wraps the body in a `match` or moves the early-return to a different indentation, the check fires even though no regression has occurred. The current source code uses `?` on a method call, not a `None` literal return, so the check passes today. Acceptable for M1; consider a structural regex (e.g., `pub fn ... -> Option<TextRange(?:Utf)?> \{[^}]*Some\(`) for the next guardrail revision.
+
+**5. The script's `validate_source_dep_guard` shells out to `scripts/check_source_crate_dependency_direction.py`.** If the source-dep script is renamed or moved, the M1 guardrail fails with an unhelpful message. Low priority — the dep script is stable — but worth a clearer error path.
+
+**6. The doc lists six `crates/sifr_package/src/projection.rs` lines (`100, 109, 127, 129, 169, 187`) as permitted exceptions, but only two (`129, 187`) match the read regex.** The other four are `fs::write` calls and `.exists()` checks. They are correctly categorized as package-management output and repair-state effects, but since the regex doesn't catch writes or `exists()`, the script's enforcement of these exceptions is purely textual (the doc must contain those exact `path:line` substrings). Fine for M1; the future M2/M15 closeout will need to know these rows are write-side, not read-side.
+
+## Summary of M1 contract items
+
+- Locked terms (`sifr_source`, `SourceProvider`, `WorkspaceSession`, `WorkspaceSnapshot`, `DirtyScope`, `DirtyReason`, `ModuleSignature`, `CompilerFingerprint`, `CacheKeyFingerprint`, `FlowGraph`, `.sifrbuildinfo`, `QueryReadiness`): all present in the M1 doc. ✓
+- Source-map guardrail (`byte_offset_with_encoding(position, encoding)`, `range_at(span, encoding)`, stub-pattern check): pins M0 correctness. ✓
+- LSP current-state checks (`AnalysisHost::open_single_file` + `FrontendMode::SingleFile` in `document_store.rs`; `lane_for_method` + no `CancellationToken` in `scheduler.rs`; `pending: BTreeSet<String>` + `remove_pending` in `request_queue.rs`): all current. ✓
+- Aggregate-only LSP budget pinned to `perf.lsp.request_families`: manifest has exactly one `lsp-query` case with that budget id. ✓
+- M1-M4 serialization language: present in M1 doc and `lsp_server.md`. ✓
+- Doc updates: `lsp_server.md` (status line, "is being migrated toward" wording, new "Current M1 Compiler-Service Caveats" section); `frontend_cache_invalidation.md` (6-line M1 note); `frontend_query_architecture.md` (M1 note deferring to M3/M4); `architecture.md` (M1 line at 271, parallel to M0 line); `performance_budgets.md` (3-line note). All on point. ✓
+- M1 checker wired into `scripts/run_all_tests.sh`: ✓
+- M1 checker self-test: ✓
+- M1 execution-tracker update: ✓
+- `sifr_source` dependency direction: ✓ (no behavior migration)
+- No M2+ identifiers (`SourceProvider`, `WorkspaceSession`, `WorkspaceSnapshot`, `DirtyScope`, etc.) in `crates/`: not in scope of this review, but the pass-1 review already confirmed.
+
+## Verdict
+
+**NOT APPROVED.**
+
+The M1 spec calls for the inventory to be the input list for M2's provider migration and for the script to catch drift on the inventory. Item 1 means the script is materially weaker than the doc claims, and item 2 means the inventory is genuinely incomplete. Both are one-line fixes. Once they land (regex fix in `verification/tooling/check_typescript_go_m1_guardrails.py:24` and a new row for `crates/sifr_package/src/cargo/lock_modes.rs:46` in the inventory table), M1 is ready to open as a PR.

--- a/reviews/typescript-go-architecture-transfer-m1-review-pass-3.md
+++ b/reviews/typescript-go-architecture-transfer-m1-review-pass-3.md
@@ -1,0 +1,21 @@
+Review complete.
+
+## Findings
+
+Pass-2 blockers — both resolved:
+
+1. **DIRECT_FS_PATTERN regex** — `verification/tooling/check_typescript_go_m1_guardrails.py:23-25` now uses `\.is_file\(\)` / `\.is_dir\(\)` (escaped backslash + escaped parens) inside the raw string. The new pattern correctly matches `lock_modes.rs:46`'s `if package_root.is_dir() {` (confirmed via direct probe and regex smoke test). Negative cases (`is_file()` without a leading dot, bare `read_to_string(...)`) still don't match.
+
+2. **Inventory miss for `lock_modes.rs:46`** — `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:52` now records it under "Package offline availability" with documented effect ("Offline dependency validation probes whether package roots are available.") and M2 expectation. Cross-check: the script discovers 59 direct-fs sites, 0 missing from the doc.
+
+Additional non-blocker touch-up also present: inventory heading at `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:30` now reads "Current Direct-Read, Probe, And Documented Effect Inventory".
+
+Validation results (all green):
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` → PASS (exit 0)
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` → PASS
+- `python3 scripts/check_file_size_guardrails.py` → PASS (2014 files, 900-line cap)
+- `python3 scripts/check_source_crate_dependency_direction.py` → exit 0
+- `cargo fmt --check` → clean
+- `git diff --check` → clean
+
+M1 approved for PR

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -99,6 +99,10 @@ python3 "${SCRIPT_DIR}/check_file_size_guardrails.py"
 echo "Running source crate dependency-direction guardrail"
 python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py"
 
+echo "Running TypeScript-Go architecture transfer M1 guardrails"
+python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py"
+python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py" --self-test
+
 echo "Running sifr_driver maintainability guardrails"
 python3 "${SCRIPT_DIR}/check_sifr_driver_maintainability_guardrails.py"
 

--- a/verification/tooling/check_typescript_go_m1_guardrails.py
+++ b/verification/tooling/check_typescript_go_m1_guardrails.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""M1 pre-flight guardrails for the TypeScript-Go architecture transfer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "internal_docs" / "typescript_go_architecture_transfer_m1_guardrails.md"
+SOURCE_MAPS = REPO_ROOT / "crates" / "sifr_frontend" / "src" / "source_maps.rs"
+DOCUMENT_STORE = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "document_store.rs"
+SCHEDULER = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "scheduler.rs"
+REQUEST_QUEUE = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "request_queue.rs"
+PERF_MANIFEST = REPO_ROOT / "verification" / "performance" / "manifest.json"
+SOURCE_DEP_GUARD = REPO_ROOT / "scripts" / "check_source_crate_dependency_direction.py"
+DIRECT_FS_PATTERN = re.compile(
+    r"(?:std::fs::|fs::)(?:read_to_string|read_dir)|\.is_file\(\)|\.is_dir\(\)"
+)
+DIRECT_FS_SCAN_ROOTS = [
+    REPO_ROOT / "crates" / "sifr" / "src",
+    REPO_ROOT / "crates" / "sifr_driver" / "src",
+    REPO_ROOT / "crates" / "sifr_frontend" / "src",
+    REPO_ROOT / "crates" / "sifr_format" / "src",
+    REPO_ROOT / "crates" / "sifr_lint" / "src",
+    REPO_ROOT / "crates" / "sifr_package" / "src",
+]
+
+REQUIRED_DOC_SNIPPETS = [
+    "SourceProvider",
+    "WorkspaceSession",
+    "WorkspaceSnapshot",
+    "DirtyScope",
+    "DirtyReason",
+    "ModuleSignature",
+    "CompilerFingerprint",
+    "CacheKeyFingerprint",
+    "FlowGraph",
+    ".sifrbuildinfo",
+    "crates/sifr_frontend/src/graph_cache_and_queries.rs:312",
+    "crates/sifr_frontend/src/graph_cache_and_queries.rs:322",
+    "crates/sifr_frontend/src/graph_cache_and_queries.rs:359",
+    "crates/sifr_driver/src/project/discovery.rs:90",
+    "crates/sifr_driver/src/project/discovery.rs:118",
+    "crates/sifr_driver/src/project/discovery.rs:180",
+    "crates/sifr_driver/src/project/discovery.rs:332",
+    "crates/sifr_driver/src/project/discovery.rs:574",
+    "crates/sifr_driver/src/workspace/mod.rs:32",
+    "crates/sifr_driver/src/workspace/mod.rs:49",
+    "crates/sifr_driver/src/workspace/mod.rs:156",
+    "crates/sifr_driver/src/project/package_discovery.rs:53",
+    "crates/sifr_driver/src/build/workspace.rs:219",
+    "crates/sifr_driver/src/build/workspace.rs:282",
+    "crates/sifr_driver/src/build/workspace.rs:296",
+    "crates/sifr_lint/src/engine.rs:134",
+    "crates/sifr_lint/src/config.rs:48",
+    "crates/sifr_lint/src/config.rs:72",
+    "crates/sifr_lint/src/discovery.rs:29",
+    "crates/sifr_lint/src/discovery.rs:33",
+    "crates/sifr_lint/src/discovery.rs:79",
+    "crates/sifr_format/src/lib.rs:177",
+    "crates/sifr_format/src/lib.rs:180",
+    "crates/sifr_format/src/lib.rs:197",
+    "crates/sifr_format/src/lib.rs:215",
+    "crates/sifr_format/src/lib.rs:446",
+    "crates/sifr_format/src/lib.rs:456",
+    "crates/sifr_format/src/config.rs:85",
+    "crates/sifr_format/src/config.rs:109",
+    "crates/sifr_package/src/manifest/sifr.rs:55",
+    "crates/sifr_package/src/manifest/validate.rs:14",
+    "crates/sifr_package/src/manifest/validate.rs:43",
+    "crates/sifr_package/src/manifest/validate.rs:44",
+    "crates/sifr_package/src/imports/source_map.rs:240",
+    "crates/sifr_package/src/imports/source_map.rs:254",
+    "crates/sifr_package/src/imports/namespace_api.rs:32",
+    "crates/sifr_package/src/imports/namespace_api.rs:264",
+    "crates/sifr_package/src/source/layout.rs:30",
+    "crates/sifr_package/src/ops/session_discovery.rs:6",
+    "crates/sifr_package/src/ops/session_discovery.rs:13",
+    "crates/sifr_package/src/ops/session_discovery.rs:25",
+    "crates/sifr_package/src/ops/session_targets.rs:17",
+    "crates/sifr_package/src/ops/session_targets.rs:34",
+    "crates/sifr_package/src/ops/session_targets.rs:42",
+    "crates/sifr_package/src/projection.rs:100",
+    "crates/sifr_package/src/projection.rs:109",
+    "crates/sifr_package/src/projection.rs:127",
+    "crates/sifr_package/src/projection.rs:129",
+    "crates/sifr_package/src/projection.rs:169",
+    "crates/sifr_package/src/projection.rs:187",
+    "crates/sifr/src/lint_cli.rs:308",
+    "crates/sifr/src/lint_cli.rs:496",
+    "crates/sifr/src/check_and_package_commands.rs:409",
+    "crates/sifr/src/check_and_package_commands.rs:415",
+    "crates/sifr/src/check_and_package_commands.rs:427",
+    "crates/sifr/src/check_and_package_commands.rs:551",
+    "crates/sifr/src/check_and_package_commands.rs:554",
+    "crates/sifr/src/check_and_package_commands.rs:583",
+    "crates/sifr/src/check_and_package_commands.rs:590",
+    "crates/sifr/src/check_and_package_commands.rs:601",
+    "crates/sifr/src/cli_model_and_entrypoint.rs:634",
+    "crates/sifr/src/cli_model_and_entrypoint.rs:690",
+    "crates/sifr/src/cli_model_and_entrypoint.rs:716",
+    "crates/sifr/src/cli_model_and_entrypoint.rs:721",
+    "path probes",
+    "DocumentState::rebuild",
+    "AnalysisHost::open_single_file",
+    "M1-M4 remain serialized",
+    "M5 must update",
+    "M12 must update",
+    "perf.lsp.request_families",
+]
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def validate_doc(text: str, failures: list[str]) -> None:
+    for snippet in REQUIRED_DOC_SNIPPETS:
+        require(snippet in text, f"M1 guardrail doc missing snippet: {snippet}", failures)
+
+
+def is_production_source(path: Path) -> bool:
+    relative_parts = path.relative_to(REPO_ROOT).parts
+    if "tests" in relative_parts or "bin" in relative_parts:
+        return False
+    name = path.name
+    return not (name.endswith("_tests.rs") or name == "tests.rs")
+
+
+def direct_fs_sites() -> list[tuple[str, int, str]]:
+    sites: list[tuple[str, int, str]] = []
+    for root in DIRECT_FS_SCAN_ROOTS:
+        for path in sorted(root.rglob("*.rs")):
+            if not is_production_source(path):
+                continue
+            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if DIRECT_FS_PATTERN.search(line):
+                    sites.append((path.relative_to(REPO_ROOT).as_posix(), line_number, line.strip()))
+    return sites
+
+
+def validate_direct_fs_inventory(text: str, failures: list[str]) -> None:
+    for path, line_number, source_line in direct_fs_sites():
+        reference = f"{path}:{line_number}"
+        require(
+            reference in text,
+            f"M1 direct-read/probe inventory missing {reference}: {source_line}",
+            failures,
+        )
+
+
+def validate_source_maps(text: str, failures: list[str]) -> None:
+    # These string checks intentionally pin the current `sifr_source` parameter
+    # shape. If that API is renamed, update this guardrail with the signature
+    # change so source-map conversions cannot silently become stubs again.
+    require(
+        "byte_offset_with_encoding(position, encoding)" in text,
+        "SourceMapView::text_position_to_span must delegate to sifr_source conversion",
+        failures,
+    )
+    require(
+        "range_at(span, encoding)" in text,
+        "SourceMapView::span_to_text_range must delegate to sifr_source conversion",
+        failures,
+    )
+    require(
+        "pub fn text_position_to_span" in text and "pub fn span_to_text_range" in text,
+        "SourceMapView conversion APIs are missing",
+        failures,
+    )
+    require(
+        "-> Option<TextRange> {\n        None" not in text and "-> Option<TextRangeUtf> {\n        None" not in text,
+        "SourceMapView conversion APIs must not be no-op stubs",
+        failures,
+    )
+
+
+def validate_lsp_current_state(failures: list[str]) -> None:
+    document_store = DOCUMENT_STORE.read_text(encoding="utf-8")
+    scheduler = SCHEDULER.read_text(encoding="utf-8")
+    request_queue = REQUEST_QUEUE.read_text(encoding="utf-8")
+    require(
+        "AnalysisHost::open_single_file" in document_store
+        and "FrontendMode::SingleFile" in document_store,
+        "M1 must explicitly track the current LSP single-file rebuild path until M5 replaces it",
+        failures,
+    )
+    require(
+        "pub(crate) fn lane_for_method" in scheduler and "CancellationToken" not in scheduler,
+        "M1 scheduler guardrail expects lane labels only, with cancellation deferred",
+        failures,
+    )
+    require(
+        "pending: BTreeSet<String>" in request_queue and "remove_pending" in request_queue,
+        "M1 request queue guardrail expects pending-id tracking only",
+        failures,
+    )
+
+
+def validate_lsp_budget_reality(failures: list[str]) -> None:
+    manifest = json.loads(PERF_MANIFEST.read_text(encoding="utf-8"))
+    cases = manifest.get("cases", []) if isinstance(manifest, dict) else manifest
+    lsp_cases = [
+        case
+        for case in cases
+        if case.get("kind") == "lsp-query" or str(case.get("scenario", "")).startswith("lsp.")
+    ]
+    scenarios = sorted(case.get("scenario") for case in lsp_cases)
+    require(
+        scenarios == ["lsp.request_families"],
+        f"M1 expects aggregate-only LSP budget reality until M12, found: {scenarios}",
+        failures,
+    )
+    require(
+        lsp_cases[0].get("budget_id") == "perf.lsp.request_families" if lsp_cases else False,
+        "M1 aggregate LSP budget id must be perf.lsp.request_families",
+        failures,
+    )
+
+
+def validate_source_dep_guard(failures: list[str]) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SOURCE_DEP_GUARD)],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    require(result.returncode == 0, f"sifr_source dependency guard failed:\n{result.stdout}", failures)
+
+
+def run_self_test() -> None:
+    with tempfile.TemporaryDirectory(dir=REPO_ROOT / "target") as tmp:
+        incomplete_doc = Path(tmp) / "m1.md"
+        incomplete_doc.write_text("WorkspaceSession only\n", encoding="utf-8")
+        failures: list[str] = []
+        validate_doc(incomplete_doc.read_text(encoding="utf-8"), failures)
+    if not failures:
+        raise SystemExit("M1 guardrail self-test failed: incomplete doc passed")
+    failures = []
+    validate_direct_fs_inventory("WorkspaceSession only\n", failures)
+    if not failures:
+        raise SystemExit("M1 guardrail self-test failed: incomplete inventory passed")
+    print("TypeScript-Go M1 guardrail self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+
+    failures: list[str] = []
+    doc_text = DOC.read_text(encoding="utf-8")
+    validate_doc(doc_text, failures)
+    validate_direct_fs_inventory(doc_text, failures)
+    validate_source_maps(SOURCE_MAPS.read_text(encoding="utf-8"), failures)
+    validate_lsp_current_state(failures)
+    validate_lsp_budget_reality(failures)
+    validate_source_dep_guard(failures)
+
+    if failures:
+        print("TypeScript-Go M1 guardrails: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("TypeScript-Go M1 guardrails: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add the M1 architecture-transfer guardrail document with the current direct-read/probe inventory, LSP caveats, aggregate LSP budget caveat, and future milestone update obligations.
- Add verification/tooling/check_typescript_go_m1_guardrails.py and wire it into scripts/run_all_tests.sh.
- Update architecture/frontend/LSP/performance docs and the phase execution tracker with M1 status and review evidence.

## Validation
- python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test
- git diff --check
- cargo fmt --check
- python3 scripts/check_file_size_guardrails.py
- scripts/run_all_tests.sh --profile quick (233.87s)

## Review
- reviews/typescript-go-architecture-transfer-m1-review-pass-1.md
- reviews/typescript-go-architecture-transfer-m1-review-pass-2.md
- reviews/typescript-go-architecture-transfer-m1-review-pass-3.md approved M1 for PR after fixes.