### PR TITLE
Avoid orphan loop else flow joins

### DIFF
--- a/crates/sifr_hir/src/flow_graph.rs
+++ b/crates/sifr_hir/src/flow_graph.rs
@@ -481,12 +481,12 @@ impl FlowGraphBuilder {
         body: &[HirStmt],
         else_body: Option<&[HirStmt]>,
     ) -> Vec<FlowNodeId> {
-        let join = self.join_node("loop");
         let body_frontier = self.build_stmt_list(vec![node], FlowEdgeKind::True, body, false);
         self.connect_frontier(&body_frontier, node, FlowEdgeKind::LoopBack);
         if let Some(else_body) = else_body {
             self.build_stmt_list(vec![node], FlowEdgeKind::False, else_body, false)
         } else {
+            let join = self.join_node("loop");
             self.add_edge(node, join, FlowEdgeKind::False);
             vec![join]
         }
@@ -515,5 +515,6 @@ impl FlowGraphBuilder {
         )
     }
 }
+
 #[cfg(test)]
 mod tests;

--- a/crates/sifr_hir/src/flow_graph/tests.rs
+++ b/crates/sifr_hir/src/flow_graph/tests.rs
@@ -7,6 +7,51 @@ fn lower_source(source: &str) -> crate::LoweringResult {
     lower_module(parsed.suite()).expect("source should lower")
 }
 
+fn call_stmt(callee: &str) -> HirStmt {
+    HirStmt::Expr {
+        expr: HirExpr::Call {
+            func: callee.to_string(),
+            args: vec![],
+            ty: Type::None,
+        },
+    }
+}
+
+fn loop_node_id(graph: &FlowGraph) -> FlowNodeId {
+    graph
+        .nodes()
+        .iter()
+        .find_map(|node| match &node.kind {
+            FlowNodeKind::Loop { label } if label == "while" => Some(node.id),
+            _ => None,
+        })
+        .expect("flow graph should contain a while loop node")
+}
+
+fn call_node_id(graph: &FlowGraph, callee: &str) -> FlowNodeId {
+    graph
+        .nodes()
+        .iter()
+        .find_map(|node| {
+            node.effects
+                .iter()
+                .any(|effect| matches!(effect, FlowEffect::Call { callee: name } if name == callee))
+                .then_some(node.id)
+        })
+        .expect("flow graph should contain the requested call node")
+}
+
+fn loop_join_ids(graph: &FlowGraph) -> Vec<FlowNodeId> {
+    graph
+        .nodes()
+        .iter()
+        .filter_map(|node| match &node.kind {
+            FlowNodeKind::Join { label } if label == "loop" => Some(node.id),
+            _ => None,
+        })
+        .collect()
+}
+
 #[test]
 fn statement_graph_tracks_branches_loops_mutations_and_exits() {
     let stmts = vec![
@@ -46,21 +91,58 @@ fn statement_graph_tracks_branches_loops_mutations_and_exits() {
 }
 
 #[test]
+fn loop_with_else_omits_synthetic_loop_join() {
+    let graph = build_statement_flow_graph(&[
+        HirStmt::While {
+            condition: HirExpr::BoolLiteral(true),
+            body: vec![call_stmt("loop_body")],
+            else_body: Some(vec![call_stmt("loop_else")]),
+        },
+        call_stmt("after_loop"),
+    ]);
+
+    assert!(loop_join_ids(&graph).is_empty());
+
+    let loop_node = loop_node_id(&graph);
+    let else_node = call_node_id(&graph, "loop_else");
+    let after_loop_node = call_node_id(&graph, "after_loop");
+    assert!(graph.edges().iter().any(|edge| edge.from == loop_node
+        && edge.to == else_node
+        && edge.kind == FlowEdgeKind::False));
+    assert!(graph.edges().iter().any(|edge| edge.from == else_node
+        && edge.to == after_loop_node
+        && edge.kind == FlowEdgeKind::Sequence));
+}
+
+#[test]
+fn loop_without_else_emits_single_synthetic_loop_join() {
+    let graph = build_statement_flow_graph(&[
+        HirStmt::While {
+            condition: HirExpr::BoolLiteral(true),
+            body: vec![call_stmt("loop_body")],
+            else_body: None,
+        },
+        call_stmt("after_loop"),
+    ]);
+
+    let joins = loop_join_ids(&graph);
+    assert_eq!(joins.len(), 1);
+
+    let loop_node = loop_node_id(&graph);
+    let join_node = joins[0];
+    let after_loop_node = call_node_id(&graph, "after_loop");
+    assert!(graph.edges().iter().any(|edge| edge.from == loop_node
+        && edge.to == join_node
+        && edge.kind == FlowEdgeKind::False));
+    assert!(graph.edges().iter().any(|edge| edge.from == join_node
+        && edge.to == after_loop_node
+        && edge.kind == FlowEdgeKind::Sequence));
+}
+
+#[test]
 fn graph_fingerprint_includes_effect_payloads() {
-    let first = build_statement_flow_graph(&[HirStmt::Expr {
-        expr: HirExpr::Call {
-            func: "first".to_string(),
-            args: vec![],
-            ty: Type::None,
-        },
-    }]);
-    let second = build_statement_flow_graph(&[HirStmt::Expr {
-        expr: HirExpr::Call {
-            func: "second".to_string(),
-            args: vec![],
-            ty: Type::None,
-        },
-    }]);
+    let first = build_statement_flow_graph(&[call_stmt("first")]);
+    let second = build_statement_flow_graph(&[call_stmt("second")]);
 
     assert_ne!(first.shape_fingerprint(), second.shape_fingerprint());
 }

--- a/internal_docs/typescript_go_architecture_transfer_m8_first_class_flow_graph.md
+++ b/internal_docs/typescript_go_architecture_transfer_m8_first_class_flow_graph.md
@@ -1,6 +1,6 @@
 # TypeScript-Go Architecture Transfer M8 First-Class Flow Graph
 
-status: M8 implementation review
+status: M8 merged
 
 M8 adds a first-class HIR flow graph alongside the existing control-flow graph.
 The CFG remains responsible for structural reachability and return facts. The
@@ -27,6 +27,10 @@ Each `FlowGraph` exposes:
 Effects use the existing type model directly. A narrowing to `None` is recorded
 as `FlowEffect::Narrow` with `narrowed_type = Type::None`; M8 does not introduce
 a parallel `RefinedToNone` vocabulary.
+
+Loop graphs emit a synthetic `Join { label: "loop" }` for the no-`else` exit
+frontier. Loops with an `else` body use the else-body frontier as the loop exit
+instead, so they do not add an unused loop join node.
 
 `shape_fingerprint()` includes effect payload labels as well as node/edge shape,
 so structurally identical graphs with different calls, mutations, or narrowed
@@ -75,3 +79,8 @@ M8 focused validation so far:
   advisories: warm wall-time budget exceeded; group skew is high
 - Claude reviewer pass 3 -> SATISFIED
   (`reviews/typescript-go-m8-first-class-flow-graph-review-pass-3.md`)
+- M8 loop-else follow-up: `cargo fmt --check`,
+  `cargo test -p sifr_hir flow_graph -- --nocapture`,
+  `cargo clippy -p sifr_hir -- -D warnings`
+- Claude reviewer loop-else follow-up pass 1 -> SATISFIED
+  (`reviews/typescript-go-m8-loop-else-follow-up-review-pass-1.md`)

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -14,7 +14,7 @@ Status: in progress
 | M5 LSP Persistent Session Integration | merged | [#2238](https://github.com/sifr-lang/sifr/pull/2238) | Moves LSP analysis ownership from `DocumentStore` into the serialized `Session`, feeds open/change/save buffers into `WorkspaceSession` overlays, and rejects stale request publication by captured snapshot plus document version while preserving serialized request handling. |
 | M6 Event Compaction And Dirty Scope | merged | [#2239](https://github.com/sifr-lang/sifr/pull/2239) | Compacts batched document edits before analysis updates, summarizes watcher events before dirty-scope classification, records precise dirty scope/reason reports, and degrades incompatible or stormy invalidation conservatively. |
 | M7 Module Signatures And Dependency Invalidation | merged | [#2241](https://github.com/sifr-lang/sifr/pull/2241) | Adds import/export/module signatures, reverse-dependency closure invalidation, and local private-body edit reuse for unchanged public/import signatures. |
-| M8 First-Class Flow Graph | in progress | [#2243](https://github.com/sifr-lang/sifr/pull/2243) | Adds `sifr_hir::flow_graph`, snapshot-scoped `LoweringResult.flow_graph`, graph-backed `FlowFacts` debug/fingerprint access, and lowering-time flow effects for narrowing, mutation invalidation, moves, and borrows. |
+| M8 First-Class Flow Graph | merged | [#2243](https://github.com/sifr-lang/sifr/pull/2243) | Adds `sifr_hir::flow_graph`, snapshot-scoped `LoweringResult.flow_graph`, graph-backed `FlowFacts` debug/fingerprint access, and lowering-time flow effects for narrowing, mutation invalidation, moves, and borrows. |
 
 M2 local validation so far:
 
@@ -134,6 +134,8 @@ M8 local validation so far:
 - `cargo clippy --workspace -- -D warnings`
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 306.27s, advisories: warm wall-time budget exceeded; group skew is high
 - Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m8-first-class-flow-graph-review-pass-3.md`)
+- M8 loop-else follow-up: `cargo fmt --check`, `cargo test -p sifr_hir flow_graph -- --nocapture`, `cargo clippy -p sifr_hir -- -D warnings`
+- Claude reviewer loop-else follow-up pass 1 -> SATISFIED (`reviews/typescript-go-m8-loop-else-follow-up-review-pass-1.md`)
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- avoid creating an unused `Join { label: "loop" }` node for loops with an `else` body
- add flow-graph regression coverage for loop `else` and no-`else` join shapes
- mark M8 merged in the tracker/docs and record the follow-up validation/reviewer pass

## Validation
- `cargo fmt --check`
- `cargo test -p sifr_hir flow_graph -- --nocapture`
- `cargo clippy -p sifr_hir -- -D warnings`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- Claude reviewer loop-else follow-up pass 1: SATISFIED
