### PR TITLE
Add source provider overlay boundary

### DIFF
--- a/crates/sifr/Cargo.toml
+++ b/crates/sifr/Cargo.toml
@@ -16,6 +16,7 @@ ruff_text_size = { workspace = true }
 sifr_diagnostics = { workspace = true }
 sifr_driver = { workspace = true }
 sifr_format = { workspace = true }
+sifr_frontend = { workspace = true }
 sifr_lint = { workspace = true }
 sifr_lsp = { workspace = true }
 sifr_package = { workspace = true }

--- a/crates/sifr/src/check_and_package_commands.rs
+++ b/crates/sifr/src/check_and_package_commands.rs
@@ -16,6 +16,7 @@ use sifr_driver::{
     CompileResult, PackageEntrypoint,
 };
 use sifr_format::config::{effective_format_config, EffectiveFormatConfig, FormatConfigOverrides};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash as _, Hasher as _};
@@ -405,31 +406,22 @@ pub(super) fn fmt_entrypoint(
         args.paths.clone()
     };
     let mut diagnostics = Vec::new();
+    let mut provider = DiskSourceProvider::new();
     for target in targets {
-        let explicit_target = target.is_file();
+        let explicit_target = provider.is_file(&target);
         let files = select_formatter_files(&target, &config, explicit_target)?;
         for file in files {
             if args.check {
                 diagnostics.extend(sifr_format::check_path_with_options(&file, options)?);
             } else if args.diff {
-                let source = fs::read_to_string(&file).map_err(|err| {
-                    vec![formatter_cli_diagnostic(format!(
-                        "could not read file {}: {err}",
-                        file.display()
-                    ))]
-                })?;
+                let source = read_formatter_source(&file)?;
                 let formatted = format_source_or_range(&source, &file, args, options)?;
                 if formatted != source {
                     write_unified_diff(&file, &source, &formatted);
                     diagnostics.push(formatting_drift_for_path(&source, &file));
                 }
             } else if args.range.is_some() {
-                let source = fs::read_to_string(&file).map_err(|err| {
-                    vec![formatter_cli_diagnostic(format!(
-                        "could not read file {}: {err}",
-                        file.display()
-                    ))]
-                })?;
+                let source = read_formatter_source(&file)?;
                 let formatted = format_source_or_range(&source, &file, args, options)?;
                 if formatted != source {
                     fs::write(&file, formatted).map_err(|err| {
@@ -548,15 +540,17 @@ fn select_formatter_files(
 
 fn read_gitignore_patterns() -> Result<Vec<String>, Vec<RenderedDiagnostic>> {
     let path = Path::new(".gitignore");
-    if !path.is_file() {
+    let mut provider = DiskSourceProvider::new();
+    if !provider.is_file(path) {
         return Ok(Vec::new());
     }
-    let source = fs::read_to_string(path).map_err(|err| {
+    let source = provider.read_file(path).map_err(|err| {
         vec![formatter_cli_diagnostic(format!(
             "could not read .gitignore for formatter discovery: {err}"
         ))]
     })?;
     Ok(source
+        .as_str()
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
@@ -580,12 +574,7 @@ fn try_formatter_cache_hit(
     if config.no_cache {
         return Ok(false);
     }
-    let source = fs::read_to_string(path).map_err(|err| {
-        vec![formatter_cli_diagnostic(format!(
-            "could not read file {}: {err}",
-            path.display()
-        ))]
-    })?;
+    let source = read_formatter_source(path)?;
     let key = formatter_cache_key(path, &source, options);
     Ok(config.cache_dir.join(key).is_file())
 }
@@ -598,12 +587,7 @@ fn write_formatter_cache_entry(
     if config.no_cache {
         return Ok(());
     }
-    let source = fs::read_to_string(path).map_err(|err| {
-        vec![formatter_cli_diagnostic(format!(
-            "could not read file {}: {err}",
-            path.display()
-        ))]
-    })?;
+    let source = read_formatter_source(path)?;
     fs::create_dir_all(&config.cache_dir).map_err(|err| {
         vec![formatter_cli_diagnostic(format!(
             "could not create formatter cache {}: {err}",
@@ -617,6 +601,18 @@ fn write_formatter_cache_entry(
             config.cache_dir.display()
         ))]
     })
+}
+
+fn read_formatter_source(path: &Path) -> Result<String, Vec<RenderedDiagnostic>> {
+    DiskSourceProvider::new()
+        .read_file(path)
+        .map(|source| source.as_str().to_string())
+        .map_err(|err| {
+            vec![formatter_cli_diagnostic(format!(
+                "could not read file {}: {err}",
+                path.display()
+            ))]
+        })
 }
 
 fn formatter_cache_key(path: &Path, source: &str, options: sifr_format::FormatOptions) -> String {

--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -10,6 +10,7 @@ use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic, Severi
 #[cfg(test)]
 use sifr_driver::diagnostic_label_for_code_str;
 use sifr_driver::find_workspace_root;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use sifr_python_ast::Stmt;
 use sifr_syntax::parse_module_suite;
 use std::collections::BTreeMap;
@@ -631,8 +632,9 @@ pub(super) fn diagnostic_explanation(code: &str) -> Option<String> {
         .parent()?
         .to_path_buf();
     let path = repo_root.join("docs/errors").join(format!("{code}.md"));
-    let text = std::fs::read_to_string(path).ok()?;
+    let text = DiskSourceProvider::new().read_file(&path).ok()?;
     let mut lines = text
+        .as_str()
         .lines()
         .filter(|line| !line.starts_with("<!--") && !line.starts_with('|'));
     let title = lines.find(|line| line.starts_with("# "))?;
@@ -687,10 +689,11 @@ pub(super) fn has_local_project_imports(file: &Path) -> bool {
     let Some(parent) = file.parent() else {
         return false;
     };
-    let Ok(source) = std::fs::read_to_string(file) else {
+    let mut provider = DiskSourceProvider::new();
+    let Ok(source) = provider.read_file(file) else {
         return false;
     };
-    let suite = match parse_module_suite(&source, Some(&file.display().to_string())) {
+    let suite = match parse_module_suite(source.as_str(), Some(&file.display().to_string())) {
         Ok(suite) => suite,
         _ => return false,
     };
@@ -713,12 +716,12 @@ pub(super) fn has_local_project_imports(file: &Path) -> bool {
         {
             return false;
         }
-        parent.join(format!("{module_name}.sifr")).is_file()
+        provider.is_file(&parent.join(format!("{module_name}.sifr")))
     })
 }
 
 pub(super) fn read_source(file: &Path) -> String {
-    match std::fs::read_to_string(file) {
+    match DiskSourceProvider::new().read_file(file) {
         Ok(source) => source,
         Err(e) => {
             let _ = writeln!(
@@ -729,6 +732,8 @@ pub(super) fn read_source(file: &Path) -> String {
             process::exit(EXIT_USAGE_OR_CONFIG);
         }
     }
+    .as_str()
+    .to_string()
 }
 
 #[cfg(test)]

--- a/crates/sifr/src/lint_cli.rs
+++ b/crates/sifr/src/lint_cli.rs
@@ -5,6 +5,7 @@ use super::cli_model_and_entrypoint::{
 use super::diagnostic_rendering_and_run::render_diagnostic_output;
 use clap::{Args, ValueEnum};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use sifr_lint::{EffectiveLintConfig, LintConfigOverrides, PerFileIgnore, UnsafeFixPolicy};
 use std::collections::BTreeMap;
 use std::io::{self, Read as _, Write as _};
@@ -303,14 +304,16 @@ fn run_fix_command(
     let mut summary_counts = BTreeMap::<String, usize>::new();
     let mut diff = String::new();
     let mut applied_count = 0usize;
+    let mut provider = DiskSourceProvider::new();
 
     for file in files {
-        let source = std::fs::read_to_string(&file).map_err(|err| {
+        let source = provider.read_file(&file).map_err(|err| {
             vec![diagnostic_with_code(
                 format!("could not read lint file {}: {err}", file.display()),
                 DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
             )]
         })?;
+        let source = source.as_str().to_string();
         let fixed = sifr_lint::fix_source(&source, Some(&file), options);
         for fix in &fixed.applied_fixes {
             *summary_counts.entry(fix.rule_id.clone()).or_default() += 1;
@@ -493,7 +496,8 @@ fn lint_start_dir(args: &LintArgs) -> PathBuf {
         .iter()
         .find(|path| path != &Path::new("-"))
         .and_then(|path| {
-            if path.is_dir() {
+            let mut provider = DiskSourceProvider::new();
+            if provider.is_dir(path) {
                 Some(path.as_path())
             } else {
                 path.parent()

--- a/crates/sifr_driver/src/project/discovery.rs
+++ b/crates/sifr_driver/src/project/discovery.rs
@@ -5,6 +5,7 @@ use sifr_diagnostics::{
     ChildSeverity, DiagnosticArg, DiagnosticBuilder, DiagnosticCode, DiagnosticSink, Severity,
     SourceMap, SourceSpan,
 };
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use sifr_python_ast::Stmt;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -85,15 +86,25 @@ impl ModuleResolver {
         self.workspace.is_some()
     }
 
+    #[cfg(test)]
     pub(crate) fn resolve(&self, module_name: &str) -> Result<ResolvedModule, ResolutionError> {
+        let mut provider = DiskSourceProvider::new();
+        self.resolve_with_provider(module_name, &mut provider)
+    }
+
+    pub(crate) fn resolve_with_provider(
+        &self,
+        module_name: &str,
+        provider: &mut impl SourceProvider,
+    ) -> Result<ResolvedModule, ResolutionError> {
         let entry_path = self.module_source_path(module_name);
-        if entry_path.is_file() {
+        if provider.is_file(&entry_path) {
             let resolved = ResolvedModule {
                 module_name: module_name.to_string(),
                 path: entry_path,
                 origin: ModuleOrigin::EntryParent,
             };
-            self.reject_namespace_file_collision(&resolved)?;
+            self.reject_namespace_file_collision(&resolved, provider)?;
             return Ok(resolved);
         }
 
@@ -115,7 +126,7 @@ impl ModuleResolver {
                 .join(source_root)
                 .join(&relative_path);
             tried_paths.push(candidate.clone());
-            if candidate.is_file() && !matches.contains(&candidate) {
+            if provider.is_file(&candidate) && !matches.contains(&candidate) {
                 matches.push(candidate);
             }
         }
@@ -141,7 +152,7 @@ impl ModuleResolver {
                 path,
                 origin: ModuleOrigin::WorkspaceSource { source_root },
             };
-            self.reject_namespace_file_collision(&resolved)?;
+            self.reject_namespace_file_collision(&resolved, provider)?;
             return Ok(resolved);
         }
 
@@ -156,8 +167,10 @@ impl ModuleResolver {
     fn reject_namespace_file_collision(
         &self,
         resolved: &ResolvedModule,
+        provider: &mut impl SourceProvider,
     ) -> Result<(), ResolutionError> {
-        let Some((parent_name, parent_path)) = self.parent_module_file(&resolved.module_name)
+        let Some((parent_name, parent_path)) =
+            self.parent_module_file(&resolved.module_name, provider)
         else {
             return Ok(());
         };
@@ -169,7 +182,11 @@ impl ModuleResolver {
         })
     }
 
-    fn parent_module_file(&self, module_name: &str) -> Option<(String, PathBuf)> {
+    fn parent_module_file(
+        &self,
+        module_name: &str,
+        provider: &mut impl SourceProvider,
+    ) -> Option<(String, PathBuf)> {
         let parts: Vec<&str> = module_name.split('.').collect();
         if parts.len() < 2 {
             return None;
@@ -177,7 +194,7 @@ impl ModuleResolver {
         for end in 1..parts.len() {
             let parent_name = parts[..end].join(".");
             for candidate in self.candidate_paths(&parent_name) {
-                if candidate.is_file() {
+                if provider.is_file(&candidate) {
                     return Some((parent_name, candidate));
                 }
             }
@@ -328,11 +345,19 @@ pub(crate) enum DiscoveryDiagnosticStyle {
 }
 
 fn discover_project_sifr_files(project_dir: &Path) -> Vec<PathBuf> {
+    let mut provider = DiskSourceProvider::new();
+    discover_project_sifr_files_with_provider(project_dir, &mut provider)
+}
+
+fn discover_project_sifr_files_with_provider(
+    project_dir: &Path,
+    provider: &mut impl SourceProvider,
+) -> Vec<PathBuf> {
     let mut sifr_files = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(project_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "sifr") {
+    if let Ok(entries) = provider.read_dir(project_dir) {
+        for entry in entries {
+            let path = entry.path;
+            if entry.is_file && path.extension().is_some_and(|ext| ext == "sifr") {
                 sifr_files.push(path);
             }
         }
@@ -554,13 +579,14 @@ pub(crate) fn parse_import_closure_source_modules(
     let mut parsed_modules: HashMap<String, ParsedProjectModule> = HashMap::new();
     let mut parsed_names: BTreeSet<String> = BTreeSet::new();
     let mut pending = root_modules.clone();
+    let mut provider = DiskSourceProvider::new();
 
     while let Some(module_name) = pending.pop_first() {
         if !parsed_names.insert(module_name.clone()) {
             continue;
         }
 
-        let path = match resolver.resolve(&module_name) {
+        let path = match resolver.resolve_with_provider(&module_name, &mut provider) {
             Ok(resolved) => resolved.path,
             Err(error) if resolver.has_workspace() => {
                 return Err(vec![error.to_diagnostic(resolver)]);
@@ -571,19 +597,22 @@ pub(crate) fn parse_import_closure_source_modules(
                 .next()
                 .unwrap_or_else(|| resolver.module_source_path(&module_name)),
         };
-        let source = std::fs::read_to_string(&path).map_err(|e| {
-            vec![crate::diagnostics::diagnostic_with_code(
-                format!("failed to read '{}': {}", path.display(), e),
-                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-            )]
-        })?;
+        let source = provider
+            .read_file(&path)
+            .map(|source| source.as_str().to_string())
+            .map_err(|e| {
+                vec![crate::diagnostics::diagnostic_with_code(
+                    format!("failed to read '{}': {}", path.display(), e),
+                    DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                )]
+            })?;
         let label = discovery_label(&module_name, &path, diagnostic_style);
         let suite = sifr_frontend::parse_source(&source, Some(&label))?;
         for dependency in collect_import_closure_module_dependencies(&suite).into_values() {
             if parsed_names.contains(dependency.module_name.as_str()) {
                 continue;
             }
-            match resolver.resolve(&dependency.module_name) {
+            match resolver.resolve_with_provider(&dependency.module_name, &mut provider) {
                 Ok(_) => {
                     pending.insert(dependency.module_name);
                 }

--- a/crates/sifr_driver/src/project/package_discovery.rs
+++ b/crates/sifr_driver/src/project/package_discovery.rs
@@ -4,8 +4,10 @@ use super::discovery::{
 use crate::diagnostics::RenderedDiagnostic;
 use ruff_text_size::{Ranged as _, TextRange};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use sifr_package::{
-    DottedModulePath, PackageImportOrigin, PackageSourceMap, SifrPackageGraph, SifrPackageId,
+    DottedModulePath, PackageImportAmbiguity, PackageImportOrigin, PackageImportResolution,
+    PackageImportResolutionResult, PackageSourceMap, SifrPackageGraph, SifrPackageId,
 };
 use sifr_python_ast::{Identifier, Stmt};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -37,6 +39,7 @@ pub(crate) fn parse_package_import_closure_source_modules(
     let entry_module_name = entry_module.module_path.0.clone();
     let mut parsed_modules: HashMap<String, ParsedProjectModule> = HashMap::new();
     let mut parsed_names: BTreeSet<PackageDiscoveryItem> = BTreeSet::new();
+    let mut provider = DiskSourceProvider::new();
     let mut pending = BTreeSet::from([PackageDiscoveryItem {
         package_id: entry_package_id.clone(),
         source_module_path: DottedModulePath(entry_module_name.clone()),
@@ -47,19 +50,21 @@ pub(crate) fn parse_package_import_closure_source_modules(
         if !parsed_names.insert(item.clone()) {
             continue;
         }
-        let resolved = source_map
-            .resolve_import(graph, &item.package_id, &item.source_module_path)
+        let resolved = package_import_resolution_for_discovery(source_map, graph, &item)
             .map_err(|error| vec![package_import_diagnostic(error)])?;
-        let source = std::fs::read_to_string(&resolved.resolved_module.file_path).map_err(|e| {
-            vec![crate::diagnostics::diagnostic_with_code(
-                format!(
-                    "failed to read '{}': {}",
-                    resolved.resolved_module.file_path.display(),
-                    e
-                ),
-                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-            )]
-        })?;
+        let source = provider
+            .read_file(&resolved.resolved_module.file_path)
+            .map(|source| source.as_str().to_string())
+            .map_err(|e| {
+                vec![crate::diagnostics::diagnostic_with_code(
+                    format!(
+                        "failed to read '{}': {}",
+                        resolved.resolved_module.file_path.display(),
+                        e
+                    ),
+                    DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                )]
+            })?;
         let label = discovery_label(
             &item.compile_module_name,
             &resolved.resolved_module.file_path,
@@ -76,22 +81,38 @@ pub(crate) fn parse_package_import_closure_source_modules(
             package_import_dependencies(&item.source_module_path.0, is_namespace_module, &suite)
                 .into_values()
         {
-            let dependency_resolution = source_map
-                .resolve_import(
-                    graph,
-                    &resolved.resolved_module.package_id,
-                    &dependency.resolved_import_path,
-                )
-                .map_err(|error| {
-                    vec![package_import_source_diagnostic(
+            let dependency_resolution = match source_map.resolve_import_result(
+                graph,
+                &resolved.resolved_module.package_id,
+                &dependency.resolved_import_path,
+            ) {
+                PackageImportResolutionResult::Resolved(resolution) => resolution,
+                PackageImportResolutionResult::Ambiguous(ambiguity) => {
+                    return Err(vec![package_import_ambiguity_source_diagnostic(
+                        &ambiguity,
+                        &dependency,
+                        &resolved.resolved_module.file_path.display().to_string(),
+                        &source,
+                    )]);
+                }
+                PackageImportResolutionResult::Unresolved(error)
+                | PackageImportResolutionResult::PrivateAccess(error) => {
+                    return Err(vec![package_import_source_diagnostic(
                         &error,
                         &dependency,
                         &resolved.resolved_module.file_path.display().to_string(),
                         &source,
                         &resolved.resolved_module.package_id,
                         graph,
-                    )]
-                })?;
+                    )]);
+                }
+                PackageImportResolutionResult::FatalPackageMapFailure(errors) => {
+                    return Err(errors
+                        .into_iter()
+                        .map(package_import_diagnostic)
+                        .collect::<Vec<_>>());
+                }
+            };
             let compile_module_name = compile_module_name_for_dependency(
                 entry_package_id,
                 &item,
@@ -183,6 +204,123 @@ fn package_import_source_diagnostic(
         &args,
         &notes,
     )
+}
+
+fn package_import_ambiguity_source_diagnostic(
+    ambiguity: &PackageImportAmbiguity,
+    dependency: &PackageImportDependency,
+    display_path: &str,
+    source: &str,
+) -> RenderedDiagnostic {
+    let candidate_paths = ambiguity
+        .candidates
+        .iter()
+        .map(|candidate| candidate.file_path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let origin = package_import_origin_label(&ambiguity.origin);
+    let args = [
+        (
+            "module",
+            DiagnosticArg::String(dependency.written_module_name.clone()),
+        ),
+        (
+            "resolution_scope",
+            DiagnosticArg::String("package".to_string()),
+        ),
+        (
+            "candidate_paths",
+            DiagnosticArg::String(candidate_paths.clone()),
+        ),
+        (
+            "written_module_path",
+            DiagnosticArg::String(dependency.written_module_name.clone()),
+        ),
+        (
+            "resolved_package_import_path",
+            DiagnosticArg::String(ambiguity.module_path.0.clone()),
+        ),
+        (
+            "package_import_origin",
+            DiagnosticArg::String(origin.clone()),
+        ),
+        (
+            "package_id",
+            DiagnosticArg::String(ambiguity.package_id.0.clone()),
+        ),
+        (
+            "cargo_package_id",
+            DiagnosticArg::String(ambiguity.cargo_package_id.0.clone()),
+        ),
+    ];
+    let mut notes = vec![
+        format!("package import path: {}", dependency.resolved_import_path.0),
+        format!("package origin: {origin}"),
+    ];
+    notes.extend(
+        ambiguity
+            .candidates
+            .iter()
+            .map(|candidate| format!("candidate path: {}", candidate.file_path.display())),
+    );
+    diagnostic_with_source_range(
+        DiagnosticCode::IMPORT_AMBIGUOUS_SOURCE_MODULE,
+        display_path,
+        source,
+        dependency.written_range,
+        "ambiguous import target: '{module}'",
+        &args,
+        &notes,
+    )
+}
+
+fn package_import_origin_label(origin: &PackageImportOrigin) -> String {
+    match origin {
+        PackageImportOrigin::OwnPackage => "own_package".to_string(),
+        PackageImportOrigin::DirectDependency {
+            import_root,
+            target_export_root,
+            dependency_package_id,
+        } => format!(
+            "direct_dependency:{}:{}->{}",
+            dependency_package_id.0, import_root.0, target_export_root.0
+        ),
+    }
+}
+
+fn package_import_resolution_for_discovery(
+    source_map: &PackageSourceMap,
+    graph: &SifrPackageGraph,
+    item: &PackageDiscoveryItem,
+) -> Result<PackageImportResolution, sifr_package::PackageDiagnostic> {
+    match source_map.resolve_import_result(graph, &item.package_id, &item.source_module_path) {
+        PackageImportResolutionResult::Resolved(resolution) => Ok(resolution),
+        PackageImportResolutionResult::Ambiguous(ambiguity) => {
+            let candidates = ambiguity
+                .candidates
+                .iter()
+                .map(|candidate| candidate.file_path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(sifr_package::PackageDiagnostic::undeclared_direct_import(
+                &ambiguity.cargo_package_id,
+                &item.package_id,
+                format!(
+                    "{} (ambiguous candidates: {candidates})",
+                    item.source_module_path.0
+                ),
+            ))
+        }
+        PackageImportResolutionResult::Unresolved(error)
+        | PackageImportResolutionResult::PrivateAccess(error) => Err(error),
+        PackageImportResolutionResult::FatalPackageMapFailure(errors) => {
+            Err(errors.into_iter().next().unwrap_or_else(|| {
+                sifr_package::PackageDiagnostic::cargo_metadata_parse(
+                    "package source map is invalid",
+                )
+            }))
+        }
+    }
 }
 
 fn package_import_targets_known_external_package(

--- a/crates/sifr_driver/src/workspace/mod.rs
+++ b/crates/sifr_driver/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::RenderedDiagnostic;
 use sifr_diagnostics::DiagnosticCode;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::path::{Component, Path, PathBuf};
 
 const MANIFEST_FILE: &str = "sifr.toml";
@@ -23,14 +24,22 @@ struct SifrManifest {
 }
 
 pub fn find_workspace_root(entry: &Path) -> Result<Option<WorkspaceRoot>, Vec<RenderedDiagnostic>> {
+    let mut provider = DiskSourceProvider::new();
+    find_workspace_root_with_provider(entry, &mut provider)
+}
+
+pub(crate) fn find_workspace_root_with_provider(
+    entry: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Option<WorkspaceRoot>, Vec<RenderedDiagnostic>> {
     let Some(mut current) = entry.parent().map(Path::to_path_buf) else {
         return Ok(None);
     };
 
     loop {
         let manifest_path = current.join(MANIFEST_FILE);
-        if manifest_path.is_file() {
-            let config = parse_workspace_config(&current, &manifest_path)?;
+        if provider.is_file(&manifest_path) {
+            let config = parse_workspace_config_with_provider(&current, &manifest_path, provider)?;
             return Ok(Some(WorkspaceRoot {
                 dir: current,
                 config,
@@ -42,17 +51,21 @@ pub fn find_workspace_root(entry: &Path) -> Result<Option<WorkspaceRoot>, Vec<Re
     }
 }
 
-fn parse_workspace_config(
+fn parse_workspace_config_with_provider(
     workspace_root: &Path,
     manifest_path: &Path,
+    provider: &mut impl SourceProvider,
 ) -> Result<SifrWorkspaceConfig, Vec<RenderedDiagnostic>> {
-    let source = std::fs::read_to_string(manifest_path)
+    let source = provider
+        .read_file(manifest_path)
         .map_err(|error| vec![parse_manifest_error(manifest_path, error)])?;
-    let manifest = parse_manifest(manifest_path, &source)?;
+    let manifest = parse_manifest(manifest_path, source.as_str())?;
     let source_roots = manifest
         .source_roots
         .iter()
-        .map(|source_root| validate_source_root(workspace_root, source_root))
+        .map(|source_root| {
+            validate_source_root_with_provider(workspace_root, source_root, provider)
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(SifrWorkspaceConfig {
@@ -115,9 +128,10 @@ fn parse_source_roots(
         .collect()
 }
 
-fn validate_source_root(
+fn validate_source_root_with_provider(
     workspace_root: &Path,
     source_root: &str,
+    provider: &mut impl SourceProvider,
 ) -> Result<PathBuf, Vec<RenderedDiagnostic>> {
     let raw = Path::new(source_root);
     if source_root.is_empty() || raw.is_absolute() {
@@ -153,7 +167,7 @@ fn validate_source_root(
         normalized
     };
     let absolute = workspace_root.join(&relative);
-    if !absolute.is_dir() {
+    if !provider.is_dir(&absolute) {
         return Err(vec![source_root_error(
             source_root,
             SourceRootErrorKind::NotDirectory,

--- a/crates/sifr_format/Cargo.toml
+++ b/crates/sifr_format/Cargo.toml
@@ -11,6 +11,7 @@ ruff_formatter = { workspace = true }
 ruff_python_formatter = { workspace = true }
 ruff_text_size = { workspace = true }
 sifr_diagnostics = { workspace = true }
+sifr_frontend = { workspace = true }
 sifr_syntax = { workspace = true }
 toml = { workspace = true }
 

--- a/crates/sifr_format/src/config.rs
+++ b/crates/sifr_format/src/config.rs
@@ -1,6 +1,6 @@
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, RenderedDiagnostic};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug)]
@@ -69,12 +69,20 @@ pub fn effective_format_options_for_file(
 }
 
 fn discover_sifr_toml(start_dir: &Path) -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
+    let mut provider = DiskSourceProvider::new();
+    discover_sifr_toml_with_provider(start_dir, &mut provider)
+}
+
+fn discover_sifr_toml_with_provider(
+    start_dir: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
     let base = if start_dir.as_os_str().is_empty() {
         Path::new(".")
     } else {
         start_dir
     };
-    let canonical = base.canonicalize().map_err(|err| {
+    let canonical = provider.canonicalize(base).map_err(|err| {
         vec![fmt_diagnostic(format!(
             "could not resolve formatter config start directory {}: {err}",
             base.display()
@@ -82,7 +90,7 @@ fn discover_sifr_toml(start_dir: &Path) -> Result<Option<PathBuf>, Vec<RenderedD
     })?;
     for dir in canonical.ancestors() {
         let candidate = dir.join("sifr.toml");
-        if candidate.is_file() {
+        if provider.is_file(&candidate) {
             return Ok(Some(candidate));
         }
     }
@@ -94,7 +102,17 @@ fn apply_config_file(
     path: &Path,
     seen: &mut BTreeSet<PathBuf>,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
-    let canonical = path.canonicalize().map_err(|err| {
+    let mut provider = DiskSourceProvider::new();
+    apply_config_file_with_provider(config, path, seen, &mut provider)
+}
+
+fn apply_config_file_with_provider(
+    config: &mut EffectiveFormatConfig,
+    path: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+    provider: &mut impl SourceProvider,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let canonical = provider.canonicalize(path).map_err(|err| {
         vec![fmt_diagnostic(format!(
             "could not resolve formatter config {}: {err}",
             path.display()
@@ -106,12 +124,15 @@ fn apply_config_file(
             path.display()
         ))]);
     }
-    let source = fs::read_to_string(&canonical).map_err(|err| {
-        vec![fmt_diagnostic(format!(
-            "could not read formatter config {}: {err}",
-            canonical.display()
-        ))]
-    })?;
+    let source = provider
+        .read_file(&canonical)
+        .map(|source| source.as_str().to_string())
+        .map_err(|err| {
+            vec![fmt_diagnostic(format!(
+                "could not read formatter config {}: {err}",
+                canonical.display()
+            ))]
+        })?;
     let value = toml::from_str::<toml::Value>(&source).map_err(|err| {
         vec![fmt_diagnostic(format!(
             "could not parse formatter config {}: {err}",
@@ -119,9 +140,9 @@ fn apply_config_file(
         ))]
     })?;
     let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
-    apply_extends(config, value.get("extend"), parent, seen)?;
+    apply_extends(config, value.get("extend"), parent, seen, provider)?;
     if let Some(format) = value.get("format") {
-        apply_extends(config, format.get("extend"), parent, seen)?;
+        apply_extends(config, format.get("extend"), parent, seen, provider)?;
         apply_format_table(config, format)?;
     }
     Ok(())
@@ -132,19 +153,20 @@ fn apply_extends(
     value: Option<&toml::Value>,
     parent: &Path,
     seen: &mut BTreeSet<PathBuf>,
+    provider: &mut impl SourceProvider,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
     let Some(value) = value else {
         return Ok(());
     };
     if let Some(path) = value.as_str() {
-        return apply_config_file(config, &parent.join(path), seen);
+        return apply_config_file_with_provider(config, &parent.join(path), seen, provider);
     }
     let Some(paths) = value.as_array() else {
         return Err(vec![fmt_diagnostic("extend must be a string or array")]);
     };
     for path in paths {
         let path = as_string("extend", path)?;
-        apply_config_file(config, &parent.join(path), seen)?;
+        apply_config_file_with_provider(config, &parent.join(path), seen, provider)?;
     }
     Ok(())
 }

--- a/crates/sifr_format/src/lib.rs
+++ b/crates/sifr_format/src/lib.rs
@@ -10,6 +10,7 @@ use ruff_python_formatter::{
 };
 use ruff_text_size::{TextRange, TextSize};
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode, DiagnosticSpan, RenderedDiagnostic};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use sifr_syntax::{parse_module, SourceText};
 use std::collections::BTreeMap;
 use std::fs;
@@ -174,10 +175,18 @@ pub fn check_path_with_options(
 }
 
 pub fn collect_sifr_files(path: &Path) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
-    if path.is_file() {
+    let mut provider = DiskSourceProvider::new();
+    collect_sifr_files_with_provider(path, &mut provider)
+}
+
+pub fn collect_sifr_files_with_provider(
+    path: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    if provider.is_file(path) {
         return Ok(vec![path.to_path_buf()]);
     }
-    if !path.is_dir() {
+    if !provider.is_dir(path) {
         return Err(vec![io_diagnostic(
             DiagnosticCode::FMT_FORMATTING_DRIFT,
             format!("format target does not exist: {}", path.display()),
@@ -185,7 +194,7 @@ pub fn collect_sifr_files(path: &Path) -> Result<Vec<PathBuf>, Vec<RenderedDiagn
         )]);
     }
     let mut files = Vec::new();
-    collect_sifr_files_inner(path, &mut files)?;
+    collect_sifr_files_inner(path, &mut files, provider)?;
     files.sort();
     Ok(files)
 }
@@ -193,31 +202,22 @@ pub fn collect_sifr_files(path: &Path) -> Result<Vec<PathBuf>, Vec<RenderedDiagn
 fn collect_sifr_files_inner(
     path: &Path,
     files: &mut Vec<PathBuf>,
+    provider: &mut impl SourceProvider,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
-    for entry in fs::read_dir(path).map_err(|err| {
+    for entry in provider.read_dir(path).map_err(|err| {
         vec![io_diagnostic(
             DiagnosticCode::FMT_FORMATTING_DRIFT,
             format!("could not read directory {}: {err}", path.display()),
             Some(path),
         )]
     })? {
-        let entry = entry.map_err(|err| {
-            vec![io_diagnostic(
-                DiagnosticCode::FMT_FORMATTING_DRIFT,
-                format!(
-                    "could not read directory entry under {}: {err}",
-                    path.display()
-                ),
-                Some(path),
-            )]
-        })?;
-        let child = entry.path();
-        if child.is_dir() {
+        let child = entry.path;
+        if entry.is_dir {
             if is_default_excluded_dir(&child) {
                 continue;
             }
-            collect_sifr_files_inner(&child, files)?;
-        } else if is_sifr_file(&child) {
+            collect_sifr_files_inner(&child, files, provider)?;
+        } else if entry.is_file && is_sifr_file(&child) {
             files.push(child);
         }
     }
@@ -443,13 +443,24 @@ fn first_diff_offset(left: &str, right: &str) -> u32 {
 }
 
 fn read_source(path: &Path) -> Result<String, Vec<RenderedDiagnostic>> {
-    fs::read_to_string(path).map_err(|err| {
-        vec![io_diagnostic(
-            DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
-            format!("could not read file {}: {err}", path.display()),
-            Some(path),
-        )]
-    })
+    let mut provider = DiskSourceProvider::new();
+    read_source_with_provider(path, &mut provider)
+}
+
+pub fn read_source_with_provider(
+    path: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<String, Vec<RenderedDiagnostic>> {
+    provider
+        .read_file(path)
+        .map(|source| source.as_str().to_string())
+        .map_err(|err| {
+            vec![io_diagnostic(
+                DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
+                format!("could not read file {}: {err}", path.display()),
+                Some(path),
+            )]
+        })
 }
 
 fn write_source(path: &Path, source: &str) -> Result<(), Vec<RenderedDiagnostic>> {

--- a/crates/sifr_frontend/src/graph_cache_and_queries.rs
+++ b/crates/sifr_frontend/src/graph_cache_and_queries.rs
@@ -1,8 +1,9 @@
 use super::{
     collect_module_exports, diagnostic_with_code, empty_hir_module, hir_diagnostic_to_rendered,
     local_import_dependencies, module_state, reveal_type_diagnostics, source_hash,
-    symbols_from_hir, warning_diagnostics, DocumentVersion, FileId, SourceFileView, SourceHash,
-    SourceMapView, SourcePath, SourceRevision, SourceText,
+    symbols_from_hir, warning_diagnostics, DiskSourceProvider, DocumentVersion, FileId,
+    SourceDependency, SourceFileView, SourceHash, SourceMapView, SourcePath, SourceProvider,
+    SourceRevision, SourceText, TrackingSourceProvider,
 };
 use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
 use sifr_hir::{
@@ -307,9 +308,26 @@ impl FrontendContext {
     }
 
     pub fn load_project(root: &ProjectRoot) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let mut provider = TrackingSourceProvider::new(DiskSourceProvider::new());
+        Self::load_project_with_provider(root, &mut provider)
+    }
+
+    pub fn load_project_tracked(
+        root: &ProjectRoot,
+    ) -> Result<(Self, Vec<SourceDependency>), Vec<RenderedDiagnostic>> {
+        let mut provider = TrackingSourceProvider::new(DiskSourceProvider::new());
+        let context = Self::load_project_with_provider(root, &mut provider)?;
+        let (_, dependencies) = provider.into_parts();
+        Ok((context, dependencies))
+    }
+
+    pub fn load_project_with_provider(
+        root: &ProjectRoot,
+        provider: &mut impl SourceProvider,
+    ) -> Result<Self, Vec<RenderedDiagnostic>> {
         let entrypoint = root.entrypoint.as_path();
         let project_dir = root.root.as_path();
-        let entry_source = std::fs::read_to_string(entrypoint).map_err(|error| {
+        let entry_source = provider.read_file(entrypoint).map_err(|error| {
             vec![diagnostic_with_code(
                 format!(
                     "failed to read project entrypoint '{}': {error}",
@@ -319,7 +337,7 @@ impl FrontendContext {
             )]
         })?;
         let mut files = vec![entrypoint.to_path_buf()];
-        for entry in std::fs::read_dir(project_dir).map_err(|error| {
+        for entry in provider.read_dir(project_dir).map_err(|error| {
             vec![diagnostic_with_code(
                 format!(
                     "failed to read project root '{}': {error}",
@@ -328,14 +346,7 @@ impl FrontendContext {
                 DiagnosticCode::WORKSPACE_MALFORMED_MANIFEST,
             )]
         })? {
-            let path = entry
-                .map_err(|error| {
-                    vec![diagnostic_with_code(
-                        format!("failed to read project root entry: {error}"),
-                        DiagnosticCode::WORKSPACE_MALFORMED_MANIFEST,
-                    )]
-                })?
-                .path();
+            let path = entry.path;
             if path.extension().is_some_and(|ext| ext == "sifr") && path != entrypoint {
                 files.push(path);
             }
@@ -356,7 +367,7 @@ impl FrontendContext {
             let source = if path == entrypoint {
                 entry_source.clone()
             } else {
-                std::fs::read_to_string(&path).map_err(|error| {
+                provider.read_file(&path).map_err(|error| {
                     vec![diagnostic_with_code(
                         format!(
                             "failed to read project module '{}': {error}",
@@ -378,7 +389,7 @@ impl FrontendContext {
                 FileId(numeric_id),
                 module_name,
                 SourcePath::new(path),
-                SourceText::new(source),
+                source,
                 None,
             ));
         }

--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -10,5 +10,7 @@ pub use graph_cache_and_queries::*;
 mod hir_views;
 mod query_diagnostics;
 pub use query_diagnostics::*;
+mod source_provider;
+pub use source_provider::*;
 mod source_maps;
 pub use source_maps::*;

--- a/crates/sifr_frontend/src/query_diagnostics.rs
+++ b/crates/sifr_frontend/src/query_diagnostics.rs
@@ -519,8 +519,9 @@ pub fn collect_module_exports(
 #[cfg(test)]
 mod tests {
     use crate::{
-        CacheStatus, DocumentVersion, FrontendContext, FrontendInput, FrontendMode, ModuleId,
-        ProjectRoot, SourcePath, SourceText,
+        CacheStatus, DiskSourceProvider, DocumentVersion, FrontendContext, FrontendInput,
+        FrontendMode, ModuleId, OverlayDocument, OverlaySourceProvider, ProjectRoot,
+        SourceDependencyKind, SourcePath, SourceText, TrackingSourceProvider,
     };
 
     fn input(source: &str) -> FrontendInput {
@@ -606,5 +607,54 @@ mod tests {
             diagnostics.is_empty(),
             "project diagnostics should consume dependency exports from the canonical frontend: {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn project_loading_uses_overlay_and_tracking_provider() {
+        let dir = std::env::temp_dir().join(format!(
+            "sifr_frontend_project_overlay_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("temp project should be created");
+        let main_path = dir.join("main.sifr");
+        let helper_path = dir.join("helper.sifr");
+        std::fs::write(
+            &main_path,
+            "from helper import value\n\ndef main():\n    print(value)\n",
+        )
+        .expect("main should be written");
+        std::fs::write(&helper_path, "value: int = 1\n").expect("helper should be written");
+
+        let mut overlay = OverlaySourceProvider::new(DiskSourceProvider::new());
+        overlay.insert_overlay(OverlayDocument::new(
+            SourcePath::new(&helper_path),
+            None,
+            DocumentVersion::new(5),
+            SourceText::new("value: int = 2\n"),
+            Some("value: int = 1\n"),
+        ));
+        let mut provider = TrackingSourceProvider::new(overlay);
+
+        let context = FrontendContext::load_project_with_provider(
+            &ProjectRoot {
+                root: SourcePath::new(&dir),
+                entrypoint: SourcePath::new(&main_path),
+            },
+            &mut provider,
+        )
+        .expect("project should load through provider");
+
+        assert!(provider
+            .dependencies()
+            .iter()
+            .any(|dependency| dependency.kind == SourceDependencyKind::DirectoryRead));
+        assert!(context.source_map().files.iter().any(|file| {
+            file.canonical_path.as_path() == helper_path
+                && file.source.as_str() == "value: int = 2\n"
+        }));
     }
 }

--- a/crates/sifr_frontend/src/source_provider.rs
+++ b/crates/sifr_frontend/src/source_provider.rs
@@ -1,0 +1,462 @@
+use super::{source_hash, DocumentVersion, SourceHash, SourcePath, SourceText};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceProviderErrorKind {
+    Canonicalize,
+    FileRead,
+    DirectoryRead,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceProviderError {
+    pub kind: SourceProviderErrorKind,
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl SourceProviderError {
+    #[must_use]
+    pub fn new(kind: SourceProviderErrorKind, path: impl Into<PathBuf>, message: String) -> Self {
+        Self {
+            kind,
+            path: path.into(),
+            message,
+        }
+    }
+}
+
+impl fmt::Display for SourceProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.path.display(), self.message)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceDirEntry {
+    pub path: PathBuf,
+    pub file_name: std::ffi::OsString,
+    pub is_file: bool,
+    pub is_dir: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SourceDependencyKind {
+    FileRead,
+    DirectoryRead,
+    FileProbe { exists: bool },
+    DirectoryProbe { exists: bool },
+    Canonicalize,
+    FailedLookup,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceDependency {
+    pub path: PathBuf,
+    pub kind: SourceDependencyKind,
+}
+
+pub trait SourceProvider {
+    fn read_file(&mut self, path: &Path) -> Result<SourceText, SourceProviderError>;
+    fn read_dir(&mut self, path: &Path) -> Result<Vec<SourceDirEntry>, SourceProviderError>;
+    fn is_file(&mut self, path: &Path) -> bool;
+    fn is_dir(&mut self, path: &Path) -> bool;
+    fn canonicalize(&mut self, path: &Path) -> Result<PathBuf, SourceProviderError>;
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DiskSourceProvider;
+
+impl DiskSourceProvider {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl SourceProvider for DiskSourceProvider {
+    fn read_file(&mut self, path: &Path) -> Result<SourceText, SourceProviderError> {
+        std::fs::read_to_string(path)
+            .map(SourceText::new)
+            .map_err(|error| {
+                SourceProviderError::new(SourceProviderErrorKind::FileRead, path, error.to_string())
+            })
+    }
+
+    fn read_dir(&mut self, path: &Path) -> Result<Vec<SourceDirEntry>, SourceProviderError> {
+        let entries = std::fs::read_dir(path).map_err(|error| {
+            SourceProviderError::new(
+                SourceProviderErrorKind::DirectoryRead,
+                path,
+                error.to_string(),
+            )
+        })?;
+        let mut output = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                SourceProviderError::new(
+                    SourceProviderErrorKind::DirectoryRead,
+                    path,
+                    error.to_string(),
+                )
+            })?;
+            let file_type = entry.file_type().map_err(|error| {
+                SourceProviderError::new(
+                    SourceProviderErrorKind::DirectoryRead,
+                    entry.path(),
+                    error.to_string(),
+                )
+            })?;
+            output.push(SourceDirEntry {
+                path: entry.path(),
+                file_name: entry.file_name(),
+                is_file: file_type.is_file(),
+                is_dir: file_type.is_dir(),
+            });
+        }
+        Ok(output)
+    }
+
+    fn is_file(&mut self, path: &Path) -> bool {
+        path.is_file()
+    }
+
+    fn is_dir(&mut self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
+    fn canonicalize(&mut self, path: &Path) -> Result<PathBuf, SourceProviderError> {
+        path.canonicalize().map_err(|error| {
+            SourceProviderError::new(
+                SourceProviderErrorKind::Canonicalize,
+                path,
+                error.to_string(),
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OverlayDocument {
+    pub path: SourcePath,
+    pub uri: Option<String>,
+    pub version: DocumentVersion,
+    pub source: SourceText,
+    pub source_hash: SourceHash,
+    pub matches_disk: bool,
+}
+
+impl OverlayDocument {
+    #[must_use]
+    pub fn new(
+        path: SourcePath,
+        uri: Option<String>,
+        version: DocumentVersion,
+        source: SourceText,
+        disk_source: Option<&str>,
+    ) -> Self {
+        let source_hash = source_hash(source.as_str());
+        let matches_disk = disk_source.is_some_and(|disk_source| disk_source == source.as_str());
+        Self {
+            path,
+            uri,
+            version,
+            source,
+            source_hash,
+            matches_disk,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OverlaySourceProvider<P> {
+    inner: P,
+    overlays: BTreeMap<PathBuf, OverlayDocument>,
+}
+
+impl<P> OverlaySourceProvider<P> {
+    #[must_use]
+    pub fn new(inner: P) -> Self {
+        Self {
+            inner,
+            overlays: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert_overlay(&mut self, overlay: OverlayDocument) {
+        self.overlays
+            .insert(overlay.path.as_path().to_path_buf(), overlay);
+    }
+
+    #[must_use]
+    pub fn overlays(&self) -> &BTreeMap<PathBuf, OverlayDocument> {
+        &self.overlays
+    }
+}
+
+impl<P: SourceProvider> SourceProvider for OverlaySourceProvider<P> {
+    fn read_file(&mut self, path: &Path) -> Result<SourceText, SourceProviderError> {
+        if let Some(overlay) = self.overlays.get(path) {
+            return Ok(overlay.source.clone());
+        }
+        self.inner.read_file(path)
+    }
+
+    fn read_dir(&mut self, path: &Path) -> Result<Vec<SourceDirEntry>, SourceProviderError> {
+        let mut entries = match self.inner.read_dir(path) {
+            Ok(entries) => entries,
+            Err(error) => {
+                if !self
+                    .overlays
+                    .keys()
+                    .any(|overlay| overlay_descends_from(overlay, path))
+                {
+                    return Err(error);
+                }
+                // TODO(m6): surface the dirty directory when watcher invalidation
+                // starts consuming overlay-backed directory dependencies.
+                Vec::new()
+            }
+        };
+        for overlay_path in self.overlays.keys() {
+            if let Some(entry) = overlay_dir_entry(path, overlay_path) {
+                if entries.iter().any(|existing| existing.path == entry.path) {
+                    continue;
+                }
+                entries.push(SourceDirEntry {
+                    path: entry.path,
+                    file_name: entry
+                        .file_name
+                        .file_name()
+                        .map_or_else(std::ffi::OsString::new, std::ffi::OsString::from),
+                    is_file: entry.is_file,
+                    is_dir: entry.is_dir,
+                });
+            }
+        }
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(entries)
+    }
+
+    fn is_file(&mut self, path: &Path) -> bool {
+        self.overlays.contains_key(path) || self.inner.is_file(path)
+    }
+
+    fn is_dir(&mut self, path: &Path) -> bool {
+        self.inner.is_dir(path)
+            || self
+                .overlays
+                .keys()
+                .any(|overlay| overlay_descends_from(overlay, path))
+    }
+
+    fn canonicalize(&mut self, path: &Path) -> Result<PathBuf, SourceProviderError> {
+        if self.overlays.contains_key(path) {
+            Ok(path.to_path_buf())
+        } else {
+            self.inner.canonicalize(path)
+        }
+    }
+}
+
+struct OverlayDirEntry {
+    path: PathBuf,
+    file_name: PathBuf,
+    is_file: bool,
+    is_dir: bool,
+}
+
+fn overlay_descends_from(overlay: &Path, directory: &Path) -> bool {
+    overlay_dir_entry(directory, overlay).is_some()
+}
+
+fn overlay_dir_entry(directory: &Path, overlay: &Path) -> Option<OverlayDirEntry> {
+    let relative = overlay.strip_prefix(directory).ok()?;
+    let mut components = relative.components();
+    let first = components.next()?;
+    let file_name = PathBuf::from(first.as_os_str());
+    let entry_path = directory.join(&file_name);
+    if components.next().is_some() {
+        Some(OverlayDirEntry {
+            path: entry_path,
+            file_name,
+            is_file: false,
+            is_dir: true,
+        })
+    } else {
+        Some(OverlayDirEntry {
+            path: overlay.to_path_buf(),
+            file_name,
+            is_file: true,
+            is_dir: false,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrackingSourceProvider<P> {
+    inner: P,
+    dependencies: Vec<SourceDependency>,
+}
+
+impl<P> TrackingSourceProvider<P> {
+    #[must_use]
+    pub fn new(inner: P) -> Self {
+        Self {
+            inner,
+            dependencies: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn dependencies(&self) -> &[SourceDependency] {
+        &self.dependencies
+    }
+
+    pub fn into_parts(self) -> (P, Vec<SourceDependency>) {
+        (self.inner, self.dependencies)
+    }
+
+    fn record(&mut self, path: &Path, kind: SourceDependencyKind) {
+        self.dependencies.push(SourceDependency {
+            path: path.to_path_buf(),
+            kind,
+        });
+    }
+}
+
+impl<P: SourceProvider> SourceProvider for TrackingSourceProvider<P> {
+    fn read_file(&mut self, path: &Path) -> Result<SourceText, SourceProviderError> {
+        match self.inner.read_file(path) {
+            Ok(source) => {
+                self.record(path, SourceDependencyKind::FileRead);
+                Ok(source)
+            }
+            Err(error) => {
+                self.record(path, SourceDependencyKind::FailedLookup);
+                Err(error)
+            }
+        }
+    }
+
+    fn read_dir(&mut self, path: &Path) -> Result<Vec<SourceDirEntry>, SourceProviderError> {
+        match self.inner.read_dir(path) {
+            Ok(entries) => {
+                self.record(path, SourceDependencyKind::DirectoryRead);
+                Ok(entries)
+            }
+            Err(error) => {
+                self.record(path, SourceDependencyKind::FailedLookup);
+                Err(error)
+            }
+        }
+    }
+
+    fn is_file(&mut self, path: &Path) -> bool {
+        let exists = self.inner.is_file(path);
+        self.record(path, SourceDependencyKind::FileProbe { exists });
+        exists
+    }
+
+    fn is_dir(&mut self, path: &Path) -> bool {
+        let exists = self.inner.is_dir(path);
+        self.record(path, SourceDependencyKind::DirectoryProbe { exists });
+        exists
+    }
+
+    fn canonicalize(&mut self, path: &Path) -> Result<PathBuf, SourceProviderError> {
+        match self.inner.canonicalize(path) {
+            Ok(canonical) => {
+                self.record(path, SourceDependencyKind::Canonicalize);
+                Ok(canonical)
+            }
+            Err(error) => {
+                self.record(path, SourceDependencyKind::FailedLookup);
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DiskSourceProvider, OverlayDocument, OverlaySourceProvider, SourceDependencyKind,
+        SourceProvider, TrackingSourceProvider,
+    };
+    use crate::{DocumentVersion, SourcePath, SourceText};
+    use std::path::Path;
+
+    #[test]
+    fn overlay_provider_prefers_unsaved_text_over_disk() {
+        let mut provider = OverlaySourceProvider::new(DiskSourceProvider::new());
+        provider.insert_overlay(OverlayDocument::new(
+            SourcePath::new("main.sifr"),
+            Some("file:///main.sifr".to_string()),
+            DocumentVersion::new(3),
+            SourceText::new("value = 2\n"),
+            Some("value = 1\n"),
+        ));
+
+        let source = provider
+            .read_file(Path::new("main.sifr"))
+            .expect("overlay source exists");
+        assert_eq!(source.as_str(), "value = 2\n");
+        assert!(!provider.overlays()[Path::new("main.sifr")].matches_disk);
+    }
+
+    #[test]
+    fn tracking_provider_records_successes_and_failed_lookups() {
+        let mut provider = TrackingSourceProvider::new(DiskSourceProvider::new());
+        assert!(!provider.is_file(Path::new("definitely_missing.sifr")));
+        let _ = provider.read_file(Path::new("definitely_missing.sifr"));
+
+        assert_eq!(
+            provider
+                .dependencies()
+                .iter()
+                .map(|dependency| &dependency.kind)
+                .collect::<Vec<_>>(),
+            vec![
+                &SourceDependencyKind::FileProbe { exists: false },
+                &SourceDependencyKind::FailedLookup,
+            ]
+        );
+    }
+
+    #[test]
+    fn overlay_provider_synthesizes_nested_directories() {
+        let root = std::env::temp_dir().join(format!(
+            "sifr_overlay_nested_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("time should move forward")
+                .as_nanos()
+        ));
+        let nested_file = root.join("pkg").join("mod.sifr");
+        let mut provider = OverlaySourceProvider::new(DiskSourceProvider::new());
+        provider.insert_overlay(OverlayDocument::new(
+            SourcePath::new(&nested_file),
+            Some("file:///tmp/pkg/mod.sifr".to_string()),
+            DocumentVersion::new(1),
+            SourceText::new("value: int = 1\n"),
+            None,
+        ));
+
+        assert!(provider.is_dir(&root));
+        let root_entries = provider.read_dir(&root).expect("overlay root is readable");
+        assert_eq!(root_entries.len(), 1);
+        assert!(root_entries[0].is_dir);
+        assert_eq!(root_entries[0].path, root.join("pkg"));
+
+        let nested_entries = provider
+            .read_dir(&root.join("pkg"))
+            .expect("overlay child directory is readable");
+        assert_eq!(nested_entries.len(), 1);
+        assert!(nested_entries[0].is_file);
+        assert_eq!(nested_entries[0].path, nested_file);
+    }
+}

--- a/crates/sifr_lint/src/config.rs
+++ b/crates/sifr_lint/src/config.rs
@@ -3,8 +3,8 @@ use crate::{
     PerFileIgnore, RuleSeverity, UnsafeFixPolicy, RULES,
 };
 use sifr_diagnostics::RenderedDiagnostic;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::collections::BTreeSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 pub fn effective_lint_config(
@@ -32,12 +32,20 @@ pub fn effective_lint_config(
 }
 
 fn discover_sifr_toml(start_dir: &Path) -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
+    let mut provider = DiskSourceProvider::new();
+    discover_sifr_toml_with_provider(start_dir, &mut provider)
+}
+
+fn discover_sifr_toml_with_provider(
+    start_dir: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Option<PathBuf>, Vec<RenderedDiagnostic>> {
     let base = if start_dir.as_os_str().is_empty() {
         Path::new(".")
     } else {
         start_dir
     };
-    let canonical = base.canonicalize().map_err(|err| {
+    let canonical = provider.canonicalize(base).map_err(|err| {
         vec![lint_config_diagnostic(format!(
             "could not resolve lint config start directory {}: {err}",
             base.display()
@@ -45,7 +53,7 @@ fn discover_sifr_toml(start_dir: &Path) -> Result<Option<PathBuf>, Vec<RenderedD
     })?;
     for dir in canonical.ancestors() {
         let candidate = dir.join("sifr.toml");
-        if candidate.is_file() {
+        if provider.is_file(&candidate) {
             return Ok(Some(candidate));
         }
     }
@@ -57,7 +65,17 @@ fn apply_config_file(
     path: &Path,
     seen: &mut BTreeSet<PathBuf>,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
-    let canonical = path.canonicalize().map_err(|err| {
+    let mut provider = DiskSourceProvider::new();
+    apply_config_file_with_provider(config, path, seen, &mut provider)
+}
+
+fn apply_config_file_with_provider(
+    config: &mut EffectiveLintConfig,
+    path: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+    provider: &mut impl SourceProvider,
+) -> Result<(), Vec<RenderedDiagnostic>> {
+    let canonical = provider.canonicalize(path).map_err(|err| {
         vec![lint_config_diagnostic(format!(
             "could not resolve lint config {}: {err}",
             path.display()
@@ -69,12 +87,15 @@ fn apply_config_file(
             path.display()
         ))]);
     }
-    let source = fs::read_to_string(&canonical).map_err(|err| {
-        vec![lint_config_diagnostic(format!(
-            "could not read lint config {}: {err}",
-            canonical.display()
-        ))]
-    })?;
+    let source = provider
+        .read_file(&canonical)
+        .map(|source| source.as_str().to_string())
+        .map_err(|err| {
+            vec![lint_config_diagnostic(format!(
+                "could not read lint config {}: {err}",
+                canonical.display()
+            ))]
+        })?;
     let value = toml::from_str::<toml::Value>(&source).map_err(|err| {
         vec![lint_config_diagnostic(format!(
             "could not parse lint config {}: {err}",
@@ -82,9 +103,9 @@ fn apply_config_file(
         ))]
     })?;
     let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
-    apply_extends(config, value.get("extend"), parent, seen)?;
+    apply_extends(config, value.get("extend"), parent, seen, provider)?;
     if let Some(lint) = value.get("lint") {
-        apply_extends(config, lint.get("extend"), parent, seen)?;
+        apply_extends(config, lint.get("extend"), parent, seen, provider)?;
         apply_lint_table(&mut config.options, lint)?;
         config.config_path = Some(canonical);
     }
@@ -96,12 +117,13 @@ fn apply_extends(
     value: Option<&toml::Value>,
     parent: &Path,
     seen: &mut BTreeSet<PathBuf>,
+    provider: &mut impl SourceProvider,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
     let Some(value) = value else {
         return Ok(());
     };
     if let Some(path) = value.as_str() {
-        return apply_config_file(config, &parent.join(path), seen);
+        return apply_config_file_with_provider(config, &parent.join(path), seen, provider);
     }
     let Some(paths) = value.as_array() else {
         return Err(vec![lint_config_diagnostic(
@@ -110,7 +132,7 @@ fn apply_extends(
     };
     for path in paths {
         let path = as_string("extend", path)?;
-        apply_config_file(config, &parent.join(path), seen)?;
+        apply_config_file_with_provider(config, &parent.join(path), seen, provider)?;
     }
     Ok(())
 }

--- a/crates/sifr_lint/src/discovery.rs
+++ b/crates/sifr_lint/src/discovery.rs
@@ -2,6 +2,7 @@ use crate::{diagnostic, LintOptions};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -16,6 +17,15 @@ pub fn collect_sifr_files_for_targets(
     paths: &[PathBuf],
     options: &LintOptions,
 ) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
+    let mut provider = DiskSourceProvider::new();
+    collect_sifr_files_for_targets_with_provider(paths, options, &mut provider)
+}
+
+pub(crate) fn collect_sifr_files_for_targets_with_provider(
+    paths: &[PathBuf],
+    options: &LintOptions,
+    provider: &mut impl SourceProvider,
+) -> Result<Vec<PathBuf>, Vec<RenderedDiagnostic>> {
     let targets = if paths.is_empty() {
         vec![PathBuf::from(".")]
     } else {
@@ -26,12 +36,12 @@ pub fn collect_sifr_files_for_targets(
     let exclude = globset("exclude", &exclude_patterns)?;
     let mut files = BTreeSet::new();
     for target in targets {
-        if target.is_file() {
+        if provider.is_file(&target) {
             if should_include_explicit_file(&target, &include, &exclude, options) {
                 files.insert(target);
             }
-        } else if target.is_dir() {
-            collect_directory_files(&target, &include, &exclude, options, &mut files)?;
+        } else if provider.is_dir(&target) {
+            collect_directory_files(&target, &include, &exclude, options, &mut files, provider)?;
         } else {
             return Err(vec![diagnostic(
                 DiagnosticCode::WORKSPACE_INVALID_SOURCE_ROOT,
@@ -51,6 +61,7 @@ fn collect_directory_files(
     exclude: &GlobSet,
     options: &LintOptions,
     files: &mut BTreeSet<PathBuf>,
+    provider: &mut impl SourceProvider,
 ) -> Result<(), Vec<RenderedDiagnostic>> {
     let mut builder = WalkBuilder::new(root);
     builder
@@ -76,7 +87,7 @@ fn collect_directory_files(
             )]
         })?;
         let path = entry.path();
-        if path.is_dir() || is_default_excluded_dir(path) {
+        if provider.is_dir(path) || is_default_excluded_dir(path) {
             continue;
         }
         if path_matches(root, path, include) && !path_matches(root, path, exclude) {

--- a/crates/sifr_lint/src/engine.rs
+++ b/crates/sifr_lint/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{LintOptions, LintResult, RuleMetadata, RULES};
 use sifr_diagnostics::{DiagnosticCode, RenderedDiagnostic};
-use std::fs;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -130,8 +130,9 @@ impl<'a> LintRunner<'a> {
         set_phase(&mut phases, LintPhase::FileDiscovery, true);
         let files = crate::collect_sifr_files_for_targets(paths, self.options)?;
         let mut diagnostics = Vec::new();
+        let mut provider = DiskSourceProvider::new();
         for file in files {
-            let source = fs::read_to_string(&file).map_err(|err| {
+            let source = provider.read_file(&file).map_err(|err| {
                 vec![crate::diagnostic(
                     DiagnosticCode::BUILD_MATERIALIZATION_FAILURE,
                     format!("could not read file {}: {err}", file.display()),
@@ -140,7 +141,7 @@ impl<'a> LintRunner<'a> {
                     None,
                 )]
             })?;
-            let file_run = self.run_source(&source, Some(&file));
+            let file_run = self.run_source(source.as_str(), Some(&file));
             merge_phases(&mut phases, &file_run.phases);
             diagnostics.extend(file_run.result.diagnostics);
         }
@@ -281,6 +282,7 @@ fn merge_phases(target: &mut [PhaseExecution], source: &[PhaseExecution]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]

--- a/crates/sifr_package/Cargo.toml
+++ b/crates/sifr_package/Cargo.toml
@@ -8,6 +8,7 @@ license = { workspace = true }
 
 [dependencies]
 sifr_diagnostics = { workspace = true }
+sifr_frontend = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/sifr_package/src/cargo/lock_modes.rs
+++ b/crates/sifr_package/src/cargo/lock_modes.rs
@@ -1,3 +1,7 @@
+use crate::cargo::metadata::NormalizedCargoMetadata;
+use crate::diag::PackageDiagnostic;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum CargoLockMode {
     #[default]
@@ -33,6 +37,15 @@ pub fn validate_offline_source_availability(
     metadata: &NormalizedCargoMetadata,
     lock_mode: CargoLockMode,
 ) -> Result<(), Vec<PackageDiagnostic>> {
+    let mut provider = DiskSourceProvider::new();
+    validate_offline_source_availability_with_provider(metadata, lock_mode, &mut provider)
+}
+
+pub fn validate_offline_source_availability_with_provider(
+    metadata: &NormalizedCargoMetadata,
+    lock_mode: CargoLockMode,
+    provider: &mut impl SourceProvider,
+) -> Result<(), Vec<PackageDiagnostic>> {
     if !lock_mode.is_network_disallowed() {
         return Ok(());
     }
@@ -43,7 +56,7 @@ pub fn validate_offline_source_availability(
         .filter(|package| package.sifr_metadata.is_some())
         .filter_map(|package| {
             let package_root = package.manifest_path.parent()?;
-            if package_root.is_dir() {
+            if provider.is_dir(package_root) {
                 None
             } else {
                 Some(PackageDiagnostic::source_unavailable_offline(
@@ -61,5 +74,3 @@ pub fn validate_offline_source_availability(
         Err(diagnostics)
     }
 }
-use crate::cargo::metadata::NormalizedCargoMetadata;
-use crate::diag::PackageDiagnostic;

--- a/crates/sifr_package/src/graph/digest.rs
+++ b/crates/sifr_package/src/graph/digest.rs
@@ -146,6 +146,7 @@ struct CanonicalGraph<'a> {
 struct CanonicalSourceMap<'a> {
     roots: Vec<CanonicalSourceRoot<'a>>,
     modules: Vec<CanonicalSourceModule<'a>>,
+    ambiguous_modules: Vec<CanonicalSourceModule<'a>>,
 }
 
 #[derive(Serialize)]
@@ -178,6 +179,17 @@ impl<'a> From<&'a PackageSourceMap> for CanonicalSourceMap<'a> {
             modules: source_map
                 .modules
                 .values()
+                .map(|module| CanonicalSourceModule {
+                    package_id: &module.package_id.0,
+                    module_path: &module.module_path.0,
+                    file_path: module.file_path.display().to_string(),
+                    source_root: module.source_root.display().to_string(),
+                })
+                .collect(),
+            ambiguous_modules: source_map
+                .ambiguous_modules
+                .values()
+                .flat_map(|modules| modules.iter())
                 .map(|module| CanonicalSourceModule {
                     package_id: &module.package_id.0,
                     module_path: &module.module_path.0,

--- a/crates/sifr_package/src/imports/namespace_api.rs
+++ b/crates/sifr_package/src/imports/namespace_api.rs
@@ -1,6 +1,7 @@
 use crate::diag::PackageDiagnostic;
 use crate::imports::source_map::DottedModulePath;
 use crate::CargoPackageId;
+use sifr_frontend::SourceProvider;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -28,8 +29,9 @@ pub fn parse_init_sifr_reexports(
     namespace_path: &DottedModulePath,
     init_path: &Path,
     package_source_root: &Path,
+    provider: &mut impl SourceProvider,
 ) -> Result<NamespaceApi, Vec<PackageDiagnostic>> {
-    let source = match std::fs::read_to_string(init_path) {
+    let source = match provider.read_file(init_path) {
         Ok(source) => source,
         Err(error) => {
             return Err(vec![PackageDiagnostic::invalid_sifr_manifest(
@@ -46,7 +48,7 @@ pub fn parse_init_sifr_reexports(
     };
     let mut diagnostics = Vec::new();
 
-    for raw_line in source.lines() {
+    for raw_line in source.as_str().lines() {
         if raw_line.starts_with(char::is_whitespace) {
             continue;
         }
@@ -68,6 +70,7 @@ pub fn parse_init_sifr_reexports(
                 sifr_manifest,
                 namespace_path,
                 package_source_root,
+                provider,
                 &mut api,
                 rest,
             ) {
@@ -109,6 +112,7 @@ fn parse_relative_from(
     sifr_manifest: &Path,
     namespace_path: &DottedModulePath,
     package_source_root: &Path,
+    provider: &mut impl SourceProvider,
     api: &mut NamespaceApi,
     rest: &str,
 ) -> Result<(), PackageDiagnostic> {
@@ -125,6 +129,7 @@ fn parse_relative_from(
             sifr_manifest,
             namespace_path,
             package_source_root,
+            provider,
             api,
             imported,
         )
@@ -145,6 +150,7 @@ fn parse_child_namespace_exports(
     sifr_manifest: &Path,
     namespace_path: &DottedModulePath,
     package_source_root: &Path,
+    provider: &mut impl SourceProvider,
     api: &mut NamespaceApi,
     imported: &str,
 ) -> Result<(), PackageDiagnostic> {
@@ -158,7 +164,7 @@ fn parse_child_namespace_exports(
             .map_or(child, |(_, alias)| alias)
             .trim();
         if !valid_identifier(child_name)
-            || !public_child_namespace_exists(package_source_root, child_name)
+            || !public_child_namespace_exists(package_source_root, child_name, provider)
         {
             return Err(unsupported_api_form(
                 cargo_package_id,
@@ -257,11 +263,12 @@ fn top_level_definition_name(line: &str) -> Option<&str> {
     valid_identifier(name).then_some(name)
 }
 
-fn public_child_namespace_exists(package_source_root: &Path, child: &str) -> bool {
-    package_source_root
-        .join(child)
-        .join("__init__.sifr")
-        .is_file()
+fn public_child_namespace_exists(
+    package_source_root: &Path,
+    child: &str,
+    provider: &mut impl SourceProvider,
+) -> bool {
+    provider.is_file(&package_source_root.join(child).join("__init__.sifr"))
 }
 
 fn looks_like_public_assignment(line: &str) -> bool {

--- a/crates/sifr_package/src/imports/source_map.rs
+++ b/crates/sifr_package/src/imports/source_map.rs
@@ -1,15 +1,25 @@
 use crate::diag::PackageDiagnostic;
-use crate::graph::derive::{SifrPackageGraph, SifrPackageId, SifrPackageMetadata};
-use crate::imports::namespace_api::{parse_init_sifr_reexports, NamespaceApi};
+use crate::graph::derive::{SifrPackageGraph, SifrPackageId};
+use crate::imports::namespace_api::NamespaceApi;
 use crate::manifest::sifr::ImportRoot;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
+mod discovery;
+use discovery::{
+    discover_namespace_apis, discover_package_modules, package_source_roots, root_for,
+};
+mod resolution;
+use resolution::{is_private_dependency_module, matching_scoped_import, remap_import_path};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct PackageSourceMap {
     pub roots: BTreeMap<(SifrPackageId, ImportRoot), PathBuf>,
     pub modules: BTreeMap<PackageModuleKey, PackageModuleSource>,
+    pub ambiguous_modules: BTreeMap<PackageModuleKey, Vec<PackageModuleSource>>,
     pub public_apis: BTreeMap<PackageModuleKey, NamespaceApi>,
+    pub fatal_diagnostics: Vec<PackageDiagnostic>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48,8 +58,36 @@ pub enum PackageImportOrigin {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackageImportAmbiguity {
+    pub importing_package_id: SifrPackageId,
+    pub import_path: DottedModulePath,
+    pub package_id: SifrPackageId,
+    pub cargo_package_id: crate::CargoPackageId,
+    pub module_path: DottedModulePath,
+    pub candidates: Vec<PackageModuleSource>,
+    pub origin: PackageImportOrigin,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PackageImportResolutionResult {
+    Resolved(PackageImportResolution),
+    Ambiguous(PackageImportAmbiguity),
+    Unresolved(PackageDiagnostic),
+    PrivateAccess(PackageDiagnostic),
+    FatalPackageMapFailure(Vec<PackageDiagnostic>),
+}
+
 impl PackageSourceMap {
     pub fn build(graph: &SifrPackageGraph) -> Result<Self, Vec<PackageDiagnostic>> {
+        let mut provider = DiskSourceProvider::new();
+        Self::build_with_provider(graph, &mut provider)
+    }
+
+    pub fn build_with_provider(
+        graph: &SifrPackageGraph,
+        provider: &mut impl SourceProvider,
+    ) -> Result<Self, Vec<PackageDiagnostic>> {
         let mut source_map = Self::default();
         let mut diagnostics = Vec::new();
 
@@ -59,21 +97,10 @@ impl PackageSourceMap {
                     (package.package_id.clone(), root_for(package)),
                     source_root.clone(),
                 );
-                match discover_package_modules(package, &source_root) {
+                match discover_package_modules(package, &source_root, provider) {
                     Ok(modules) => {
                         for module in modules {
-                            let key = PackageModuleKey {
-                                package_id: package.package_id.clone(),
-                                module_path: module.module_path.clone(),
-                            };
-                            if source_map.modules.insert(key, module).is_some() {
-                                diagnostics.push(PackageDiagnostic::invalid_sifr_manifest(
-                                    &package.cargo_package_id,
-                                    package.sifr_manifest.clone(),
-                                    "source.roots",
-                                    "multiple source files define the same module path",
-                                ));
-                            }
+                            source_map.insert_module(module);
                         }
                     }
                     Err(error) => diagnostics.push(PackageDiagnostic::invalid_sifr_manifest(
@@ -83,7 +110,7 @@ impl PackageSourceMap {
                         error,
                     )),
                 }
-                match discover_namespace_apis(package, &source_root) {
+                match discover_namespace_apis(package, &source_root, provider) {
                     Ok(apis) => {
                         for api in apis {
                             source_map.public_apis.insert(
@@ -103,7 +130,16 @@ impl PackageSourceMap {
         if diagnostics.is_empty() {
             Ok(source_map)
         } else {
+            source_map.fatal_diagnostics.clone_from(&diagnostics);
             Err(diagnostics)
+        }
+    }
+
+    #[must_use]
+    pub fn from_fatal_diagnostics(diagnostics: Vec<PackageDiagnostic>) -> Self {
+        Self {
+            fatal_diagnostics: diagnostics,
+            ..Self::default()
         }
     }
 
@@ -113,18 +149,81 @@ impl PackageSourceMap {
         importing_package_id: &SifrPackageId,
         import_path: &DottedModulePath,
     ) -> Result<PackageImportResolution, PackageDiagnostic> {
+        match self.resolve_import_result(graph, importing_package_id, import_path) {
+            PackageImportResolutionResult::Resolved(resolution) => Ok(resolution),
+            PackageImportResolutionResult::Ambiguous(ambiguity) => {
+                let candidates = ambiguity
+                    .candidates
+                    .iter()
+                    .map(|candidate| candidate.file_path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(PackageDiagnostic::undeclared_direct_import(
+                    &ambiguity.cargo_package_id,
+                    importing_package_id,
+                    format!("{} (ambiguous candidates: {candidates})", import_path.0),
+                ))
+            }
+            PackageImportResolutionResult::Unresolved(diagnostic)
+            | PackageImportResolutionResult::PrivateAccess(diagnostic) => Err(diagnostic),
+            PackageImportResolutionResult::FatalPackageMapFailure(diagnostics) => {
+                Err(diagnostics.into_iter().next().unwrap_or_else(|| {
+                    PackageDiagnostic::cargo_metadata_parse("package source map is invalid")
+                }))
+            }
+        }
+    }
+
+    pub fn resolve_import_result(
+        &self,
+        graph: &SifrPackageGraph,
+        importing_package_id: &SifrPackageId,
+        import_path: &DottedModulePath,
+    ) -> PackageImportResolutionResult {
+        if !self.fatal_diagnostics.is_empty() {
+            return PackageImportResolutionResult::FatalPackageMapFailure(
+                self.fatal_diagnostics.clone(),
+            );
+        }
         let importer = graph
             .packages
             .get(importing_package_id)
-            .ok_or_else(|| PackageDiagnostic::cargo_metadata_parse("unknown importing package"))?;
+            .ok_or_else(|| PackageDiagnostic::cargo_metadata_parse("unknown importing package"));
+        let importer = match importer {
+            Ok(importer) => importer,
+            Err(diagnostic) => return PackageImportResolutionResult::Unresolved(diagnostic),
+        };
 
-        if let Some(module) = self.module(importing_package_id, import_path) {
-            return Ok(PackageImportResolution {
-                importing_package_id: importing_package_id.clone(),
-                import_path: import_path.clone(),
-                resolved_module: module.clone(),
-                origin: PackageImportOrigin::OwnPackage,
-            });
+        match self.module_resolution(importing_package_id, import_path) {
+            ModuleResolution::Resolved(module) => {
+                return PackageImportResolutionResult::Resolved(PackageImportResolution {
+                    importing_package_id: importing_package_id.clone(),
+                    import_path: import_path.clone(),
+                    resolved_module: module.clone(),
+                    origin: PackageImportOrigin::OwnPackage,
+                });
+            }
+            ModuleResolution::Ambiguous(candidates) => {
+                let Some(first) = candidates.first() else {
+                    return PackageImportResolutionResult::Unresolved(
+                        PackageDiagnostic::undeclared_direct_import(
+                            &importer.cargo_package_id,
+                            importing_package_id,
+                            &import_path.0,
+                        ),
+                    );
+                };
+                return PackageImportResolutionResult::Ambiguous(PackageImportAmbiguity {
+                    importing_package_id: importing_package_id.clone(),
+                    import_path: import_path.clone(),
+                    package_id: importing_package_id.clone(),
+                    cargo_package_id: first.cargo_package_id.clone(),
+                    module_path: import_path.clone(),
+                    candidates: candidates.to_vec(),
+                    origin: PackageImportOrigin::OwnPackage,
+                });
+            }
+            ModuleResolution::Missing => {}
         }
 
         let Some(scoped_import) = graph
@@ -132,11 +231,13 @@ impl PackageSourceMap {
             .get(importing_package_id)
             .and_then(|scope| matching_scoped_import(&scope.imports, import_path))
         else {
-            return Err(PackageDiagnostic::undeclared_direct_import(
-                &importer.cargo_package_id,
-                importing_package_id,
-                &import_path.0,
-            ));
+            return PackageImportResolutionResult::Unresolved(
+                PackageDiagnostic::undeclared_direct_import(
+                    &importer.cargo_package_id,
+                    importing_package_id,
+                    &import_path.0,
+                ),
+            );
         };
 
         let target_path = remap_import_path(
@@ -144,24 +245,55 @@ impl PackageSourceMap {
             &scoped_import.import_root,
             &scoped_import.target_export_root,
         );
-        let Some(module) = self.module(&scoped_import.package_id, &target_path) else {
-            return Err(PackageDiagnostic::undeclared_direct_import(
-                &importer.cargo_package_id,
-                importing_package_id,
-                &import_path.0,
-            ));
+        let module = match self.module_resolution(&scoped_import.package_id, &target_path) {
+            ModuleResolution::Resolved(module) => module,
+            ModuleResolution::Ambiguous(candidates) => {
+                let Some(first) = candidates.first() else {
+                    return PackageImportResolutionResult::Unresolved(
+                        PackageDiagnostic::undeclared_direct_import(
+                            &importer.cargo_package_id,
+                            importing_package_id,
+                            &import_path.0,
+                        ),
+                    );
+                };
+                return PackageImportResolutionResult::Ambiguous(PackageImportAmbiguity {
+                    importing_package_id: importing_package_id.clone(),
+                    import_path: import_path.clone(),
+                    package_id: scoped_import.package_id.clone(),
+                    cargo_package_id: first.cargo_package_id.clone(),
+                    module_path: target_path,
+                    candidates: candidates.to_vec(),
+                    origin: PackageImportOrigin::DirectDependency {
+                        import_root: scoped_import.import_root.clone(),
+                        target_export_root: scoped_import.target_export_root.clone(),
+                        dependency_package_id: scoped_import.package_id.clone(),
+                    },
+                });
+            }
+            ModuleResolution::Missing => {
+                return PackageImportResolutionResult::Unresolved(
+                    PackageDiagnostic::undeclared_direct_import(
+                        &importer.cargo_package_id,
+                        importing_package_id,
+                        &import_path.0,
+                    ),
+                );
+            }
         };
 
         if is_private_dependency_module(self, graph, module, &target_path) {
-            return Err(PackageDiagnostic::private_module_access(
-                &importer.cargo_package_id,
-                importing_package_id,
-                &import_path.0,
-                &scoped_import.package_id,
-            ));
+            return PackageImportResolutionResult::PrivateAccess(
+                PackageDiagnostic::private_module_access(
+                    &importer.cargo_package_id,
+                    importing_package_id,
+                    &import_path.0,
+                    &scoped_import.package_id,
+                ),
+            );
         }
 
-        Ok(PackageImportResolution {
+        PackageImportResolutionResult::Resolved(PackageImportResolution {
             importing_package_id: importing_package_id.clone(),
             import_path: import_path.clone(),
             resolved_module: module.clone(),
@@ -173,15 +305,38 @@ impl PackageSourceMap {
         })
     }
 
-    fn module(
+    fn insert_module(&mut self, module: PackageModuleSource) {
+        let key = PackageModuleKey {
+            package_id: module.package_id.clone(),
+            module_path: module.module_path.clone(),
+        };
+        if let Some(existing) = self.modules.remove(&key) {
+            self.ambiguous_modules
+                .entry(key)
+                .or_insert_with(|| vec![existing])
+                .push(module);
+        } else if let Some(candidates) = self.ambiguous_modules.get_mut(&key) {
+            candidates.push(module);
+        } else {
+            self.modules.insert(key, module);
+        }
+    }
+
+    fn module_resolution(
         &self,
         package_id: &SifrPackageId,
         module_path: &DottedModulePath,
-    ) -> Option<&PackageModuleSource> {
-        self.modules.get(&PackageModuleKey {
+    ) -> ModuleResolution<'_> {
+        let key = PackageModuleKey {
             package_id: package_id.clone(),
             module_path: module_path.clone(),
-        })
+        };
+        if let Some(candidates) = self.ambiguous_modules.get(&key) {
+            return ModuleResolution::Ambiguous(candidates);
+        }
+        self.modules
+            .get(&key)
+            .map_or(ModuleResolution::Missing, ModuleResolution::Resolved)
     }
 
     pub fn module_for_file(
@@ -192,219 +347,26 @@ impl PackageSourceMap {
         let normalized_file = file_path
             .canonicalize()
             .unwrap_or_else(|_| file_path.to_path_buf());
-        self.modules.values().find(|module| {
-            &module.package_id == package_id
-                && module
-                    .file_path
-                    .canonicalize()
-                    .unwrap_or_else(|_| module.file_path.clone())
-                    == normalized_file
-        })
-    }
-}
-
-fn package_source_roots(package: &SifrPackageMetadata) -> Vec<PathBuf> {
-    package
-        .manifest
-        .source_roots
-        .iter()
-        .map(|root| package.package_root.join(&root.0))
-        .collect()
-}
-
-fn root_for(package: &SifrPackageMetadata) -> ImportRoot {
-    package
-        .manifest
-        .exports
-        .first()
-        .cloned()
-        .unwrap_or_else(|| ImportRoot(package.sifr_name.0.clone()))
-}
-
-fn discover_package_modules(
-    package: &SifrPackageMetadata,
-    source_root: &Path,
-) -> Result<Vec<PackageModuleSource>, String> {
-    let mut modules = Vec::new();
-    discover_modules_recursive(package, source_root, source_root, &mut modules)?;
-    modules.sort_by(|left, right| left.module_path.cmp(&right.module_path));
-    Ok(modules)
-}
-
-fn discover_modules_recursive(
-    package: &SifrPackageMetadata,
-    source_root: &Path,
-    directory: &Path,
-    modules: &mut Vec<PackageModuleSource>,
-) -> Result<(), String> {
-    let entries = std::fs::read_dir(directory).map_err(|error| {
-        format!(
-            "could not read source root '{}': {error}",
-            directory.display()
-        )
-    })?;
-    for entry in entries {
-        let entry = entry.map_err(|error| {
-            format!(
-                "could not read source entry under '{}': {error}",
-                directory.display()
+        self.modules
+            .values()
+            .chain(
+                self.ambiguous_modules
+                    .values()
+                    .flat_map(|modules| modules.iter()),
             )
-        })?;
-        let path = entry.path();
-        if path.is_dir() {
-            discover_modules_recursive(package, source_root, &path, modules)?;
-            continue;
-        }
-        if path.extension().and_then(|value| value.to_str()) != Some("sifr") {
-            continue;
-        }
-        let Some(module_path) = module_path_from_file(package, source_root, &path) else {
-            continue;
-        };
-        modules.push(PackageModuleSource {
-            package_id: package.package_id.clone(),
-            cargo_package_id: package.cargo_package_id.clone(),
-            module_path,
-            file_path: path,
-            source_root: source_root.to_path_buf(),
-        });
-    }
-    Ok(())
-}
-
-fn discover_namespace_apis(
-    package: &SifrPackageMetadata,
-    source_root: &Path,
-) -> Result<Vec<NamespaceApi>, Vec<PackageDiagnostic>> {
-    let modules = discover_package_modules(package, source_root).map_err(|error| {
-        vec![PackageDiagnostic::invalid_sifr_manifest(
-            &package.cargo_package_id,
-            package.sifr_manifest.clone(),
-            if package.manifest.production_schema {
-                "source.root"
-            } else {
-                "source.roots"
-            },
-            error,
-        )]
-    })?;
-    let mut apis = Vec::new();
-    let mut diagnostics = Vec::new();
-    for module in modules {
-        if module.file_path.file_name().and_then(|name| name.to_str()) != Some("__init__.sifr") {
-            continue;
-        }
-        match parse_init_sifr_reexports(
-            &package.cargo_package_id,
-            &package.sifr_manifest,
-            &module.module_path,
-            &module.file_path,
-            source_root,
-        ) {
-            Ok(api) => apis.push(api),
-            Err(errors) => diagnostics.extend(errors),
-        }
-    }
-    if diagnostics.is_empty() {
-        Ok(apis)
-    } else {
-        Err(diagnostics)
+            .find(|module| {
+                &module.package_id == package_id
+                    && module
+                        .file_path
+                        .canonicalize()
+                        .unwrap_or_else(|_| module.file_path.clone())
+                        == normalized_file
+            })
     }
 }
 
-fn module_path_from_file(
-    package: &SifrPackageMetadata,
-    source_root: &Path,
-    file_path: &Path,
-) -> Option<DottedModulePath> {
-    let relative = file_path.strip_prefix(source_root).ok()?;
-    let mut parts = relative
-        .components()
-        .map(|component| component.as_os_str().to_string_lossy().to_string())
-        .collect::<Vec<_>>();
-    let last = parts.last_mut()?;
-    if last == "__init__.sifr" {
-        let _ = parts.pop();
-    } else if let Some(stripped) = last.strip_suffix(".sifr") {
-        *last = stripped.to_string();
-    }
-    if !parts.iter().all(|part| valid_identifier(part)) {
-        return None;
-    }
-    if package.manifest.production_schema {
-        parts.insert(0, package.sifr_name.0.clone());
-    }
-    if parts.is_empty() {
-        return None;
-    }
-    Some(DottedModulePath(parts.join(".")))
-}
-
-fn valid_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn matching_scoped_import<'a>(
-    imports: &'a BTreeMap<ImportRoot, crate::ScopedImport>,
-    import_path: &DottedModulePath,
-) -> Option<&'a crate::ScopedImport> {
-    imports
-        .iter()
-        .filter(|(root, _)| import_root_matches(root, import_path))
-        .max_by_key(|(root, _)| root.0.split('.').count())
-        .map(|(_, import)| import)
-}
-
-fn import_root_matches(root: &ImportRoot, import_path: &DottedModulePath) -> bool {
-    import_path.0 == root.0
-        || import_path
-            .0
-            .strip_prefix(&root.0)
-            .is_some_and(|suffix| suffix.starts_with('.'))
-}
-
-fn remap_import_path(
-    import_path: &DottedModulePath,
-    import_root: &ImportRoot,
-    target_export_root: &ImportRoot,
-) -> DottedModulePath {
-    if import_path.0 == import_root.0 {
-        return DottedModulePath(target_export_root.0.clone());
-    }
-    let suffix = import_path
-        .0
-        .strip_prefix(&format!("{}.", import_root.0))
-        .unwrap_or_default();
-    DottedModulePath(format!("{}.{}", target_export_root.0, suffix))
-}
-
-fn is_private_dependency_module(
-    source_map: &PackageSourceMap,
-    graph: &SifrPackageGraph,
-    module: &PackageModuleSource,
-    module_path: &DottedModulePath,
-) -> bool {
-    let Some(package) = graph.packages.get(&module.package_id) else {
-        return false;
-    };
-    if !package.manifest.production_schema
-        && package.manifest.exports.iter().any(|export| {
-            import_root_matches(export, module_path)
-                && !module_path.0.split('.').any(|part| part.starts_with('_'))
-        })
-    {
-        return false;
-    }
-    if source_map.public_apis.contains_key(&PackageModuleKey {
-        package_id: module.package_id.clone(),
-        module_path: module_path.clone(),
-    }) {
-        return false;
-    }
-    true
+enum ModuleResolution<'a> {
+    Resolved(&'a PackageModuleSource),
+    Ambiguous(&'a [PackageModuleSource]),
+    Missing,
 }

--- a/crates/sifr_package/src/imports/source_map/discovery.rs
+++ b/crates/sifr_package/src/imports/source_map/discovery.rs
@@ -1,0 +1,151 @@
+use super::{DottedModulePath, PackageModuleSource};
+use crate::diag::PackageDiagnostic;
+use crate::graph::derive::SifrPackageMetadata;
+use crate::imports::namespace_api::{parse_init_sifr_reexports, NamespaceApi};
+use crate::manifest::sifr::ImportRoot;
+use sifr_frontend::SourceProvider;
+use std::path::{Path, PathBuf};
+
+pub(super) fn package_source_roots(package: &SifrPackageMetadata) -> Vec<PathBuf> {
+    package
+        .manifest
+        .source_roots
+        .iter()
+        .map(|root| package.package_root.join(&root.0))
+        .collect()
+}
+
+pub(super) fn root_for(package: &SifrPackageMetadata) -> ImportRoot {
+    package
+        .manifest
+        .exports
+        .first()
+        .cloned()
+        .unwrap_or_else(|| ImportRoot(package.sifr_name.0.clone()))
+}
+
+pub(super) fn discover_package_modules(
+    package: &SifrPackageMetadata,
+    source_root: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Vec<PackageModuleSource>, String> {
+    let mut modules = Vec::new();
+    discover_modules_recursive(package, source_root, source_root, &mut modules, provider)?;
+    modules.sort_by(|left, right| left.module_path.cmp(&right.module_path));
+    Ok(modules)
+}
+
+fn discover_modules_recursive(
+    package: &SifrPackageMetadata,
+    source_root: &Path,
+    directory: &Path,
+    modules: &mut Vec<PackageModuleSource>,
+    provider: &mut impl SourceProvider,
+) -> Result<(), String> {
+    let entries = provider.read_dir(directory).map_err(|error| {
+        format!(
+            "could not read source root '{}': {error}",
+            directory.display()
+        )
+    })?;
+    for entry in entries {
+        let path = entry.path;
+        if entry.is_dir {
+            discover_modules_recursive(package, source_root, &path, modules, provider)?;
+            continue;
+        }
+        if !entry.is_file || path.extension().and_then(|value| value.to_str()) != Some("sifr") {
+            continue;
+        }
+        let Some(module_path) = module_path_from_file(package, source_root, &path) else {
+            continue;
+        };
+        modules.push(PackageModuleSource {
+            package_id: package.package_id.clone(),
+            cargo_package_id: package.cargo_package_id.clone(),
+            module_path,
+            file_path: path,
+            source_root: source_root.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn discover_namespace_apis(
+    package: &SifrPackageMetadata,
+    source_root: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<Vec<NamespaceApi>, Vec<PackageDiagnostic>> {
+    let modules = discover_package_modules(package, source_root, provider).map_err(|error| {
+        vec![PackageDiagnostic::invalid_sifr_manifest(
+            &package.cargo_package_id,
+            package.sifr_manifest.clone(),
+            if package.manifest.production_schema {
+                "source.root"
+            } else {
+                "source.roots"
+            },
+            error,
+        )]
+    })?;
+    let mut apis = Vec::new();
+    let mut diagnostics = Vec::new();
+    for module in modules {
+        if module.file_path.file_name().and_then(|name| name.to_str()) != Some("__init__.sifr") {
+            continue;
+        }
+        match parse_init_sifr_reexports(
+            &package.cargo_package_id,
+            &package.sifr_manifest,
+            &module.module_path,
+            &module.file_path,
+            source_root,
+            provider,
+        ) {
+            Ok(api) => apis.push(api),
+            Err(errors) => diagnostics.extend(errors),
+        }
+    }
+    if diagnostics.is_empty() {
+        Ok(apis)
+    } else {
+        Err(diagnostics)
+    }
+}
+
+fn module_path_from_file(
+    package: &SifrPackageMetadata,
+    source_root: &Path,
+    file_path: &Path,
+) -> Option<DottedModulePath> {
+    let relative = file_path.strip_prefix(source_root).ok()?;
+    let mut parts = relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let last = parts.last_mut()?;
+    if last == "__init__.sifr" {
+        let _ = parts.pop();
+    } else if let Some(stripped) = last.strip_suffix(".sifr") {
+        *last = stripped.to_string();
+    }
+    if !parts.iter().all(|part| valid_identifier(part)) {
+        return None;
+    }
+    if package.manifest.production_schema {
+        parts.insert(0, package.sifr_name.0.clone());
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(DottedModulePath(parts.join(".")))
+}
+
+fn valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}

--- a/crates/sifr_package/src/imports/source_map/resolution.rs
+++ b/crates/sifr_package/src/imports/source_map/resolution.rs
@@ -1,0 +1,64 @@
+use super::{DottedModulePath, PackageModuleKey, PackageModuleSource, PackageSourceMap};
+use crate::graph::derive::SifrPackageGraph;
+use crate::manifest::sifr::ImportRoot;
+use std::collections::BTreeMap;
+
+pub(super) fn matching_scoped_import<'a>(
+    imports: &'a BTreeMap<ImportRoot, crate::ScopedImport>,
+    import_path: &DottedModulePath,
+) -> Option<&'a crate::ScopedImport> {
+    imports
+        .iter()
+        .filter(|(root, _)| import_root_matches(root, import_path))
+        .max_by_key(|(root, _)| root.0.split('.').count())
+        .map(|(_, import)| import)
+}
+
+fn import_root_matches(root: &ImportRoot, import_path: &DottedModulePath) -> bool {
+    import_path.0 == root.0
+        || import_path
+            .0
+            .strip_prefix(&root.0)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+pub(super) fn remap_import_path(
+    import_path: &DottedModulePath,
+    import_root: &ImportRoot,
+    target_export_root: &ImportRoot,
+) -> DottedModulePath {
+    if import_path.0 == import_root.0 {
+        return DottedModulePath(target_export_root.0.clone());
+    }
+    let suffix = import_path
+        .0
+        .strip_prefix(&format!("{}.", import_root.0))
+        .unwrap_or_default();
+    DottedModulePath(format!("{}.{}", target_export_root.0, suffix))
+}
+
+pub(super) fn is_private_dependency_module(
+    source_map: &PackageSourceMap,
+    graph: &SifrPackageGraph,
+    module: &PackageModuleSource,
+    module_path: &DottedModulePath,
+) -> bool {
+    let Some(package) = graph.packages.get(&module.package_id) else {
+        return false;
+    };
+    if !package.manifest.production_schema
+        && package.manifest.exports.iter().any(|export| {
+            import_root_matches(export, module_path)
+                && !module_path.0.split('.').any(|part| part.starts_with('_'))
+        })
+    {
+        return false;
+    }
+    if source_map.public_apis.contains_key(&PackageModuleKey {
+        package_id: module.package_id.clone(),
+        module_path: module_path.clone(),
+    }) {
+        return false;
+    }
+    true
+}

--- a/crates/sifr_package/src/lib.rs
+++ b/crates/sifr_package/src/lib.rs
@@ -44,8 +44,8 @@ pub use crate::graph::workspace::{
     WorkspacePackageSelection,
 };
 pub use crate::imports::source_map::{
-    DottedModulePath, PackageImportOrigin, PackageImportResolution, PackageModuleKey,
-    PackageModuleSource, PackageSourceMap,
+    DottedModulePath, PackageImportAmbiguity, PackageImportOrigin, PackageImportResolution,
+    PackageImportResolutionResult, PackageModuleKey, PackageModuleSource, PackageSourceMap,
 };
 pub use crate::manifest::metadata::{CargoSifrAliasMetadata, CargoSifrMetadata};
 pub use crate::manifest::package_sections::{SifrDependency, SifrScript};
@@ -86,6 +86,8 @@ mod milestone_adhoc_pkg_1_tests;
 mod milestone_adhoc_pkg_2_tests;
 #[cfg(test)]
 mod milestone_adhoc_pkg_3_tests;
+#[cfg(test)]
+mod milestone_adhoc_tsgo_m2_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/sifr_package/src/manifest/mod.rs
+++ b/crates/sifr_package/src/manifest/mod.rs
@@ -2,4 +2,5 @@ pub mod metadata;
 pub mod package_sections;
 mod production;
 pub mod sifr;
+mod sifr_fields;
 pub mod validate;

--- a/crates/sifr_package/src/manifest/sifr.rs
+++ b/crates/sifr_package/src/manifest/sifr.rs
@@ -6,8 +6,13 @@ use crate::manifest::package_sections::{
 use crate::manifest::production::{
     parse_source_config, reject_production_manifest_bins, reject_production_manifest_exports,
 };
+use crate::manifest::sifr_fields::{
+    parse_exports, parse_trust, validate_compiler_requirement, validate_edition,
+};
 use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
+
+mod load;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SifrPackageName(pub String);
@@ -48,20 +53,6 @@ pub struct SifrManifest {
 }
 
 impl SifrManifest {
-    pub fn load(
-        cargo_package_id: &CargoPackageId,
-        manifest_path: &Path,
-    ) -> Result<Self, PackageDiagnostic> {
-        let source = std::fs::read_to_string(manifest_path).map_err(|error| {
-            PackageDiagnostic::missing_sifr_manifest(
-                cargo_package_id,
-                manifest_path.to_path_buf(),
-                error.to_string(),
-            )
-        })?;
-        Self::parse(cargo_package_id, manifest_path, &source)
-    }
-
     pub fn parse(
         cargo_package_id: &CargoPackageId,
         manifest_path: &Path,
@@ -224,104 +215,6 @@ pub(super) fn parse_source_roots(
         .collect()
 }
 
-fn parse_exports(
-    cargo_package_id: &CargoPackageId,
-    manifest_path: &Path,
-    value: &toml::Value,
-) -> Result<Vec<ImportRoot>, PackageDiagnostic> {
-    let Some(entries) = value.as_array() else {
-        return Err(PackageDiagnostic::invalid_sifr_manifest(
-            cargo_package_id,
-            manifest_path.to_path_buf(),
-            "exports.modules",
-            "expected a list of import roots",
-        ));
-    };
-
-    entries
-        .iter()
-        .map(|entry| {
-            let Some(export) = entry.as_str().filter(|value| !value.is_empty()) else {
-                return Err(PackageDiagnostic::invalid_sifr_manifest(
-                    cargo_package_id,
-                    manifest_path.to_path_buf(),
-                    "exports.modules",
-                    "expected every export to be a non-empty string",
-                ));
-            };
-            if !export.split('.').all(valid_identifier) {
-                return Err(PackageDiagnostic::invalid_sifr_manifest(
-                    cargo_package_id,
-                    manifest_path.to_path_buf(),
-                    "exports.modules",
-                    format!("`{export}` is not a valid dotted import root"),
-                ));
-            }
-            Ok(ImportRoot(export.to_string()))
-        })
-        .collect()
-}
-
-fn parse_trust(
-    cargo_package_id: &CargoPackageId,
-    manifest_path: &Path,
-    table: &toml::Table,
-) -> Result<TrustPolicy, PackageDiagnostic> {
-    Ok(TrustPolicy {
-        native: optional_string_list(cargo_package_id, manifest_path, table, "trust.native")?,
-        build_scripts: optional_string_list(
-            cargo_package_id,
-            manifest_path,
-            table,
-            "trust.build-scripts",
-        )?,
-        proc_macros: optional_string_list(
-            cargo_package_id,
-            manifest_path,
-            table,
-            "trust.proc-macros",
-        )?,
-    })
-}
-
-fn optional_string_list(
-    cargo_package_id: &CargoPackageId,
-    manifest_path: &Path,
-    table: &toml::Table,
-    dotted_key: &'static str,
-) -> Result<Vec<String>, PackageDiagnostic> {
-    let local_key = dotted_key.rsplit('.').next().unwrap_or(dotted_key);
-    let Some(value) = table.get(local_key) else {
-        return Ok(Vec::new());
-    };
-    let Some(entries) = value.as_array() else {
-        return Err(PackageDiagnostic::invalid_sifr_manifest(
-            cargo_package_id,
-            manifest_path.to_path_buf(),
-            dotted_key,
-            "expected a list of strings",
-        ));
-    };
-
-    entries
-        .iter()
-        .map(|entry| {
-            entry
-                .as_str()
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-                .ok_or_else(|| {
-                    PackageDiagnostic::invalid_sifr_manifest(
-                        cargo_package_id,
-                        manifest_path.to_path_buf(),
-                        dotted_key,
-                        "expected every entry to be a non-empty string",
-                    )
-                })
-        })
-        .collect()
-}
-
 pub(super) fn validate_relative_path(
     cargo_package_id: &CargoPackageId,
     manifest_path: &Path,
@@ -366,50 +259,4 @@ pub(super) fn validate_relative_path(
     } else {
         Ok(normalized)
     }
-}
-
-fn validate_edition(
-    cargo_package_id: &CargoPackageId,
-    manifest_path: &Path,
-    edition: &SifrEdition,
-) -> Result<(), PackageDiagnostic> {
-    if edition.0 == "2026" {
-        Ok(())
-    } else {
-        Err(PackageDiagnostic::invalid_sifr_manifest(
-            cargo_package_id,
-            manifest_path.to_path_buf(),
-            "package.edition",
-            format!("unsupported Sifr edition `{}`", edition.0),
-        ))
-    }
-}
-
-fn validate_compiler_requirement(
-    cargo_package_id: &CargoPackageId,
-    manifest_path: &Path,
-    requirement: &CompilerRequirement,
-) -> Result<(), PackageDiagnostic> {
-    if requirement.0.contains("0.3") || requirement.0 == "*" {
-        Ok(())
-    } else {
-        Err(PackageDiagnostic::invalid_sifr_manifest(
-            cargo_package_id,
-            manifest_path.to_path_buf(),
-            "package.sifr-version",
-            format!(
-                "compiler requirement `{}` does not match this milestone compiler compatibility window",
-                requirement.0
-            ),
-        ))
-    }
-}
-
-fn valid_identifier(segment: &str) -> bool {
-    let mut chars = segment.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }

--- a/crates/sifr_package/src/manifest/sifr/load.rs
+++ b/crates/sifr_package/src/manifest/sifr/load.rs
@@ -1,0 +1,30 @@
+use super::SifrManifest;
+use crate::cargo::metadata::CargoPackageId;
+use crate::diag::PackageDiagnostic;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
+use std::path::Path;
+
+impl SifrManifest {
+    pub fn load(
+        cargo_package_id: &CargoPackageId,
+        manifest_path: &Path,
+    ) -> Result<Self, PackageDiagnostic> {
+        let mut provider = DiskSourceProvider::new();
+        Self::load_with_provider(cargo_package_id, manifest_path, &mut provider)
+    }
+
+    pub fn load_with_provider(
+        cargo_package_id: &CargoPackageId,
+        manifest_path: &Path,
+        provider: &mut impl SourceProvider,
+    ) -> Result<Self, PackageDiagnostic> {
+        let source = provider.read_file(manifest_path).map_err(|error| {
+            PackageDiagnostic::missing_sifr_manifest(
+                cargo_package_id,
+                manifest_path.to_path_buf(),
+                error.to_string(),
+            )
+        })?;
+        Self::parse(cargo_package_id, manifest_path, source.as_str())
+    }
+}

--- a/crates/sifr_package/src/manifest/sifr_fields.rs
+++ b/crates/sifr_package/src/manifest/sifr_fields.rs
@@ -1,0 +1,148 @@
+use crate::cargo::metadata::CargoPackageId;
+use crate::diag::PackageDiagnostic;
+use crate::manifest::sifr::{CompilerRequirement, ImportRoot, SifrEdition, TrustPolicy};
+use std::path::Path;
+
+pub(super) fn parse_exports(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    value: &toml::Value,
+) -> Result<Vec<ImportRoot>, PackageDiagnostic> {
+    let Some(entries) = value.as_array() else {
+        return Err(PackageDiagnostic::invalid_sifr_manifest(
+            cargo_package_id,
+            manifest_path.to_path_buf(),
+            "exports.modules",
+            "expected a list of import roots",
+        ));
+    };
+
+    entries
+        .iter()
+        .map(|entry| {
+            let Some(export) = entry.as_str().filter(|value| !value.is_empty()) else {
+                return Err(PackageDiagnostic::invalid_sifr_manifest(
+                    cargo_package_id,
+                    manifest_path.to_path_buf(),
+                    "exports.modules",
+                    "expected every export to be a non-empty string",
+                ));
+            };
+            if !export.split('.').all(valid_identifier) {
+                return Err(PackageDiagnostic::invalid_sifr_manifest(
+                    cargo_package_id,
+                    manifest_path.to_path_buf(),
+                    "exports.modules",
+                    format!("`{export}` is not a valid dotted import root"),
+                ));
+            }
+            Ok(ImportRoot(export.to_string()))
+        })
+        .collect()
+}
+
+pub(super) fn parse_trust(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    table: &toml::Table,
+) -> Result<TrustPolicy, PackageDiagnostic> {
+    Ok(TrustPolicy {
+        native: optional_string_list(cargo_package_id, manifest_path, table, "trust.native")?,
+        build_scripts: optional_string_list(
+            cargo_package_id,
+            manifest_path,
+            table,
+            "trust.build-scripts",
+        )?,
+        proc_macros: optional_string_list(
+            cargo_package_id,
+            manifest_path,
+            table,
+            "trust.proc-macros",
+        )?,
+    })
+}
+
+fn optional_string_list(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    table: &toml::Table,
+    dotted_key: &'static str,
+) -> Result<Vec<String>, PackageDiagnostic> {
+    let local_key = dotted_key.rsplit('.').next().unwrap_or(dotted_key);
+    let Some(value) = table.get(local_key) else {
+        return Ok(Vec::new());
+    };
+    let Some(entries) = value.as_array() else {
+        return Err(PackageDiagnostic::invalid_sifr_manifest(
+            cargo_package_id,
+            manifest_path.to_path_buf(),
+            dotted_key,
+            "expected a list of strings",
+        ));
+    };
+
+    entries
+        .iter()
+        .map(|entry| {
+            entry
+                .as_str()
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    PackageDiagnostic::invalid_sifr_manifest(
+                        cargo_package_id,
+                        manifest_path.to_path_buf(),
+                        dotted_key,
+                        "expected every entry to be a non-empty string",
+                    )
+                })
+        })
+        .collect()
+}
+
+pub(super) fn validate_edition(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    edition: &SifrEdition,
+) -> Result<(), PackageDiagnostic> {
+    if edition.0 == "2026" {
+        Ok(())
+    } else {
+        Err(PackageDiagnostic::invalid_sifr_manifest(
+            cargo_package_id,
+            manifest_path.to_path_buf(),
+            "package.edition",
+            format!("unsupported Sifr edition `{}`", edition.0),
+        ))
+    }
+}
+
+pub(super) fn validate_compiler_requirement(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    requirement: &CompilerRequirement,
+) -> Result<(), PackageDiagnostic> {
+    if requirement.0.contains("0.3") || requirement.0 == "*" {
+        Ok(())
+    } else {
+        Err(PackageDiagnostic::invalid_sifr_manifest(
+            cargo_package_id,
+            manifest_path.to_path_buf(),
+            "package.sifr-version",
+            format!(
+                "compiler requirement `{}` does not match this milestone compiler compatibility window",
+                requirement.0
+            ),
+        ))
+    }
+}
+
+fn valid_identifier(segment: &str) -> bool {
+    let mut chars = segment.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}

--- a/crates/sifr_package/src/manifest/validate.rs
+++ b/crates/sifr_package/src/manifest/validate.rs
@@ -1,6 +1,7 @@
 use crate::cargo::metadata::CargoPackageId;
 use crate::diag::PackageDiagnostic;
 use crate::manifest::sifr::SifrManifest;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::path::Path;
 
 pub fn validate_source_roots_exist(
@@ -9,9 +10,26 @@ pub fn validate_source_roots_exist(
     package_root: &Path,
     manifest: &SifrManifest,
 ) -> Result<(), PackageDiagnostic> {
+    let mut provider = DiskSourceProvider::new();
+    validate_source_roots_exist_with_provider(
+        cargo_package_id,
+        manifest_path,
+        package_root,
+        manifest,
+        &mut provider,
+    )
+}
+
+pub fn validate_source_roots_exist_with_provider(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    package_root: &Path,
+    manifest: &SifrManifest,
+    provider: &mut impl SourceProvider,
+) -> Result<(), PackageDiagnostic> {
     for source_root in &manifest.source_roots {
         let absolute = package_root.join(&source_root.0);
-        if !absolute.is_dir() {
+        if !provider.is_dir(&absolute) {
             return Err(PackageDiagnostic::invalid_sifr_manifest(
                 cargo_package_id,
                 manifest_path.to_path_buf(),
@@ -33,6 +51,23 @@ pub fn validate_exports_match_sources(
     package_root: &Path,
     manifest: &SifrManifest,
 ) -> Result<(), PackageDiagnostic> {
+    let mut provider = DiskSourceProvider::new();
+    validate_exports_match_sources_with_provider(
+        cargo_package_id,
+        manifest_path,
+        package_root,
+        manifest,
+        &mut provider,
+    )
+}
+
+pub fn validate_exports_match_sources_with_provider(
+    cargo_package_id: &CargoPackageId,
+    manifest_path: &Path,
+    package_root: &Path,
+    manifest: &SifrManifest,
+    provider: &mut impl SourceProvider,
+) -> Result<(), PackageDiagnostic> {
     if manifest.production_schema {
         return Ok(());
     }
@@ -40,8 +75,8 @@ pub fn validate_exports_match_sources(
         let export_path = export.0.replace('.', "/");
         let found = manifest.source_roots.iter().any(|source_root| {
             let root = package_root.join(&source_root.0);
-            root.join(format!("{export_path}.sifr")).is_file()
-                || root.join(&export_path).join("__init__.sifr").is_file()
+            provider.is_file(&root.join(format!("{export_path}.sifr")))
+                || provider.is_file(&root.join(&export_path).join("__init__.sifr"))
         });
         if !found {
             return Err(PackageDiagnostic::invalid_sifr_manifest(

--- a/crates/sifr_package/src/milestone_37_3_tests.rs
+++ b/crates/sifr_package/src/milestone_37_3_tests.rs
@@ -255,7 +255,11 @@ fn write_pure_package(
 }
 
 fn write_module(package_root: &Path, module: &str) {
-    let mut path = package_root.join("sifr");
+    write_module_under(package_root, "sifr", module);
+}
+
+fn write_module_under(package_root: &Path, source_root: &str, module: &str) {
+    let mut path = package_root.join(source_root);
     for part in module.split('.') {
         path.push(part);
     }

--- a/crates/sifr_package/src/milestone_37_6_tests.rs
+++ b/crates/sifr_package/src/milestone_37_6_tests.rs
@@ -373,7 +373,9 @@ fn source_map(package: &SifrPackageMetadata) -> PackageSourceMap {
                 main,
             ),
         ]),
+        ambiguous_modules: BTreeMap::new(),
         public_apis: BTreeMap::new(),
+        fatal_diagnostics: Vec::new(),
     }
 }
 

--- a/crates/sifr_package/src/milestone_adhoc_tsgo_m2_tests.rs
+++ b/crates/sifr_package/src/milestone_adhoc_tsgo_m2_tests.rs
@@ -1,0 +1,269 @@
+use crate::cargo::metadata::parse_metadata_json;
+use crate::graph::derive::{derive_package_graph, SifrPackageId};
+use crate::imports::source_map::{
+    DottedModulePath, PackageImportOrigin, PackageImportResolutionResult, PackageSourceMap,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn import_resolution_result_preserves_ambiguous_candidates() {
+    let temp = TestWorkspace::new("source_map_ambiguous_result");
+    let app = package(&temp, "app", "sifr-app", "0.1.0", "app", &["app.main"]);
+    let math = package(
+        &temp,
+        "math",
+        "sifr-math",
+        "1.0.0",
+        "math",
+        &["math.vector"],
+    );
+    fs::write(
+        math.root.join("sifr.toml"),
+        "[package]\nname = \"math\"\nedition = \"2026\"\nsifr-version = \">=0.3,<0.4\"\n\n[source]\nroots = [\"sifr\", \"alt\"]\n\n[exports]\nmodules = [\"math\"]\n",
+    )
+    .expect("rewrite roots");
+    write_module_under(&math.root, "alt", "math.vector");
+
+    let graph = graph(&temp, &[&app, &math], &[edge(&app, "math", &math)]);
+    let source_map = PackageSourceMap::build(&graph).expect("ambiguous map is queryable");
+
+    let PackageImportResolutionResult::Ambiguous(ambiguity) = source_map.resolve_import_result(
+        &graph,
+        &sifr_id(&app),
+        &DottedModulePath("math.vector".to_string()),
+    ) else {
+        panic!("expected ambiguous package import result");
+    };
+
+    assert_eq!(ambiguity.candidates.len(), 2);
+    assert!(matches!(
+        ambiguity.origin,
+        PackageImportOrigin::DirectDependency { .. }
+    ));
+}
+
+#[test]
+fn import_resolution_result_distinguishes_unresolved_private_and_fatal_states() {
+    let temp = TestWorkspace::new("source_map_resolution_states");
+    let app = package(&temp, "app", "sifr-app", "0.1.0", "app", &["app.main"]);
+    let math = package(
+        &temp,
+        "math",
+        "sifr-math",
+        "1.0.0",
+        "math",
+        &["math._internal"],
+    );
+    let graph = graph(&temp, &[&app, &math], &[edge(&app, "math", &math)]);
+    let source_map = PackageSourceMap::build(&graph).expect("source map builds");
+
+    assert!(matches!(
+        source_map.resolve_import_result(
+            &graph,
+            &sifr_id(&app),
+            &DottedModulePath("missing.module".to_string())
+        ),
+        PackageImportResolutionResult::Unresolved(_)
+    ));
+    assert!(matches!(
+        source_map.resolve_import_result(
+            &graph,
+            &sifr_id(&app),
+            &DottedModulePath("math._internal".to_string())
+        ),
+        PackageImportResolutionResult::PrivateAccess(_)
+    ));
+
+    let fatal = PackageSourceMap::from_fatal_diagnostics(vec![
+        crate::PackageDiagnostic::cargo_metadata_parse("synthetic fatal package map failure"),
+    ]);
+    assert!(matches!(
+        fatal.resolve_import_result(
+            &graph,
+            &sifr_id(&app),
+            &DottedModulePath("math.vector".to_string())
+        ),
+        PackageImportResolutionResult::FatalPackageMapFailure(_)
+    ));
+}
+
+fn graph(
+    temp: &TestWorkspace,
+    packages: &[&TestPackage],
+    edges: &[ResolveEdge],
+) -> crate::SifrPackageGraph {
+    let metadata =
+        parse_metadata_json(&metadata_json(&temp.root, packages, edges)).expect("metadata parses");
+    derive_package_graph(metadata).expect("graph derives")
+}
+
+fn package(
+    temp: &TestWorkspace,
+    dir: &str,
+    cargo_name: &str,
+    version: &str,
+    export: &str,
+    modules: &[&str],
+) -> TestPackage {
+    let root = temp.package(dir);
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::write(
+        root.join("src/lib.rs"),
+        "// Pure Sifr package marker. Sifr source lives in sifr.toml source roots.\n",
+    )
+    .expect("write marker");
+    fs::write(
+        root.join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"{cargo_name}\"\nversion = \"{version}\"\nedition = \"2024\"\n\n[package.metadata.sifr]\nmanifest = \"sifr.toml\"\n"
+        ),
+    )
+    .expect("write Cargo.toml");
+    fs::write(
+        root.join("sifr.toml"),
+        format!(
+            "[package]\nname = \"{export}\"\nedition = \"2026\"\nsifr-version = \">=0.3,<0.4\"\n\n[source]\nroots = [\"sifr\"]\n\n[exports]\nmodules = [\"{export}\"]\n"
+        ),
+    )
+    .expect("write sifr.toml");
+    write_module_under(&root, "sifr", export);
+    for module in modules {
+        write_module_under(&root, "sifr", module);
+    }
+    TestPackage {
+        root,
+        cargo_name: cargo_name.to_string(),
+        version: version.to_string(),
+    }
+}
+
+fn write_module_under(package_root: &Path, source_root: &str, module: &str) {
+    let mut path = package_root.join(source_root);
+    for part in module.split('.') {
+        path.push(part);
+    }
+    fs::create_dir_all(path.parent().expect("module has parent")).expect("create module parent");
+    fs::write(path.with_extension("sifr"), "").expect("write module");
+}
+
+fn metadata_json(
+    workspace_root: &Path,
+    packages: &[&TestPackage],
+    edges: &[ResolveEdge],
+) -> String {
+    let package_json = packages
+        .iter()
+        .map(|package| metadata_package_json(package, edges))
+        .collect::<Vec<_>>()
+        .join(",");
+    let members = packages
+        .iter()
+        .map(|package| format!(r#""{}""#, cargo_id(package)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let nodes = packages
+        .iter()
+        .map(|package| {
+            let deps = edges
+                .iter()
+                .filter(|edge| edge.from == cargo_id(package))
+                .map(|edge| format!(r#"{{"name":"{}","pkg":"{}"}}"#, edge.name, edge.to))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(r#"{{"id":"{}","deps":[{deps}]}}"#, cargo_id(package))
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        r#"{{"packages":[{package_json}],"resolve":{{"nodes":[{nodes}]}},"workspace_members":[{members}],"target_directory":"{}/target","workspace_root":"{}"}}"#,
+        workspace_root.display(),
+        workspace_root.display()
+    )
+}
+
+fn metadata_package_json(package: &TestPackage, edges: &[ResolveEdge]) -> String {
+    let dependencies = edges
+        .iter()
+        .filter(|edge| edge.from == cargo_id(package))
+        .map(|edge| {
+            format!(
+                r#"{{"name":"{}","package":"{}","req":"*","kind":null,"target":null,"uses_workspace":false}}"#,
+                edge.name, edge.package
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        r#"{{
+            "id":"{}","name":"{}","version":"{}","source":null,
+            "manifest_path":"{}/Cargo.toml","dependencies":[{dependencies}],
+            "targets":[{{"name":"{}","kind":["lib"],"crate_types":["lib"],"src_path":"{}/src/lib.rs"}}],
+            "features":{{}},"metadata":{{"sifr":{{"manifest":"sifr.toml"}}}}
+        }}"#,
+        cargo_id(package),
+        package.cargo_name,
+        package.version,
+        package.root.display(),
+        package.cargo_name,
+        package.root.display()
+    )
+}
+
+fn edge(from: &TestPackage, name: &str, to: &TestPackage) -> ResolveEdge {
+    ResolveEdge {
+        from: cargo_id(from),
+        name: name.to_string(),
+        to: cargo_id(to),
+        package: to.cargo_name.clone(),
+    }
+}
+
+fn sifr_id(package: &TestPackage) -> SifrPackageId {
+    SifrPackageId(format!("{}@{}#path", package.cargo_name, package.version))
+}
+
+fn cargo_id(package: &TestPackage) -> String {
+    format!(
+        "path+file://{}#{}@{}",
+        package.root.display(),
+        package.cargo_name,
+        package.version
+    )
+}
+
+struct ResolveEdge {
+    from: String,
+    name: String,
+    to: String,
+    package: String,
+}
+
+struct TestPackage {
+    root: PathBuf,
+    cargo_name: String,
+    version: String,
+}
+
+struct TestWorkspace {
+    root: PathBuf,
+}
+
+impl TestWorkspace {
+    fn new(name: &str) -> Self {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sifr_pkg_m2_{name}_{stamp}"));
+        fs::create_dir_all(&root).expect("create temp workspace");
+        Self { root }
+    }
+
+    fn package(&self, name: &str) -> PathBuf {
+        let path = self.root.join(name);
+        fs::create_dir_all(&path).expect("create temp package");
+        path
+    }
+}

--- a/crates/sifr_package/src/ops/session_discovery.rs
+++ b/crates/sifr_package/src/ops/session_discovery.rs
@@ -1,31 +1,33 @@
 use crate::cargo::metadata::CargoPackageId;
-use std::fs;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::path::{Path, PathBuf};
 
 pub(super) fn find_manifest(start: &Path) -> Option<PathBuf> {
-    let mut current = if start.is_file() {
+    let mut provider = DiskSourceProvider::new();
+    let mut current = if provider.is_file(start) {
         start.parent()?
     } else {
         start
     };
     loop {
         let candidate = current.join("sifr.toml");
-        if candidate.is_file() {
+        if provider.is_file(&candidate) {
             return Some(candidate);
         }
-        if is_cargo_workspace_root(current) {
+        if is_cargo_workspace_root(current, &mut provider) {
             return None;
         }
         current = current.parent()?;
     }
 }
 
-fn is_cargo_workspace_root(root: &Path) -> bool {
+fn is_cargo_workspace_root(root: &Path, provider: &mut impl SourceProvider) -> bool {
     let manifest = root.join("Cargo.toml");
-    let Ok(source) = fs::read_to_string(manifest) else {
+    let Ok(source) = provider.read_file(&manifest) else {
         return false;
     };
     source
+        .as_str()
         .parse::<toml::Table>()
         .is_ok_and(|table| table.contains_key("workspace"))
 }

--- a/crates/sifr_package/src/ops/session_targets.rs
+++ b/crates/sifr_package/src/ops/session_targets.rs
@@ -1,4 +1,5 @@
 use crate::diag::PackageDiagnostic;
+use sifr_frontend::{DiskSourceProvider, SourceProvider};
 use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -12,16 +13,17 @@ pub(super) fn discover_app_targets(
     package_name: &str,
 ) -> Result<Vec<AppTarget>, PackageDiagnostic> {
     let mut targets = Vec::new();
+    let mut provider = DiskSourceProvider::new();
     for source_root in source_roots {
         let main = source_root.join("main.sifr");
-        if main.is_file() {
+        if provider.is_file(&main) {
             targets.push(AppTarget {
                 name: package_name.to_string(),
                 path: main,
             });
         }
         let bin_root = source_root.join("bin");
-        collect_bin_targets(&bin_root, &bin_root, &mut targets)?;
+        collect_bin_targets(&bin_root, &bin_root, &mut targets, &mut provider)?;
     }
     Ok(targets)
 }
@@ -30,20 +32,19 @@ fn collect_bin_targets(
     root: &Path,
     current: &Path,
     targets: &mut Vec<AppTarget>,
+    provider: &mut impl SourceProvider,
 ) -> Result<(), PackageDiagnostic> {
-    let Ok(entries) = std::fs::read_dir(current) else {
+    let Ok(entries) = provider.read_dir(current) else {
         return Ok(());
     };
     for entry in entries {
-        let Ok(entry) = entry else {
-            continue;
-        };
-        let path = entry.path();
-        if path.is_dir() {
-            collect_bin_targets(root, &path, targets)?;
-        } else if path
-            .extension()
-            .is_some_and(|extension| extension == "sifr")
+        let path = entry.path;
+        if entry.is_dir {
+            collect_bin_targets(root, &path, targets, provider)?;
+        } else if entry.is_file
+            && path
+                .extension()
+                .is_some_and(|extension| extension == "sifr")
         {
             let Some(name) = target_name(root, &path) else {
                 continue;

--- a/crates/sifr_package/src/source/layout.rs
+++ b/crates/sifr_package/src/source/layout.rs
@@ -1,3 +1,4 @@
+use sifr_frontend::{DiskSourceProvider, SourceProvider, SourceProviderError};
 use std::path::Path;
 
 const CANONICAL_PURE_MARKER: &str =
@@ -27,7 +28,18 @@ pub fn validate_pure_marker_source(source: &str) -> MarkerValidation {
 }
 
 pub fn validate_pure_marker_file(path: &Path) -> Result<MarkerValidation, std::io::Error> {
-    std::fs::read_to_string(path).map(|source| validate_pure_marker_source(&source))
+    let mut provider = DiskSourceProvider::new();
+    validate_pure_marker_file_with_provider(path, &mut provider)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
+pub fn validate_pure_marker_file_with_provider(
+    path: &Path,
+    provider: &mut impl SourceProvider,
+) -> Result<MarkerValidation, SourceProviderError> {
+    provider
+        .read_file(path)
+        .map(|source| validate_pure_marker_source(source.as_str()))
 }
 
 fn strip_rust_comments_and_whitespace(source: &str) -> String {

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -270,6 +270,7 @@ New crates added per milestone as needed:
 - Ad-hoc semantic diagnostic taxonomy: `sifr_diagnostics` (shared diagnostic model and schema, introduced before migrating existing emission paths)
 - TypeScript-Go architecture transfer M0: `sifr_source` (bottom-of-graph source text, line-map, source-file metadata, and editor position conversion authority)
 - TypeScript-Go architecture transfer M1: `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md` records the pre-session direct-read inventory, current LSP single-file rebuild caveat, aggregate LSP budget caveat, and guardrail automation before M2-M5 behavior migration.
+- TypeScript-Go architecture transfer M2: `sifr_frontend::SourceProvider` is the typed semantic filesystem boundary. `internal_docs/typescript_go_architecture_transfer_m2_source_provider.md` records how `DiskSourceProvider`, `OverlaySourceProvider`, and `TrackingSourceProvider` cover disk reads, unsaved editor buffers, read/probe/canonicalization dependency records, failed lookup records, and package import ambiguity before `WorkspaceSession` owns overlay lifecycle in M3.
 - milestone_ffi: FFI codegen extensions in `sifr_codegen`
 - Phase 35 shared analysis/query architecture: `sifr_frontend` (canonical frontend API and query/database ownership)
 - milestone_dev_tooling: `sifr_lsp` (language server), `sifr_format` (formatter), `sifr_lint` (linter)
@@ -282,7 +283,9 @@ flows through `sifr_syntax` into the Sifr Ruff fork parser, AST, comments,
 trivia, and formatter rules, then through the Sifr-owned `sifr_format` wrapper.
 `sifr_format` owns Sifr-facing options, config conversion, deterministic
 diagnostics, and text edits; it does not lower to HIR, type-check, or run
-ownership analysis.
+ownership analysis. Standalone file and config reads use short-lived
+`sifr_frontend::SourceProvider` instances so formatting does not create a
+separate source text or line-map authority.
 
 The single formatter core is shared by:
 
@@ -653,7 +656,7 @@ This contract is split across three milestones: milestone_imports (multi-file co
 
 - **Cargo-backed package substrate:** `Cargo.toml` and `Cargo.lock` own external dependency resolution, lockfile behavior, registries, Git/path sources, workspaces, publishing, vendoring, and backend Rust/native dependencies.
 - **Sifr compiler metadata:** `sifr.toml` owns Sifr package name, edition, compiler requirement, source roots, exports, privacy, aliases, and native trust policy. It does not own external dependency resolution or registry credentials.
-- **Package graph:** `crates/sifr_package` consumes `cargo metadata --format-version 1`, normalizes Cargo packages and resolved dependency edges, and derives `SifrPackageGraph` plus `PackageSourceMap` for the normal frontend/HIR/codegen pipeline.
+- **Package graph:** `crates/sifr_package` consumes `cargo metadata --format-version 1`, normalizes Cargo packages and resolved dependency edges, and derives `SifrPackageGraph` plus `PackageSourceMap` for the normal frontend/HIR/codegen pipeline. Package source-map construction uses the SourceProvider boundary for source-root traversal and `__init__.sifr` API reads, and preserves otherwise legal ambiguous module candidates for import-site `SIFR-IMPORT-0005` diagnostics instead of failing construction as `SIFR-PACKAGE-*`.
 - **Package identity:** package instance identity includes Cargo package id, version, and source identity. Multiple Cargo-selected versions are allowed when each package's direct dependency scope remains unambiguous.
 - **Distribution:** a Sifr package is a valid Cargo package carrying `.sifr` source and `[package.metadata.sifr] manifest = "sifr.toml"`. Pure Sifr packages include only the canonical Rust marker target; Rust-backed packages must declare and pass backend trust validation.
 - **No Sifr-native lockfile in Phase 37:** there is no committed `sifr.lock`; reproducibility is derived from `Cargo.toml`, `Cargo.lock`, `sifr.toml`, selected Sifr source, compiler/toolchain inputs, and package feature/selector inputs.

--- a/internal_docs/frontend_cache_invalidation.md
+++ b/internal_docs/frontend_cache_invalidation.md
@@ -10,6 +10,13 @@ classification, module signatures, structural replacement, and snapshot-scoped
 cache reuse are planned in M6-M10 and are not implemented by the current
 `FrontendContext::update_module_source` path.
 
+TypeScript-Go architecture transfer M2 note: project loading can now record
+source-provider dependency reads before snapshots exist. The tracked records
+include successful file reads, directory reads, file and directory probes,
+canonicalization, and failed lookups. These records are not yet consumed for
+dirty-scope invalidation; M3-M6 wire them into session snapshots and
+dependency-sensitive invalidation.
+
 ## Cache State
 
 Each `FrontendContext` module owns cached parse, lower, diagnostics, and analysis entries. Query results include metadata with:

--- a/internal_docs/frontend_query_architecture.md
+++ b/internal_docs/frontend_query_architecture.md
@@ -24,6 +24,14 @@ here is the pre-session, process-local query facade. M3/M4 own re-expressing
 this surface around `WorkspaceSession` and immutable `WorkspaceSnapshot`
 handles; M2 owns moving semantic file reads behind `SourceProvider` first.
 
+TypeScript-Go architecture transfer M2 note: `sifr_frontend` now exposes the
+source-provider boundary. `FrontendContext::load_project_with_provider` accepts
+any `SourceProvider`, `load_project_tracked` returns dependency reads captured
+by `TrackingSourceProvider`, and `OverlaySourceProvider` can substitute unsaved
+buffer text for disk files without mutating disk state. The overlay record owns
+URI, path, document version, source hash, source text/line map, and disk-match
+state; M3 will move overlay lifecycle ownership into `WorkspaceSession`.
+
 ## Driver Consumption
 
 Phase 35 m35.4b routes `check`, `build`, `run`, `emit`, project compilation, and test-runner frontend flows through `sifr_frontend` without preserving duplicate semantics-bearing driver frontend paths. The driver remains responsible for stdlib bootstrap/cache plumbing, build planning, codegen invocation, Cargo/rustc execution, and renderer/CLI presentation.

--- a/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
+++ b/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
@@ -8,6 +8,12 @@ the actual pre-session state after M0 and before M2-M5 behavior migration. Later
 milestones may update this file and its checker when they intentionally replace
 one of these current limitations.
 
+M2 update: `crates/sifr_frontend/src/source_provider.rs` is now the intentional
+filesystem boundary implementation and is excluded from the direct-read
+inventory scan. Direct `std::fs` calls or physical `Path` probes outside that
+boundary remain inventory-controlled until they are migrated or explicitly
+classified as non-semantic exceptions.
+
 ## Locked Terms
 
 M1 locks the following terms before behavior migration starts:
@@ -56,8 +62,8 @@ without treating probes as source content reads.
 | Package namespace API | `crates/sifr_package/src/imports/namespace_api.rs:32`, `crates/sifr_package/src/imports/namespace_api.rs:264` | Package public API extraction reads `__init__.sifr` and probes child namespaces. | Provider-tracked package source reads and probes. |
 | Package source layout | `crates/sifr_package/src/source/layout.rs:30` | Pure-marker validation reads generated package source files. | Reviewed provider-backed package tooling read or non-semantic generated-output exception. |
 | Package session discovery and targets | `crates/sifr_package/src/ops/session_discovery.rs:6`, `crates/sifr_package/src/ops/session_discovery.rs:13`, `crates/sifr_package/src/ops/session_discovery.rs:25`, `crates/sifr_package/src/ops/session_targets.rs:17`, `crates/sifr_package/src/ops/session_targets.rs:34`, `crates/sifr_package/src/ops/session_targets.rs:42` | Package CLI/session discovery probes manifests and source roots. | Provider-tracked package session reads and probes where they affect compilation. |
-| CLI lint command reads | `crates/sifr/src/lint_cli.rs:308`, `crates/sifr/src/lint_cli.rs:496` | CLI lint command reads individual files for linting and probes path exclusion. | Provider-backed for semantic source reads; CLI target filtering remains a documented command-surface probe until M2 classifies it. |
-| CLI check/package command reads | `crates/sifr/src/check_and_package_commands.rs:409`, `crates/sifr/src/check_and_package_commands.rs:415`, `crates/sifr/src/check_and_package_commands.rs:427`, `crates/sifr/src/check_and_package_commands.rs:551`, `crates/sifr/src/check_and_package_commands.rs:554`, `crates/sifr/src/check_and_package_commands.rs:583`, `crates/sifr/src/check_and_package_commands.rs:590`, `crates/sifr/src/check_and_package_commands.rs:601` | CLI package/check command surfaces probe targets and cache paths and read package sources for command output. | Provider-backed for semantic source reads; command-output/cache probes remain documented exceptions where non-semantic. |
+| CLI lint command reads | `crates/sifr/src/lint_cli.rs:308`, `crates/sifr/src/lint_cli.rs:496`, `crates/sifr/src/lint_cli.rs:499` | CLI lint command reads individual files for linting and probes path exclusion/start-dir shape. | Provider-backed for semantic source reads; CLI target filtering remains a documented command-surface probe until M2 classifies it. |
+| CLI check/package command reads | `crates/sifr/src/check_and_package_commands.rs:409`, `crates/sifr/src/check_and_package_commands.rs:415`, `crates/sifr/src/check_and_package_commands.rs:427`, `crates/sifr/src/check_and_package_commands.rs:551`, `crates/sifr/src/check_and_package_commands.rs:554`, `crates/sifr/src/check_and_package_commands.rs:579`, `crates/sifr/src/check_and_package_commands.rs:583`, `crates/sifr/src/check_and_package_commands.rs:590`, `crates/sifr/src/check_and_package_commands.rs:601` | CLI package/check command surfaces probe targets and cache paths and read package sources for command output. | Provider-backed for semantic source reads; command-output/cache probes remain documented exceptions where non-semantic. |
 | CLI entrypoint probing | `crates/sifr/src/cli_model_and_entrypoint.rs:634`, `crates/sifr/src/cli_model_and_entrypoint.rs:690`, `crates/sifr/src/cli_model_and_entrypoint.rs:716`, `crates/sifr/src/cli_model_and_entrypoint.rs:721` | CLI mode resolution reads manifests/source files and probes sibling modules. | Provider-backed for semantic source reads; CLI mode-selection probes remain tracked lookup dependencies. |
 
 Permitted M1 exceptions:
@@ -80,6 +86,27 @@ Permitted M1 exceptions:
   `crates/sifr_package/src/projection.rs:187` are package-management output and
   repair-state effects unless a later package-aware snapshot milestone promotes
   a specific read into package identity.
+
+## M2 Disposition
+
+M2 introduced `sifr_frontend::SourceProvider` and moved the following rows
+behind provider-backed APIs while keeping disk-backed compatibility wrappers for
+pre-session callers:
+
+- Frontend project entrypoint, directory, and module reads.
+- Formatter source, config, and directory traversal reads.
+- Linter source, config, and target-probe reads that are not delegated to the
+  `ignore` walker.
+- Package manifest reads and manifest validation probes.
+- Package source-map traversal, namespace API reads, and namespace child probes.
+- Package session manifest discovery and app target discovery.
+- Package pure-marker validation and offline source-availability probes.
+
+Remaining CLI command-output and cache probes, including
+`crates/sifr/src/check_and_package_commands.rs:579`, stay documented
+non-semantic command-surface exceptions until a later package-aware snapshot or
+build-metadata milestone promotes a specific path into compiler-service
+identity.
 
 ## Current Source-Map Guardrail
 
@@ -140,6 +167,12 @@ coverage is smoke coverage only.
 
 - M2 must either route every non-exempt inventory row through `SourceProvider`
   or update this inventory with a reviewed exception before closure.
+- M3 must move overlay lifecycle and tracked dependency records into
+  `WorkspaceSession` snapshots instead of leaving them as ad hoc provider
+  outputs.
+- M6 must consume tracked file, directory, canonicalization, probe, and failed
+  lookup records for dirty-scope classification and dependency-sensitive
+  invalidation.
 - M5 must update the current LSP single-file rebuild caveat and the matching
   script checks when `DocumentStore` stops owning request-local
   `AnalysisHost::open_single_file` rebuilds.

--- a/internal_docs/typescript_go_architecture_transfer_m2_source_provider.md
+++ b/internal_docs/typescript_go_architecture_transfer_m2_source_provider.md
@@ -1,0 +1,92 @@
+# TypeScript-Go Architecture Transfer M2 Source Provider
+
+status: M2 implementation review
+
+M2 introduces the first compiler-service filesystem boundary before the
+workspace/session layer exists. The new boundary is intentionally small:
+callers can read files, enumerate directories, probe files/directories, and
+canonicalize paths through `sifr_frontend::SourceProvider`.
+
+## Provider Model
+
+`sifr_frontend` now exposes:
+
+- `SourceProvider`: typed source filesystem interface for semantic reads,
+  directory reads, path probes, and canonicalization.
+- `DiskSourceProvider`: production disk-backed implementation.
+- `OverlaySourceProvider`: read-through provider that can substitute open
+  editor buffer text for disk files without mutating disk state.
+- `TrackingSourceProvider`: wrapper that records successful reads, path probes,
+  canonicalization, and failed lookups as `SourceDependency` records.
+- `OverlayDocument`: overlay metadata with URI, path, document version, source
+  text, source hash, and disk-match state.
+
+The overlay record stores `SourceText`, so the source text/line-map authority
+continues to flow through the M0 `sifr_source` model instead of reintroducing a
+second line-map implementation.
+
+## Migrated Reads
+
+The following semantic read paths now use the provider boundary:
+
+- `FrontendContext::load_project_with_provider` reads project entrypoints,
+  project directories, and project modules through a supplied provider.
+- `FrontendContext::load_project_tracked` returns the dependency records
+  captured during project loading.
+- Driver module resolution, workspace manifest discovery, project file
+  discovery, and package import closure materialization use provider-backed
+  reads and probes.
+- Package manifest loading, source-root validation, source-map traversal, and
+  namespace API extraction accept provider-backed reads.
+- Formatter and linter source/config reads use short-lived disk providers
+  rather than separate direct source reads.
+- Package CLI/session discovery and target selection use provider-backed
+  manifest/source-root probes where those probes affect package selection.
+
+M2 does not consume dependency records for invalidation yet. M3-M6 own session
+snapshot capture, event compaction, dirty-scope classification, and precise
+invalidation.
+
+## Package Import Ambiguity
+
+`PackageSourceMap` now separates fatal source-map construction failures from
+queryable import ambiguity:
+
+- valid duplicate module candidates are retained in `ambiguous_modules`
+  instead of turning source-map construction into a package-fatal error;
+- `PackageImportResolutionResult` distinguishes `Resolved`, `Ambiguous`,
+  `Unresolved`, `PrivateAccess`, and `FatalPackageMapFailure`;
+- package import closure diagnostics can map ambiguity back to the import site
+  with `SIFR-IMPORT-0005` and candidate paths;
+- legacy `resolve_import` remains available and maps ambiguity into a package
+  diagnostic for existing non-source-callers.
+
+End-to-end package runtime fixtures remain M17 scope. M2 proves the state model
+and import-resolution branch coverage in package unit tests.
+
+## Direct-Read Exceptions After M2
+
+The M1 guardrail scanner remains active. After M2, remaining production direct
+filesystem sites are documented exceptions rather than semantic source reads:
+
+- build artifact metadata/cache checks in `crates/sifr_driver/src/build`;
+- formatter artifact-cache existence probing in `crates/sifr/src`;
+- package projection and repair-state effects in `crates/sifr_package`;
+- package lock/source-layout checks that remain package-management or generated
+  output validation until package-aware snapshots promote them.
+
+M15 owns persistent build metadata and any future `.sifrbuildinfo` boundary.
+
+## Validation
+
+M2 focused validation:
+
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`
+- `cargo fmt --check`
+- `python3 scripts/check_file_size_guardrails.py`
+- `cargo test -p sifr -- --skip test_e2e_pass`
+- `cargo test -p sifr_driver -p sifr_package -p sifr_frontend -p sifr_format -p sifr_lint`
+- `cargo clippy --workspace -- -D warnings`
+
+The full quick validation gate remains required before PR closure.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
@@ -157,6 +157,22 @@ This phase locks the TypeScript-Go-derived architecture transfer before implemen
 - `2026-06-01`: M1 implementation review pass 2 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-2.md`; reviewer requested fixing the direct-read/probe regex and adding `crates/sifr_package/src/cargo/lock_modes.rs:46`.
 - `2026-06-01`: M1 implementation review pass 3 recorded in `reviews/typescript-go-architecture-transfer-m1-review-pass-3.md`; reviewer approved M1 for PR after focused validation.
 - `2026-06-01`: M1 merged via PR [#2230](https://github.com/sifr-lang/sifr/pull/2230), merge commit `a1a402c01348181684fc028c6fc14fba76d8b0cf`. Duplicate PR [#2231](https://github.com/sifr-lang/sifr/pull/2231) was closed without merge.
+- `2026-06-01`: M2 validation in progress on branch `wave_tsgo_m2_source_provider_overlay`.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS for M2 after excluding the intentional `SourceProvider` boundary implementation from the direct-read scan and documenting remaining non-semantic exceptions.
+- `2026-06-01`: `cargo fmt --check` -> PASS for M2.
+- `2026-06-01`: `python3 scripts/check_file_size_guardrails.py` -> PASS for M2.
+- `2026-06-01`: `cargo test -p sifr -- --skip test_e2e_pass` -> PASS for M2.
+- `2026-06-01`: `cargo test -p sifr_driver -p sifr_package -p sifr_frontend -p sifr_format -p sifr_lint` -> PASS for M2.
+- `2026-06-01`: `cargo clippy --workspace -- -D warnings` -> PASS for M2.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` initially failed for M2 on package-manager file-size guardrails; `imports/source_map.rs`, `manifest/sifr.rs`, and the M2 package tests were split by responsibility.
+- `2026-06-01`: `python3 scripts/check_package_manager_guardrails.py` and `cargo test -p sifr_package` -> PASS after M2 package guardrail remediation.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS for M2; report `target/validation_lane_reports/quick.latest.json`, wall time 274.59s.
+- `2026-06-01`: `cargo clippy --workspace -- -D warnings` -> PASS after final M2 package guardrail splits.
+- `2026-06-01`: M2 implementation review pass 3 recorded in `reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md`; reviewer approved M2 for PR with non-blocking follow-up notes.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` initially failed on package-manager file-size guardrails after M2 expanded `source_map.rs`, `manifest/sifr.rs`, and `milestone_37_3_tests.rs`; source-map discovery/resolution and manifest field parsing were split by responsibility.
+- `2026-06-01`: `cargo test -p sifr_package`, `cargo clippy --workspace -- -D warnings`, and `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS after the package-manager guardrail remediation.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS after M2 remediation; report `target/validation_lane_reports/quick.latest.json`, wall time 260.57s.
+- `2026-06-01`: M2 final implementation review pass 4 recorded in `reviews/typescript-go-m2-source-provider-overlay-review-pass-4.md`; reviewer approved the current post-remediation tree for PR.
 
 ## PR Log
 

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -1,6 +1,26 @@
 # Ad Hoc Phase: TypeScript-Go Compiler Architecture Transfer
 
-Status: planned on 2026-05-27
+Status: in progress
+
+## Execution Tracker
+
+| Milestone | State | PR | Notes |
+| --- | --- | --- | --- |
+| M0 Source And Position Foundation | merged | [#2229](https://github.com/sifr-lang/sifr/pull/2229) | Added `sifr_source`, real source-map conversions, and source-position guardrails. |
+| M1 Architecture Contract And Guardrails | merged | [#2230](https://github.com/sifr-lang/sifr/pull/2230), [#2232](https://github.com/sifr-lang/sifr/pull/2232) | Added pre-flight direct-read/LSP/budget guardrails and follow-up tracker update. |
+| M2 Source Provider And Overlay Store | in PR | [#2233](https://github.com/sifr-lang/sifr/pull/2233) | Adds `SourceProvider`, `DiskSourceProvider`, `OverlaySourceProvider`, `TrackingSourceProvider`, `OverlayDocument`, `SourceDependency*`, provider-backed project/package/lint/format reads, `PackageImportAmbiguity`, and `PackageImportResolutionResult`; new tests cover overlay shadowing, nested overlay directories, tracked reads, provider-backed project loading, package ambiguity, unresolved/private/fatal import states, and existing lint/format/package behavior. |
+
+M2 local validation so far:
+
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`
+- `cargo fmt --check`
+- `python3 scripts/check_file_size_guardrails.py`
+- `cargo test -p sifr -- --skip test_e2e_pass`
+- `cargo test -p sifr_driver -p sifr_package -p sifr_frontend -p sifr_format -p sifr_lint`
+- `cargo clippy --workspace -- -D warnings`
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 274.59s
+- `scripts/run_all_tests.sh --profile quick` passed after package source-map and manifest helper modules were split under the package-manager line guardrail.
 
 ## Purpose
 
@@ -280,10 +300,10 @@ The current repo has enough compiler-service foundation to start a TypeScript-Go
 | D0-2 | A shared source text and line-map authority is required before overlay snapshots. | `sifr_frontend::SourceText` is a string wrapper, `sifr_syntax::SourceText` has UTF-8 line starts, and `sifr_diagnostics::SourceMap` has a separate line-start model. | M0 must define which type owns canonical line maps and UTF-8/UTF-16/UTF-32 conversions so frontend, diagnostics, and LSP do not keep diverging conversion logic. |
 | D0-3 | The VFS/source-provider boundary is a phase-start blocker for project snapshots. | `FrontendContext::load_project` reads entrypoints, project directories, and modules through `std::fs` directly. Additional examples include `crates/sifr_driver/src/project/discovery.rs` project directory and module reads, `crates/sifr_lint/src/engine.rs` lint file reads, `crates/sifr_format/src/lib.rs` formatter directory/file reads, and `crates/sifr_package/src/manifest/sifr.rs` manifest reads. | M1 must inventory every production direct read with file/line references. M2 cannot close until workspace-backed compiler reads go through a typed source provider with disk, overlay, and tracked-read implementations. |
 | D0-4 | LSP must stop owning per-document compiler hosts before snapshot scheduling can be meaningful. | `DocumentState::new`, `change_full`, `change_incremental`, and `save` call `rebuild`; `rebuild` creates `FrontendMode::SingleFile` and calls `AnalysisHost::open_single_file`. | Persistent workspace `AnalysisSession` is required before M4 scheduler/cancellation work. Until then, LSP performance evidence mostly measures fast single-file rebuilds, not a long-lived project service. |
-| D0-5 | The current snapshot type is only a revision token. | `AnalysisSnapshot` stores only `AnalysisRevision`; it does not own immutable file, graph, source-map, cache, symbol-index, or overlay state. | M1 must define real snapshot contents. M2 must introduce immutable snapshot handles before any copy-on-write or stale-result guarantees are claimed. |
+| D0-5 | The current snapshot type is only a revision token. | `AnalysisSnapshot` stores only `AnalysisRevision`; it does not own immutable file, graph, source-map, cache, symbol-index, or overlay state. | M1 defines real snapshot contents. M3 introduces the workspace session data model and M4 migrates analysis onto immutable snapshot handles before any copy-on-write or stale-result guarantees are claimed. |
 | D0-6 | Dirty-scope and module-signature design must precede structural replacement. | `FrontendContext::update_module_source` clears lower, diagnostics, and analysis for all modules on any text change and bumps graph revision. Repository search finds no existing `DirtyScope`, `ModuleSignature`, `ExportSignature`, `can_replace_module_in_project`, `CowProjectState`, `WorkspaceSession`, or `WorkspaceSnapshot` implementation outside this planning issue. | M1 defines `DirtyScope` and `ModuleSignature`; M3 implements them before `can_replace_module_in_project` is allowed to reuse state. |
 | D0-7 | A real scheduler needs cancellation tokens and snapshot identity first. | `Scheduler` only maps methods to labels, `RequestQueue` only tracks pending IDs, request handling is synchronous, and `$/cancelRequest` only removes an ID from the pending set. | M1-M3 implementation must stay serialized unless cancellation/snapshot tokens are introduced earlier. M4 builds cancellation around captured snapshots and request tokens before background diagnostics, references, index warming, progress, or parallel request work are enabled. |
-| D0-8 | Raw editor/watch events must be compacted before asynchronous scheduling or fine-grained watcher invalidation. | `workspace/didChangeWatchedFiles` republishes diagnostics directly; `didChange` applies each edit immediately and republishes diagnostics. | Event compaction is not a standalone phase-start correctness blocker while the server stays synchronous. It becomes required before async scheduler behavior or watcher-storm invalidation ships. M2 introduces editor-event compaction for open/change/save/close; M9 extends it to watcher storms and seen-file-derived watch globs. |
+| D0-8 | Raw editor/watch events must be compacted before asynchronous scheduling or fine-grained watcher invalidation. | `workspace/didChangeWatchedFiles` republishes diagnostics directly; `didChange` applies each edit immediately and republishes diagnostics. | Event compaction is not a standalone phase-start correctness blocker while the server stays synchronous. M6 introduces editor-event compaction and dirty-scope classification for open/change/save/close; M15 extends watcher-storm degradation and seen-file-derived watch globs. |
 | D0-9 | Protocol-level performance gates are not yet split enough to prove editor latency. | `verification/performance/manifest.json` has Phase 35 `perf.interactive.*` cases and one aggregate `perf.lsp.request_families` case. `lsp_query_bench.py` only implements the aggregate scenario. | M10 must split the harness and manifest into per-request LSP cases. Aggregate request-family timing remains smoke coverage only. |
 | D0-10 | Symbol/index ranges need the M0 source-map foundation before editor features can claim range correctness. | `SymbolIndex::document_symbols` currently returns `range: None`, and workspace symbols use one whole-project index keyed by graph/source revision. | M1/M4 LSP correctness work must not claim precise symbol/navigation ranges until M0 conversion is complete. M5 bucketed indexes then require project/package/stdlib buckets before auto-import or workspace completion scaling is claimed. |
 | D0-11 | Current docs overstate some desired layers as implemented reality. | `internal_docs/lsp_server.md` describes `RequestQueue`, `Scheduler`, `SnapshotLayer`, line indexes, cancellation tokens, and UTF conversion as required layers, but the current code only implements a small subset. | M0/M1 must update issue wording and implementation trackers to distinguish completed foundations from planned architecture. Future closeout gates must verify behavior, not only names. |

--- a/reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md
+++ b/reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md
@@ -1,0 +1,72 @@
+# M2 Source Provider & Overlay Store — Review Pass 2
+
+Branch: `wave_tsgo_m2_source_provider_overlay` (diff vs `origin/main`)
+Scope: `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md` M2 row + AC-31
+
+---
+
+## 1. Blocking findings
+
+**None.**
+
+The two pass-1 blockers have both closed:
+
+- **M1 guardrail drift (was: `check_typescript_go_m1_guardrails.py` failing).** The script now passes against the working tree, including `--self-test`. The one remaining direct read in `crates/sifr/src/check_and_package_commands.rs:579` (`Ok(config.cache_dir.join(key).is_file())`) is the documented CLI cache-probe exception, referenced in the M1 doc inventory.
+- **"Direct production reads migrated or listed as exceptions" not met (was: `source/layout.rs:30`, `cargo/lock_modes.rs:46`, `ops/session_discovery.rs`, `ops/session_targets.rs`).** All four are now provider-backed: `validate_pure_marker_file_with_provider` (`source/layout.rs:36-43`), `validate_offline_source_availability_with_provider` (`cargo/lock_modes.rs:44-76`), `session_discovery.rs` and `session_targets.rs` all consume `provider.is_file`/`provider.read_file`/`provider.read_dir`.
+
+Provider implementations, overlay metadata, and the package ambiguity model all match the M2 spec. Validations listed in the request all pass locally; no regressions in `cargo test -p sifr_driver` (144), `sifr_package` (68), `sifr_frontend` (9), `sifr_lint` (22), `sifr_format` (7), or `sifr` unit/integration (89 total).
+
+---
+
+## 2. Non-blocking findings
+
+Ordered by severity within this section.
+
+### 2.1 M1 doc inventory line numbers have drifted from current code
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md`
+The "Direct FS reads in production source" table references line numbers that no longer host direct reads after the M2 migration, e.g. `graph_cache_and_queries.rs:312/322/359`, `discovery.rs:90/118/180/332/574`, `imports/namespace_api.rs:34`. The M1 guardrail script's `REQUIRED_DOC_SNIPPETS` only checks that the *symbols* appear, not that the line numbers point at code that still does a direct read. The doc is therefore misleading but not incorrect.
+**Suggested fix:** re-run the inventory against the post-M2 tree and update the table; the M1 doc's "Future Milestone Update Obligations" already establishes the convention.
+
+### 2.2 M1 doc does not name M3/M6 as owners of `TrackingSourceProvider` records
+**File:** `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:11-15` ("Future Milestone Update Obligations")
+The M2 update note says readers must consult `load_project_tracked` outputs, but does not state which later milestone is responsible for consuming the recorded `SourceDependency` stream (M3 `WorkspaceSession`/workspace snapshot work, or M6 file-watcher). The TrackingProvider already records FileRead / DirectoryRead / FileProbe / DirectoryProbe / Canonicalize / FailedLookup — the doc should pin the consumer so the next milestone's diff can be reviewed against a known contract.
+**Suggested fix:** add one line in the update-obligations section naming the consumer milestone.
+
+### 2.3 Visibility of `_with_provider` variants is inconsistent
+**Files:**
+- `crates/sifr_format/src/lib.rs:450-464` — `read_source_with_provider` is `pub`
+- `crates/sifr_format/src/config.rs` — provider-backed, `pub`
+- `crates/sifr_package/src/manifest/sifr.rs:60-73` — `load_with_provider` is `pub`
+- `crates/sifr_package/src/manifest/validate.rs`, `source/layout.rs`, `cargo/lock_modes.rs` — provider variants are `pub(crate)` / crate-local
+- `crates/sifr_driver/src/project/discovery.rs`, `workspace/mod.rs` — `pub(crate)` provider variants
+- `crates/sifr_lint/src/{config,discovery,engine}.rs` — `pub(crate)` provider variants
+
+The public surface is the `SourceProvider` trait itself, which is `pub` in `crates/sifr_frontend/src/source_provider.rs:61-67`. The `*_with_provider` functions are plumbing, not API. Pick one (recommend `pub(crate)`) and apply uniformly so the boundary is unambiguous to the next reader.
+**Suggested fix:** standardize on `pub(crate)` for all `*_with_provider` plumbing functions; only `SourceProvider`, `OverlayDocument`, `SourceProviderError`, `SourceProviderErrorKind`, `SourceDirEntry`, `SourceDependency`, `SourceDependencyKind`, and the new `PackageImport*` types belong on the public surface.
+
+### 2.4 `OverlaySourceProvider::read_dir` silent fallback deserves a TODO
+**File:** `crates/sifr_frontend/src/source_provider.rs:174-260`
+When an inner `read_dir` call returns `Err(_)`, the method returns an empty `Vec<SourceDirEntry>` rather than propagating the error. For `read_file`/`is_file` the provider does propagate. The asymmetry is intentional (so overlay additions from unsaved buffers still surface in the directory listing) but a future file-watcher (M6) will want a "dirty directory" signal. Add a one-line `// TODO(m6):` here so the M6 reviewer finds it.
+
+### 2.5 `package_import_ambiguity_source_diagnostic` has no driver-level test
+**File:** `crates/sifr_driver/src/project/package_discovery.rs:209-275`
+The conversion from `PackageImportAmbiguity` → `sifr_diagnostics::Diagnostic` with `DiagnosticCode::IMPORT_AMBIGUOUS_SOURCE_MODULE` is untested at the driver layer. The package-layer test in `milestone_37_3_tests.rs` covers the source-map half, but the diagnostic-emission half (package id, cargo id, candidate paths, severity) is uncovered. This is M17 scope but closing it now would prevent silent regressions during M3.
+
+---
+
+## 3. Missing validation or test coverage
+
+- **AC-31 negative check** — confirm that ambiguity does *not* also emit `SIFR-IMPORT-0005` (unresolved) or any `SIFR-PACKAGE-*` diagnostic. The current `import_resolution_result_preserves_ambiguous_candidates` test asserts the source-map state; an end-to-end check that the diagnostic stream contains exactly one `SIFR-IMPORT-AMBIGUOUS-SOURCE-MODULE` and nothing else would close the spec criterion tightly. **M17 scope; M2 is not blocking on this.**
+- **Driver-level ambiguity diagnostic test** — see 2.5 above.
+- **`OverlaySourceProvider` round-trip with a deep overlay** — the current test `overlay_provider_synthesizes_nested_directories` covers depth 1; a depth-2/3 case would protect against a future refactor that flattens `Path` comparisons. Not blocking.
+- **CI workflow step for `check_typescript_go_m1_guardrails.py`** — the M1 doc says this script must be run, but no `.github/workflows` step enforces it. Recommended, not blocking for M2.
+
+---
+
+## 4. Verdict
+
+**M2 is APPROVED for PR after the listed validations.**
+
+The provider model, overlay metadata, provider-backed read migration, tracking taxonomy, and `PackageSourceMap` ambiguity/fatal representation all match the spec. The two pass-1 blockers are closed. Items 2.1–2.5 are non-blocking follow-ups — recommend opening them as follow-up issues against the owning milestones (M3 doc sync, M6 watcher, M17 diagnostic e2e) rather than holding this PR.
+
+Ready to push the branch and open the PR.

--- a/reviews/typescript-go-m2-source-provider-overlay-review-pass-4.md
+++ b/reviews/typescript-go-m2-source-provider-overlay-review-pass-4.md
@@ -1,0 +1,71 @@
+# M2 Source Provider And Overlay Store — Review Pass 4 (post-remediation)
+
+Branch: `wave_tsgo_m2_source_provider_overlay` · diff vs `origin/main` · 37 modified files, 8 new files (incl. the 5 that comprise the package-manager guardrail remediation).
+
+## 1. Blocking findings
+
+**None.**
+
+The remediation is a pure responsibility-based split of the two package-manager files that were tripping the 420-line guardrail in the post-pass-3 quick-lane run. No call sites, no public API, no behavior changed; only the layout of the existing helpers moved.
+
+Verification I re-ran from a clean state:
+
+- `python3 scripts/check_package_manager_guardrails.py` → `PASS` (file-size + required-files + cargo-terms + banned-API + fixture matrix + demo repo checks all green)
+- `python3 scripts/check_file_size_guardrails.py` → `PASS (2020 files, limit 900 lines)`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` → `PASS`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` → `PASS`
+- `cargo test -p sifr_package` → 68/68 ok
+- `cargo test -p sifr_package -p sifr_frontend -p sifr_driver -p sifr_format -p sifr_lint` → all suites ok, 0 failed
+- `cargo clippy --workspace -- -D warnings` → clean
+
+## 2. Non-blocking findings
+
+### 2.1 Remediation layout review
+
+Both splits follow the responsibility-based decomposition the AGENTS doc calls out (split by compiler concern and ownership boundary, not line-count chunks):
+
+**`crates/sifr_package/src/imports/source_map/`** — coordinator vs I/O vs resolution
+
+- `source_map.rs:372` — coordinator: types, `PackageSourceMap::build[_with_provider]`, `resolve_import[_result]`, `from_fatal_diagnostics`, `insert_module`, `module_resolution`, `module_for_file`, private `ModuleResolution` enum, the two new `mod` declarations.
+- `source_map/discovery.rs:151` — I/O: `package_source_roots`, `root_for`, `discover_package_modules`, `discover_modules_recursive`, `discover_namespace_apis`, `module_path_from_file`, `valid_identifier`. Source-provider I/O lives here.
+- `source_map/resolution.rs:64` — pure resolution: `matching_scoped_import`, `import_root_matches`, `remap_import_path`, `is_private_dependency_module`. No I/O.
+- The `use` block in `source_map.rs:9-14` matches the new file contents (`discovery::{discover_namespace_apis, discover_package_modules, package_source_roots, root_for}` and `resolution::{is_private_dependency_module, matching_scoped_import, remap_import_path}`) — no compile-error risk.
+- All three are well under the 420-line package cap.
+
+**`crates/sifr_package/src/manifest/{sifr.rs,sifr_fields.rs,sifr/load.rs}`** — types/parse vs field-parsing vs file I/O
+
+- `manifest/sifr.rs:262` — types (`SifrPackageName`, `SifrEdition`, `CompilerRequirement`, `PackageSourceRoot`, `ImportRoot`, `TrustPolicy`, `SifrManifest`), `SifrManifest::parse`, `declares_rust_backend`, helpers `table` / `required_string` / `parse_source_roots` / `validate_relative_path`, and the `mod load;` glue.
+- `manifest/sifr_fields.rs:148` — field-level parsers: `parse_exports`, `parse_trust`, private `optional_string_list`, `validate_edition`, `validate_compiler_requirement`, `valid_identifier`. Re-exported via `sifr_fields::{parse_exports, parse_trust, validate_compiler_requirement, validate_edition}` from `sifr.rs:9-11` — the visibility is `pub(super)`, so it stays crate-internal.
+- `manifest/sifr/load.rs:30` — file-I/O entry: `SifrManifest::load` (delegates to `DiskSourceProvider::new().read_file`) and the new `SifrManifest::load_with_provider`. Error mapping (`PackageDiagnostic::missing_sifr_manifest` with the same args and `error.to_string()`) matches the pre-remediation `std::fs::read_to_string(...).map_err(...)` exactly — behavior preserved.
+- The new `sifr_fields` module is wired in `manifest/mod.rs:5` as a private `mod sifr_fields;` so it does not leak past the `manifest` facade.
+
+### 2.2 Behavioral/API equivalence check
+
+Walked each old vs new call path:
+
+- `SifrManifest::load` (was 14 lines, now 2-line delegation into `load_with_provider`) — error variant, error path, and parsed-source path are identical. `DiskSourceProvider::read_file` (sifr_frontend/src/source_provider.rs:80-86) calls `std::fs::read_to_string(path)` and wraps the error with `SourceProviderErrorKind::FileRead`, whose `Display` is `"{path}: {error}"` — note the display format is slightly different (it prefixes the path and a colon). `load_with_provider` then calls `error.to_string()` and threads that into `PackageDiagnostic::missing_sifr_manifest`, so the final user-facing diagnostic is the same shape as before. The error-message format change is contained inside the provider and is not observable to manifest consumers in any test or call site.
+- `PackageSourceMap::build` (was direct `std::fs::read_dir`, now `build_with_provider` + `DiskSourceProvider`) — discovery (`discover_modules_recursive`) uses `provider.read_dir(directory)`, which returns `Vec<SourceDirEntry>` and the function reads `entry.path` / `entry.is_dir` / `entry.is_file` — the old code did the same reads off `entry.path()` / `path.is_dir()`. The new `DiskSourceProvider::read_dir` maps each `DirEntry` into a `SourceDirEntry` carrying the same `path`, `is_file`, `is_dir` fields, and the `path` is the same `entry.path()`. So this is a one-for-one behavioral equivalent. The error path now goes through `SourceProviderError`'s `Display` (`"{path}: {error}"`) — again, the same surface diagnostic via the existing `PackageDiagnostic::invalid_sifr_manifest("source.roots", format!("could not read source root '{}': {error}", directory.display()))`. Test `import_resolution_result_preserves_ambiguous_candidates` exercises this path; passing.
+- `parse_init_sifr_reexports` — same delegation pattern (`std::fs::read_to_string` → `provider.read_file`), no behavior change.
+
+### 2.3 Pre-existing non-blocking items from pass 3 (still apply, still not blocking)
+
+The five non-blocking findings from `reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md` remain open: M1 doc line-number drift (2.1), M3/M6 ownership of `TrackingSourceProvider` consumer (2.2), `_with_provider` visibility inconsistency (2.3), `OverlaySourceProvider::read_dir` silent fallback TODO (2.4), driver-level ambiguity diagnostic test (2.5). None of these are touched by the remediation; the remediation is strictly additive (new files, new `mod` decls, removed bodies) and does not regress them.
+
+### 2.4 `sifr_frontend/src/source_provider.rs:462`
+
+Under both the 900-line repo cap and the more relaxed M1 cap, but the file hosts three distinct provider types (`DiskSourceProvider`, `OverlaySourceProvider`, `TrackingSourceProvider`) plus `SourceProviderError` / `SourceDirEntry` / `SourceDependency` / `OverlayDocument` / `SourceDependencyKind` plus the trait, with 78 lines of tests at the bottom. `check_file_size_guardrails.py` is satisfied; the M1 guardrail does not require splitting. Optional follow-up if M3 wants it — not blocking for M2.
+
+## 3. Missing validation
+
+None for M2 scope. The full `scripts/run_all_tests.sh --profile quick` was already reported PASS in the user-supplied post-remediation validation summary (wall time 260.57s, `target/validation_lane_reports/quick.latest.json`); I re-ran the targeted scripts and individual `cargo test`/`cargo clippy` lanes that exercise the split, all green.
+
+The two open follow-ups from pass 3 that are *validation* items (rather than findings): AC-31 negative check for `IMPORT_AMBIGUOUS_SOURCE_MODULE` exclusivity, and a driver-level `package_import_ambiguity_source_diagnostic` test (pass 3 §3, §2.5). These were scoped to M17 / M3 and remain non-blocking.
+
+## 4. Verdict
+
+**M2 is APPROVED for PR on the current tree.** The package-manager guardrail remediation is a clean responsibility-based split with no behavioral or API change. All quick-lane guardrails pass, all targeted test suites pass, clippy is clean. Open the PR.
+
+Sources:
+- [Pass 3 review](reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md) — the prior approval this pass revalidates after the remediation
+- [M2 source-provider doc](internal_docs/typescript_go_architecture_transfer_m2_source_provider.md) — scope and validation list
+- [Issue tracker](issues/ad-hoc-typescript-go-compiler-architecture-transfer.md) — M2 row now reflects "in review" + remediation note

--- a/verification/tooling/check_typescript_go_m1_guardrails.py
+++ b/verification/tooling/check_typescript_go_m1_guardrails.py
@@ -31,6 +31,7 @@ DIRECT_FS_SCAN_ROOTS = [
     REPO_ROOT / "crates" / "sifr_lint" / "src",
     REPO_ROOT / "crates" / "sifr_package" / "src",
 ]
+SOURCE_PROVIDER_BOUNDARY = REPO_ROOT / "crates" / "sifr_frontend" / "src" / "source_provider.rs"
 
 REQUIRED_DOC_SNIPPETS = [
     "SourceProvider",
@@ -95,11 +96,13 @@ REQUIRED_DOC_SNIPPETS = [
     "crates/sifr_package/src/projection.rs:187",
     "crates/sifr/src/lint_cli.rs:308",
     "crates/sifr/src/lint_cli.rs:496",
+    "crates/sifr/src/lint_cli.rs:499",
     "crates/sifr/src/check_and_package_commands.rs:409",
     "crates/sifr/src/check_and_package_commands.rs:415",
     "crates/sifr/src/check_and_package_commands.rs:427",
     "crates/sifr/src/check_and_package_commands.rs:551",
     "crates/sifr/src/check_and_package_commands.rs:554",
+    "crates/sifr/src/check_and_package_commands.rs:579",
     "crates/sifr/src/check_and_package_commands.rs:583",
     "crates/sifr/src/check_and_package_commands.rs:590",
     "crates/sifr/src/check_and_package_commands.rs:601",
@@ -128,6 +131,8 @@ def validate_doc(text: str, failures: list[str]) -> None:
 
 
 def is_production_source(path: Path) -> bool:
+    if path == SOURCE_PROVIDER_BOUNDARY:
+        return False
     relative_parts = path.relative_to(REPO_ROOT).parts
     if "tests" in relative_parts or "bin" in relative_parts:
         return False


### PR DESCRIPTION
## Summary

- add `sifr_frontend::SourceProvider` with disk, overlay, and tracking implementations
- route frontend/project/package/lint/format semantic reads through provider-backed APIs
- preserve package import ambiguity as queryable source-map state and split package helpers under guardrail caps
- document M2 source-provider closeout and reviewer/validation evidence

## Validation

- `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_package_manager_guardrails.py`
- `cargo test -p sifr -- --skip test_e2e_pass`
- `cargo test -p sifr_driver -p sifr_package -p sifr_frontend -p sifr_format -p sifr_lint`
- `cargo test -p sifr_package`
- `cargo clippy --workspace -- -D warnings`
- `scripts/run_all_tests.sh --profile quick` (`target/validation_lane_reports/quick.latest.json`, wall time 260.57s)

## Reviews

- `reviews/typescript-go-m2-source-provider-overlay-review-pass-3.md`
- `reviews/typescript-go-m2-source-provider-overlay-review-pass-4.md`