### PR TITLE
Mark M16 trace status milestone merged

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_m16_trace_status.md
+++ b/internal_docs/typescript_go_architecture_transfer_m16_trace_status.md
@@ -1,6 +1,6 @@
 # TypeScript-Go Architecture Transfer M16: Trace And Status Surfaces
 
-Status: in progress
+Status: merged via [#2263](https://github.com/sifr-lang/sifr/pull/2263)
 
 M16 normalizes compiler-service trace and status output so stale requests,
 cache state, invalidation, and editor-facing readiness can be explained from a

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -22,7 +22,7 @@ Status: in progress
 | M13 LSP Cancellation, Progress, And Watchdog | merged | [#2257](https://github.com/sifr-lang/sifr/pull/2257) | Adds queued/in-flight request cancellation state, phase-boundary cancellation checks, delayed work progress for multi-document diagnostics, and `sifr lsp --parent-pid` watchdog plumbing. |
 | M14 Bucketed Indexes And Safe Parallel Lanes | merged | [#2259](https://github.com/sifr-lang/sifr/pull/2259) | Adds workspace/package/stdlib symbol and import bucket readiness states, dirty-bucket symbol-index refreshes, and explicit approved worker-lane versus single-owner compiler-phase policy; package and stdlib buckets are explicit unavailable states until frontend graph views carry those identities. |
 | M15 Project Residency, Watchers, And Build Info | merged | [#2261](https://github.com/sifr-lang/sifr/pull/2261) | Adds project residency snapshots, config pending reload state, deduped watch registrations, and verified non-authoritative `.sifrbuildinfo` metadata. |
-| M16 Trace And Status Surfaces | in progress | pending | Adds deterministic compiler-service trace phases, bounded debug status snapshots, LSP scheduler/cancellation/stale/timing trace events via `sifr/debugTrace`, analysis index-readiness status, and `sifr trace` CLI output. |
+| M16 Trace And Status Surfaces | merged | [#2263](https://github.com/sifr-lang/sifr/pull/2263) | Adds deterministic compiler-service trace phases, bounded debug status snapshots, LSP scheduler/cancellation/stale/timing trace events via `sifr/debugTrace`, analysis index-readiness status, and `sifr trace` CLI output. |
 
 M2 local validation so far:
 


### PR DESCRIPTION
## Summary
- mark M16 Trace And Status Surfaces as merged in the phase tracker
- update the M16 trace/status doc status with implementation PR #2263

## Validation
- `git diff --check` -> PASS
