### PR TITLE
Mark M15 project residency merged

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_m15_project_residency.md
+++ b/internal_docs/typescript_go_architecture_transfer_m15_project_residency.md
@@ -1,6 +1,6 @@
 # TypeScript-Go Architecture Transfer M15: Project Residency, Watchers, And Build Info
 
-Status: in progress
+Status: merged in [#2261](https://github.com/sifr-lang/sifr/pull/2261)
 
 M15 keeps long-lived compiler-service sessions bounded without making generated
 metadata authoritative.

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -21,7 +21,7 @@ Status: in progress
 | M12 Per-Request Editor Latency Budgets | merged | [#2255](https://github.com/sifr-lang/sifr/pull/2255) | Splits aggregate LSP request-family performance evidence into per-request protocol latency scenarios with explicit `perf.lsp.*` budgets while retaining the aggregate case as smoke coverage. |
 | M13 LSP Cancellation, Progress, And Watchdog | merged | [#2257](https://github.com/sifr-lang/sifr/pull/2257) | Adds queued/in-flight request cancellation state, phase-boundary cancellation checks, delayed work progress for multi-document diagnostics, and `sifr lsp --parent-pid` watchdog plumbing. |
 | M14 Bucketed Indexes And Safe Parallel Lanes | merged | [#2259](https://github.com/sifr-lang/sifr/pull/2259) | Adds workspace/package/stdlib symbol and import bucket readiness states, dirty-bucket symbol-index refreshes, and explicit approved worker-lane versus single-owner compiler-phase policy; package and stdlib buckets are explicit unavailable states until frontend graph views carry those identities. |
-| M15 Project Residency, Watchers, And Build Info | in progress | pending | Adds project residency snapshots, config pending reload state, deduped watch registrations, and verified non-authoritative `.sifrbuildinfo` metadata. |
+| M15 Project Residency, Watchers, And Build Info | merged | [#2261](https://github.com/sifr-lang/sifr/pull/2261) | Adds project residency snapshots, config pending reload state, deduped watch registrations, and verified non-authoritative `.sifrbuildinfo` metadata. |
 
 M2 local validation so far:
 


### PR DESCRIPTION
## Summary

- Mark M15 as merged in the architecture-transfer tracker.
- Update the M15 residency doc status with PR #2261.

## Validation

- `git diff --check` -> PASS
- `python3 scripts/check_file_size_guardrails.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py` -> PASS
- `python3 verification/tooling/check_typescript_go_m1_guardrails.py --self-test` -> PASS
