### PR TITLE
Refine M9 cache key inputs

### DIFF
--- a/crates/sifr_frontend/src/cache_keys.rs
+++ b/crates/sifr_frontend/src/cache_keys.rs
@@ -1,6 +1,6 @@
 use super::{
-    FrontendMode, ProjectRoot, SourceHash, SourcePath, WorkspaceCompilerOptions,
-    WorkspacePackageConfigIdentity, WorkspaceSessionTarget,
+    FrontendDiagnosticStyle, FrontendMode, ProjectRoot, SourceHash, SourcePath,
+    WorkspaceCompilerOptions, WorkspacePackageConfigIdentity, WorkspaceSessionTarget,
 };
 
 const CACHE_KEY_SCHEMA_VERSION: &str = "m9-cache-key-v1";
@@ -11,6 +11,7 @@ const LOWERING_OPTIONS_VERSION: &str = "sifr-hir-lowering-v1";
 const DIAGNOSTIC_POLICY_VERSION: &str = "sifr-diagnostics-v1";
 const LINT_POLICY_VERSION: &str = "sifr-lint-v1";
 const FORMAT_POLICY_VERSION: &str = "sifr-format-v1";
+const FORMAT_OPTIONS_VERSION: &str = "sifr-format-options-default-v1";
 const PACKAGE_GRAPH_POLICY_VERSION: &str = "sifr-package-graph-v1";
 const SYMBOL_BUCKET_POLICY_VERSION: &str = "sifr-symbol-buckets-v1";
 const FLOW_GRAPH_POLICY_VERSION: &str = "sifr-flow-graph-v1";
@@ -30,15 +31,11 @@ impl CompilerFingerprint {
         builder.field("diagnostic_policy", DIAGNOSTIC_POLICY_VERSION);
         builder.field("lint_policy", LINT_POLICY_VERSION);
         builder.field("format_policy", FORMAT_POLICY_VERSION);
+        builder.field("format_options", FORMAT_OPTIONS_VERSION);
         builder.field("package_graph_policy", PACKAGE_GRAPH_POLICY_VERSION);
         builder.field("symbol_bucket_policy", SYMBOL_BUCKET_POLICY_VERSION);
         builder.field("flow_graph_policy", FLOW_GRAPH_POLICY_VERSION);
         Self(builder.finish_hex())
-    }
-
-    #[must_use]
-    pub fn for_testing(value: impl Into<String>) -> Self {
-        Self(value.into())
     }
 
     #[must_use]
@@ -66,7 +63,7 @@ impl WorkspaceContextFingerprint {
         let mut builder = FingerprintBuilder::new("workspace-context");
         builder.field("kind", "single-file");
         builder.path_field("path", path);
-        builder.field("mode", format!("{mode:?}"));
+        builder.field("mode", frontend_mode_label(mode));
         Self(builder.finish_hex())
     }
 
@@ -90,11 +87,6 @@ impl WorkspaceContextFingerprint {
     }
 
     #[must_use]
-    pub fn for_testing(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
-    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -106,15 +98,14 @@ pub struct PackageContextFingerprint(String);
 impl PackageContextFingerprint {
     #[must_use]
     pub fn from_identity(identity: &WorkspacePackageConfigIdentity) -> Self {
+        let WorkspacePackageConfigIdentity {
+            workspace_root,
+            entrypoint,
+        } = identity;
         let mut builder = FingerprintBuilder::new("package-context");
-        builder.optional_path_field("workspace_root", identity.workspace_root.as_ref());
-        builder.optional_path_field("entrypoint", identity.entrypoint.as_ref());
+        builder.optional_path_field("workspace_root", workspace_root.as_ref());
+        builder.optional_path_field("entrypoint", entrypoint.as_ref());
         Self(builder.finish_hex())
-    }
-
-    #[must_use]
-    pub fn for_testing(value: impl Into<String>) -> Self {
-        Self(value.into())
     }
 
     #[must_use]
@@ -241,9 +232,22 @@ pub struct ParseCacheKey {
 impl ParseCacheKey {
     #[must_use]
     pub fn new(source_hash: SourceHash, context: CacheKeyContext) -> Self {
+        Self::with_parser_options(
+            source_hash,
+            QueryPolicyFingerprint::default_for_cache_family(CacheFamily::Parse),
+            context,
+        )
+    }
+
+    #[must_use]
+    pub fn with_parser_options(
+        source_hash: SourceHash,
+        parser_options: QueryPolicyFingerprint,
+        context: CacheKeyContext,
+    ) -> Self {
         Self {
             source_hash,
-            parser_options: QueryPolicyFingerprint::default_for_cache_family(CacheFamily::Parse),
+            parser_options,
             context,
         }
     }
@@ -296,7 +300,10 @@ impl HirLoweringCacheKey {
     pub fn fingerprint(&self) -> CacheKeyFingerprint {
         let mut builder = key_builder(CacheFamily::HirLowering, &self.source_hash, &self.context);
         builder.field("parse_fingerprint", self.parse_fingerprint.as_str());
-        builder.field("compiler_options", format!("{:?}", self.compiler_options));
+        builder.field(
+            "compiler_options",
+            compiler_options_fingerprint(&self.compiler_options),
+        );
         builder.finish()
     }
 }
@@ -305,7 +312,7 @@ impl HirLoweringCacheKey {
 pub struct DiagnosticsCacheKey {
     pub source_hash: SourceHash,
     pub hir_fingerprint: CacheKeyFingerprint,
-    pub diagnostic_style: String,
+    pub diagnostic_style: FrontendDiagnosticStyle,
     pub context: CacheKeyContext,
 }
 
@@ -314,7 +321,10 @@ impl DiagnosticsCacheKey {
     pub fn fingerprint(&self) -> CacheKeyFingerprint {
         let mut builder = key_builder(CacheFamily::Diagnostics, &self.source_hash, &self.context);
         builder.field("hir_fingerprint", self.hir_fingerprint.as_str());
-        builder.field("diagnostic_style", &self.diagnostic_style);
+        builder.field(
+            "diagnostic_style",
+            diagnostic_style_label(self.diagnostic_style),
+        );
         builder.finish()
     }
 }
@@ -341,14 +351,26 @@ impl LintCacheKey {
 pub struct FormatCacheKey {
     pub source_hash: SourceHash,
     pub formatter_policy: QueryPolicyFingerprint,
+    pub formatter_options: QueryPolicyFingerprint,
     pub context: CacheKeyContext,
 }
 
 impl FormatCacheKey {
     #[must_use]
+    pub fn new(source_hash: SourceHash, context: CacheKeyContext) -> Self {
+        Self {
+            source_hash,
+            formatter_policy: QueryPolicyFingerprint::default_for_cache_family(CacheFamily::Format),
+            formatter_options: QueryPolicyFingerprint::new(FORMAT_OPTIONS_VERSION),
+            context,
+        }
+    }
+
+    #[must_use]
     pub fn fingerprint(&self) -> CacheKeyFingerprint {
         let mut builder = key_builder(CacheFamily::Format, &self.source_hash, &self.context);
         builder.field("formatter_policy", self.formatter_policy.as_str());
+        builder.field("formatter_options", self.formatter_options.as_str());
         builder.finish()
     }
 }
@@ -373,7 +395,7 @@ impl PackageGraphCacheKey {
 pub struct SymbolBucketsCacheKey {
     pub source_hash: SourceHash,
     pub module_graph_fingerprint: CacheKeyFingerprint,
-    pub bucket_scope: String,
+    pub bucket_scope: SymbolBucketScope,
     pub context: CacheKeyContext,
 }
 
@@ -385,8 +407,27 @@ impl SymbolBucketsCacheKey {
             "module_graph_fingerprint",
             self.module_graph_fingerprint.as_str(),
         );
-        builder.field("bucket_scope", &self.bucket_scope);
+        builder.field("bucket_scope", self.bucket_scope.label());
         builder.finish()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SymbolBucketScope {
+    Workspace,
+    Package,
+    Module,
+    Stdlib,
+}
+
+impl SymbolBucketScope {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Package => "package",
+            Self::Module => "module",
+            Self::Stdlib => "stdlib",
+        }
     }
 }
 
@@ -430,6 +471,27 @@ fn key_builder(
     builder.field("package", context.package.as_str());
     builder.field("query_policy", context.query_policy.as_str());
     builder
+}
+
+fn compiler_options_fingerprint(options: &WorkspaceCompilerOptions) -> String {
+    let WorkspaceCompilerOptions { mode } = options;
+    let mut builder = FingerprintBuilder::new("workspace-compiler-options");
+    builder.field("mode", frontend_mode_label(*mode));
+    builder.finish_hex()
+}
+
+fn frontend_mode_label(mode: FrontendMode) -> &'static str {
+    match mode {
+        FrontendMode::SingleFile => "single-file",
+        FrontendMode::ProjectEntrypoint => "project-entrypoint",
+    }
+}
+
+fn diagnostic_style_label(style: FrontendDiagnosticStyle) -> &'static str {
+    match style {
+        FrontendDiagnosticStyle::Bare => "bare",
+        FrontendDiagnosticStyle::ModulePrefixed => "module-prefixed",
+    }
 }
 
 struct CacheKeyBuilder {
@@ -506,11 +568,12 @@ mod tests {
         CacheFamily, CacheKeyContext, CacheKeyFingerprint, CompilerFingerprint,
         DiagnosticsCacheKey, FlowGraphCacheKey, FormatCacheKey, HirLoweringCacheKey, LintCacheKey,
         PackageContextFingerprint, PackageGraphCacheKey, ParseCacheKey, QueryPolicyFingerprint,
-        SourceMapCacheKey, SymbolBucketsCacheKey, WorkspaceContextFingerprint,
+        SourceMapCacheKey, SymbolBucketScope, SymbolBucketsCacheKey, WorkspaceContextFingerprint,
     };
     use crate::{
-        FrontendMode, SourceHash, SourcePath, WorkspaceCompilerOptions,
-        WorkspacePackageConfigIdentity, WorkspaceSessionTarget, WorkspaceSingleFileTarget,
+        DocumentVersion, FileId, FrontendDiagnosticStyle, FrontendMode, SourceHash, SourcePath,
+        WorkspaceCompilerOptions, WorkspacePackageConfigIdentity, WorkspaceSessionTarget,
+        WorkspaceSingleFileTarget,
     };
 
     fn source(value: &str) -> SourceHash {
@@ -524,9 +587,9 @@ mod tests {
     fn context(family: CacheFamily) -> CacheKeyContext {
         CacheKeyContext::new(
             family,
-            CompilerFingerprint::for_testing("compiler-a"),
-            WorkspaceContextFingerprint::for_testing("workspace-a"),
-            PackageContextFingerprint::for_testing("package-a"),
+            CompilerFingerprint("compiler-a".to_string()),
+            WorkspaceContextFingerprint("workspace-a".to_string()),
+            PackageContextFingerprint("package-a".to_string()),
         )
     }
 
@@ -553,21 +616,28 @@ mod tests {
         assert_ne!(base_fingerprint, changed_source.fingerprint());
 
         let mut changed_compiler = base.clone();
-        changed_compiler.context.compiler = CompilerFingerprint::for_testing("compiler-b");
+        changed_compiler.context.compiler = CompilerFingerprint("compiler-b".to_string());
         assert_ne!(base_fingerprint, changed_compiler.fingerprint());
 
         let mut changed_workspace = base.clone();
         changed_workspace.context.workspace =
-            WorkspaceContextFingerprint::for_testing("workspace-b");
+            WorkspaceContextFingerprint("workspace-b".to_string());
         assert_ne!(base_fingerprint, changed_workspace.fingerprint());
 
         let mut changed_package = base.clone();
-        changed_package.context.package = PackageContextFingerprint::for_testing("package-b");
+        changed_package.context.package = PackageContextFingerprint("package-b".to_string());
         assert_ne!(base_fingerprint, changed_package.fingerprint());
 
         let mut changed_policy = base;
         changed_policy.context.query_policy = QueryPolicyFingerprint::new("policy-b");
         assert_ne!(base_fingerprint, changed_policy.fingerprint());
+
+        let custom_parser_options = ParseCacheKey::with_parser_options(
+            source("x = 1"),
+            QueryPolicyFingerprint::new("parser-options-b"),
+            context(CacheFamily::Parse),
+        );
+        assert_ne!(base_fingerprint, custom_parser_options.fingerprint());
     }
 
     #[test]
@@ -604,7 +674,7 @@ mod tests {
         let base = DiagnosticsCacheKey {
             source_hash: source("x = 1"),
             hir_fingerprint: fingerprint("hir-a"),
-            diagnostic_style: "bare".to_string(),
+            diagnostic_style: FrontendDiagnosticStyle::Bare,
             context: context(CacheFamily::Diagnostics),
         };
         let mut changed_hir = base.clone();
@@ -612,7 +682,7 @@ mod tests {
         assert_ne!(base.fingerprint(), changed_hir.fingerprint());
 
         let mut changed_style = base.clone();
-        changed_style.diagnostic_style = "module-prefixed".to_string();
+        changed_style.diagnostic_style = FrontendDiagnosticStyle::ModulePrefixed;
         assert_ne!(base.fingerprint(), changed_style.fingerprint());
     }
 
@@ -631,11 +701,15 @@ mod tests {
         let format = FormatCacheKey {
             source_hash: source("x = 1"),
             formatter_policy: QueryPolicyFingerprint::new("format-a"),
+            formatter_options: QueryPolicyFingerprint::new("line-width-88"),
             context: context(CacheFamily::Format),
         };
         let mut format_changed = format.clone();
         format_changed.formatter_policy = QueryPolicyFingerprint::new("format-b");
         assert_ne!(format.fingerprint(), format_changed.fingerprint());
+        let mut format_options_changed = format.clone();
+        format_options_changed.formatter_options = QueryPolicyFingerprint::new("line-width-100");
+        assert_ne!(format.fingerprint(), format_options_changed.fingerprint());
 
         let package = PackageGraphCacheKey {
             source_hash: source("manifest-a"),
@@ -649,11 +723,11 @@ mod tests {
         let symbols = SymbolBucketsCacheKey {
             source_hash: source("x = 1"),
             module_graph_fingerprint: fingerprint("graph-a"),
-            bucket_scope: "workspace".to_string(),
+            bucket_scope: SymbolBucketScope::Workspace,
             context: context(CacheFamily::SymbolBuckets),
         };
         let mut symbols_changed = symbols.clone();
-        symbols_changed.bucket_scope = "package".to_string();
+        symbols_changed.bucket_scope = SymbolBucketScope::Package;
         assert_ne!(symbols.fingerprint(), symbols_changed.fingerprint());
 
         let flow = FlowGraphCacheKey {
@@ -665,6 +739,9 @@ mod tests {
         let mut flow_changed = flow.clone();
         flow_changed.control_flow_fingerprint = fingerprint("cfg-b");
         assert_ne!(flow.fingerprint(), flow_changed.fingerprint());
+        let mut flow_hir_changed = flow.clone();
+        flow_hir_changed.hir_fingerprint = fingerprint("hir-b");
+        assert_ne!(flow.fingerprint(), flow_hir_changed.fingerprint());
     }
 
     #[test]
@@ -714,5 +791,98 @@ mod tests {
         let key = ParseCacheKey::new(source("x = 1"), context);
         let changed_key = ParseCacheKey::new(source("x = 1"), changed_context);
         assert_ne!(key.fingerprint(), changed_key.fingerprint());
+    }
+
+    #[test]
+    fn document_identity_inputs_are_intentionally_omitted_from_content_keys() {
+        fn parse_key_for_document(
+            source_text: &str,
+            _version: DocumentVersion,
+            _file: FileId,
+            _uri: Option<&str>,
+        ) -> ParseCacheKey {
+            ParseCacheKey::new(source(source_text), context(CacheFamily::Parse))
+        }
+
+        fn diagnostics_key_for_document(
+            source_text: &str,
+            _version: DocumentVersion,
+            _file: FileId,
+            _uri: Option<&str>,
+        ) -> DiagnosticsCacheKey {
+            DiagnosticsCacheKey {
+                source_hash: source(source_text),
+                hir_fingerprint: fingerprint("hir-a"),
+                diagnostic_style: FrontendDiagnosticStyle::Bare,
+                context: context(CacheFamily::Diagnostics),
+            }
+        }
+
+        let first = parse_key_for_document(
+            "x = 1",
+            DocumentVersion::new(1),
+            FileId::new(1),
+            Some("file:///first.sifr"),
+        );
+        let second = parse_key_for_document(
+            "x = 1",
+            DocumentVersion::new(99),
+            FileId::new(2),
+            Some("file:///second.sifr"),
+        );
+
+        assert_eq!(first.fingerprint(), second.fingerprint());
+
+        let diagnostics_first = diagnostics_key_for_document(
+            "x = 1",
+            DocumentVersion::new(1),
+            FileId::new(1),
+            Some("file:///first.sifr"),
+        );
+        let diagnostics_second = diagnostics_key_for_document(
+            "x = 1",
+            DocumentVersion::new(99),
+            FileId::new(2),
+            Some("file:///second.sifr"),
+        );
+        assert_eq!(
+            diagnostics_first.fingerprint(),
+            diagnostics_second.fingerprint()
+        );
+    }
+
+    #[test]
+    fn package_identity_optional_paths_are_distinct_and_exhaustive() {
+        let none = PackageContextFingerprint::from_identity(&WorkspacePackageConfigIdentity {
+            workspace_root: None,
+            entrypoint: None,
+        });
+        let root_only = PackageContextFingerprint::from_identity(&WorkspacePackageConfigIdentity {
+            workspace_root: Some(SourcePath::new("pkg")),
+            entrypoint: None,
+        });
+        let entry_only =
+            PackageContextFingerprint::from_identity(&WorkspacePackageConfigIdentity {
+                workspace_root: None,
+                entrypoint: Some(SourcePath::new("pkg/main.sifr")),
+            });
+
+        assert_ne!(none.as_str(), root_only.as_str());
+        assert_ne!(none.as_str(), entry_only.as_str());
+        assert_ne!(root_only.as_str(), entry_only.as_str());
+    }
+
+    #[test]
+    fn project_workspace_context_is_path_sensitive() {
+        let first = WorkspaceContextFingerprint::project(&crate::ProjectRoot {
+            root: SourcePath::new("pkg"),
+            entrypoint: SourcePath::new("pkg/main.sifr"),
+        });
+        let second = WorkspaceContextFingerprint::project(&crate::ProjectRoot {
+            root: SourcePath::new("pkg"),
+            entrypoint: SourcePath::new("pkg/other.sifr"),
+        });
+
+        assert_ne!(first.as_str(), second.as_str());
     }
 }

--- a/internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md
+++ b/internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md
@@ -21,6 +21,8 @@ identities, not security hashes.
 helper instead of `DefaultHasher`, so source identity is stable across
 processes and public cache-key constructors can be built without internal
 frontend access.
+Pre-M9 `SourceHash` strings are intentionally not comparable to M9 hashes; no
+snapshot cache reuse exists yet, so M10 starts from this identity contract.
 
 ## Common Inputs
 
@@ -52,8 +54,26 @@ M9 defines typed keys for:
 
 Family-specific inputs include parser options, line-map algorithm, parse/HIR
 fingerprints, compiler options, diagnostic rendering style, lint/format policy,
-manifest fingerprint, module graph fingerprint, bucket scope, and control-flow
-fingerprint where relevant.
+formatter options, manifest fingerprint, module graph fingerprint, typed bucket
+scope, and control-flow fingerprint where relevant.
+
+Default constructors use the current M9 policy constants. `ParseCacheKey` also
+exposes `with_parser_options`, and `FormatCacheKey` carries a separate
+`formatter_options` fingerprint so M10 can key user-configured parser and
+formatter behavior without changing the key shape.
+
+## Intentionally Omitted Inputs
+
+Content-derived keys intentionally omit transient editor identity:
+
+- document version;
+- file id;
+- URI/display path.
+
+Those values affect stale-result publication and editor routing, but they do not
+change parse, source-map, HIR, diagnostic, lint, format, symbol, or flow results
+when source content, workspace/package context, compiler fingerprint, and query
+policy are unchanged. M9 tests pin this omission before M10 introduces reuse.
 
 ## Validation
 
@@ -75,5 +95,5 @@ M9 focused validation so far:
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report
   `target/validation_lane_reports/quick.latest.json`, wall time 274.87s,
   advisory: group skew is high
-- Claude reviewer pass 4 -> SATISFIED
-  (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-4.md`)
+- Claude reviewer pass 6 -> SATISFIED
+  (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md`)

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -15,7 +15,7 @@ Status: in progress
 | M6 Event Compaction And Dirty Scope | merged | [#2239](https://github.com/sifr-lang/sifr/pull/2239) | Compacts batched document edits before analysis updates, summarizes watcher events before dirty-scope classification, records precise dirty scope/reason reports, and degrades incompatible or stormy invalidation conservatively. |
 | M7 Module Signatures And Dependency Invalidation | merged | [#2241](https://github.com/sifr-lang/sifr/pull/2241) | Adds import/export/module signatures, reverse-dependency closure invalidation, and local private-body edit reuse for unchanged public/import signatures. |
 | M8 First-Class Flow Graph | merged | [#2243](https://github.com/sifr-lang/sifr/pull/2243), [#2244](https://github.com/sifr-lang/sifr/pull/2244), [#2245](https://github.com/sifr-lang/sifr/pull/2245) | Adds `sifr_hir::flow_graph`, snapshot-scoped `LoweringResult.flow_graph`, graph-backed `FlowFacts` debug/fingerprint access, and lowering-time flow effects for narrowing, mutation invalidation, moves, and borrows. |
-| M9 Fingerprints And Cache Keys | merged | [#2246](https://github.com/sifr-lang/sifr/pull/2246) | Adds deterministic compiler/cache fingerprints and typed key identities for parse, source-map, HIR/lowering, diagnostics, lint, format, package graph, symbol bucket, and flow graph caches before reuse lands. |
+| M9 Fingerprints And Cache Keys | merged | [#2246](https://github.com/sifr-lang/sifr/pull/2246), [#2248](https://github.com/sifr-lang/sifr/pull/2248) | Adds deterministic compiler/cache fingerprints and typed key identities for parse, source-map, HIR/lowering, diagnostics, lint, format, package graph, symbol bucket, and flow graph caches before reuse lands. |
 
 M2 local validation so far:
 

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -156,7 +156,7 @@ M9 local validation so far:
 - `cargo clippy -p sifr_frontend -- -D warnings`
 - `cargo clippy --workspace -- -D warnings`
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 274.87s, advisory: group skew is high
-- Claude reviewer pass 4 -> SATISFIED (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-4.md`)
+- Claude reviewer pass 6 -> SATISFIED (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md`)
 
 ## Purpose
 

--- a/reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md
+++ b/reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md
@@ -1,0 +1,105 @@
+# M9 Fingerprints And Cache Keys — Pass 6 Review
+
+## Verdict: **SATISFIED**
+
+All pass-5 specific fixes have been applied correctly. M9 scope is fulfilled: no cache-reuse behavior is introduced, identity is exhaustive, and the documented boundary is honored. A few small findings and test/doc gaps remain.
+
+---
+
+## Findings
+
+### 1. `compiler_options_fingerprint` exhaustive destructuring (cache_keys.rs, `fn compiler_options_fingerprint`)
+```rust
+let WorkspaceCompilerOptions { mode } = options;
+```
+This is the right pattern (exhaustive, forces a compile error on struct growth), but the body only fingerprints `mode`. If `WorkspaceCompilerOptions` adds even a derived field later, the destructure will force the maintainer to think about it — which is desired — but a brief `// add field to fingerprint here` guard comment would make the intent explicit. **Minor.**
+
+### 2. Mode label inconsistency in workspace context (cache_keys.rs, `WorkspaceContextFingerprint::single_file`)
+```rust
+builder.field("mode", format!("{mode:?}"));
+```
+The same `FrontendMode` enum is now labeled by a typed helper (`frontend_mode_label`) in `compiler_options_fingerprint`, but `WorkspaceContextFingerprint::single_file` still Debug-formats it. The Debug output (`"SingleFile"` / `"ProjectEntrypoint"`) is stable, so this isn't a correctness bug, but it is an inconsistency vs. the new typed-label pattern introduced by this pass. **Minor — likely acceptable since the labels are stable and the field is consumed in the same `FingerprintBuilder` flow.**
+
+### 3. Magic default string in `FormatCacheKey::new` (cache_keys.rs)
+```rust
+formatter_options: QueryPolicyFingerprint::new("default-format-options"),
+```
+All other families use a module-level constant for their default policy/version (`PARSER_OPTIONS_VERSION`, `LOWERING_OPTIONS_VERSION`, etc.). `FormatCacheKey` is the only family that hard-codes its default. There is no `FORMAT_OPTIONS_VERSION` constant. Either introduce a constant or accept the magic string with a `// M9 sentinel` comment. **Minor consistency issue.**
+
+### 4. Duplicate `new file` diff entry for `cache_keys.rs`
+The diff contains both a modification hunk and a `new file mode 100644` hunk for `crates/sifr_frontend/src/cache_keys.rs` with identical content. This looks like a diff generation artifact (perhaps the file was re-added during a rebase or the diff was produced with a wrong option). The final file content is correct, but reviewers and patch-apply tools will be confused. **Verify the diff generation path; not a content issue.**
+
+### 5. `WorkspaceContextFingerprint::project` not directly tested
+Not a regression in this pass — but worth noting: only `single_file` is exercised in tests, while `project` is only exercised indirectly via `CacheKeyContext::from_workspace` (and even that path uses `SingleFile` in the existing test). Adding a dedicated `project` path-sensitivity test would be a low-cost coverage improvement. **Pre-existing gap.**
+
+---
+
+## Test Gaps
+
+### T1. `ParseCacheKey::with_parser_options` is not directly tested (cache_keys.rs, tests module)
+The new override surface is added but no test exercises it. The existing `parse_key_includes_source_compiler_workspace_package_and_policy` only verifies the default policy path. A test like:
+```rust
+let custom = ParseCacheKey::with_parser_options(
+    source("x = 1"),
+    QueryPolicyFingerprint::new("experimental-parser-v2"),
+    context(CacheFamily::Parse),
+);
+let default = ParseCacheKey::new(source("x = 1"), context(CacheFamily::Parse));
+assert_ne!(custom.fingerprint(), default.fingerprint());
+```
+would close the loop. **Should add.**
+
+### T2. `document_identity_inputs_are_intentionally_omitted_from_content_keys` only covers `ParseCacheKey`
+The negative test is well-formed, but only one of the nine key families is exercised. Given the M9 spec explicitly enumerates parse, source-map, HIR, diagnostics, lint, format, symbol buckets, and flow graph as "content-derived", the omission contract should be pinned for at least one more family (HIR or diagnostics is the natural second target). **Should extend or add a sibling test.**
+
+### T3. `FormatCacheKey::new` defaults are not asserted (cache_keys.rs, tests module)
+`FormatCacheKey::new` sets `formatter_options = "default-format-options"`, but no test asserts the default value or that the constructor wires the right `formatter_policy`. The `formatter_options` field is mutated in `format_options_changed`, but the "default" path is not pinned. **Minor — low priority.**
+
+### T4. `package_identity_none_and_some_are_distinct_and_exhaustive` name oversells coverage (cache_keys.rs, tests module)
+The test compares `(None, None)` vs `(Some, None)`. It does not exercise `(None, Some)` or the `(Some, Some) → (Some, Some with different entrypoint)` case explicitly — the latter is in `workspace_and_package_contexts_are_path_sensitive`, but the `None, Some` arm is uncovered. Either rename the test or add the missing case. **Minor.**
+
+---
+
+## Doc Gaps
+
+### D1. MD validation section still cites "Claude reviewer pass 4" (internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md)
+The `## Validation` block ends with:
+> Claude reviewer pass 4 -> SATISFIED (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-4.md`)
+
+This is pass 6. Either the validation list should be updated to reference the current pass (and any newly run validation commands), or the pass-N line should be moved out of `## Validation` into a separate `## Review History` section so it can grow without polluting the "what we ran" list. **Update before merge.**
+
+### D2. MD doesn't mention the new override surfaces by name (internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md)
+The "Family-specific inputs" line now lists "formatter options", but the existence of `ParseCacheKey::with_parser_options` (a public override constructor distinct from the default `new`) and the separate `formatter_options` slot on `FormatCacheKey` is not called out. A short paragraph or bullet explaining that M9 keys expose default-and-override construction (no live reuse) would make the override surfaces easier to discover for M10. **Should add.**
+
+### D3. MD doesn't cross-reference the SourceHash boundary with `SourceHash::from_source_text` behavior
+The new paragraph states the boundary correctly ("Pre-M9 `SourceHash` strings are intentionally not comparable to M9 hashes"), but does not name the function whose behavior changed. A one-line mention of `SourceHash::from_source_text` switching off `DefaultHasher` (which the section already alludes to) would let a future reader find the diff in the public API. **Minor wording fix.**
+
+---
+
+## Pass-5 Fix Audit
+
+| Pass-5 fix | Status | Evidence |
+|---|---|---|
+| Negative test for omitted document identity | ✅ Applied | `document_identity_inputs_are_intentionally_omitted_from_content_keys` (cache_keys.rs tests) |
+| Diagnostics style → typed enum | ✅ Applied | `diagnostic_style: FrontendDiagnosticStyle` + `diagnostic_style_label` |
+| Symbol bucket scope → typed enum | ✅ Applied | `SymbolBucketScope` enum + `.label()` |
+| Parser option override surface | ✅ Applied | `ParseCacheKey::with_parser_options` |
+| Formatter option override surface | ✅ Applied | `FormatCacheKey.formatter_options` field |
+| Stop Debug-formatting `WorkspaceCompilerOptions` | ✅ Applied | `compiler_options_fingerprint` helper |
+| `#[cfg(test)]` on testing constructors | ✅ Applied | `for_testing` is gated on `#[cfg(test)]` for all three types |
+| Exhaustive `WorkspacePackageConfigIdentity` destructure | ✅ Applied | `let WorkspacePackageConfigIdentity { workspace_root, entrypoint } = identity;` |
+| Document omitted inputs | ✅ Applied | New "Intentionally Omitted Inputs" section |
+| Document `SourceHash` boundary | ✅ Applied | New paragraph under "Fingerprint Model" |
+
+All ten pass-5 fixes are addressed. M10 reuse still does not exist (no map, no LRU, no eviction, no entry construction). M9 contract is correctly scoped.
+
+---
+
+## Recommendation
+
+**Accept for merge** with the following non-blocking follow-ups:
+
+1. Add a direct test for `ParseCacheKey::with_parser_options` (T1).
+2. Extend or duplicate the document-identity-omitted test for at least one non-parse family (T2).
+3. Update the MD validation section to reference the current pass review (D1) and call out the override constructors (D2).
+4. Promote the magic `"default-format-options"` string in `FormatCacheKey::new` to a module-level constant for parity with other families (Finding 3).


### PR DESCRIPTION
## Summary
- tighten M9 cache keys with typed diagnostic style and symbol bucket scope inputs
- add formatter option identity and deterministic compiler-option labels
- document intentionally omitted transient editor identity inputs
- add targeted tests for parser option overrides, omitted document identity, package optional paths, and project context sensitivity

## Validation
- cargo fmt --check
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- cargo test -p sifr_frontend cache_key
- cargo test -p sifr_frontend
- cargo clippy -p sifr_frontend -- -D warnings
- Claude reviewer pass 6 -> SATISFIED