### PR TITLE
Add LSP cancellation progress and watchdog

### DIFF
--- a/crates/sifr/src/cli_model_and_entrypoint.rs
+++ b/crates/sifr/src/cli_model_and_entrypoint.rs
@@ -263,6 +263,9 @@ pub(crate) enum Commands {
         /// Use stdio transport
         #[arg(long)]
         stdio: bool,
+        /// Exit the language server when the parent process is no longer alive
+        #[arg(long = "parent-pid")]
+        parent_pid: Option<u32>,
     },
     /// Show the generated Rust source code
     Emit {
@@ -504,7 +507,7 @@ fn run_cli(cli: Cli) -> i32 {
         }
         Commands::Fmt(args) => cmd_fmt(&args, &config, isolated, diagnostic_format),
         Commands::Lint(args) => cmd_lint(&args, &config, isolated, diagnostic_format),
-        Commands::Lsp { stdio } => cmd_lsp(stdio),
+        Commands::Lsp { stdio, parent_pid } => cmd_lsp(stdio, parent_pid),
         Commands::Emit { file } => cmd_emit(&file, diagnostic_format),
         Commands::Test { dir } => cmd_test(&dir, diagnostic_format),
     }
@@ -646,7 +649,7 @@ pub(super) fn diagnostic_explanation(code: &str) -> Option<String> {
     ))
 }
 
-pub(super) fn cmd_lsp(stdio: bool) -> i32 {
+pub(super) fn cmd_lsp(stdio: bool, parent_pid: Option<u32>) -> i32 {
     if !stdio {
         let diagnostic = diagnostic_with_code(
             "sifr lsp requires --stdio in Phase 36",
@@ -655,7 +658,7 @@ pub(super) fn cmd_lsp(stdio: bool) -> i32 {
         render_diagnostics(&[diagnostic], DiagnosticFormat::Human);
         return EXIT_USAGE_OR_CONFIG;
     }
-    match sifr_lsp::run_stdio() {
+    match sifr_lsp::run_stdio_with_options(sifr_lsp::LspServerOptions { parent_pid }) {
         Ok(()) => EXIT_SUCCESS,
         Err(error) => {
             let diagnostic = diagnostic_with_code(

--- a/crates/sifr_lsp/src/cancellation.rs
+++ b/crates/sifr_lsp/src/cancellation.rs
@@ -1,0 +1,32 @@
+use lsp_server::RequestId;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CancellationToken {
+    request_id: RequestId,
+}
+
+impl CancellationToken {
+    pub(crate) fn new(request_id: &RequestId) -> Self {
+        Self {
+            request_id: request_id.clone(),
+        }
+    }
+
+    pub(crate) fn request_id(&self) -> &RequestId {
+        &self.request_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CancellationToken;
+    use lsp_server::RequestId;
+
+    #[test]
+    fn token_preserves_request_identity() {
+        let id = RequestId::from("m13-token".to_string());
+        let token = CancellationToken::new(&id);
+
+        assert_eq!(token.request_id(), &id);
+    }
+}

--- a/crates/sifr_lsp/src/diagnostics.rs
+++ b/crates/sifr_lsp/src/diagnostics.rs
@@ -1,6 +1,7 @@
 use crate::conversion;
 use crate::document_store::DiagnosticsMode;
 use crate::errors::LspResult;
+use crate::progress::{begin_notification, end_notification, ProgressKind};
 use crate::session::Session;
 use lsp_server::{Connection, Message, Notification};
 use serde_json::{json, Value};
@@ -29,10 +30,23 @@ impl DiagnosticsController {
             session.clear_diagnostic_jobs();
             return Ok(());
         }
-        for uri in session.document_uris() {
-            session.schedule_document_diagnostics(&uri)?;
+        let uris = session.document_uris();
+        let progress = session.begin_progress(ProgressKind::FullDiagnostics, uris.len());
+        if let Some(handle) = &progress {
+            publish_progress(
+                connection,
+                begin_notification(handle, "Checking Sifr workspace"),
+            )?;
+        }
+        for uri in &uris {
+            session.schedule_document_diagnostics(uri)?;
         }
         Self::flush_ready(connection, session, mode)?;
+        if let Some(handle) = progress {
+            let message = format!("checked {} document(s)", uris.len());
+            publish_progress(connection, end_notification(&handle, &message))?;
+            session.end_progress(handle, &message);
+        }
         Ok(())
     }
 
@@ -80,6 +94,18 @@ impl DiagnosticsController {
         }
         Ok(())
     }
+}
+
+fn publish_progress(connection: &Connection, params: Value) -> LspResult<()> {
+    connection
+        .sender
+        .send(Message::Notification(Notification {
+            method: "$/progress".to_string(),
+            params,
+        }))
+        .map_err(|error| {
+            crate::errors::LspError::internal(format!("failed to publish progress: {error}"))
+        })
 }
 
 pub(crate) fn document_diagnostics(session: &mut Session, uri: &str) -> LspResult<Vec<Value>> {

--- a/crates/sifr_lsp/src/lib.rs
+++ b/crates/sifr_lsp/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::needless_pass_by_value, clippy::unnecessary_wraps)]
 
 mod analysis_workspace;
+mod cancellation;
 mod capabilities;
 mod commands;
 mod conversion;
@@ -15,11 +16,14 @@ mod document_events;
 mod document_store;
 mod errors;
 mod notifications;
+mod progress;
 mod request_queue;
 mod requests;
 mod scheduler;
 mod server;
 mod session;
 mod settings;
+mod watchdog;
 
-pub use server::run_stdio;
+pub use server::{run_stdio, run_stdio_with_options};
+pub use watchdog::LspServerOptions;

--- a/crates/sifr_lsp/src/notifications/mod.rs
+++ b/crates/sifr_lsp/src/notifications/mod.rs
@@ -1,7 +1,7 @@
 use crate::diagnostics::DiagnosticsController;
 use crate::errors::{optional_i32, required_string, LspError, LspResult};
 use crate::session::Session;
-use lsp_server::Connection;
+use lsp_server::{Connection, RequestId};
 use serde_json::Value;
 
 pub(crate) fn handle(
@@ -12,7 +12,6 @@ pub(crate) fn handle(
 ) -> LspResult<()> {
     match method {
         "initialized" => initialized(session),
-        "$/cancelRequest" => cancel_request(session, &params),
         "workspace/didChangeConfiguration" => workspace_did_change_configuration(session, params),
         "workspace/didChangeWatchedFiles" => {
             workspace_did_change_watched_files(session, params, connection)
@@ -37,11 +36,14 @@ fn initialized(session: &mut Session) -> LspResult<()> {
     Ok(())
 }
 
-fn cancel_request(session: &mut Session, params: &Value) -> LspResult<()> {
-    if let Some(id) = params.get("id") {
-        session.cancel_request(id);
+pub(crate) fn cancel_request_id(params: &Value) -> Option<RequestId> {
+    let id = params.get("id")?;
+    if let Some(raw) = id.as_i64() {
+        let raw = i32::try_from(raw).ok()?;
+        Some(RequestId::from(raw))
+    } else {
+        id.as_str().map(|raw| RequestId::from(raw.to_string()))
     }
-    Ok(())
 }
 
 fn workspace_did_change_configuration(session: &mut Session, params: Value) -> LspResult<()> {

--- a/crates/sifr_lsp/src/progress.rs
+++ b/crates/sifr_lsp/src/progress.rs
@@ -1,0 +1,180 @@
+use serde_json::{json, Value};
+
+const DIAGNOSTICS_PROGRESS_DOCUMENT_THRESHOLD: usize = 2;
+const REFERENCES_PROGRESS_LOCATION_THRESHOLD: usize = 8;
+const INDEX_WARMING_PROGRESS_UNIT_THRESHOLD: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum ProgressKind {
+    FullDiagnostics,
+    References,
+    IndexWarming,
+    WorkspaceLoad,
+}
+
+impl ProgressKind {
+    #[cfg(test)]
+    fn title(self) -> &'static str {
+        match self {
+            Self::FullDiagnostics => "Checking Sifr workspace",
+            Self::References => "Finding Sifr references",
+            Self::IndexWarming => "Warming Sifr index",
+            Self::WorkspaceLoad => "Loading Sifr workspace",
+        }
+    }
+
+    fn threshold(self) -> usize {
+        match self {
+            Self::FullDiagnostics | Self::WorkspaceLoad => DIAGNOSTICS_PROGRESS_DOCUMENT_THRESHOLD,
+            Self::References => REFERENCES_PROGRESS_LOCATION_THRESHOLD,
+            Self::IndexWarming => INDEX_WARMING_PROGRESS_UNIT_THRESHOLD,
+        }
+    }
+
+    fn token_prefix(self) -> &'static str {
+        match self {
+            Self::FullDiagnostics => "sifr/full-diagnostics",
+            Self::References => "sifr/references",
+            Self::IndexWarming => "sifr/index-warming",
+            Self::WorkspaceLoad => "sifr/workspace-load",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProgressHandle {
+    token: String,
+}
+
+impl ProgressHandle {
+    pub(crate) fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ProgressState {
+    enabled: bool,
+    next_token: u64,
+    #[cfg(test)]
+    events: Vec<ProgressEvent>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProgressEvent {
+    token: String,
+    phase: ProgressPhase,
+    title: String,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProgressPhase {
+    Begin,
+    End,
+}
+
+impl ProgressState {
+    pub(crate) fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    pub(crate) fn begin(
+        &mut self,
+        kind: ProgressKind,
+        work_units: usize,
+    ) -> Option<ProgressHandle> {
+        if !self.enabled || work_units < kind.threshold() {
+            return None;
+        }
+        let token = format!("{}-{}", kind.token_prefix(), self.next_token);
+        self.next_token = self.next_token.saturating_add(1);
+        #[cfg(test)]
+        {
+            self.events.push(ProgressEvent {
+                token: token.clone(),
+                phase: ProgressPhase::Begin,
+                title: kind.title().to_string(),
+            });
+        }
+        Some(ProgressHandle { token })
+    }
+
+    #[cfg_attr(not(test), allow(clippy::unused_self))]
+    pub(crate) fn end(&mut self, handle: ProgressHandle, title: &str) {
+        #[cfg(not(test))]
+        {
+            let _ = (&handle, title);
+        }
+        #[cfg(test)]
+        {
+            self.events.push(ProgressEvent {
+                token: handle.token,
+                phase: ProgressPhase::End,
+                title: title.to_string(),
+            });
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn events(&self) -> &[ProgressEvent] {
+        &self.events
+    }
+}
+
+pub(crate) fn begin_notification(handle: &ProgressHandle, title: &str) -> Value {
+    json!({
+        "token": handle.token(),
+        "value": {
+            "kind": "begin",
+            "title": title,
+        }
+    })
+}
+
+pub(crate) fn end_notification(handle: &ProgressHandle, message: &str) -> Value {
+    json!({
+        "token": handle.token(),
+        "value": {
+            "kind": "end",
+            "message": message,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProgressKind, ProgressState};
+
+    #[test]
+    fn progress_stays_quiet_for_fast_path_work() {
+        let mut progress = ProgressState::default();
+        progress.set_enabled(true);
+
+        assert!(progress.begin(ProgressKind::FullDiagnostics, 1).is_none());
+        assert!(progress.events().is_empty());
+    }
+
+    #[test]
+    fn progress_records_begin_and_end_after_delay_gate() {
+        let mut progress = ProgressState::default();
+        progress.set_enabled(true);
+
+        let handle = progress
+            .begin(ProgressKind::FullDiagnostics, 2)
+            .expect("threshold should start progress");
+        progress.end(handle, "checked 2 document(s)");
+
+        assert_eq!(progress.events().len(), 2);
+    }
+
+    #[test]
+    fn disabled_progress_does_not_record_events() {
+        let mut progress = ProgressState::default();
+
+        assert!(progress.begin(ProgressKind::References, 100).is_none());
+        assert!(progress.events().is_empty());
+    }
+}

--- a/crates/sifr_lsp/src/request_queue.rs
+++ b/crates/sifr_lsp/src/request_queue.rs
@@ -43,11 +43,19 @@ struct QueuedRequest {
 pub(crate) struct RequestQueue {
     queued: BTreeMap<WorkLane, VecDeque<QueuedRequest>>,
     in_flight: BTreeMap<String, ScheduledRequest>,
+    cancelled: BTreeSet<String>,
     queued_keys: BTreeSet<String>,
     shutdown_requested: bool,
     next_sequence: u64,
     priority_dispatches_since_fairness: usize,
     fairness_cursor: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CancellationTarget {
+    None,
+    Queued,
+    InFlight,
 }
 
 impl RequestQueue {
@@ -93,19 +101,30 @@ impl RequestQueue {
     }
 
     pub(crate) fn finish(&mut self, id: &RequestId) {
-        self.in_flight.remove(&request_key(id));
+        let key = request_key(id);
+        self.in_flight.remove(&key);
+        self.cancelled.remove(&key);
     }
 
-    pub(crate) fn remove_pending(&mut self, id: &RequestId) -> bool {
+    pub(crate) fn mark_cancelled(&mut self, id: &RequestId) -> CancellationTarget {
         let key = request_key(id);
         for lane_queue in self.queued.values_mut() {
             if let Some(index) = lane_queue.iter().position(|request| request.key == key) {
                 lane_queue.remove(index);
                 self.queued_keys.remove(&key);
-                return true;
+                self.cancelled.insert(key);
+                return CancellationTarget::Queued;
             }
         }
-        self.in_flight.remove(&key).is_some()
+        if self.in_flight.contains_key(&key) {
+            self.cancelled.insert(key);
+            return CancellationTarget::InFlight;
+        }
+        CancellationTarget::None
+    }
+
+    pub(crate) fn is_cancelled(&self, id: &RequestId) -> bool {
+        self.cancelled.contains(&request_key(id))
     }
 
     pub(crate) fn begin_shutdown(&mut self) {
@@ -113,6 +132,7 @@ impl RequestQueue {
         self.queued.clear();
         self.queued_keys.clear();
         self.in_flight.clear();
+        self.cancelled.clear();
     }
 
     fn select_next_lane(&mut self) -> Option<WorkLane> {
@@ -153,7 +173,7 @@ pub(crate) fn request_key(id: &RequestId) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::RequestQueue;
+    use super::{CancellationTarget, RequestQueue};
     use crate::scheduler::WorkLane;
     use lsp_server::RequestId;
 
@@ -237,7 +257,26 @@ mod tests {
             .enqueue(&id, "workspace/diagnostic", WorkLane::Workspace)
             .expect("request should enqueue");
 
-        assert!(queue.remove_pending(&id));
+        assert_eq!(queue.mark_cancelled(&id), CancellationTarget::Queued);
         assert!(queue.start_next().is_none());
+        assert!(queue.is_cancelled(&id));
+        queue.finish(&id);
+        assert!(!queue.is_cancelled(&id));
+    }
+
+    #[test]
+    fn cancellation_marks_in_flight_request_until_finish() {
+        let mut queue = RequestQueue::default();
+        let id = RequestId::from(42);
+        queue
+            .enqueue(&id, "textDocument/references", WorkLane::Workspace)
+            .expect("request should enqueue");
+        let scheduled = queue.start_next().expect("request should start");
+
+        assert_eq!(scheduled.id(), &id);
+        assert_eq!(queue.mark_cancelled(&id), CancellationTarget::InFlight);
+        assert!(queue.is_cancelled(&id));
+        queue.finish(&id);
+        assert!(!queue.is_cancelled(&id));
     }
 }

--- a/crates/sifr_lsp/src/server.rs
+++ b/crates/sifr_lsp/src/server.rs
@@ -2,30 +2,38 @@ use crate::capabilities;
 use crate::errors::{LspError, ServerResult};
 use crate::notifications;
 use crate::request_queue;
+use crate::request_queue::CancellationTarget;
 use crate::requests;
 use crate::scheduler::Scheduler;
 use crate::session::Session;
+use crate::watchdog::{LspServerOptions, ParentWatchdog};
 use lsp_server::{Connection, IoThreads, Message, Request, Response};
 use std::collections::BTreeMap;
 
 pub fn run_stdio() -> ServerResult<()> {
-    LspServer::stdio().run()
+    run_stdio_with_options(LspServerOptions::stdio())
+}
+
+pub fn run_stdio_with_options(options: LspServerOptions) -> ServerResult<()> {
+    LspServer::stdio(options).run()
 }
 
 struct LspServer {
     connection: Connection,
     io_threads: IoThreads,
     session: Session,
+    watchdog: ParentWatchdog,
     queued_requests: BTreeMap<String, Request>,
 }
 
 impl LspServer {
-    fn stdio() -> Self {
+    fn stdio(options: LspServerOptions) -> Self {
         let (connection, io_threads) = Connection::stdio();
         Self {
             connection,
             io_threads,
             session: Session::new(),
+            watchdog: ParentWatchdog::new(options.parent_pid),
             queued_requests: BTreeMap::new(),
         }
     }
@@ -36,6 +44,9 @@ impl LspServer {
             &initialize_params,
             self.session.store().settings(),
         )?;
+        self.session.set_work_done_progress_enabled(
+            crate::settings::work_done_progress_from_initialize_params(&initialize_params),
+        );
         self.session.store_mut().apply_settings(settings.clone());
         let initialize_data = serde_json::json!({
             "capabilities": capabilities::server_capabilities(settings.format_enable),
@@ -47,6 +58,7 @@ impl LspServer {
         self.connection
             .initialize_finish(initialize_id, initialize_data)?;
         while let Ok(message) = self.connection.receiver.recv() {
+            self.watchdog.check()?;
             match message {
                 Message::Request(request) => {
                     if request.method == "shutdown" {
@@ -58,6 +70,12 @@ impl LspServer {
                     self.handle_request(request)?;
                 }
                 Message::Notification(notification) => {
+                    if notification.method == "$/cancelRequest" {
+                        if let Some(id) = notifications::cancel_request_id(&notification.params) {
+                            self.cancel_request(&id)?;
+                        }
+                        continue;
+                    }
                     let is_exit = notification.method == "exit";
                     if let Err(error) = notifications::handle(
                         &mut self.session,
@@ -107,6 +125,21 @@ impl LspServer {
         Ok(())
     }
 
+    fn cancel_request(&mut self, id: &lsp_server::RequestId) -> ServerResult<()> {
+        match self.session.cancel_request(id) {
+            CancellationTarget::None => {}
+            CancellationTarget::Queued => {
+                self.queued_requests.remove(&request_queue::request_key(id));
+                self.send_cancelled_response(
+                    id.clone(),
+                    format!("request {id:?} was cancelled before dispatch"),
+                )?;
+            }
+            CancellationTarget::InFlight => {}
+        }
+        Ok(())
+    }
+
     fn drain_queued_requests(&mut self) -> ServerResult<()> {
         while let Some(scheduled) = self.session.start_next_request() {
             let Some(request) = self.queued_requests.remove(scheduled.key()) else {
@@ -126,7 +159,14 @@ impl LspServer {
                 continue;
             };
             let id = request.id.clone();
-            let result = requests::handle(&mut self.session, &request.method, request.params);
+            let result = self
+                .session
+                .begin_request_execution(&id)
+                .and_then(|()| requests::handle(&mut self.session, &request.method, request.params))
+                .and_then(|result| {
+                    self.session.check_request_cancelled(&id)?;
+                    Ok(result)
+                });
             self.session.finish_request(&id);
             let response = match result {
                 Ok(result) => Response::new_ok(id, result),
@@ -142,11 +182,26 @@ impl LspServer {
         Ok(())
     }
 
+    fn send_cancelled_response(
+        &self,
+        id: lsp_server::RequestId,
+        message: String,
+    ) -> ServerResult<()> {
+        let error = LspError::request_cancelled(message);
+        let response = Response::new_err(id, error.code(), error.message());
+        self.connection
+            .sender
+            .send(Message::Response(response))
+            .map_err(|error| LspError::internal(format!("failed to send LSP response: {error}")))?;
+        Ok(())
+    }
+
     fn finish(self) -> ServerResult<()> {
         let Self {
             connection,
             io_threads,
             session: _,
+            watchdog: _,
             queued_requests: _,
         } = self;
         drop(connection);

--- a/crates/sifr_lsp/src/session.rs
+++ b/crates/sifr_lsp/src/session.rs
@@ -1,8 +1,10 @@
 use crate::analysis_workspace::LspAnalysisWorkspace;
+use crate::cancellation::CancellationToken;
 use crate::document_events::{compact_content_changes, CompactedDocumentChange};
 use crate::document_store::DocumentStore;
-use crate::errors::LspResult;
-use crate::request_queue::{RequestQueue, ScheduledRequest};
+use crate::errors::{LspError, LspResult};
+use crate::progress::{ProgressHandle, ProgressKind, ProgressState};
+use crate::request_queue::{CancellationTarget, RequestQueue, ScheduledRequest};
 use crate::scheduler::WorkLane;
 use lsp_server::RequestId;
 use serde_json::Value;
@@ -14,6 +16,8 @@ pub(crate) struct Session {
     store: DocumentStore,
     analysis: LspAnalysisWorkspace,
     queue: RequestQueue,
+    progress: ProgressState,
+    active_request: Option<CancellationToken>,
     initialized: bool,
     shutdown_requested: bool,
     exit_requested: bool,
@@ -41,6 +45,8 @@ impl Session {
             store: DocumentStore::new(),
             analysis: LspAnalysisWorkspace::default(),
             queue: RequestQueue::default(),
+            progress: ProgressState::default(),
+            active_request: None,
             initialized: false,
             shutdown_requested: false,
             exit_requested: false,
@@ -142,11 +148,13 @@ impl Session {
         uri: &str,
         operation: impl FnOnce(&AnalysisSnapshot, &mut AnalysisHost, FileId, &str) -> LspResult<T>,
     ) -> LspResult<T> {
+        self.check_active_request_cancelled()?;
         let before_version = self.store.document(uri)?.version();
         let result = {
             let document = self.store.document(uri)?;
             self.analysis.with_document(document, operation)?
         };
+        self.check_active_request_cancelled()?;
         let after_version = self.store.document(uri)?.version();
         if after_version != before_version {
             return Err(crate::errors::LspError::request_cancelled(
@@ -154,6 +162,31 @@ impl Session {
             ));
         }
         Ok(result)
+    }
+
+    pub(crate) fn set_work_done_progress_enabled(&mut self, enabled: bool) {
+        self.progress.set_enabled(enabled);
+    }
+
+    pub(crate) fn begin_progress(
+        &mut self,
+        kind: ProgressKind,
+        work_units: usize,
+    ) -> Option<ProgressHandle> {
+        let handle = self.progress.begin(kind, work_units)?;
+        self.trace(format!(
+            "started progress token={} kind={kind:?} units={work_units}",
+            handle.token()
+        ));
+        Some(handle)
+    }
+
+    pub(crate) fn end_progress(&mut self, handle: ProgressHandle, message: &str) {
+        self.trace(format!(
+            "ended progress token={} message={message}",
+            handle.token()
+        ));
+        self.progress.end(handle, message);
     }
 
     pub(crate) fn enqueue_request(
@@ -180,30 +213,52 @@ impl Session {
         Some(scheduled)
     }
 
+    pub(crate) fn begin_request_execution(&mut self, id: &RequestId) -> LspResult<()> {
+        self.active_request = Some(CancellationToken::new(id));
+        self.check_request_cancelled(id)
+    }
+
     pub(crate) fn finish_request(&mut self, id: &RequestId) {
+        if self
+            .active_request
+            .as_ref()
+            .is_some_and(|token| token.request_id() == id)
+        {
+            self.active_request = None;
+        }
         self.queue.finish(id);
     }
 
-    pub(crate) fn cancel_request(&mut self, id: &Value) {
-        let request_id = if let Some(raw) = id.as_i64() {
-            let Ok(raw) = i32::try_from(raw) else {
-                return;
-            };
-            RequestId::from(raw)
-        } else if let Some(raw) = id.as_str() {
-            RequestId::from(raw.to_string())
-        } else {
-            return;
-        };
-        if self.queue.remove_pending(&request_id) {
-            self.trace(format!("cancelled request {request_id:?}"));
+    pub(crate) fn cancel_request(&mut self, id: &RequestId) -> CancellationTarget {
+        let target = self.queue.mark_cancelled(id);
+        if target != CancellationTarget::None {
+            self.trace(format!("cancelled request {id:?} target={target:?}"));
         }
+        target
+    }
+
+    pub(crate) fn check_request_cancelled(&self, id: &RequestId) -> LspResult<()> {
+        if self.queue.is_cancelled(id) {
+            Err(LspError::request_cancelled(format!(
+                "request {id:?} was cancelled"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn check_active_request_cancelled(&self) -> LspResult<()> {
+        if let Some(token) = &self.active_request {
+            self.check_request_cancelled(token.request_id())?;
+        }
+        Ok(())
     }
 
     pub(crate) fn begin_shutdown(&mut self) {
         self.shutdown_requested = true;
         self.queue.begin_shutdown();
         self.diagnostic_jobs.clear();
+        self.active_request = None;
     }
 
     pub(crate) fn clear_diagnostic_jobs(&mut self) {
@@ -275,6 +330,9 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::Session;
+    use crate::progress::ProgressKind;
+    use crate::request_queue::CancellationTarget;
+    use lsp_server::RequestId;
     use serde_json::json;
 
     #[test]
@@ -341,6 +399,42 @@ mod tests {
             session.store().document(&uri).expect("document").version(),
             Some(2)
         );
+    }
+
+    #[test]
+    fn active_request_cancellation_fails_phase_boundary_checks() {
+        let mut session = Session::new();
+        let id = RequestId::from(7);
+        session
+            .enqueue_request(
+                &id,
+                "textDocument/references",
+                crate::scheduler::WorkLane::Workspace,
+            )
+            .expect("request should enqueue");
+        let scheduled = session.start_next_request().expect("request should start");
+
+        session
+            .begin_request_execution(scheduled.id())
+            .expect("request should not start cancelled");
+        assert_eq!(session.cancel_request(&id), CancellationTarget::InFlight);
+        assert!(session.check_active_request_cancelled().is_err());
+        session.finish_request(&id);
+        assert!(session.check_request_cancelled(&id).is_ok());
+    }
+
+    #[test]
+    fn progress_gate_records_only_delayed_work() {
+        let mut session = Session::new();
+        session.set_work_done_progress_enabled(true);
+
+        assert!(session
+            .begin_progress(ProgressKind::FullDiagnostics, 1)
+            .is_none());
+        let handle = session
+            .begin_progress(ProgressKind::FullDiagnostics, 2)
+            .expect("multi-document diagnostics should report progress");
+        session.end_progress(handle, "checked 2 document(s)");
     }
 
     #[test]

--- a/crates/sifr_lsp/src/settings.rs
+++ b/crates/sifr_lsp/src/settings.rs
@@ -10,6 +10,13 @@ pub(crate) fn settings_from_initialize_params(
     parse_workspace_settings(root, current)
 }
 
+pub(crate) fn work_done_progress_from_initialize_params(params: &Value) -> bool {
+    params
+        .pointer("/capabilities/window/workDoneProgress")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 pub(crate) fn parse_workspace_settings(
     root: &Value,
     current: &WorkspaceSettings,

--- a/crates/sifr_lsp/src/watchdog.rs
+++ b/crates/sifr_lsp/src/watchdog.rs
@@ -1,0 +1,80 @@
+use crate::errors::{LspError, LspResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LspServerOptions {
+    pub parent_pid: Option<u32>,
+}
+
+impl LspServerOptions {
+    pub const fn stdio() -> Self {
+        Self { parent_pid: None }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ParentWatchdog {
+    parent_pid: Option<u32>,
+}
+
+impl ParentWatchdog {
+    pub(crate) const fn new(parent_pid: Option<u32>) -> Self {
+        Self { parent_pid }
+    }
+
+    pub(crate) fn check(self) -> LspResult<()> {
+        let Some(parent_pid) = self.parent_pid else {
+            return Ok(());
+        };
+        if parent_is_alive(parent_pid) {
+            Ok(())
+        } else {
+            Err(LspError::request_cancelled(format!(
+                "parent process {parent_pid} is no longer alive"
+            )))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn parent_is_alive(parent_pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .arg("-0")
+        .arg(parent_pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(not(unix))]
+fn parent_is_alive(_parent_pid: u32) -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parent_is_alive, ParentWatchdog};
+
+    #[test]
+    fn missing_parent_pid_disables_watchdog() {
+        ParentWatchdog::new(None)
+            .check()
+            .expect("disabled watchdog");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_process_is_alive_for_watchdog() {
+        let pid = std::process::id();
+        assert!(parent_is_alive(pid));
+        ParentWatchdog::new(Some(pid))
+            .check()
+            .expect("current process should be alive");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn obviously_missing_parent_pid_cancels_server() {
+        assert!(ParentWatchdog::new(Some(u32::MAX)).check().is_err());
+    }
+}

--- a/internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md
+++ b/internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md
@@ -1,0 +1,54 @@
+# TypeScript-Go Architecture Transfer M13: LSP Cancellation, Progress, And Watchdog
+
+status: in progress
+
+M13 makes LSP work operationally bounded while keeping execution serialized.
+The server now creates an explicit `CancellationToken` for the active request and
+tracks cancellation separately for queued and in-flight requests: queued
+requests can be removed before dispatch, while in-flight requests retain a
+cancellation marker that phase-boundary checks observe before and after
+compiler-service work.
+
+The scheduler remains a lane classifier. Cancellation state lives in
+`RequestQueue` and `Session`, which keeps request priority separate from
+publication validity. `Session::with_document_analysis` now checks the active
+request before and after analysis work, and the server suppresses a completed
+result if the request was canceled before response publication.
+Because M13 keeps the LSP loop serialized, in-flight cancellation cannot be
+observed from stdio while a synchronous compiler-service call is running; those
+phase-boundary checks are the deterministic propagation point for later worker
+lanes.
+
+Delayed work progress is gated by workload size so single-document fast editor
+paths stay quiet. Clients that advertise `window.workDoneProgress` can receive
+`$/progress` begin/end notifications for multi-document full diagnostics. The
+progress state also reserves stable kinds for references, index warming, and
+workspace loading as later milestones make those operations genuinely
+long-lived.
+
+`sifr lsp --stdio --parent-pid <pid>` wires an explicit Unix parent watchdog
+into the server options. The watchdog checks parent liveness at message
+boundaries and cancels the server loop if the parent process is gone. On
+non-Unix targets the option is accepted but currently treated as a no-op until a
+platform-specific process liveness API is wired.
+
+Validation so far:
+
+- `cargo fmt --check` -> PASS
+- `cargo build -p sifr` -> PASS
+- `cargo test -p sifr_lsp` -> PASS, 23 tests
+- `cargo clippy -p sifr_lsp -p sifr -- -D warnings` -> PASS
+- `python3 -m py_compile verification/tooling/lsp_protocol.py verification/tooling/lsp_protocol_smoke.py verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
+- `python3 verification/tooling/check_phase36_closeout.py` -> PASS
+- `python3 verification/tooling/check_phase36_closeout.py --self-test` -> PASS
+- `python3 scripts/check_diagnostic_cancel_usage.py` -> PASS
+- `git diff --check` -> PASS
+- `python3 scripts/check_file_size_guardrails.py` -> PASS
+- Claude reviewer pass 1 -> SATISFIED with residual cleanup (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-1.md`)
+- Claude reviewer pass 2 -> SATISFIED with residual cleanup (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-2.md`)
+- Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-3.md`)
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 280.41s, advisory: group skew is high

--- a/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
+++ b/internal_docs/typescript_go_architecture_transfer_m1_guardrails.md
@@ -128,17 +128,20 @@ future compiler-service layers. At the M1 planning gate:
 - `DocumentState::rebuild` calls `AnalysisHost::open_single_file` with
   `FrontendMode::SingleFile` on open/change/save.
 - The current `RequestQueue` tracks pending request ids and shutdown state only.
-- The current `Scheduler` maps request methods to lane labels only; it does not
-  yet provide priority queues, cancellation tokens, debounce, background lanes,
-  progress, or worker execution.
+- The current `Scheduler` maps request methods to lane labels only. M11 moved
+  priority queues and debounce into `RequestQueue`/`Session`; M13 moved
+  cancellation tokens/state, delayed progress gates, and parent-pid watchdog
+  state into `CancellationToken`, `RequestQueue`, `ProgressState`, `Session`,
+  and `ParentWatchdog`.
 - Stale-result rejection is revision-token based inside per-document
   `AnalysisHost` use, not `WorkspaceSnapshot`/document-version publication
   identity.
 
 M1-M4 remain serialized. M5 is the first milestone allowed to remove the
 request-local LSP host shape by making LSP consume captured workspace snapshots.
-M11/M13 own priority queues, cancellation, progress, debounce, and operational
-hardening.
+M11 owns priority queues and debounce. M13 owns request cancellation tokens,
+delayed progress, parent-pid watchdogs, and operational hardening. Worker
+execution remains serialized until a later milestone proves safe parallel lanes.
 
 M5 replaced the request-local LSP host shape. `DocumentStore` now owns protocol
 document state only, and `Session` owns `LspAnalysisWorkspace`, which feeds
@@ -167,8 +170,9 @@ type hierarchy, code actions, formatting, and generated Rust preview
 - `SourceMapView` no longer has no-op conversion stubs.
 - M5 LSP session ownership is visible in code: `DocumentStore` has no
   per-document analysis host, `Session` owns `LspAnalysisWorkspace`, and overlay
-  updates flow through the analysis workspace. The scheduler/request queue
-  remain shallow until M11/M13.
+  updates flow through the analysis workspace. M11/M13 scheduler, request-queue,
+  progress, and watchdog surfaces are visible without moving compiler ownership
+  out of the serialized session.
 - The performance manifest contains the M12 split LSP request-family scenarios
   and keeps `lsp.request_families` as aggregate smoke coverage only.
 
@@ -187,7 +191,8 @@ type hierarchy, code actions, formatting, and generated Rust preview
   `AnalysisHost::open_single_file` rebuilds.
 - M12 updated the aggregate-only LSP budget caveat and the matching script
   checks when `lsp.request_families` was split into per-request scenarios.
-- M13 must update the scheduler/request-queue caveats if cancellation tokens,
-  progress, or background queues land in the scheduler modules.
+- M13 updated the scheduler/request-queue caveats and matching script checks
+  when cancellation tokens/state, delayed progress gates, and parent-pid
+  watchdogs landed in the LSP modules.
 - M15 must update the build-metadata exception when `.sifrbuildinfo` or
   equivalent persistent metadata becomes an explicit compiler-service input.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -19,6 +19,7 @@ Status: in progress
 | M10 Snapshot Reuse And Structural Replacement | merged | [#2251](https://github.com/sifr-lang/sifr/pull/2251) | Adds ref-counted M9-keyed parse/source-map/HIR/diagnostics/index reuse, Arc-backed snapshot payloads, and conservative safe one-module replacement when import/export signatures are unchanged. |
 | M11 LSP Scheduler Queues | merged | [#2253](https://github.com/sifr-lang/sifr/pull/2253) | Adds real request priority queues for latency-sensitive, formatting, workspace, and background lanes plus debounced diagnostic jobs guarded by captured document versions. |
 | M12 Per-Request Editor Latency Budgets | merged | [#2255](https://github.com/sifr-lang/sifr/pull/2255) | Splits aggregate LSP request-family performance evidence into per-request protocol latency scenarios with explicit `perf.lsp.*` budgets while retaining the aggregate case as smoke coverage. |
+| M13 LSP Cancellation, Progress, And Watchdog | in progress | pending | Adds queued/in-flight request cancellation state, phase-boundary cancellation checks, delayed work progress for multi-document diagnostics, and `sifr lsp --parent-pid` watchdog plumbing. |
 
 M2 local validation so far:
 
@@ -102,6 +103,27 @@ M12 local validation so far:
 - Claude reviewer pass 2 -> SATISFIED with residual cleanup (`reviews/typescript-go-m12-lsp-latency-budgets-review-pass-2.md`)
 - Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m12-lsp-latency-budgets-review-pass-3.md`)
 - `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 256.95s, advisory: group skew is high
+
+M13 local validation so far:
+
+- `cargo fmt --check` -> PASS
+- `cargo build -p sifr` -> PASS
+- `cargo test -p sifr_lsp` -> PASS, 23 tests
+- `cargo clippy -p sifr_lsp -p sifr -- -D warnings` -> PASS
+- `python3 -m py_compile verification/tooling/lsp_protocol.py verification/tooling/lsp_protocol_smoke.py verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
+- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
+- `python3 verification/tooling/check_phase36_closeout.py` -> PASS
+- `python3 verification/tooling/check_phase36_closeout.py --self-test` -> PASS
+- `python3 scripts/check_diagnostic_cancel_usage.py` -> PASS
+- `git diff --check` -> PASS
+- `python3 scripts/check_file_size_guardrails.py` -> PASS
+- Claude reviewer pass 1 -> SATISFIED with residual cleanup (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-1.md`)
+- Claude reviewer pass 2 -> SATISFIED with residual cleanup (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-2.md`)
+- Claude reviewer pass 3 -> SATISFIED (`reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-3.md`)
+- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 280.41s, advisory: group skew is high
 
 M4 local validation so far:
 

--- a/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-1.md
+++ b/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-1.md
@@ -1,0 +1,34 @@
+# M13 Review — SATISFIED with non-blocking residual risks
+
+## Decision: SATISFIED
+
+The implementation lands the milestone surface area required by the scope: per-request `CancellationToken`, queued vs in-flight cancellation distinction in `RequestQueue`, phase-boundary checks inside `Session::with_document_analysis` and before response publication, delayed `$/progress` begin/end notifications for multi-document workspace diagnostics, and `sifr lsp --parent-pid` with a parent-liveness watchdog at message boundaries. Behavior is consistent with the locked decision that M13 keeps execution serialized; cancellation propagation is naturally limited to phase boundaries on either side of each compiler-service call.
+
+Validation passes (23 sifr_lsp tests, clippy clean, fmt clean, stress + smoke + M1 guardrail + closeout scripts all PASS).
+
+## Residual non-blocking risks
+
+1. **`ProgressState.events` grows unbounded in production** — `crates/sifr_lsp/src/progress.rs:59,90,99` push a `ProgressEvent` for every begin/end. The only reader is `events()` at line 107, which is `#[cfg(test)]`. In a long-lived editor session, this leaks memory each time `publish_all` runs for ≥2 documents. Either gate the `events` field behind `#[cfg(test)]` or remove it and rely on `Session::trace` for observability. Note: `Session.traces` (`session.rs:24,284`) has the same pre-existing pattern — worth fixing together rather than expanding it.
+
+2. **`CancellationToken` is a tautological wrapper** — `cancellation.rs` stores only a cloned `RequestId` and exposes only `request_id()`. The locked architecture decision says the token should expose `is_cancelled()` and `check_cancelled() -> Result<(), Cancelled>`; the actual cancellation predicate lives on `Session`/`RequestQueue`. Today the token adds indirection without behavior. Either:
+   - move the predicate onto the token by giving it an `Arc<AtomicBool>` (sets up the future async story), or
+   - replace `active_request: Option<CancellationToken>` with `active_request_id: Option<RequestId>` until M14+ needs real propagation.
+   This is structural, not a correctness bug, but it diverges from the locked decision shape.
+
+3. **Parent-death exit is misclassified as `INTERNAL_COMPILER_PANIC`** — `crates/sifr/src/cli_model_and_entrypoint.rs:660-670` maps any `run_stdio_with_options` error to `INTERNAL_COMPILER_PANIC` with exit code 3. The watchdog returns `LspError::request_cancelled("parent process N is no longer alive")` (`watchdog.rs:31`), which is an expected operational shutdown, not a panic. Recommend distinguishing watchdog-initiated termination so the server exits 0 (or a dedicated "parent gone" code) rather than rendering a misleading internal-failure diagnostic to a stream nobody is reading anyway.
+
+4. **Dead `$/cancelRequest` branch in `notifications::handle`** — `notifications/mod.rs:15-20` still handles `$/cancelRequest`, but `server.rs:73-77` intercepts the same notification with `continue` before generic dispatch. The notifications branch is unreachable and lacks the `send_cancelled_response`/`queued_requests.remove` cleanup. Remove the dead arm to avoid confusion about which path is authoritative.
+
+5. **Watchdog spawns `kill -0` per message** — `watchdog.rs:39-47` `Command::new("kill").arg("-0")` runs once per LSP message in the receive loop (`server.rs:61`). At editor message rates (semantic tokens, hover, completion deltas during typing) this is a meaningful per-message cost on top of the actual request. A direct `libc::kill(pid, 0)` (via `rustix` to stay clear of `unsafe_code`) would be one syscall instead of a fork+exec. Non-blocking but worth a follow-up.
+
+6. **Watchdog is a no-op on Windows** — `watchdog.rs:50-52` returns `true` unconditionally for non-unix. VS Code on Windows is a real consumer; the `--parent-pid` flag provides no protection there. Document the limitation in the M13 doc, or use `OpenProcess`/`GetExitCodeProcess` to make it real cross-platform.
+
+7. **Progress threshold is work-unit-based, not time-based** — `DIAGNOSTICS_PROGRESS_DOCUMENT_THRESHOLD = 2` (`progress.rs:3`) means every multi-document publish fires begin/end even when the work is fast. The M13 doc claims "fast editor paths stay quiet" but with two open files a quick `didChangeWatchedFiles` always emits progress. The locked decision wording ("only after a threshold") is ambiguous between time and count, and TypeScript-Go uses time. Consider gating on `Instant::now()` elapsed at the begin call, or accept this trade-off and update the doc to say the threshold is document-count, not latency.
+
+8. **Reserved-but-unused `ProgressKind` variants** — `References`, `IndexWarming`, `WorkspaceLoad` are declared (`progress.rs:9-14`) with `#[allow(dead_code)]` but no call site emits them. The M13 doc acknowledges this is intentional for future milestones; just flagging so it stays visible in the closeout tracker.
+
+9. **Stress test does not exercise a real cancel race** — `lsp_protocol_stress.py:44` sends `$/cancelRequest` for id `99999` which was never issued. It verifies "unknown id cancel is harmless," not "an in-flight cancel produces `-32800`." Given the serialized model, a deterministic in-flight cancellation race may be hard to drive over stdio, but adding a queued-request cancel test (enqueue a workspace request, immediately cancel by its id, expect a `-32800` response) would tighten the protocol-level guarantee. The unit test at `request_queue.rs:267-281` exercises the queue but not the publication path.
+
+## Summary
+
+The milestone is implementable and shippable as-is; the residual items above are quality, not correctness. Item 1 (unbounded `events` Vec) is the closest to blocking — recommend fixing before closeout — and item 4 (dead `$/cancelRequest` branch) is a quick removal that prevents future maintainer confusion.

--- a/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-2.md
+++ b/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-2.md
@@ -1,0 +1,120 @@
+# M13 Review Pass 2 — SATISFIED with non-blocking residual risks
+
+## Decision: SATISFIED
+
+The two close-to-blocking items from pass 1 are fixed and the working tree
+re-validates cleanly.
+
+Verification re-run on the working tree (matches the validation list in
+`internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md`):
+
+- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
+- `cargo test -p sifr_lsp` -> PASS, 23 tests
+- `cargo clippy -p sifr_lsp -p sifr -- -D warnings` -> PASS
+- `git diff --check` -> PASS
+
+## What pass 1 raised and what changed
+
+- Pass 1 item 1 (unbounded `ProgressState.events` Vec). Fixed.
+  `events: Vec<ProgressEvent>` is now `#[cfg(test)]`-only
+  (`crates/sifr_lsp/src/progress.rs:62`); production state retains only a
+  bounded `completed: u64` counter (`progress.rs:60,107`) with
+  `saturating_add`. No production-path Vec growth on multi-document publishes
+  remains. The matching test-only `events()` accessor and
+  `ProgressEvent`/`ProgressPhase` types are also gated.
+- Pass 1 item 4 (dead generic `$/cancelRequest` arm in `notifications::handle`).
+  Fixed. `notifications/mod.rs:13-31` no longer contains a `$/cancelRequest`
+  branch; `server.rs:73-77` is the only path and runs the
+  `send_cancelled_response` / `queued_requests.remove` cleanup via
+  `cancel_request` (`server.rs:128-141`). Confirmed by reading both files end
+  to end.
+- Pass 1 items 6 and 7 (Windows watchdog no-op; progress threshold is
+  document-count not time) are now explicitly documented in the M13 doc
+  (`internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md:19,25-29`)
+  rather than reworked. Reasonable scope choice; the user-visible behavior
+  matches the doc.
+
+## Residual non-blocking risks
+
+Carried forward unchanged from pass 1 (still accurate, still non-blocking):
+
+1. **`CancellationToken` is still a tautological wrapper** —
+   `crates/sifr_lsp/src/cancellation.rs:3-18` stores only a cloned `RequestId`
+   and exposes only `request_id()`. The locked architecture decision text says
+   the token should expose `is_cancelled()` /
+   `check_cancelled() -> Result<(), Cancelled>`. Today the predicate lives on
+   `Session::check_request_cancelled` / `Session::check_active_request_cancelled`
+   (`session.rs:240-255`). Structural divergence from the locked decision shape,
+   not a correctness bug.
+2. **Parent-death exit is still classified as
+   `INTERNAL_COMPILER_PANIC`** —
+   `crates/sifr/src/cli_model_and_entrypoint.rs:661-670` maps any
+   `run_stdio_with_options` error to `INTERNAL_COMPILER_PANIC` /
+   `EXIT_INTERNAL_COMPILER_FAILURE`, including the
+   `LspError::request_cancelled("parent process N is no longer alive")` raised
+   by `ParentWatchdog::check` (`watchdog.rs:31`). Cosmetic for a stream nobody
+   is reading after the parent dies, but the diagnostic is misleading.
+3. **Watchdog still forks `kill -0` per message** — `watchdog.rs:39-47` runs
+   `Command::new("kill").arg("-0")` from the LSP message loop
+   (`server.rs:61`). Per-message fork+exec overhead. Worth a follow-up with
+   `rustix::process::test_kill_process` to stay clear of `unsafe_code`.
+4. **Reserved-but-unused `ProgressKind` variants** —
+   `References`, `IndexWarming`, `WorkspaceLoad` remain declared with
+   `#[allow(dead_code)]` (`progress.rs:8-14,27-42`) with no emit sites. The
+   M13 doc acknowledges this is intentional for future milestones.
+5. **Stress test does not drive a real cancel race** —
+   `verification/tooling/lsp_protocol_stress.py:44` still sends
+   `$/cancelRequest` for id `99999`, which was never issued. Given the new
+   pass-2 observation in the next section, a true in-flight cancel race cannot
+   be driven over stdio in the M13 serialized model; the queue-only unit test
+   at `request_queue.rs:267-281` continues to cover the queued path.
+
+## New pass-2 observations
+
+These were not in pass 1. Neither is blocking.
+
+A. **`ProgressState.completed` is a write-only field.**
+`progress.rs:60` declares `completed: u64`; `progress.rs:107` increments it on
+every `end`. No reader exists in the crate (`grep completed crates/sifr_lsp`
+finds only the two lines). It is bounded (`saturating_add`), so this is not the
+pass-1 leak, but it is dead state per AGENTS.md "don't add features beyond what
+the task requires." Either wire it into the future M16 status surface or drop
+the field. Non-blocking.
+
+B. **`CancellationTarget::InFlight` is unreachable through the LSP protocol
+in M13's serialized model.** The message loop at `server.rs:60-104` is
+single-threaded; `Message::Request` is dispatched through
+`handle_request` -> `drain_queued_requests`, which blocks on the synchronous
+`requests::handle` until `finish_request` runs. A `$/cancelRequest`
+notification sitting in the connection receiver cannot be polled until the
+outer `connection.receiver.recv()` runs again — by which time the in-flight
+request has already cleared from both `queued` and `in_flight`, so
+`RequestQueue::cancel` (`request_queue.rs:109-124`) returns
+`CancellationTarget::None`. The same logic means
+`Session::check_active_request_cancelled` (`session.rs:250-255`) inside
+`with_document_analysis` (`session.rs:146-165`) cannot observe a cancel during
+analysis. The in-flight branch is exercised by direct-API unit tests
+(`session.rs:404-424`), so the mechanism works; it just cannot fire from the
+protocol surface today. This is consistent with the locked decision that M11-M13
+stay serialized, but the M13 doc currently says "phase-boundary checks observe
+before and after compiler-service work" without flagging that those checks are
+dormant scaffolding for M14+ concurrency. Worth a one-line clarification in the
+M13 doc on the next pass through the docs.
+
+C. **Stress assertion on multi-document progress is structural, not
+content-bound.** `lsp_protocol_stress.py:35-40` correctly asserts
+`begin` and `end` `$/progress` notifications around the multi-document
+`workspace/didChangeWatchedFiles`. It does not assert the progress message body
+("checked N document(s)"). Acceptable — body text is a UI string and changing
+it should not be a protocol-level break — but worth knowing that future copy
+edits will not be caught by the stress harness.
+
+## Summary
+
+M13 is shippable as-is. Pass 1's two flagged-quality items (unbounded `events`
+Vec, dead `$/cancelRequest` arm) are resolved. The remaining residuals are
+quality and forward-looking concerns: a structural-shape divergence on
+`CancellationToken`, a cosmetic exit-code misclassification on parent death,
+per-message `kill -0` cost, and the dormant in-flight cancellation path that
+cannot fire from stdio until concurrency lands. None block closing the
+milestone.

--- a/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-3.md
+++ b/reviews/typescript-go-m13-lsp-cancellation-progress-watchdog-review-pass-3.md
@@ -1,0 +1,17 @@
+I verified the pass-2 cleanup landed and re-ran the four checks.
+
+**SATISFIED**
+
+Verified on the working tree:
+
+- Pass-2 observation A (write-only `ProgressState.completed`) — resolved at `crates/sifr_lsp/src/progress.rs:56-62,79-119`: the field is gone, `events: Vec<ProgressEvent>` stays `#[cfg(test)]`, and `end` is annotated `#[cfg_attr(not(test), allow(clippy::unused_self))]` with a `let _ = (&handle, title);` in the non-test arm. No production state growth.
+- Pass-2 observation B (dormant in-flight cancellation under serialized stdio) — addressed at `internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md:17-20`: "Because M13 keeps the LSP loop serialized, in-flight cancellation cannot be observed from stdio while a synchronous compiler-service call is running; those phase-boundary checks are the deterministic propagation point for later worker lanes." Reads exactly as the pass-2 note requested.
+- Pass-2 observation C (stress harness doesn't assert progress body text) — still acceptable, unchanged.
+
+Re-validation:
+- `cargo fmt --check` → PASS
+- `cargo test -p sifr_lsp` → PASS, 23 tests (matches pass-2 count, no skipped/disabled regressions)
+- `cargo clippy -p sifr_lsp -p sifr -- -D warnings` → PASS
+- `git diff --check` → PASS
+
+Carried-forward non-blocking residuals from pass 1/2 are unchanged (CancellationToken shape divergence, parent-death exit-code classification, per-message `kill -0`, reserved `ProgressKind` variants, stress harness does not drive a real cancel race). None introduced by this pass. No new blockers.

--- a/verification/tooling/check_typescript_go_m1_guardrails.py
+++ b/verification/tooling/check_typescript_go_m1_guardrails.py
@@ -20,6 +20,9 @@ LSP_ANALYSIS_WORKSPACE = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "analysis_w
 LSP_SESSION = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "session.rs"
 SCHEDULER = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "scheduler.rs"
 REQUEST_QUEUE = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "request_queue.rs"
+CANCELLATION = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "cancellation.rs"
+PROGRESS = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "progress.rs"
+WATCHDOG = REPO_ROOT / "crates" / "sifr_lsp" / "src" / "watchdog.rs"
 PERF_MANIFEST = REPO_ROOT / "verification" / "performance" / "manifest.json"
 SOURCE_DEP_GUARD = REPO_ROOT / "scripts" / "check_source_crate_dependency_direction.py"
 DIRECT_FS_PATTERN = re.compile(
@@ -118,6 +121,10 @@ REQUIRED_DOC_SNIPPETS = [
     "M1-M4 remain serialized",
     "M5 updated",
     "M12 updated",
+    "M13 updated",
+    "CancellationToken",
+    "ParentWatchdog",
+    "ProgressState",
     "perf.lsp.request_families",
     "perf.lsp.generated_rust_preview.document",
 ]
@@ -239,6 +246,9 @@ def validate_lsp_current_state(failures: list[str]) -> None:
     session = LSP_SESSION.read_text(encoding="utf-8")
     scheduler = SCHEDULER.read_text(encoding="utf-8")
     request_queue = REQUEST_QUEUE.read_text(encoding="utf-8")
+    cancellation = CANCELLATION.read_text(encoding="utf-8")
+    progress = PROGRESS.read_text(encoding="utf-8")
+    watchdog = WATCHDOG.read_text(encoding="utf-8")
     require(
         "AnalysisHost::open_single_file" not in document_store
         and "FrontendMode::SingleFile" not in document_store
@@ -264,15 +274,37 @@ def validate_lsp_current_state(failures: list[str]) -> None:
         "pub(crate) fn lane_for_method" in scheduler
         and "Background" in scheduler
         and "CancellationToken" not in scheduler,
-        "scheduler guardrail expects M11 lane classification, with cancellation deferred",
+        "scheduler guardrail expects lane classification to remain separate from cancellation state",
         failures,
     )
     require(
         "VecDeque<QueuedRequest>" in request_queue
         and "start_next" in request_queue
         and "FAIRNESS_INTERVAL" in request_queue
-        and "remove_pending" in request_queue,
-        "request queue guardrail expects M11 priority queues with bounded fairness",
+        and "CancellationTarget" in request_queue
+        and "is_cancelled" in request_queue,
+        "request queue guardrail expects M11 priority queues plus M13 cancellation state",
+        failures,
+    )
+    require(
+        "ProgressState" in progress
+        and "ProgressKind" in progress
+        and "FullDiagnostics" in progress,
+        "M13 requires delayed LSP progress state for long-running work",
+        failures,
+    )
+    require(
+        "CancellationToken" in cancellation
+        and "request_id" in cancellation
+        and "RequestId" in cancellation,
+        "M13 requires explicit LSP request cancellation tokens",
+        failures,
+    )
+    require(
+        "ParentWatchdog" in watchdog
+        and "LspServerOptions" in watchdog
+        and "parent_pid" in watchdog,
+        "M13 requires parent-pid watchdog options for LSP",
         failures,
     )
 

--- a/verification/tooling/lsp_protocol.py
+++ b/verification/tooling/lsp_protocol.py
@@ -21,7 +21,7 @@ class LspProtocolError(RuntimeError):
 
 
 class LspClient:
-    def __init__(self, timeout: float = 90.0) -> None:
+    def __init__(self, timeout: float = 90.0, extra_args: list[str] | None = None) -> None:
         command = os.environ.get("SIFR_LSP_COMMAND")
         binary = REPO_ROOT / "target" / "debug" / "sifr"
         args = (
@@ -31,6 +31,8 @@ class LspClient:
             if binary.exists()
             else ["cargo", "run", "-q", "-p", "sifr", "--", "lsp", "--stdio"]
         )
+        if extra_args:
+            args.extend(extra_args)
         self.process = subprocess.Popen(
             args,
             cwd=REPO_ROOT,

--- a/verification/tooling/lsp_protocol_smoke.py
+++ b/verification/tooling/lsp_protocol_smoke.py
@@ -28,19 +28,28 @@ def main()->int:
     return value
 """
 
-def initialize(client: LspClient, root: Path, initialization_options: dict[str, Any] | None = None) -> dict[str, Any]:
+def initialize(
+    client: LspClient,
+    root: Path,
+    initialization_options: dict[str, Any] | None = None,
+    *,
+    work_done_progress: bool = False,
+) -> dict[str, Any]:
+    capabilities: dict[str, Any] = {
+        "textDocument": {
+            "publishDiagnostics": {"relatedInformation": True},
+            "semanticTokens": {"requests": {"full": True, "range": True}},
+        },
+        "workspace": {"configuration": True, "workspaceFolders": True},
+    }
+    if work_done_progress:
+        capabilities["window"] = {"workDoneProgress": True}
     result = client.request(
         "initialize",
         {
             "processId": None,
             "rootUri": file_uri(root),
-            "capabilities": {
-                "textDocument": {
-                    "publishDiagnostics": {"relatedInformation": True},
-                    "semanticTokens": {"requests": {"full": True, "range": True}},
-                },
-                "workspace": {"configuration": True, "workspaceFolders": True},
-            },
+            "capabilities": capabilities,
             "workspaceFolders": [{"uri": file_uri(root), "name": "sifr-lsp-smoke"}],
             "initializationOptions": initialization_options or {},
         },

--- a/verification/tooling/lsp_protocol_stress.py
+++ b/verification/tooling/lsp_protocol_stress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -22,10 +23,23 @@ def run_stress() -> None:
         source = root / "main.sifr"
         source.write_text(SAMPLE, encoding="utf-8")
         uri = file_uri(source)
-        client = LspClient()
+        client = LspClient(extra_args=["--parent-pid", str(os.getpid())])
         try:
-            initialize(client, root)
+            initialize(client, root, work_done_progress=True)
             open_document(client, source, SAMPLE)
+            secondary = root / "secondary.sifr"
+            secondary.write_text(SAMPLE, encoding="utf-8")
+            open_document(client, secondary, SAMPLE)
+
+            client.notify("workspace/didChangeWatchedFiles", {"changes": [{"uri": uri, "type": 2}]})
+            progress = client.wait_for_notification("$/progress")
+            if progress.get("params", {}).get("value", {}).get("kind") != "begin":
+                raise LspProtocolError("workspace diagnostics progress did not begin")
+            progress = client.wait_for_notification("$/progress")
+            if progress.get("params", {}).get("value", {}).get("kind") != "end":
+                raise LspProtocolError("workspace diagnostics progress did not end")
+            for _ in range(2):
+                client.wait_for_notification("textDocument/publishDiagnostics")
 
             client.notify("$/cancelRequest", {"id": 99999})
             client.notify(


### PR DESCRIPTION
## Summary
- Add explicit LSP request cancellation tokens plus queued/in-flight cancellation state and phase-boundary cancellation checks.
- Add delayed work-progress support for multi-document diagnostics and `sifr lsp --parent-pid` watchdog plumbing.
- Extend protocol stress coverage for parent-pid/progress and update TypeScript-Go guardrails/docs for M13.

## Validation
- `cargo fmt --check` -> PASS
- `cargo build -p sifr` -> PASS
- `cargo test -p sifr_lsp` -> PASS, 23 tests
- `cargo clippy -p sifr_lsp -p sifr -- -D warnings` -> PASS
- `python3 -m py_compile verification/tooling/lsp_protocol.py verification/tooling/lsp_protocol_smoke.py verification/tooling/lsp_protocol_stress.py` -> PASS
- `python3 verification/tooling/lsp_protocol_smoke.py` -> PASS
- `python3 verification/tooling/lsp_protocol_stress.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
- `python3 verification/tooling/check_phase36_closeout.py` -> PASS
- `python3 verification/tooling/check_phase36_closeout.py --self-test` -> PASS
- `python3 scripts/check_diagnostic_cancel_usage.py` -> PASS
- `git diff --check` -> PASS
- `python3 scripts/check_file_size_guardrails.py` -> PASS
- `scripts/run_all_tests.sh --profile quick` -> PASS, report `target/validation_lane_reports/quick.latest.json`, wall time 280.41s, advisory: group skew is high

## Reviewer
- Claude pass 1 -> SATISFIED with residual cleanup
- Claude pass 2 -> SATISFIED with residual cleanup
- Claude pass 3 -> SATISFIED
