### PR TITLE
Correct M9 quick validation timing

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md
+++ b/internal_docs/typescript_go_architecture_transfer_m9_fingerprints_cache_keys.md
@@ -93,7 +93,7 @@ M9 focused validation so far:
 - `cargo clippy -p sifr_frontend -- -D warnings`
 - `cargo clippy --workspace -- -D warnings`
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report
-  `target/validation_lane_reports/quick.latest.json`, wall time 274.87s,
-  advisory: group skew is high
+  `target/validation_lane_reports/quick.latest.json`, wall time 338.91s,
+  advisories: warm wall-time budget exceeded; group skew is high
 - Claude reviewer pass 6 -> SATISFIED
   (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md`)

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -155,7 +155,7 @@ M9 local validation so far:
 - `cargo test -p sifr -- --skip test_e2e_pass`
 - `cargo clippy -p sifr_frontend -- -D warnings`
 - `cargo clippy --workspace -- -D warnings`
-- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 274.87s, advisory: group skew is high
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 338.91s, advisories: warm wall-time budget exceeded; group skew is high
 - Claude reviewer pass 6 -> SATISFIED (`reviews/typescript-go-m9-fingerprints-cache-keys-review-pass-6.md`)
 
 ## Purpose


### PR DESCRIPTION
## Summary
- update M9 quick validation wall time and advisory text to the latest run

## Validation
- git diff --check