### PR TITLE
Add LSP scheduler queues

### DIFF
--- a/crates/sifr_lsp/src/diagnostics.rs
+++ b/crates/sifr_lsp/src/diagnostics.rs
@@ -16,40 +16,76 @@ impl DiagnosticsController {
         mode: DiagnosticsMode,
     ) -> LspResult<()> {
         if mode == DiagnosticsMode::Off {
+            session.clear_diagnostic_jobs();
             return Ok(());
         }
-        let diagnostics = document_diagnostics(session, uri)?;
-        let document = session.store().document(uri)?;
-        let params = json!({
-            "uri": document.uri(),
-            "version": document.version(),
-            "diagnostics": diagnostics
-        });
-        connection
-            .sender
-            .send(Message::Notification(Notification {
-                method: "textDocument/publishDiagnostics".to_string(),
-                params,
-            }))
-            .map_err(|error| {
-                crate::errors::LspError::internal(format!("failed to publish diagnostics: {error}"))
-            })?;
-        Ok(())
+        session.schedule_document_diagnostics(uri)?;
+        Self::flush_ready(connection, session, mode)
     }
 
     pub(crate) fn publish_all(connection: &Connection, session: &mut Session) -> LspResult<()> {
         let mode = session.store().settings().diagnostics_mode;
         if mode == DiagnosticsMode::Off {
+            session.clear_diagnostic_jobs();
             return Ok(());
         }
         for uri in session.document_uris() {
-            Self::publish_document(connection, session, &uri, mode)?;
+            session.schedule_document_diagnostics(&uri)?;
+        }
+        Self::flush_ready(connection, session, mode)?;
+        Ok(())
+    }
+
+    fn flush_ready(
+        connection: &Connection,
+        session: &mut Session,
+        mode: DiagnosticsMode,
+    ) -> LspResult<()> {
+        if mode == DiagnosticsMode::Off {
+            session.clear_diagnostic_jobs();
+            return Ok(());
+        }
+        while let Some(job) = session.take_next_diagnostic_job() {
+            if !session.document_version_matches(&job.uri, job.version)? {
+                session.trace(format!(
+                    "skipped stale diagnostics for {} captured at version {:?}",
+                    job.uri, job.version
+                ));
+                continue;
+            }
+            let diagnostics = document_diagnostics(session, &job.uri)?;
+            if !session.document_version_matches(&job.uri, job.version)? {
+                session.trace(format!(
+                    "skipped stale diagnostics publish for {} captured at version {:?}",
+                    job.uri, job.version
+                ));
+                continue;
+            }
+            let params = json!({
+                "uri": job.uri,
+                "version": job.version,
+                "diagnostics": diagnostics
+            });
+            connection
+                .sender
+                .send(Message::Notification(Notification {
+                    method: "textDocument/publishDiagnostics".to_string(),
+                    params,
+                }))
+                .map_err(|error| {
+                    crate::errors::LspError::internal(format!(
+                        "failed to publish diagnostics: {error}"
+                    ))
+                })?;
         }
         Ok(())
     }
 }
 
 pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResult<Vec<Value>> {
+    // Load-time diagnostics are replaced whenever the document analysis owner is
+    // opened or updated. Publication still captures and checks the document
+    // version in `DiagnosticsController` before this shortcut can be observed.
     if !session.load_diagnostics(uri).is_empty() {
         return Ok(session
             .load_diagnostics(uri)

--- a/crates/sifr_lsp/src/notifications/mod.rs
+++ b/crates/sifr_lsp/src/notifications/mod.rs
@@ -46,8 +46,13 @@ fn cancel_request(session: &mut Session, params: &Value) -> LspResult<()> {
 
 fn workspace_did_change_configuration(session: &mut Session, params: Value) -> LspResult<()> {
     let root = params.get("settings").unwrap_or(&params);
+    let previous_mode = session.store().settings().diagnostics_mode;
     let settings = crate::settings::parse_workspace_settings(root, session.store().settings())?;
+    let next_mode = settings.diagnostics_mode;
     session.store_mut().apply_settings(settings);
+    if previous_mode != next_mode && next_mode == crate::document_store::DiagnosticsMode::Off {
+        session.clear_diagnostic_jobs();
+    }
     Ok(())
 }
 

--- a/crates/sifr_lsp/src/request_queue.rs
+++ b/crates/sifr_lsp/src/request_queue.rs
@@ -1,35 +1,243 @@
+use crate::scheduler::{Scheduler, WorkLane};
 use lsp_server::RequestId;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+const FAIRNESS_INTERVAL: usize = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ScheduledRequest {
+    id: RequestId,
+    key: String,
+    method: String,
+    lane: WorkLane,
+}
+
+impl ScheduledRequest {
+    pub(crate) fn id(&self) -> &RequestId {
+        &self.id
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub(crate) fn method(&self) -> &str {
+        &self.method
+    }
+
+    pub(crate) fn lane(&self) -> WorkLane {
+        self.lane
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct QueuedRequest {
+    id: RequestId,
+    key: String,
+    method: String,
+    lane: WorkLane,
+    sequence: u64,
+}
 
 #[derive(Default)]
 pub(crate) struct RequestQueue {
-    pending: BTreeSet<String>,
+    queued: BTreeMap<WorkLane, VecDeque<QueuedRequest>>,
+    in_flight: BTreeMap<String, ScheduledRequest>,
+    queued_keys: BTreeSet<String>,
     shutdown_requested: bool,
+    next_sequence: u64,
+    priority_dispatches_since_fairness: usize,
+    fairness_cursor: usize,
 }
 
 impl RequestQueue {
-    pub(crate) fn start(&mut self, id: &RequestId) -> Result<(), &'static str> {
+    pub(crate) fn enqueue(
+        &mut self,
+        id: &RequestId,
+        method: &str,
+        lane: WorkLane,
+    ) -> Result<(), &'static str> {
         if self.shutdown_requested {
             return Err("server is shutting down");
         }
-        self.pending.insert(request_key(id));
+        let key = request_key(id);
+        let request = QueuedRequest {
+            id: id.clone(),
+            key: key.clone(),
+            method: method.to_string(),
+            lane,
+            sequence: self.next_sequence,
+        };
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.queued.entry(lane).or_default().push_back(request);
+        self.queued_keys.insert(key);
         Ok(())
     }
 
+    pub(crate) fn start_next(&mut self) -> Option<ScheduledRequest> {
+        let lane = self.select_next_lane()?;
+        let request = self.queued.get_mut(&lane)?.pop_front()?;
+        if self.queued.get(&lane).is_some_and(VecDeque::is_empty) {
+            self.queued.remove(&lane);
+        }
+        self.queued_keys.remove(&request.key);
+        let scheduled = ScheduledRequest {
+            id: request.id,
+            key: request.key,
+            method: request.method,
+            lane: request.lane,
+        };
+        self.in_flight
+            .insert(scheduled.key.clone(), scheduled.clone());
+        Some(scheduled)
+    }
+
     pub(crate) fn finish(&mut self, id: &RequestId) {
-        self.pending.remove(&request_key(id));
+        self.in_flight.remove(&request_key(id));
     }
 
     pub(crate) fn remove_pending(&mut self, id: &RequestId) -> bool {
-        self.pending.remove(&request_key(id))
+        let key = request_key(id);
+        for lane_queue in self.queued.values_mut() {
+            if let Some(index) = lane_queue.iter().position(|request| request.key == key) {
+                lane_queue.remove(index);
+                self.queued_keys.remove(&key);
+                return true;
+            }
+        }
+        self.in_flight.remove(&key).is_some()
     }
 
     pub(crate) fn begin_shutdown(&mut self) {
         self.shutdown_requested = true;
-        self.pending.clear();
+        self.queued.clear();
+        self.queued_keys.clear();
+        self.in_flight.clear();
+    }
+
+    fn select_next_lane(&mut self) -> Option<WorkLane> {
+        if self.priority_dispatches_since_fairness >= FAIRNESS_INTERVAL {
+            if let Some(lane) = self.next_fair_lane() {
+                self.priority_dispatches_since_fairness = 0;
+                return Some(lane);
+            }
+        }
+        let lane = Scheduler::LANES
+            .into_iter()
+            .find(|lane| self.queued.get(lane).is_some_and(|queue| !queue.is_empty()))?;
+        self.priority_dispatches_since_fairness =
+            self.priority_dispatches_since_fairness.saturating_add(1);
+        Some(lane)
+    }
+
+    fn next_fair_lane(&mut self) -> Option<WorkLane> {
+        for offset in 1..=Scheduler::LANES.len() {
+            let index = (self.fairness_cursor + offset) % Scheduler::LANES.len();
+            let lane = Scheduler::LANES[index];
+            if self
+                .queued
+                .get(&lane)
+                .is_some_and(|queue| !queue.is_empty())
+            {
+                self.fairness_cursor = index;
+                return Some(lane);
+            }
+        }
+        None
     }
 }
 
-fn request_key(id: &RequestId) -> String {
+pub(crate) fn request_key(id: &RequestId) -> String {
     format!("{id:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RequestQueue;
+    use crate::scheduler::WorkLane;
+    use lsp_server::RequestId;
+
+    #[test]
+    fn scheduler_prefers_latency_but_eventually_services_background() {
+        let mut queue = RequestQueue::default();
+        for id in 0..12 {
+            queue
+                .enqueue(
+                    &RequestId::from(id),
+                    "textDocument/completion",
+                    WorkLane::LatencySensitive,
+                )
+                .expect("latency request should enqueue");
+        }
+        queue
+            .enqueue(
+                &RequestId::from(100),
+                "sifr/backgroundIndex",
+                WorkLane::Background,
+            )
+            .expect("background request should enqueue");
+
+        let scheduled = (0..6)
+            .map(|_| queue.start_next().expect("request should schedule").lane())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            scheduled,
+            vec![
+                WorkLane::LatencySensitive,
+                WorkLane::LatencySensitive,
+                WorkLane::LatencySensitive,
+                WorkLane::LatencySensitive,
+                WorkLane::Background,
+                WorkLane::LatencySensitive
+            ]
+        );
+    }
+
+    #[test]
+    fn scheduler_rotates_fairness_lane_across_nonempty_queues() {
+        let mut queue = RequestQueue::default();
+        for id in 0..10 {
+            queue
+                .enqueue(
+                    &RequestId::from(id),
+                    "textDocument/hover",
+                    WorkLane::LatencySensitive,
+                )
+                .expect("latency request should enqueue");
+        }
+        queue
+            .enqueue(
+                &RequestId::from(100),
+                "workspace/diagnostic",
+                WorkLane::Workspace,
+            )
+            .expect("workspace request should enqueue");
+        queue
+            .enqueue(
+                &RequestId::from(101),
+                "sifr/backgroundIndex",
+                WorkLane::Background,
+            )
+            .expect("background request should enqueue");
+
+        let scheduled = (0..10)
+            .map(|_| queue.start_next().expect("request should schedule").lane())
+            .collect::<Vec<_>>();
+
+        assert_eq!(scheduled[4], WorkLane::Workspace);
+        assert_eq!(scheduled[9], WorkLane::Background);
+    }
+
+    #[test]
+    fn cancellation_removes_queued_request_before_dispatch() {
+        let mut queue = RequestQueue::default();
+        let id = RequestId::from(42);
+        queue
+            .enqueue(&id, "workspace/diagnostic", WorkLane::Workspace)
+            .expect("request should enqueue");
+
+        assert!(queue.remove_pending(&id));
+        assert!(queue.start_next().is_none());
+    }
 }

--- a/crates/sifr_lsp/src/requests/mod.rs
+++ b/crates/sifr_lsp/src/requests/mod.rs
@@ -13,13 +13,10 @@ mod type_hierarchy;
 
 use crate::commands::CommandRegistry;
 use crate::errors::{LspError, LspResult};
-use crate::scheduler::Scheduler;
 use crate::session::Session;
 use serde_json::Value;
 
 pub(crate) fn handle(session: &mut Session, method: &str, params: Value) -> LspResult<Value> {
-    let lane = Scheduler::lane_for_method(method);
-    session.trace(format!("dispatching {method} on {lane:?} lane"));
     match method {
         "workspace/symbol" => symbols::workspace_symbol(session, params),
         "workspace/executeCommand" => execute_command(session, params),

--- a/crates/sifr_lsp/src/scheduler.rs
+++ b/crates/sifr_lsp/src/scheduler.rs
@@ -1,8 +1,9 @@
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum WorkLane {
     LatencySensitive,
     Formatting,
     Workspace,
+    Background,
 }
 
 #[derive(Default)]
@@ -13,7 +14,17 @@ impl Scheduler {
         match method {
             "textDocument/formatting" | "textDocument/rangeFormatting" => WorkLane::Formatting,
             "workspace/symbol" | "workspace/diagnostic" => WorkLane::Workspace,
+            // Internal lane sentinel for scheduler/background-index tests. M13 wires
+            // real background worker entrypoints.
+            "sifr/backgroundIndex" => WorkLane::Background,
             _ => WorkLane::LatencySensitive,
         }
     }
+
+    pub(crate) const LANES: [WorkLane; 4] = [
+        WorkLane::LatencySensitive,
+        WorkLane::Formatting,
+        WorkLane::Workspace,
+        WorkLane::Background,
+    ];
 }

--- a/crates/sifr_lsp/src/server.rs
+++ b/crates/sifr_lsp/src/server.rs
@@ -1,9 +1,12 @@
 use crate::capabilities;
 use crate::errors::{LspError, ServerResult};
 use crate::notifications;
+use crate::request_queue;
 use crate::requests;
+use crate::scheduler::Scheduler;
 use crate::session::Session;
 use lsp_server::{Connection, IoThreads, Message, Request, Response};
+use std::collections::BTreeMap;
 
 pub fn run_stdio() -> ServerResult<()> {
     LspServer::stdio().run()
@@ -13,6 +16,7 @@ struct LspServer {
     connection: Connection,
     io_threads: IoThreads,
     session: Session,
+    queued_requests: BTreeMap<String, Request>,
 }
 
 impl LspServer {
@@ -22,6 +26,7 @@ impl LspServer {
             connection,
             io_threads,
             session: Session::new(),
+            queued_requests: BTreeMap::new(),
         }
     }
 
@@ -84,20 +89,56 @@ impl LspServer {
 
     fn handle_request(&mut self, request: Request) -> ServerResult<()> {
         let id = request.id.clone();
-        let result = self
-            .session
-            .start_request(&id)
-            .map_err(LspError::request_cancelled)
-            .and_then(|()| requests::handle(&mut self.session, &request.method, request.params));
-        self.session.finish_request(&id);
-        let response = match result {
-            Ok(result) => Response::new_ok(id, result),
-            Err(error) => Response::new_err(id, error.code(), error.message()),
-        };
-        self.connection
-            .sender
-            .send(Message::Response(response))
-            .map_err(|error| LspError::internal(format!("failed to send LSP response: {error}")))?;
+        let lane = Scheduler::lane_for_method(&request.method);
+        if let Err(error) = self.session.enqueue_request(&id, &request.method, lane) {
+            let error = LspError::request_cancelled(error);
+            let response = Response::new_err(id, error.code(), error.message());
+            self.connection
+                .sender
+                .send(Message::Response(response))
+                .map_err(|error| {
+                    LspError::internal(format!("failed to send LSP response: {error}"))
+                })?;
+            return Ok(());
+        }
+        self.queued_requests
+            .insert(request_queue::request_key(&id), request);
+        self.drain_queued_requests()?;
+        Ok(())
+    }
+
+    fn drain_queued_requests(&mut self) -> ServerResult<()> {
+        while let Some(scheduled) = self.session.start_next_request() {
+            let Some(request) = self.queued_requests.remove(scheduled.key()) else {
+                let id = scheduled.id().clone();
+                self.session.finish_request(scheduled.id());
+                let error = LspError::internal(format!(
+                    "scheduled request body was missing for key {}",
+                    scheduled.key()
+                ));
+                let response = Response::new_err(id, error.code(), error.message());
+                self.connection
+                    .sender
+                    .send(Message::Response(response))
+                    .map_err(|error| {
+                        LspError::internal(format!("failed to send LSP response: {error}"))
+                    })?;
+                continue;
+            };
+            let id = request.id.clone();
+            let result = requests::handle(&mut self.session, &request.method, request.params);
+            self.session.finish_request(&id);
+            let response = match result {
+                Ok(result) => Response::new_ok(id, result),
+                Err(error) => Response::new_err(id, error.code(), error.message()),
+            };
+            self.connection
+                .sender
+                .send(Message::Response(response))
+                .map_err(|error| {
+                    LspError::internal(format!("failed to send LSP response: {error}"))
+                })?;
+        }
         Ok(())
     }
 
@@ -106,6 +147,7 @@ impl LspServer {
             connection,
             io_threads,
             session: _,
+            queued_requests: _,
         } = self;
         drop(connection);
         io_threads.join()?;

--- a/crates/sifr_lsp/src/session.rs
+++ b/crates/sifr_lsp/src/session.rs
@@ -2,7 +2,8 @@ use crate::analysis_workspace::LspAnalysisWorkspace;
 use crate::document_events::{compact_content_changes, CompactedDocumentChange};
 use crate::document_store::DocumentStore;
 use crate::errors::LspResult;
-use crate::request_queue::RequestQueue;
+use crate::request_queue::{RequestQueue, ScheduledRequest};
+use crate::scheduler::WorkLane;
 use lsp_server::RequestId;
 use serde_json::Value;
 use sifr_analysis::{AnalysisHost, AnalysisSnapshot, FileId};
@@ -17,12 +18,21 @@ pub(crate) struct Session {
     shutdown_requested: bool,
     exit_requested: bool,
     traces: Vec<String>,
+    diagnostic_jobs: BTreeMap<String, ScheduledDiagnosticJob>,
+    next_diagnostic_sequence: u64,
 }
 
 pub(crate) struct DocumentChangeSummary {
     pub(crate) raw_change_count: usize,
     pub(crate) compacted_change_count: usize,
     pub(crate) text_changed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ScheduledDiagnosticJob {
+    pub(crate) uri: String,
+    pub(crate) version: Option<i32>,
+    sequence: u64,
 }
 
 impl Session {
@@ -35,6 +45,8 @@ impl Session {
             shutdown_requested: false,
             exit_requested: false,
             traces: Vec::new(),
+            diagnostic_jobs: BTreeMap::new(),
+            next_diagnostic_sequence: 0,
         }
     }
 
@@ -97,6 +109,7 @@ impl Session {
     }
 
     pub(crate) fn close_document(&mut self, uri: &str) -> bool {
+        self.diagnostic_jobs.remove(uri);
         self.analysis.close_document(uri);
         self.store.close(uri)
     }
@@ -143,8 +156,28 @@ impl Session {
         Ok(result)
     }
 
-    pub(crate) fn start_request(&mut self, id: &RequestId) -> Result<(), &'static str> {
-        self.queue.start(id)
+    pub(crate) fn enqueue_request(
+        &mut self,
+        id: &RequestId,
+        method: &str,
+        lane: WorkLane,
+    ) -> Result<(), &'static str> {
+        self.queue.enqueue(id, method, lane)?;
+        self.trace(format!(
+            "queued request {id:?} method={method} lane={lane:?}"
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn start_next_request(&mut self) -> Option<ScheduledRequest> {
+        let scheduled = self.queue.start_next()?;
+        self.trace(format!(
+            "dispatching request {:?} method={} lane={:?}",
+            scheduled.id(),
+            scheduled.method(),
+            scheduled.lane()
+        ));
+        Some(scheduled)
     }
 
     pub(crate) fn finish_request(&mut self, id: &RequestId) {
@@ -170,6 +203,11 @@ impl Session {
     pub(crate) fn begin_shutdown(&mut self) {
         self.shutdown_requested = true;
         self.queue.begin_shutdown();
+        self.diagnostic_jobs.clear();
+    }
+
+    pub(crate) fn clear_diagnostic_jobs(&mut self) {
+        self.diagnostic_jobs.clear();
     }
 
     pub(crate) fn shutdown_requested(&self) -> bool {
@@ -189,6 +227,48 @@ impl Session {
 
     pub(crate) fn trace(&mut self, message: String) {
         self.traces.push(message);
+    }
+
+    pub(crate) fn schedule_document_diagnostics(
+        &mut self,
+        uri: &str,
+    ) -> LspResult<ScheduledDiagnosticJob> {
+        let version = self.store.document(uri)?.version();
+        let sequence = if let Some(existing) = self.diagnostic_jobs.get(uri) {
+            existing.sequence
+        } else {
+            let sequence = self.next_diagnostic_sequence;
+            self.next_diagnostic_sequence = self.next_diagnostic_sequence.saturating_add(1);
+            sequence
+        };
+        let job = ScheduledDiagnosticJob {
+            uri: uri.to_string(),
+            version,
+            sequence,
+        };
+        self.diagnostic_jobs.insert(uri.to_string(), job.clone());
+        self.trace(format!(
+            "scheduled diagnostics for {uri} at version {:?}",
+            job.version
+        ));
+        Ok(job)
+    }
+
+    pub(crate) fn take_next_diagnostic_job(&mut self) -> Option<ScheduledDiagnosticJob> {
+        let uri = self
+            .diagnostic_jobs
+            .iter()
+            .min_by_key(|(_, job)| job.sequence)
+            .map(|(uri, _)| uri.clone())?;
+        self.diagnostic_jobs.remove(&uri)
+    }
+
+    pub(crate) fn document_version_matches(
+        &self,
+        uri: &str,
+        version: Option<i32>,
+    ) -> LspResult<bool> {
+        Ok(self.store.document(uri)?.version() == version)
     }
 }
 
@@ -303,5 +383,166 @@ mod tests {
             session.store().document(&uri).expect("document").version(),
             Some(2)
         );
+    }
+
+    #[test]
+    fn diagnostic_scheduling_debounces_to_latest_document_version() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("main.sifr");
+        std::fs::write(&path, "def main() -> int:\n    return 1\n").expect("write disk source");
+        let uri = url::Url::from_file_path(&path)
+            .expect("file uri")
+            .to_string();
+
+        let mut session = Session::new();
+        session
+            .open_document(
+                uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                "def main() -> int:\n    return 1\n".to_string(),
+            )
+            .expect("open document");
+        session
+            .schedule_document_diagnostics(&uri)
+            .expect("schedule diagnostics");
+        session
+            .change_compacted(
+                &uri,
+                Some(2),
+                &[json!({"text": "def main() -> int:\n    return 2\n"})],
+            )
+            .expect("change document");
+        session
+            .schedule_document_diagnostics(&uri)
+            .expect("reschedule diagnostics");
+
+        let job = session
+            .take_next_diagnostic_job()
+            .expect("latest diagnostics job should remain");
+        assert_eq!(job.version, Some(2));
+        assert!(session.take_next_diagnostic_job().is_none());
+    }
+
+    #[test]
+    fn diagnostic_job_version_guard_rejects_stale_capture() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("main.sifr");
+        std::fs::write(&path, "def main() -> int:\n    return 1\n").expect("write disk source");
+        let uri = url::Url::from_file_path(&path)
+            .expect("file uri")
+            .to_string();
+
+        let mut session = Session::new();
+        session
+            .open_document(
+                uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                "def main() -> int:\n    return 1\n".to_string(),
+            )
+            .expect("open document");
+        let job = session
+            .schedule_document_diagnostics(&uri)
+            .expect("schedule diagnostics");
+        session
+            .change_compacted(
+                &uri,
+                Some(2),
+                &[json!({"text": "def main() -> int:\n    return 2\n"})],
+            )
+            .expect("change document");
+
+        assert!(!session
+            .document_version_matches(&job.uri, job.version)
+            .expect("document should still exist"));
+    }
+
+    #[test]
+    fn close_document_discards_pending_diagnostic_job() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("main.sifr");
+        std::fs::write(&path, "def main() -> int:\n    return 1\n").expect("write disk source");
+        let uri = url::Url::from_file_path(&path)
+            .expect("file uri")
+            .to_string();
+
+        let mut session = Session::new();
+        session
+            .open_document(
+                uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                "def main() -> int:\n    return 1\n".to_string(),
+            )
+            .expect("open document");
+        session
+            .schedule_document_diagnostics(&uri)
+            .expect("schedule diagnostics");
+
+        assert!(session.close_document(&uri));
+        assert!(session.take_next_diagnostic_job().is_none());
+    }
+
+    #[test]
+    fn diagnostic_reschedule_preserves_original_queue_order() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let first_path = temp.path().join("first.sifr");
+        let second_path = temp.path().join("second.sifr");
+        std::fs::write(&first_path, "def main() -> int:\n    return 1\n")
+            .expect("write first source");
+        std::fs::write(&second_path, "def main() -> int:\n    return 2\n")
+            .expect("write second source");
+        let first_uri = url::Url::from_file_path(&first_path)
+            .expect("first file uri")
+            .to_string();
+        let second_uri = url::Url::from_file_path(&second_path)
+            .expect("second file uri")
+            .to_string();
+
+        let mut session = Session::new();
+        session
+            .open_document(
+                first_uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                "def main() -> int:\n    return 1\n".to_string(),
+            )
+            .expect("open first document");
+        session
+            .open_document(
+                second_uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                "def main() -> int:\n    return 2\n".to_string(),
+            )
+            .expect("open second document");
+
+        session
+            .schedule_document_diagnostics(&first_uri)
+            .expect("schedule first diagnostics");
+        session
+            .schedule_document_diagnostics(&second_uri)
+            .expect("schedule second diagnostics");
+        session
+            .change_compacted(
+                &first_uri,
+                Some(2),
+                &[json!({"text": "def main() -> int:\n    return 3\n"})],
+            )
+            .expect("change first document");
+        session
+            .schedule_document_diagnostics(&first_uri)
+            .expect("reschedule first diagnostics");
+
+        let first_job = session
+            .take_next_diagnostic_job()
+            .expect("first diagnostics job should remain first");
+        let second_job = session
+            .take_next_diagnostic_job()
+            .expect("second diagnostics job should remain second");
+        assert_eq!(first_job.uri, first_uri);
+        assert_eq!(first_job.version, Some(2));
+        assert_eq!(second_job.uri, second_uri);
     }
 }

--- a/internal_docs/lsp_server.md
+++ b/internal_docs/lsp_server.md
@@ -60,9 +60,9 @@ the required LSP shutdown sequence.
 
 ## Current M5 Compiler-Service State
 
-The TypeScript-Go architecture transfer keeps M5 serialized while moving LSP
-analysis ownership into the language-server session. Current implementation
-reality:
+The TypeScript-Go architecture transfer keeps request execution serialized while
+moving LSP analysis ownership and scheduling state into the language-server
+session. Current implementation reality:
 
 - `DocumentStore` owns only protocol text, URI, path, and version state.
 - `Session` owns `LspAnalysisWorkspace`, which holds persistent analysis handles
@@ -82,14 +82,22 @@ reality:
 - `workspace/didChangeWatchedFiles` summarizes each watcher batch once before
   invalidation. Normal watcher batches select graph-structure dirty scope;
   watcher storms degrade to workspace dirty scope with `WatcherStorm`.
-- `RequestQueue` tracks pending request ids and shutdown state; it is not yet a
-  cancellation-token registry.
-- `Scheduler` maps methods to lane labels only; it does not yet run priority
-  queues, debounce, background workers, delayed progress, or cancellation.
+- `RequestQueue` owns M11 priority queues for latency-sensitive, formatting,
+  workspace, and background lanes. Dispatch remains serialized, but queued
+  requests are selected through bounded-fairness scheduling so workspace and
+  background work cannot permanently starve and cannot dominate latency-sensitive
+  work.
+- `DiagnosticsController` schedules document diagnostics as debounced jobs keyed
+  by URI and captured document version. Publication skips jobs whose captured
+  version is no longer current, preserves a document's original queue slot when
+  the same URI is rescheduled, and clears pending jobs when diagnostics are
+  disabled.
+- `Scheduler` does not yet run background worker threads, delayed progress, or
+  cancellation tokens.
 
 M7 owns dependency-sensitive signature invalidation. M11 owns priority
-queues/debounce. M13 owns cancellation, progress, and parent-process watchdog
-behavior.
+queues/debounce. M13 owns cancellation, progress, background execution, and
+parent-process watchdog behavior.
 
 ## Capability Matrix
 

--- a/internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md
+++ b/internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md
@@ -1,0 +1,52 @@
+# TypeScript-Go Architecture Transfer M11: LSP Scheduler Queues
+
+status: in progress
+
+M11 makes LSP request scheduling concrete while deliberately keeping execution
+serialized until M13 adds cancellation tokens, progress, and worker execution.
+`sifr_lsp::RequestQueue` now stores FIFO queues per lane:
+
+- latency-sensitive
+- formatting
+- workspace
+- background
+
+The scheduler prefers latency-sensitive work but runs a bounded fairness pass
+after a fixed interval so workspace and background work cannot starve forever.
+Formatting has its own lane, so large workspace requests cannot sit ahead of
+formatting or hover/completion-style work.
+
+Diagnostics publication now flows through debounced jobs keyed by document URI.
+Each scheduled diagnostic job captures the current document version; publication
+checks that version both before and after analysis, then skips stale jobs instead
+of publishing superseded diagnostics. Re-scheduling a document refreshes the
+captured version while preserving that document's original queue slot, and
+pending diagnostic jobs are cleared when diagnostics are disabled.
+
+Current limitations:
+
+- request execution remains serialized in the stdio loop
+- M13 still owns cancellation tokens, progress, delayed progress, worker loops,
+  and parent-process watchdog behavior
+- request bodies are retained in the stdio server until dispatch; if M13 makes
+  queued cancellation reachable across async worker turns, it must remove the
+  matching retained body when a queued request is cancelled
+- background index work is represented by a scheduler lane and fairness tests,
+  but no background worker is started in M11
+
+Validation so far:
+
+- `cargo test -p sifr_lsp` -> PASS, 13 tests
+- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
+- `cargo fmt --check` -> PASS
+- `cargo clippy -p sifr_lsp -- -D warnings` -> PASS
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+- Claude reviewer pass 1 -> CHANGES_REQUESTED (`reviews/typescript-go-m11-lsp-scheduler-review-pass-1.md`)
+- Claude reviewer pass 2 -> SATISFIED with residual low-priority cleanup (`reviews/typescript-go-m11-lsp-scheduler-review-pass-2.md`)
+- Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m11-lsp-scheduler-review-pass-3.md`)
+- `cargo clippy --workspace -- -D warnings` -> PASS
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 263.26s, advisory: group skew is high

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -17,6 +17,7 @@ Status: in progress
 | M8 First-Class Flow Graph | merged | [#2243](https://github.com/sifr-lang/sifr/pull/2243), [#2244](https://github.com/sifr-lang/sifr/pull/2244), [#2245](https://github.com/sifr-lang/sifr/pull/2245) | Adds `sifr_hir::flow_graph`, snapshot-scoped `LoweringResult.flow_graph`, graph-backed `FlowFacts` debug/fingerprint access, and lowering-time flow effects for narrowing, mutation invalidation, moves, and borrows. |
 | M9 Fingerprints And Cache Keys | merged | [#2246](https://github.com/sifr-lang/sifr/pull/2246), [#2247](https://github.com/sifr-lang/sifr/pull/2247), [#2248](https://github.com/sifr-lang/sifr/pull/2248), [#2249](https://github.com/sifr-lang/sifr/pull/2249) | Adds deterministic compiler/cache fingerprints and typed key identities for parse, source-map, HIR/lowering, diagnostics, lint, format, package graph, symbol bucket, and flow graph caches before reuse lands. |
 | M10 Snapshot Reuse And Structural Replacement | merged | [#2251](https://github.com/sifr-lang/sifr/pull/2251) | Adds ref-counted M9-keyed parse/source-map/HIR/diagnostics/index reuse, Arc-backed snapshot payloads, and conservative safe one-module replacement when import/export signatures are unchanged. |
+| M11 LSP Scheduler Queues | in progress | pending | Adds real request priority queues for latency-sensitive, formatting, workspace, and background lanes plus debounced diagnostic jobs guarded by captured document versions. |
 
 M2 local validation so far:
 
@@ -61,6 +62,23 @@ M10 local validation so far:
 - Claude reviewer pass 2 -> SATISFIED with residual recommendations (`reviews/typescript-go-m10-snapshot-reuse-review-pass-2.md`)
 - Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m10-snapshot-reuse-review-pass-3.md`)
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 330.61s, advisories: warm wall-time budget exceeded; group skew is high
+
+M11 local validation so far:
+
+- `cargo test -p sifr_lsp` -> PASS, 13 tests
+- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
+- `cargo fmt --check` -> PASS
+- `cargo clippy -p sifr_lsp -- -D warnings` -> PASS
+- `git diff --check`
+- `python3 scripts/check_file_size_guardrails.py`
+- Claude reviewer pass 1 -> CHANGES_REQUESTED (`reviews/typescript-go-m11-lsp-scheduler-review-pass-1.md`)
+- Claude reviewer pass 2 -> SATISFIED with residual low-priority cleanup (`reviews/typescript-go-m11-lsp-scheduler-review-pass-2.md`)
+- Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m11-lsp-scheduler-review-pass-3.md`)
+- `cargo clippy --workspace -- -D warnings` -> PASS
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 263.26s, advisory: group skew is high
 
 M4 local validation so far:
 

--- a/reviews/typescript-go-m11-lsp-scheduler-review-pass-1.md
+++ b/reviews/typescript-go-m11-lsp-scheduler-review-pass-1.md
@@ -1,0 +1,157 @@
+I have enough information to produce the review.
+
+```markdown
+# Code Review: M11 LSP Scheduler Queues (wave_tsgo_m11_lsp_scheduler)
+
+## Findings (severity-ordered)
+
+### HIGH — Post-shutdown requests now terminate the server instead of being rejected
+`crates/sifr_lsp/src/server.rs:90-100`
+
+`handle_request` now propagates `enqueue_request`'s `Err` out of the run loop:
+
+```rust
+self.session
+    .enqueue_request(&id, &request.method, lane)
+    .map_err(LspError::request_cancelled)?;   // ← breaks the recv loop
+```
+
+`RequestQueue::enqueue` returns `Err("server is shutting down")` once
+`begin_shutdown` has been called (`request_queue.rs:60`). In the previous
+implementation (`session.start_request` failure inside `and_then`), that
+error was converted into a `Response::new_err(id, code, message)` and shipped
+back to the client; the loop continued. Now the `?` propagates a boxed
+`LspError` out of `LspServer::run`, the loop exits via `self.finish()`, and
+the client never gets a response.
+
+This contradicts the documented LSP contract in
+`verification/tooling/lsp_protocol_matrix.json:51`
+(`"requests after shutdown fail deterministically"`) and is the existing
+behavior the matrix is asserting. No automated test exercises the
+shutdown→request→exit sequence (smoke/stress both end with
+`shutdown` then `exit` with no requests in between), so the regression is
+silent.
+
+Fix: keep request-cancelled errors inside the response branch — e.g.
+build a `Response::new_err` and send it instead of `?`-ing out of the
+recv loop. Failing to enqueue is per-request, not per-server.
+
+### MEDIUM — Diagnostic jobs are not cleared when a document closes (orphan jobs poison later flushes)
+`crates/sifr_lsp/src/session.rs:111-114, 202-206, 227-244`
+`crates/sifr_lsp/src/diagnostics.rs:45-52`
+
+`close_document` only touches `analysis` and `store`; it does not remove
+the URI from `Session::diagnostic_jobs`. If a job for URI `X` is queued
+and the surrounding flush errors out partway (e.g. transport send fails,
+or `document_diagnostics` returns `Err`), the entry survives. Once
+`X` is closed, the next `flush_ready` invocation pops that stale job and
+calls `session.document_version_matches(&job.uri, job.version)?` —
+`store.document(uri)` returns `LspError::invalid_params("document is not
+open: …")`, the `?` propagates, and the new flush fails with an error
+unrelated to whatever triggered it.
+
+Also: there is no test covering a close-with-pending-job; both the new
+unit tests assume the document stays open between schedule and take.
+
+Fix options: drop `diagnostic_jobs` entries for the URI inside
+`close_document`, or treat an `invalid_params` lookup inside `flush_ready`
+as "drop the orphaned job and continue".
+
+### LOW — `RequestQueue::remove_pending` corrupts `queued_keys` on invariant violation
+`crates/sifr_lsp/src/request_queue.rs:99-113`
+
+```rust
+let removed_queued = if self.queued_keys.remove(&key) {
+    for lane_queue in self.queued.values_mut() {
+        if let Some(index) = lane_queue.iter().position(|r| r.key == key) {
+            lane_queue.remove(index);
+            return true;
+        }
+    }
+    false           // queued_keys says yes, lane queues say no → key dropped
+} else { false };
+```
+
+If the `queued_keys` set and the lane queues ever fall out of sync, we
+silently drop the `queued_keys` entry without removing anything from the
+queue. Today the data structure stays consistent, so this is a defensive
+issue rather than a live bug — but it's safer to check the lane queues
+first and only mutate `queued_keys` after confirming removal, mirroring
+the way `start_next` updates both atomically.
+
+### LOW — `take_next_diagnostic_job` is `O(n)` per pop
+`crates/sifr_lsp/src/session.rs:246-253`
+
+`min_by_key` scans the whole `BTreeMap` for each pop, so draining `n`
+diagnostic jobs is `O(n²)`. With M11's single-document common path this
+is invisible, but `publish_all` from `workspace/didChangeWatchedFiles`
+fans out across every open document. A `BTreeMap<u64 /* sequence */,
+String /* uri */>` ordered index alongside the URI map would keep the
+debounce semantics and pop in `O(log n)`.
+
+### LOW — Duplicate lane classification and triple trace per request
+`crates/sifr_lsp/src/server.rs:92`, `crates/sifr_lsp/src/requests/mod.rs:21`,
+`crates/sifr_lsp/src/session.rs:165-167, 173-178`
+
+`Scheduler::lane_for_method` runs in `handle_request` (for enqueue) and
+again in `requests::handle` (for the dispatch trace). Each request now
+emits three traces: `queued …`, `dispatching request …`, and
+`dispatching {method} on {lane:?} lane`. Cosmetic, but worth tidying —
+e.g. drop the older trace in `requests::handle` now that the new
+`start_next_request` trace already records method + lane.
+
+### NIT — `Background` lane is dead until M13
+`crates/sifr_lsp/src/scheduler.rs:13-20`
+
+`sifr/backgroundIndex` isn't handled by `requests::handle`; it exists
+only so the scheduling tests can prove fairness. That's fine per the
+M11 plan ("background index work is represented by a scheduler lane and
+fairness tests, but no background worker is started"), but worth a
+one-line comment near `lane_for_method` so a future reader does not try
+to wire it to a handler. Optional.
+
+## Residual risks / missing tests
+
+- **No protocol-level test for post-shutdown requests** — the very
+  scenario the matrix promises ("requests after shutdown fail
+  deterministically"). Add a stress-test step that issues a non-shutdown
+  request between `shutdown` and `exit` and asserts an error response is
+  returned and the server still processes `exit` cleanly. This would
+  have caught the HIGH finding above.
+- **No test exercising close-with-pending-job.** Add a session unit test
+  that schedules diagnostics, closes the document, then calls
+  `flush_ready` (directly or via another `publish_document`) and asserts
+  no error.
+- **`scripts/run_all_tests.sh --profile quick` is not listed in M11
+  validation** in `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md`
+  (lines 66–76). Every prior milestone records it; AGENTS.md calls it
+  the "authoritative gate". Run it and append the result before merge.
+- **Fairness/debounce is only proved by unit tests.** Acceptable for
+  M11 since the stdio loop drains synchronously, but worth a comment in
+  `internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md`
+  noting that the data-structure guarantees become observable only once
+  M13 introduces a worker.
+- **Cached diagnostics shortcut bypasses version capture** (existing
+  behavior at `diagnostics.rs:83-90`). `document_diagnostics` returns
+  cached `load_diagnostics(uri)` without re-running analysis or
+  consulting the captured version. Today the cache is invalidated on
+  every document update so it is harmless, but the new version-guard
+  story only holds because of that invariant. Worth at least an
+  inline comment so a future cache-tuning change doesn't silently
+  break the "captured-version" contract.
+
+## Verdict
+
+**CHANGES_REQUESTED**
+
+The HIGH finding is a real protocol regression: after the client issues
+`shutdown`, the very next request now tears the server loop down instead
+of returning an error response, contradicting the LSP contract recorded
+in `lsp_protocol_matrix.json`. The MEDIUM orphan-job issue is narrower
+but lives along an error path the new debounce design introduced.
+Neither has a regression test. Please address the HIGH finding, add the
+missing post-shutdown stress step, and run `scripts/run_all_tests.sh
+--profile quick` before this milestone closes.
+```
+
+Findings summary: one HIGH regression in `server.rs` post-shutdown handling, one MEDIUM around orphaned diagnostic jobs after close, plus several low/nit items and process gaps (missing protocol test, missing quick-profile validation). Verdict: **CHANGES_REQUESTED**.

--- a/reviews/typescript-go-m11-lsp-scheduler-review-pass-2.md
+++ b/reviews/typescript-go-m11-lsp-scheduler-review-pass-2.md
@@ -1,0 +1,146 @@
+I have enough context. Let me produce the review.
+
+```markdown
+# Code Review (Pass 2): M11 LSP Scheduler Queues (wave_tsgo_m11_lsp_scheduler)
+
+## Status of pass 1 findings
+
+| Pass 1 finding | Status | Evidence |
+| --- | --- | --- |
+| HIGH — post-shutdown requests tear down the run loop | Fixed | `crates/sifr_lsp/src/server.rs:93-103` builds a `Response::new_err(RequestCancelled)` and continues the loop; matched by `lsp_protocol_stress.py:111-117` |
+| MEDIUM — close-with-pending diagnostic job poisons later flushes | Fixed | `crates/sifr_lsp/src/session.rs:111-115` drops the URI from `diagnostic_jobs` in `close_document`; covered by `close_document_discards_pending_diagnostic_job` at `session.rs:451-475` |
+| LOW — `remove_pending` corrupts `queued_keys` on invariant violation | Fixed | `request_queue.rs:99-109` searches the lane queues first and only removes `queued_keys` after confirming a removal |
+| LOW — duplicate dispatch trace | Fixed | `requests/mod.rs:19-20` no longer emits a per-dispatch trace; the single trace now lives at `session.rs:172-181` |
+| NIT — background lane has no explanatory comment | Fixed | `scheduler.rs:17-18` explains the lane is a sentinel until M13 |
+| NIT — cached-diagnostics shortcut bypassed version capture | Fixed (comment only) | `diagnostics.rs:83-85` documents why the shortcut is safe under the new version guard |
+
+## Findings (severity-ordered)
+
+### LOW — `LspServer::queued_requests` leaks request bodies if a request is cancelled before dispatch
+`crates/sifr_lsp/src/server.rs:104-129`, `crates/sifr_lsp/src/session.rs:187-201`,
+`crates/sifr_lsp/src/request_queue.rs:99-109`
+
+`handle_request` now records the original `Request` in
+`self.queued_requests` keyed by `request_key(&id)`, and `drain_queued_requests`
+only removes that entry when `start_next_request` returns the same key. But
+`Session::cancel_request` (via `$/cancelRequest`) goes through
+`RequestQueue::remove_pending`, which only touches the scheduler's lane queue
+plus `queued_keys` — it never reaches `LspServer::queued_requests`. If a
+request is cancelled while still queued, its `Request` body sits in
+`queued_requests` forever. The current stdio loop is fully synchronous, so the
+cancel notification can't arrive before `drain_queued_requests` empties the
+queue, and the leak is unreachable today. It becomes reachable as soon as M13
+introduces a worker. Either move the request body into the scheduler entry,
+or have `Session::cancel_request` return the cancelled key so the server can
+discard the body in step.
+
+### LOW — Defensive `else` branch in `drain_queued_requests` silently drops requests
+`crates/sifr_lsp/src/server.rs:111-115`
+
+```rust
+let Some(request) = self.queued_requests.remove(scheduled.key()) else {
+    self.session.finish_request(scheduled.id());
+    continue;
+};
+```
+
+If the scheduler ever yields a key whose `Request` body is missing, the
+server clears `in_flight` and continues without responding — violating LSP's
+exactly-one-response contract. The path is unreachable in the current
+synchronous design (every enqueue is followed by an insert, which is followed
+by a drain), but the silent drop will be a debugging nightmare if a future
+refactor pulls enqueue and drain apart. Recommend emitting an
+`InternalError` response on this branch (and/or a `debug_assert!`) so a
+broken invariant is loud rather than silent.
+
+### LOW — `Session::take_next_diagnostic_job` remains `O(n)` per pop
+`crates/sifr_lsp/src/session.rs:247-254`
+
+Pass 1's `O(n²)` `min_by_key` scan was acknowledged but not addressed: each
+`flush_ready` iteration still walks the full `BTreeMap<String,
+ScheduledDiagnosticJob>` to find the smallest `sequence`. Invisible at
+single-document scale; observable when `workspace/didChangeWatchedFiles` fans
+out across a large open workspace. A parallel `BTreeMap<u64 /* sequence */,
+String /* uri */>` (kept in sync with `diagnostic_jobs`) would make this
+`O(log n)` and preserve the URI-keyed debounce.
+
+### LOW — Newest schedule for a URI inherits a new `sequence`, reordering flush across URIs
+`crates/sifr_lsp/src/session.rs:228-245`
+
+`schedule_document_diagnostics` always bumps `next_diagnostic_sequence` and
+overwrites the existing entry, so if URI A is scheduled (seq 1), URI B is
+scheduled (seq 2), and URI A is re-scheduled (seq 3), `flush_ready` now
+publishes B before A even though A was queued first. The version guard keeps
+the published *content* correct, but it does change the order
+`publishDiagnostics` notifications arrive at the client. Cheap fix: when an
+entry already exists, keep its existing `sequence` and only refresh
+`version`. Worth a comment if the new ordering is intentional.
+
+### LOW — Pending diagnostic jobs are not cleared when `diagnostics.mode` flips to `off`
+`crates/sifr_lsp/src/diagnostics.rs:11-35`,
+`crates/sifr_lsp/src/notifications/mod.rs:47-52`
+
+`workspace_did_change_configuration` swaps settings but doesn't drop the
+`diagnostic_jobs` accumulated under the previous mode. The
+`mode == Off` early-return in `publish_document` / `flush_ready` then leaves
+those jobs idling until the next event re-enables the mode, at which point
+they all flush at once. The version guard keeps them safe, but it's strictly
+more state than necessary. Either clear `diagnostic_jobs` when mode becomes
+`Off`, or document why holding them is intended.
+
+### NIT — `start_next_request` trace fires even for the request the same call enqueued
+`crates/sifr_lsp/src/session.rs:159-181`
+
+`enqueue_request` traces `queued request …` and `start_next_request` then
+traces `dispatching request …` for the same id within a single
+`handle_request`, so every request still produces two traces (down from
+three). Tolerable, but worth folding into one trace when the scheduler is
+synchronous, e.g. only trace the dispatch.
+
+## Residual risks / missing tests
+
+- **`scripts/run_all_tests.sh --profile quick` is still absent from M11
+  validation** (`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:66-77`
+  and the user-provided validation list). Pass 1 already flagged this; every
+  prior milestone records it; AGENTS.md calls it the "authoritative gate".
+  This needs to land before the milestone closes — current entries only
+  cover `cargo test -p sifr_lsp` plus the verification scripts.
+- **Workspace-wide clippy was narrowed to `-p sifr_lsp`**. The diff is
+  LSP-scoped so this is unlikely to regress other crates, but every prior
+  milestone records `cargo clippy --workspace -- -D warnings`. Re-run that
+  before merge to stay consistent.
+- **Latent cancellation leak (LOW above)** has no test because the sync
+  loop can't reach it. Document the expectation in
+  `internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md`
+  so M13 picks it up — today the doc states `request execution remains
+  serialized` but does not name the cancel-while-queued path that M13 will
+  unlock.
+- **No end-to-end test for the version-guard skipping a stale publish.**
+  Unit tests cover the predicates and `flush_ready`'s consumers, but no
+  stress-test step actually races `didChange` against a queued diagnostic
+  job to observe `skipped stale diagnostics …`. A best-effort variant would
+  schedule diagnostics, mutate the document, and assert that the resulting
+  `publishDiagnostics` carries the latest version. The current stress test
+  asserts the *latest* version field but never demonstrates a stale capture
+  being dropped (because the sync loop also can't reach that state in
+  practice).
+- **Background lane still has no live consumer.** The architecture doc
+  acknowledges this; just make sure the `sifr/backgroundIndex` sentinel
+  remains internal until M13 — today nothing forbids a client from
+  triggering the path with a manual JSON-RPC message, and `requests::handle`
+  would simply return `MethodNotFound` (correct, but worth a deliberate
+  smoke check before adding any real client surface).
+
+## Verdict
+
+**SATISFIED**
+
+The HIGH protocol regression and MEDIUM orphan-job bug from pass 1 are both
+fixed with focused regression tests (`lsp_protocol_stress.py:111-117`,
+`session.rs::close_document_discards_pending_diagnostic_job`), the LOW
+`remove_pending` invariant is restored, the duplicate dispatch trace is
+gone, and the small documentation/comment gaps are addressed. The remaining
+items are LOW/NIT defensive cleanups and one process gap (the
+`--profile quick` validation entry) that should be settled before the
+milestone is marked merged, but none of them block the code change itself.
+```

--- a/reviews/typescript-go-m11-lsp-scheduler-review-pass-3.md
+++ b/reviews/typescript-go-m11-lsp-scheduler-review-pass-3.md
@@ -1,0 +1,62 @@
+# Code Review (Pass 3): M11 LSP Scheduler Queues (wave_tsgo_m11_lsp_scheduler)
+
+## Status of pass 2 findings
+
+| Pass 2 finding | Status | Evidence |
+| --- | --- | --- |
+| LOW — `queued_requests` leaks request bodies if cancelled before dispatch (M13 doc note recommended) | Fixed (doc only) | `internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md:30-33` explicitly calls out the M13 obligation to drop retained bodies when queued cancellation becomes reachable across worker turns |
+| LOW — defensive missing-body branch in `drain_queued_requests` silently drops requests | Fixed | `crates/sifr_lsp/src/server.rs:112-126` now finishes the request and sends a `Response::new_err` with `LspError::internal` instead of silently `continue`-ing |
+| LOW — newest schedule for a URI inherits a fresh `sequence`, reordering flush across URIs | Fixed | `crates/sifr_lsp/src/session.rs:237-243` preserves the existing entry's `sequence` on re-schedule; regression test `diagnostic_reschedule_preserves_original_queue_order` at `session.rs:487-547` |
+| LOW — pending diagnostic jobs not cleared when `diagnostics.mode` flips to `off` | Fixed | `crates/sifr_lsp/src/notifications/mod.rs:53-55` clears on mode transition; `crates/sifr_lsp/src/diagnostics.rs:18-19,28-29,44-46` also clears when callers/`flush_ready` observe `Off`; new `Session::clear_diagnostic_jobs` at `session.rs:209-211` |
+| LOW — `take_next_diagnostic_job` remains `O(n)` per pop | Not addressed | `session.rs:257-264` still scans the `BTreeMap` via `min_by_key`. Acknowledged as acceptable at M11 single-document scale; worth revisiting when M13 makes workspace-wide flushes more frequent |
+| NIT — `start_next_request` trace fires alongside `queued request` for the same id | Not addressed | `session.rs:159-181` still emits both. Two traces per request is tolerable while the scheduler is synchronous |
+
+## Findings (severity-ordered)
+
+### LOW — `flush_ready`'s mode check is now dead defensive code
+`crates/sifr_lsp/src/diagnostics.rs:39-47`
+
+Both callers (`publish_document` at `diagnostics.rs:18-23`, `publish_all` at `diagnostics.rs:27-35`) return early when `mode == Off`, so `flush_ready`'s own `if mode == DiagnosticsMode::Off { … clear … return }` block is unreachable. Harmless, but the duplicate state-clearing call at three sites makes it easy to forget which one is authoritative. Pick one (the caller) and drop the others, or document that `flush_ready` is the sole authoritative clearer.
+
+### LOW — `Session::cancel_request` does not communicate the cancelled key back to the server
+`crates/sifr_lsp/src/session.rs:187-201`, `crates/sifr_lsp/src/server.rs:104-105`
+
+`cancel_request` returns `()` even though `RequestQueue::remove_pending` knows whether a queued entry was removed. The body of that request stays in `LspServer::queued_requests` until `drain_queued_requests` pops the next scheduled entry — which now will never produce that key. Today the stdio loop is fully synchronous so the leak is unreachable (cancel cannot interleave with drain), and the M11 doc records the M13 obligation. Closing the loop now would be one line: have `cancel_request` return the cancelled `RequestId` (or its key) so `LspServer` can remove the `queued_requests` entry in step. Optional but cheap.
+
+### NIT — `Background` lane is not exercised end-to-end
+`crates/sifr_lsp/src/scheduler.rs:13-22`, `crates/sifr_lsp/src/requests/mod.rs`
+
+`sifr/backgroundIndex` has no `requests::handle` arm, so a client that sends it gets `MethodNotFound`. Good — that's the intended M11 surface and the inline comment now says so. Worth noting that no smoke step asserts the sentinel stays internal; a single negative assertion (request returns method-not-found) would make the contract observable. Acceptable to defer to M13 where the lane gains a real worker.
+
+## Phase-scope check
+
+- **Required closeout: workspace/background cannot starve latency-sensitive/formatting/diagnostic-style work.**
+  Satisfied by `RequestQueue::select_next_lane` and `next_fair_lane` (`request_queue.rs:118-147`) plus `FAIRNESS_INTERVAL = 4` (line 5). Covered by `scheduler_prefers_latency_but_eventually_services_background` and `scheduler_rotates_fairness_lane_across_nonempty_queues` (`request_queue.rs:160-230`).
+- **Required closeout: queued work publishes only if the captured snapshot/document version is still valid.**
+  Satisfied by `Session::schedule_document_diagnostics`/`document_version_matches` and the dual pre/post-analysis guards in `DiagnosticsController::flush_ready` (`diagnostics.rs:48-63`). Covered by `diagnostic_scheduling_debounces_to_latest_document_version` and `diagnostic_job_version_guard_rejects_stale_capture` (`session.rs:388-459`). The version-guard short-circuit comment at `diagnostics.rs:85-88` correctly explains why the cached load path is still safe.
+- **Phase scope: cancellation tokens, progress, background workers stay deferred to M13.**
+  Confirmed — `scheduler.rs` has no cancellation token type, the architecture doc states the deferrals explicitly (`typescript_go_architecture_transfer_m11_lsp_scheduler.md:26-35`), and the M1 guardrail still asserts `CancellationToken` does not appear in `scheduler.rs` (`check_typescript_go_m1_guardrails.py:220-225`).
+- **Protocol regressions from pass 1 stay fixed.**
+  Post-shutdown request handling at `server.rs:90-103` returns `RequestCancelled` (code `-32800`) without tearing down the loop; covered by `lsp_protocol_stress.py:111-117`. Close-with-pending-job orphan path at `session.rs:111-115` covered by `close_document_discards_pending_diagnostic_job` at `session.rs:461-485`.
+
+## Residual risks / missing tests (non-blocking)
+
+- **Validation block still missing the `--profile quick` and workspace-clippy entries**
+  (`issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:66-78`). Pass 1 and Pass 2 both flagged this; every prior milestone records both, and AGENTS.md calls `scripts/run_all_tests.sh --profile quick` the "authoritative gate". Please run them and append the result before this milestone is marked merged — the change isn't to the code, but the milestone closeout is incomplete without it.
+- **No protocol-level test for the version-guard skipping a stale publish.** Existing unit tests cover the predicates, and `lsp_protocol_stress.py` asserts that the published notification carries the latest version (line 39), but no test demonstrates an actually stale capture being dropped (the sync loop can't reach that state today). Acceptable; document in the M11 doc that this becomes observable under M13.
+- **`Background` lane has no negative-path smoke step** — see NIT above.
+- **`take_next_diagnostic_job` `O(n)` per pop** — see pass-2 finding carried forward.
+- **NIT: double trace per request** — see pass-2 finding carried forward.
+
+## Verdict
+
+**SATISFIED**
+
+All four LOW issues from pass 2 that were actionable for M11 have been addressed with focused regression coverage:
+
+- `drain_queued_requests` now produces an `InternalError` response on a missing body instead of silently dropping (`server.rs:112-126`).
+- `schedule_document_diagnostics` preserves the original queue slot when the same URI is rescheduled (`session.rs:237-243`), with `diagnostic_reschedule_preserves_original_queue_order` exercising the multi-URI reordering scenario.
+- Mode→`Off` transitions now clear pending diagnostic jobs at every entry point (`notifications/mod.rs:53-55`, `diagnostics.rs:18-19,28-29,44-46`), via the new `Session::clear_diagnostic_jobs` helper.
+- The M13 doc note acknowledging the latent cancel-while-queued body retention is in `internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md:30-33`.
+
+The required closeout invariants (no workspace/background starvation; stale snapshot/document publication is skipped) hold and are covered by both unit and protocol-level tests. The two carried-forward items (`O(n)` `take_next_diagnostic_job`, double-trace) are LOW/NIT and acceptable at M11 scale. The one process gap left — adding `scripts/run_all_tests.sh --profile quick` and `cargo clippy --workspace -- -D warnings` to the M11 validation block — should land before merge but doesn't block the code change itself.

--- a/verification/tooling/check_typescript_go_m1_guardrails.py
+++ b/verification/tooling/check_typescript_go_m1_guardrails.py
@@ -218,13 +218,18 @@ def validate_lsp_current_state(failures: list[str]) -> None:
         failures,
     )
     require(
-        "pub(crate) fn lane_for_method" in scheduler and "CancellationToken" not in scheduler,
-        "M1 scheduler guardrail expects lane labels only, with cancellation deferred",
+        "pub(crate) fn lane_for_method" in scheduler
+        and "Background" in scheduler
+        and "CancellationToken" not in scheduler,
+        "scheduler guardrail expects M11 lane classification, with cancellation deferred",
         failures,
     )
     require(
-        "pending: BTreeSet<String>" in request_queue and "remove_pending" in request_queue,
-        "M1 request queue guardrail expects pending-id tracking only",
+        "VecDeque<QueuedRequest>" in request_queue
+        and "start_next" in request_queue
+        and "FAIRNESS_INTERVAL" in request_queue
+        and "remove_pending" in request_queue,
+        "request queue guardrail expects M11 priority queues with bounded fairness",
         failures,
     )
 

--- a/verification/tooling/lsp_protocol_stress.py
+++ b/verification/tooling/lsp_protocol_stress.py
@@ -109,6 +109,12 @@ def run_stress() -> None:
                 raise LspProtocolError(f"closed document query returned unexpected error: {error}")
 
             client.request("shutdown", {})
+            error = client.request_error(
+                "textDocument/hover",
+                {"textDocument": {"uri": uri}, "position": {"line": 4, "character": 19}},
+            )
+            if error.get("code") != -32800:
+                raise LspProtocolError(f"post-shutdown request returned unexpected error: {error}")
             client.notify("exit", {})
         finally:
             client.close()


### PR DESCRIPTION
## Summary
- add per-lane FIFO LSP request queues for latency-sensitive, formatting, workspace, and background work with bounded fairness
- route stdio request dispatch through the scheduler while keeping execution serialized and post-shutdown requests deterministic
- debounce diagnostic publication by document URI with captured-version guards, close/off cleanup, and queue-order-preserving reschedules
- update M11 docs, phase tracker, guardrail checks, protocol stress coverage, and reviewer artifacts

## Validation
- `cargo test -p sifr_lsp` -> PASS, 13 tests
- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
- `cargo fmt --check` -> PASS
- `cargo clippy -p sifr_lsp -- -D warnings` -> PASS
- `git diff --check` -> PASS
- `python3 scripts/check_file_size_guardrails.py` -> PASS
- Claude reviewer pass 1 -> CHANGES_REQUESTED
- Claude reviewer pass 2 -> SATISFIED with residual low-priority cleanup
- Claude reviewer pass 3 -> SATISFIED
- `cargo clippy --workspace -- -D warnings` -> PASS
- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 263.26s, advisory: group skew is high
