### PR TITLE
M3: add workspace session snapshot model

### DIFF
--- a/crates/sifr_frontend/src/lib.rs
+++ b/crates/sifr_frontend/src/lib.rs
@@ -14,3 +14,5 @@ mod source_provider;
 pub use source_provider::*;
 mod source_maps;
 pub use source_maps::*;
+mod workspace_session;
+pub use workspace_session::*;

--- a/crates/sifr_frontend/src/workspace_session.rs
+++ b/crates/sifr_frontend/src/workspace_session.rs
@@ -1,0 +1,385 @@
+use super::{
+    DiskSourceProvider, DocumentVersion, FrontendContext, FrontendInput, FrontendMode,
+    ModuleGraphView, OverlayDocument, OverlaySourceProvider, ProjectRoot, SourceDependency,
+    SourceMapView, SourcePath, SourceText, TrackingSourceProvider,
+};
+use sifr_diagnostics::RenderedDiagnostic;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WorkspaceSnapshotId(u64);
+
+impl WorkspaceSnapshotId {
+    #[must_use]
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WorkspaceRevision(u64);
+
+impl WorkspaceRevision {
+    #[must_use]
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkspaceSessionTarget {
+    SingleFile(WorkspaceSingleFileTarget),
+    Project(ProjectRoot),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceSingleFileTarget {
+    pub path: SourcePath,
+    pub mode: FrontendMode,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceCompilerOptions {
+    pub mode: FrontendMode,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkspacePackageConfigIdentity {
+    pub workspace_root: Option<SourcePath>,
+    pub entrypoint: Option<SourcePath>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceCacheRegistryHandles {
+    pub parse_generation: u64,
+    pub hir_generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceSnapshot {
+    pub id: WorkspaceSnapshotId,
+    pub revision: WorkspaceRevision,
+    pub target: WorkspaceSessionTarget,
+    pub overlays: Vec<OverlayDocument>,
+    pub source_dependencies: Vec<SourceDependency>,
+    pub source_map: Option<SourceMapView>,
+    pub module_graph: Option<ModuleGraphView>,
+    pub compiler_options: WorkspaceCompilerOptions,
+    pub package_config_identity: WorkspacePackageConfigIdentity,
+    pub cache_registry: WorkspaceCacheRegistryHandles,
+}
+
+pub struct WorkspaceSession {
+    target: WorkspaceSessionTarget,
+    overlays: BTreeMap<PathBuf, OverlayDocument>,
+    single_file_source: Option<SourceText>,
+    source_dependencies: Vec<SourceDependency>,
+    context: Option<FrontendContext>,
+    revision: WorkspaceRevision,
+    next_snapshot_id: u64,
+    compiler_options: WorkspaceCompilerOptions,
+    package_config_identity: WorkspacePackageConfigIdentity,
+    cache_registry: WorkspaceCacheRegistryHandles,
+}
+
+impl WorkspaceSession {
+    pub fn open_project(root: ProjectRoot) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let mut session = Self::project(root);
+        session.reload()?;
+        Ok(session)
+    }
+
+    #[must_use]
+    pub fn project(root: ProjectRoot) -> Self {
+        let package_config_identity = WorkspacePackageConfigIdentity {
+            workspace_root: Some(root.root.clone()),
+            entrypoint: Some(root.entrypoint.clone()),
+        };
+        Self::new(
+            WorkspaceSessionTarget::Project(root),
+            WorkspaceCompilerOptions {
+                mode: FrontendMode::ProjectEntrypoint,
+            },
+            package_config_identity,
+        )
+    }
+
+    pub fn open_single_file(input: FrontendInput) -> Result<Self, Vec<RenderedDiagnostic>> {
+        let mut session = Self::single_file(input.path.clone(), input.mode);
+        session.single_file_source = Some(input.source.clone());
+        session.context = Some(FrontendContext::load_single_file(input)?);
+        Ok(session)
+    }
+
+    #[must_use]
+    pub fn single_file(path: SourcePath, mode: FrontendMode) -> Self {
+        Self::new(
+            WorkspaceSessionTarget::SingleFile(WorkspaceSingleFileTarget { path, mode }),
+            WorkspaceCompilerOptions { mode },
+            WorkspacePackageConfigIdentity::default(),
+        )
+    }
+
+    fn new(
+        target: WorkspaceSessionTarget,
+        compiler_options: WorkspaceCompilerOptions,
+        package_config_identity: WorkspacePackageConfigIdentity,
+    ) -> Self {
+        Self {
+            target,
+            overlays: BTreeMap::new(),
+            single_file_source: None,
+            source_dependencies: Vec::new(),
+            context: None,
+            revision: WorkspaceRevision(0),
+            next_snapshot_id: 0,
+            compiler_options,
+            package_config_identity,
+            cache_registry: WorkspaceCacheRegistryHandles::default(),
+        }
+    }
+
+    pub fn reload(&mut self) -> Result<(), Vec<RenderedDiagnostic>> {
+        match &self.target {
+            WorkspaceSessionTarget::Project(root) => {
+                let mut overlay_provider = OverlaySourceProvider::new(DiskSourceProvider::new());
+                for overlay in self.overlays.values().cloned() {
+                    overlay_provider.insert_overlay(overlay);
+                }
+                let mut provider = TrackingSourceProvider::new(overlay_provider);
+                let context = FrontendContext::load_project_with_provider(root, &mut provider)?;
+                let (_, dependencies) = provider.into_parts();
+                self.context = Some(context);
+                self.source_dependencies = dependencies;
+            }
+            WorkspaceSessionTarget::SingleFile(target) => {
+                let input = self.single_file_input(target);
+                self.context = Some(FrontendContext::load_single_file(input)?);
+                self.source_dependencies = Vec::new();
+            }
+        }
+        self.revision.0 += 1;
+        Ok(())
+    }
+
+    pub fn upsert_overlay(
+        &mut self,
+        path: SourcePath,
+        uri: Option<String>,
+        version: DocumentVersion,
+        source: SourceText,
+        disk_source: Option<&str>,
+    ) {
+        let overlay = OverlayDocument::new(path, uri, version, source, disk_source);
+        self.overlays
+            .insert(overlay.path.as_path().to_path_buf(), overlay);
+        self.revision.0 += 1;
+    }
+
+    pub fn remove_overlay(&mut self, path: &Path) -> Option<OverlayDocument> {
+        let removed = self.overlays.remove(path);
+        if removed.is_some() {
+            self.revision.0 += 1;
+        }
+        removed
+    }
+
+    #[must_use]
+    pub fn snapshot(&mut self) -> WorkspaceSnapshot {
+        let id = WorkspaceSnapshotId(self.next_snapshot_id);
+        self.next_snapshot_id += 1;
+        WorkspaceSnapshot {
+            id,
+            revision: self.revision,
+            target: self.target.clone(),
+            overlays: self.overlays.values().cloned().collect(),
+            source_dependencies: self.source_dependencies.clone(),
+            source_map: self.context.as_ref().map(FrontendContext::source_map),
+            module_graph: self.context.as_ref().map(FrontendContext::module_graph),
+            compiler_options: self.compiler_options.clone(),
+            package_config_identity: self.package_config_identity.clone(),
+            cache_registry: self.cache_registry.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> WorkspaceRevision {
+        self.revision
+    }
+
+    #[must_use]
+    pub fn overlays(&self) -> &BTreeMap<PathBuf, OverlayDocument> {
+        &self.overlays
+    }
+
+    #[must_use]
+    pub fn source_dependencies(&self) -> &[SourceDependency] {
+        &self.source_dependencies
+    }
+
+    #[must_use]
+    pub fn context(&self) -> Option<&FrontendContext> {
+        self.context.as_ref()
+    }
+
+    fn single_file_input(&self, target: &WorkspaceSingleFileTarget) -> FrontendInput {
+        let source = self.overlays.get(target.path.as_path()).map_or_else(
+            || {
+                self.single_file_source
+                    .clone()
+                    .unwrap_or_else(|| SourceText::new(""))
+            },
+            |overlay| overlay.source.clone(),
+        );
+        FrontendInput {
+            path: target.path.clone(),
+            source,
+            mode: target.mode,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkspaceSession, WorkspaceSessionTarget};
+    use crate::{
+        DocumentVersion, FrontendMode, ProjectRoot, SourceDependencyKind, SourcePath, SourceText,
+    };
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn project_session_snapshot_records_overlay_and_dependencies() {
+        let temp = TempProject::new("workspace_session_project");
+        temp.write("main.sifr", "from helper import value\nprint(value)\n");
+        temp.write("helper.sifr", "value = 1\n");
+        let root = ProjectRoot {
+            root: SourcePath::new(temp.root.clone()),
+            entrypoint: SourcePath::new(temp.root.join("main.sifr")),
+        };
+        let expected_root = root.root.clone();
+        let expected_entrypoint = root.entrypoint.clone();
+        let mut session = WorkspaceSession::open_project(root).expect("project opens");
+        let opened_revision = session.revision().as_u64();
+
+        session.upsert_overlay(
+            SourcePath::new(temp.root.join("helper.sifr")),
+            Some("file:///helper.sifr".to_string()),
+            DocumentVersion::new(4),
+            SourceText::new("value = 2\n"),
+            Some("value = 1\n"),
+        );
+        assert_eq!(session.revision().as_u64(), opened_revision + 1);
+        session.reload().expect("overlay-backed reload succeeds");
+        assert_eq!(session.revision().as_u64(), opened_revision + 2);
+        let snapshot = session.snapshot();
+
+        assert!(matches!(
+            snapshot.target,
+            WorkspaceSessionTarget::Project(_)
+        ));
+        assert_eq!(snapshot.revision, session.revision());
+        assert_eq!(
+            snapshot.compiler_options.mode,
+            FrontendMode::ProjectEntrypoint
+        );
+        assert_eq!(
+            snapshot.package_config_identity.workspace_root,
+            Some(expected_root)
+        );
+        assert_eq!(
+            snapshot.package_config_identity.entrypoint,
+            Some(expected_entrypoint)
+        );
+        assert_eq!(snapshot.cache_registry.parse_generation, 0);
+        assert_eq!(snapshot.cache_registry.hir_generation, 0);
+        assert_eq!(snapshot.overlays.len(), 1);
+        assert!(!snapshot.overlays[0].matches_disk);
+        assert_eq!(snapshot.overlays[0].source.as_str(), "value = 2\n");
+        assert!(snapshot
+            .source_dependencies
+            .iter()
+            .any(|dependency| matches!(dependency.kind, SourceDependencyKind::FileRead)));
+        assert_eq!(
+            snapshot
+                .source_map
+                .as_ref()
+                .expect("source map exists")
+                .files
+                .len(),
+            2
+        );
+        assert_eq!(
+            snapshot
+                .module_graph
+                .as_ref()
+                .expect("module graph exists")
+                .modules
+                .len(),
+            2
+        );
+
+        let removed = session.remove_overlay(&temp.root.join("helper.sifr"));
+        assert!(removed.is_some());
+        assert_eq!(session.revision().as_u64(), snapshot.revision.as_u64() + 1);
+        assert!(session.snapshot().overlays.is_empty());
+    }
+
+    #[test]
+    fn single_file_session_freezes_overlay_state() {
+        let path = SourcePath::new("scratch.sifr");
+        let mut session = WorkspaceSession::single_file(path.clone(), FrontendMode::SingleFile);
+        session.upsert_overlay(
+            path,
+            Some("file:///scratch.sifr".to_string()),
+            DocumentVersion::new(1),
+            SourceText::new("x = 1\n"),
+            None,
+        );
+        session.reload().expect("single file overlay reloads");
+        let first = session.snapshot();
+        let second = session.snapshot();
+
+        assert_eq!(first.id.as_u64(), 0);
+        assert_eq!(second.id.as_u64(), 1);
+        assert_eq!(first.overlays.len(), 1);
+        assert_eq!(first.compiler_options.mode, FrontendMode::SingleFile);
+        assert!(first.source_dependencies.is_empty());
+        assert!(first.module_graph.is_some());
+    }
+
+    struct TempProject {
+        root: PathBuf,
+    }
+
+    impl TempProject {
+        fn new(name: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "sifr_frontend_{name}_{}_{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).expect("create temp project");
+            Self { root }
+        }
+
+        fn write(&self, relative: &str, source: &str) {
+            let path = self.root.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create parent");
+            }
+            fs::write(path, source).expect("write source");
+        }
+    }
+
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(Path::new(&self.root));
+        }
+    }
+}

--- a/internal_docs/architecture.md
+++ b/internal_docs/architecture.md
@@ -271,6 +271,7 @@ New crates added per milestone as needed:
 - TypeScript-Go architecture transfer M0: `sifr_source` (bottom-of-graph source text, line-map, source-file metadata, and editor position conversion authority)
 - TypeScript-Go architecture transfer M1: `internal_docs/typescript_go_architecture_transfer_m1_guardrails.md` records the pre-session direct-read inventory, current LSP single-file rebuild caveat, aggregate LSP budget caveat, and guardrail automation before M2-M5 behavior migration.
 - TypeScript-Go architecture transfer M2: `sifr_frontend::SourceProvider` is the typed semantic filesystem boundary. `internal_docs/typescript_go_architecture_transfer_m2_source_provider.md` records how `DiskSourceProvider`, `OverlaySourceProvider`, and `TrackingSourceProvider` cover disk reads, unsaved editor buffers, read/probe/canonicalization dependency records, failed lookup records, and package import ambiguity before `WorkspaceSession` owns overlay lifecycle in M3.
+- TypeScript-Go architecture transfer M3: `sifr_frontend::WorkspaceSession` owns serialized compiler-service workspace state and can freeze inspectable `WorkspaceSnapshot` values. `internal_docs/typescript_go_architecture_transfer_m3_workspace_session.md` records the pre-analysis-migration session/snapshot state.
 - milestone_ffi: FFI codegen extensions in `sifr_codegen`
 - Phase 35 shared analysis/query architecture: `sifr_frontend` (canonical frontend API and query/database ownership)
 - milestone_dev_tooling: `sifr_lsp` (language server), `sifr_format` (formatter), `sifr_lint` (linter)

--- a/internal_docs/frontend_cache_invalidation.md
+++ b/internal_docs/frontend_cache_invalidation.md
@@ -17,6 +17,12 @@ canonicalization, and failed lookups. These records are not yet consumed for
 dirty-scope invalidation; M3-M6 wire them into session snapshots and
 dependency-sensitive invalidation.
 
+TypeScript-Go architecture transfer M3 note: `WorkspaceSession` now owns the
+tracked dependency records and freezes them into `WorkspaceSnapshot` alongside
+source maps, module graphs, overlay records, compiler options, package/config
+identity, and cache-registry handles. M6 still owns consuming those records for
+dirty-scope classification and dependency-sensitive invalidation.
+
 ## Cache State
 
 Each `FrontendContext` module owns cached parse, lower, diagnostics, and analysis entries. Query results include metadata with:

--- a/internal_docs/frontend_query_architecture.md
+++ b/internal_docs/frontend_query_architecture.md
@@ -32,6 +32,13 @@ buffer text for disk files without mutating disk state. The overlay record owns
 URI, path, document version, source hash, source text/line map, and disk-match
 state; M3 will move overlay lifecycle ownership into `WorkspaceSession`.
 
+TypeScript-Go architecture transfer M3 note: `WorkspaceSession` now owns the
+overlay table, last loaded `FrontendContext`, tracked provider dependencies,
+workspace revision, snapshot ids, compiler options, package/config identity, and
+cache registry generation handles. `WorkspaceSnapshot` freezes inspectable
+source-map and module-graph views, but analysis queries still use the existing
+`AnalysisHost` revision-token snapshot until M4 migrates them.
+
 ## Driver Consumption
 
 Phase 35 m35.4b routes `check`, `build`, `run`, `emit`, project compilation, and test-runner frontend flows through `sifr_frontend` without preserving duplicate semantics-bearing driver frontend paths. The driver remains responsible for stdlib bootstrap/cache plumbing, build planning, codegen invocation, Cargo/rustc execution, and renderer/CLI presentation.

--- a/internal_docs/typescript_go_architecture_transfer_m3_workspace_session.md
+++ b/internal_docs/typescript_go_architecture_transfer_m3_workspace_session.md
@@ -1,0 +1,80 @@
+# TypeScript-Go Architecture Transfer M3 Workspace Session
+
+status: M3 implementation review
+
+M3 introduces the mutable compiler-service owner in `sifr_frontend` while
+leaving analysis-query migration to M4. The session is intentionally serialized:
+callers mutate overlays or reload project state, then freeze the current state
+into an inspectable `WorkspaceSnapshot`.
+
+## Session Model
+
+`WorkspaceSession` owns:
+
+- the workspace target, either project root or single-file target;
+- open-file overlays as `OverlayDocument` records;
+- the most recently loaded `FrontendContext`;
+- provider dependency records captured during project reload;
+- workspace revision and monotonic snapshot id counters;
+- compiler options, package/config identity placeholders, and cache registry
+  generation handles for later M4-M10 expansion.
+
+Project reload builds an `OverlaySourceProvider<DiskSourceProvider>` from the
+session overlay table, wraps it in `TrackingSourceProvider`, and loads the
+project through `FrontendContext::load_project_with_provider`. The resulting
+dependency records become session-owned state instead of ad hoc provider output.
+`upsert_overlay` and `remove_overlay` mutate session state and bump the workspace
+revision, but callers still invoke `reload` before they expect `source_map` or
+`module_graph` snapshot views to reflect the overlay change.
+
+Single-file reload uses the session-owned overlay when present, or the original
+single-file source captured during `open_single_file`. Single-file reloads do
+not perform provider reads, so their tracked dependency list is intentionally
+empty in M3.
+
+## Snapshot Model
+
+`WorkspaceSnapshot` currently freezes:
+
+- snapshot id and workspace revision;
+- session target;
+- overlay records;
+- tracked source dependencies;
+- source map and module graph views cloned from `FrontendContext`;
+- compiler options;
+- package/config identity;
+- cache registry generation handles.
+
+The snapshot is an inspectable data object only in M3. M4 will convert
+`sifr_analysis::AnalysisSnapshot` into an analysis-facing handle to this state
+and make editor queries consume captured immutable snapshots.
+`WorkspaceSession::snapshot` takes `&mut self` because the serialized M3 model
+allocates snapshot ids from a session-owned counter. M11 scheduler work must
+revisit that boundary before concurrent snapshot capture is introduced.
+`WorkspaceSnapshot::source_map` and `module_graph` are optional only for
+unreloaded sessions; the public `open_project`, `open_single_file`, and
+successful `reload` paths populate both views.
+`WorkspaceSession::context` is an inspection escape hatch during M3/M4 migration
+and should not become the long-term query surface once snapshots are canonical.
+
+## Validation
+
+M3 focused validation so far:
+
+- `cargo test -p sifr_frontend workspace_session`
+- `cargo test -p sifr_frontend`
+- `cargo test -p sifr_analysis`
+- `cargo test -p sifr_lsp`
+- `cargo test -p sifr -- --skip test_e2e_pass`
+- `cargo clippy --workspace -- -D warnings`
+- `cargo fmt --check`
+- `git diff --check`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`
+- `python3 scripts/check_file_size_guardrails.py`
+- `python3 scripts/check_package_manager_guardrails.py`
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report
+  `target/validation_lane_reports/quick.latest.json`, wall time 261.09s
+
+The validation list is focused on the M3 data-model surface plus the phase's
+authoritative quick gate.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md
@@ -10,7 +10,7 @@ Phase contract: `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md`
 - [x] Phase plan reviewed and approved for implementation
 - [x] M0 source and position foundation completed
 - [x] M1 architecture contract and guardrails completed
-- [ ] M2 source provider and overlay store completed
+- [x] M2 source provider and overlay store completed
 - [ ] M3 workspace session data model completed
 - [ ] M4 analysis snapshot migration completed
 - [ ] M5 LSP persistent session integration completed
@@ -174,6 +174,12 @@ This phase locks the TypeScript-Go-derived architecture transfer before implemen
 - `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS after M2 remediation; report `target/validation_lane_reports/quick.latest.json`, wall time 260.57s.
 - `2026-06-01`: M2 final implementation review pass 4 recorded in `reviews/typescript-go-m2-source-provider-overlay-review-pass-4.md`; reviewer approved the current post-remediation tree for PR.
 - `2026-06-01`: M2 merged via PR [#2233](https://github.com/sifr-lang/sifr/pull/2233), merge commit `c74d73b59d179156b3a19c5f4176fc5738c49ab4`.
+- `2026-06-01`: M3 validation completed on branch `wave_tsgo_m3_workspace_session`.
+- `2026-06-01`: `cargo test -p sifr_frontend workspace_session`, `cargo test -p sifr_frontend`, `cargo test -p sifr_analysis`, `cargo test -p sifr_lsp`, and `cargo test -p sifr -- --skip test_e2e_pass` -> PASS for M3.
+- `2026-06-01`: `cargo fmt --check`, `git diff --check`, and `cargo clippy --workspace -- -D warnings` -> PASS for M3.
+- `2026-06-01`: `python3 verification/tooling/check_typescript_go_m1_guardrails.py && python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`, `python3 scripts/check_file_size_guardrails.py`, and `python3 scripts/check_package_manager_guardrails.py` -> PASS for M3.
+- `2026-06-01`: `scripts/run_all_tests.sh --profile quick` -> PASS for M3; report `target/validation_lane_reports/quick.latest.json`, wall time 261.09s.
+- `2026-06-01`: M3 implementation review pass 1 recorded in `reviews/typescript-go-m3-workspace-session-review-pass-1.md`; reviewer approved M3 for PR after validation and requested only pre-PR tracker/doc/test cleanup. Cleanup was applied, and `cargo test -p sifr_frontend workspace_session`, `cargo clippy -p sifr_frontend -- -D warnings`, `cargo fmt --check`, and `git diff --check` passed after cleanup.
 
 ## PR Log
 

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -9,6 +9,7 @@ Status: in progress
 | M0 Source And Position Foundation | merged | [#2229](https://github.com/sifr-lang/sifr/pull/2229) | Added `sifr_source`, real source-map conversions, and source-position guardrails. |
 | M1 Architecture Contract And Guardrails | merged | [#2230](https://github.com/sifr-lang/sifr/pull/2230), [#2232](https://github.com/sifr-lang/sifr/pull/2232) | Added pre-flight direct-read/LSP/budget guardrails and follow-up tracker update. |
 | M2 Source Provider And Overlay Store | merged | [#2233](https://github.com/sifr-lang/sifr/pull/2233) | Adds `SourceProvider`, `DiskSourceProvider`, `OverlaySourceProvider`, `TrackingSourceProvider`, `OverlayDocument`, `SourceDependency*`, provider-backed project/package/lint/format reads, `PackageImportAmbiguity`, and `PackageImportResolutionResult`; new tests cover overlay shadowing, nested overlay directories, tracked reads, provider-backed project loading, package ambiguity, unresolved/private/fatal import states, and existing lint/format/package behavior. |
+| M3 Workspace Session Data Model | in progress | pending | Adds `WorkspaceSession` and `WorkspaceSnapshot` as the serialized mutable compiler-service owner and frozen inspection handle for overlays, tracked dependencies, source maps, module graphs, compiler options, package/config identity, cache-registry handles, and revision counters while leaving analysis/LSP migration to M4/M5. |
 
 M2 local validation so far:
 
@@ -20,7 +21,22 @@ M2 local validation so far:
 - `cargo test -p sifr_driver -p sifr_package -p sifr_frontend -p sifr_format -p sifr_lint`
 - `cargo clippy --workspace -- -D warnings`
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 274.59s
-- `scripts/run_all_tests.sh --profile quick` passed after package source-map and manifest helper modules were split under the package-manager line guardrail.
+
+M3 local validation so far:
+
+- `cargo test -p sifr_frontend workspace_session`
+- `cargo test -p sifr_frontend`
+- `cargo test -p sifr_analysis`
+- `cargo test -p sifr_lsp`
+- `cargo test -p sifr -- --skip test_e2e_pass`
+- `cargo fmt --check`
+- `git diff --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_file_size_guardrails.py`
+- `python3 scripts/check_package_manager_guardrails.py`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py`
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test`
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 261.09s
 
 ## Purpose
 

--- a/reviews/typescript-go-m3-workspace-session-review-pass-1.md
+++ b/reviews/typescript-go-m3-workspace-session-review-pass-1.md
@@ -1,0 +1,73 @@
+# M3 Workspace Session Data Model — Review
+
+## 1. Blocking findings
+
+**None.** The seven M3 acceptance criteria are all met. The M1 guardrail, file-size guardrail, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test -p sifr_frontend workspace_session`, and `cargo test -p sifr_frontend` all pass on the working tree. M3 is purely additive: no caller of `FrontendContext::load_project`, `FrontendContext::load_single_file`, or `FrontendContext::load_project_with_provider` was changed (`crates/sifr_analysis/src/host/implementation.rs:36/41`, `crates/sifr_frontend/src/query_diagnostics.rs:537/553/595/642`, `crates/sifr_frontend/src/bin/frontend_query_bench.rs:296/308`, `crates/sifr_lint/src/engine.rs:252`, `crates/sifr_lint/src/rules/large_parameter_list.rs:96` — all unchanged), so CLI and existing frontend behavior are preserved by construction. `sifr_analysis::AnalysisSnapshot` is also unchanged (M4's migration target), so analysis queries remain on the existing path.
+
+## 2. Non-blocking findings
+
+### 2.1 Duplicate M3 row in the planning issue
+`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:12-13` adds two near-identical M3 rows in a single diff. Deduplicate before PR — the second row adds no new info.
+
+### 2.2 M3 doc validation list disagrees with the execution tracker
+- `internal_docs/typescript_go_architecture_transfer_m3_workspace_session.md:49-59` lists 7 items including `cargo test -p sifr_analysis`, `cargo test -p sifr_lsp`, the M1 guardrail script, and the package-manager guardrail.
+- The execution tracker (`issues/ad-hoc-typescript-go-compiler-architecture-transfer-execution.md:30-32`, mirrored in `ad-hoc-typescript-go-compiler-architecture-transfer.md:28-32`) lists only the 5 the user reported. Pick one source of truth before PR. The M3 doc's "Validation" section correctly notes that the full quick gate remains required, so either bring the tracker up to the doc's list or trim the doc to the focused subset.
+
+### 2.3 M3 doc does not list the spec's other minimum-validation items
+The phase spec (`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:905-914`) requires `git diff --check` and `cargo test -p sifr -- --skip test_e2e_pass`. The M3 doc's "Validation" section omits both; the tracker omits them too. Worth running both before PR; trivial to add.
+
+### 2.4 `upsert_overlay` does not auto-reload
+`crates/sifr_frontend/src/workspace_session.rs:166-178` records the overlay and bumps the revision, but does not rebuild the `FrontendContext`. Callers must call `reload()` to see the change reflected in the snapshot's `source_map` / `module_graph`. The existing tests do this correctly (`workspace_session.rs:271`), but the M3 doc's "Session Model" section should call this contract out so a future caller does not assume the snapshot reflects the latest `upsert_overlay`.
+
+### 2.5 `snapshot()` takes `&mut self` to bump `next_snapshot_id`
+`crates/sifr_frontend/src/workspace_session.rs:188-204` requires `&mut self` because of `self.next_snapshot_id += 1`. This is the right choice for M3's serialized model (no concurrent access), but the M3 doc does not note the constraint. M11 (scheduler) will need to revisit this (either `Cell<u64>` / `AtomicU64` or a `&mut self` boundary). A one-line note in the M3 doc would prevent surprise.
+
+### 2.6 `open_single_file` and `open_project` are asymmetric
+`open_project` calls `reload()` (`workspace_session.rs:87-91`); `open_single_file` directly assigns `self.context` via `FrontendContext::load_single_file` (`workspace_session.rs:108-113`). Both work, but the asymmetry means a future contributor adding a side effect to `reload()` (e.g., dependency capture) will silently skip it for single-file. Consider routing through `reload()` for both, or documenting why single-file skips it.
+
+### 2.7 Single-file `SourceDependency` list is always empty
+`workspace_session.rs:159` clears `source_dependencies` on every single-file `reload()`. The spec says "session owns... provider dependency records" — for project targets this is satisfied, for single-file it is an empty `Vec`. This is the correct behavior (the single-file path doesn't generate tracked reads), but the M3 doc should state it so M6 doesn't assume single-file sessions have dependencies to consume.
+
+### 2.8 `WorkspaceSnapshot` has `Option<SourceMapView>` / `Option<ModuleGraphView>`
+`workspace_session.rs:66-67` wraps both in `Option<...>` because `self.context` is `Option<FrontendContext>`. The public constructors (`open_project`, `open_single_file`) always populate `context`, so the `Option` is purely defensive against future constructors. Either drop the `Option` and add a `debug_assert!(self.context.is_some())` in `snapshot()`, or document that `None` is reserved for un-reloaded sessions.
+
+### 2.9 `WorkspaceSession::context()` is public
+`workspace_session.rs:221-224` exposes a read-only handle to the underlying `FrontendContext`. This makes M3 inspectable but bypasses the snapshot model (callers can mutate the session and observe the live context). M4 will likely need to restrict this when snapshots become the canonical handle. Worth a TODO or note in the M3 doc.
+
+### 2.10 `single_file_input` is a slight misnomer
+`workspace_session.rs:226-240` builds a `FrontendInput` from session state, not "the single-file input". Consider `build_single_file_input` for clarity.
+
+### 2.11 `TempProject` doesn't include `process::id()` in the path
+`workspace_session.rs:331-339` uses `as_nanos()` for uniqueness. The M2 test (`source_provider.rs:431-438`) includes both PID and nanos, which is more defensive against concurrent CI. Astronomically unlikely to collide, but the M2 pattern is the safer template.
+
+## 3. Missing validation or test coverage
+
+All observable in the working tree, all small.
+
+### 3.1 No test exercises `remove_overlay`
+`workspace_session.rs:180-186` adds the method, but no test asserts that an upserted overlay can be removed and is then absent from a subsequent snapshot. A trivial addition: upsert, snapshot, remove, snapshot, assert the second snapshot's `overlays` is empty.
+
+### 3.2 No test asserts `compiler_options` or `package_config_identity` on the snapshot
+The snapshot exposes both (`workspace_session.rs:68-69`), but the two existing tests don't assert their values. A one-line assertion that `snapshot.package_config_identity.workspace_root == Some(root.root)` and `snapshot.compiler_options.mode == FrontendMode::ProjectEntrypoint` would prove the snapshot freezes them.
+
+### 3.3 No test asserts `snapshot.revision` matches `session.revision()`
+`workspace_session.rs:194` freezes `revision: WorkspaceRevision` into the snapshot, and `revision()` (`:206-209`) exposes the session's revision. No test asserts the two are equal, nor that a reload bumps the revision. Worth one assertion.
+
+### 3.4 No test asserts the revision bump on `upsert_overlay` / `remove_overlay`
+`workspace_session.rs:177, 183` both increment `self.revision.0`. No test covers the increment contract. A test that asserts `session.revision().as_u64()` is `1` after one `upsert_overlay` and `2` after one `reload()` would prove it.
+
+### 3.5 No test for the `cache_registry` snapshot field
+Currently always `(0, 0)` since the field is a placeholder. A test that asserts `snapshot.cache_registry.parse_generation == 0` and `hir_generation == 0` would document the placeholder contract, even if trivial.
+
+### 3.6 M3 doc's validation list includes `cargo test -p sifr_analysis` and `cargo test -p sifr_lsp`
+The user-reported validation did not run them. Both crates are downstream consumers of `sifr_frontend`, so a regression there would be silent. Recommend running before PR.
+
+## 4. Approval verdict
+
+**M3 is APPROVED for PR** after the listed validation. The data model matches the planning issue's M3 scope (`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:587-604`): `WorkspaceSession` owns overlays, tracked dependencies, the last `FrontendContext`, revision + snapshot-id counters, compiler options, package/config identity, and cache-registry handles; `WorkspaceSnapshot` freezes a `Clone + Debug + PartialEq + Eq` inspectable value; CLI, analysis, and LSP are unchanged. The two new tests pass, clippy is clean, fmt is clean, the M1 guardrail still passes (it checks for the literal strings `WorkspaceSession` and `WorkspaceSnapshot` in the M1 doc, which are present), and the file-size guardrail reports PASS at 2021 files (the new `workspace_session.rs` is 355 lines, well under the 900-line cap). M1 doc's "Future Milestone Update Obligations" (`internal_docs/typescript_go_architecture_transfer_m1_guardrails.md:170-172`) requires M3 to move overlay lifecycle and tracked dependency records into `WorkspaceSession` snapshots — that obligation is satisfied.
+
+Before PR, the two cheap fixes that will save a reviewer pass:
+- Deduplicate the M3 row in `ad-hoc-typescript-go-compiler-architecture-transfer.md:12-13`.
+- Reconcile the M3 doc's validation list with the execution tracker (or vice versa).
+
+Optional but valuable: add the small tests in §3.1-3.4, and run `cargo test -p sifr_analysis` and `cargo test -p sifr_lsp` as the M3 doc already calls for. Everything else in §2/§3 is follow-up-worthy but not required to merge.


### PR DESCRIPTION
## Summary
- add WorkspaceSession as the serialized mutable frontend owner for overlays, dependency records, context views, compiler options, package/config identity, cache handles, and revisions
- add WorkspaceSnapshot freeze API and tests for overlay lifecycle, revision bumps, snapshot ids, source-map/module-graph views, and placeholder cache identity
- document the M3 session/snapshot contract, validation, and tracker status

## Validation
- cargo test -p sifr_frontend workspace_session
- cargo test -p sifr_frontend
- cargo test -p sifr_analysis
- cargo test -p sifr_lsp
- cargo test -p sifr -- --skip test_e2e_pass
- cargo fmt --check
- git diff --check
- cargo clippy --workspace -- -D warnings
- python3 verification/tooling/check_typescript_go_m1_guardrails.py
- python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test
- python3 scripts/check_file_size_guardrails.py
- python3 scripts/check_package_manager_guardrails.py
- scripts/run_all_tests.sh --profile quick -> PASS, target/validation_lane_reports/quick.latest.json, wall time 261.09s

## Review
- Claude Opus review pass 1 approved M3 for PR after the validation/doc/test remediations recorded in this branch.