### PR TITLE
Mark M11 scheduler queues merged

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md
+++ b/internal_docs/typescript_go_architecture_transfer_m11_lsp_scheduler.md
@@ -1,6 +1,6 @@
 # TypeScript-Go Architecture Transfer M11: LSP Scheduler Queues
 
-status: in progress
+status: merged in [#2253](https://github.com/sifr-lang/sifr/pull/2253)
 
 M11 makes LSP request scheduling concrete while deliberately keeping execution
 serialized until M13 adds cancellation tokens, progress, and worker execution.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -17,7 +17,7 @@ Status: in progress
 | M8 First-Class Flow Graph | merged | [#2243](https://github.com/sifr-lang/sifr/pull/2243), [#2244](https://github.com/sifr-lang/sifr/pull/2244), [#2245](https://github.com/sifr-lang/sifr/pull/2245) | Adds `sifr_hir::flow_graph`, snapshot-scoped `LoweringResult.flow_graph`, graph-backed `FlowFacts` debug/fingerprint access, and lowering-time flow effects for narrowing, mutation invalidation, moves, and borrows. |
 | M9 Fingerprints And Cache Keys | merged | [#2246](https://github.com/sifr-lang/sifr/pull/2246), [#2247](https://github.com/sifr-lang/sifr/pull/2247), [#2248](https://github.com/sifr-lang/sifr/pull/2248), [#2249](https://github.com/sifr-lang/sifr/pull/2249) | Adds deterministic compiler/cache fingerprints and typed key identities for parse, source-map, HIR/lowering, diagnostics, lint, format, package graph, symbol bucket, and flow graph caches before reuse lands. |
 | M10 Snapshot Reuse And Structural Replacement | merged | [#2251](https://github.com/sifr-lang/sifr/pull/2251) | Adds ref-counted M9-keyed parse/source-map/HIR/diagnostics/index reuse, Arc-backed snapshot payloads, and conservative safe one-module replacement when import/export signatures are unchanged. |
-| M11 LSP Scheduler Queues | in progress | pending | Adds real request priority queues for latency-sensitive, formatting, workspace, and background lanes plus debounced diagnostic jobs guarded by captured document versions. |
+| M11 LSP Scheduler Queues | merged | [#2253](https://github.com/sifr-lang/sifr/pull/2253) | Adds real request priority queues for latency-sensitive, formatting, workspace, and background lanes plus debounced diagnostic jobs guarded by captured document versions. |
 
 M2 local validation so far:
 


### PR DESCRIPTION
## Summary
- mark M11 LSP Scheduler Queues as merged in the TypeScript-Go architecture transfer tracker
- update the M11 design note status with PR #2253

## Validation
- `git diff --check` -> PASS
