### PR TITLE
Mark M17 editor corpus milestone merged

### DIFF
--- a/internal_docs/typescript_go_architecture_transfer_m17_editor_corpus_snapshot_handles.md
+++ b/internal_docs/typescript_go_architecture_transfer_m17_editor_corpus_snapshot_handles.md
@@ -1,6 +1,6 @@
 # TypeScript-Go Architecture Transfer M17: Editor Corpus And Snapshot Handles
 
-Status: in progress
+Status: merged via [#2265](https://github.com/sifr-lang/sifr/pull/2265)
 
 M17 locks representative editor query behavior with marker-based multi-file
 fixtures and prepares internal snapshot-scoped handles for future compiler API

--- a/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
+++ b/issues/ad-hoc-typescript-go-compiler-architecture-transfer.md
@@ -23,7 +23,7 @@ Status: in progress
 | M14 Bucketed Indexes And Safe Parallel Lanes | merged | [#2259](https://github.com/sifr-lang/sifr/pull/2259) | Adds workspace/package/stdlib symbol and import bucket readiness states, dirty-bucket symbol-index refreshes, and explicit approved worker-lane versus single-owner compiler-phase policy; package and stdlib buckets are explicit unavailable states until frontend graph views carry those identities. |
 | M15 Project Residency, Watchers, And Build Info | merged | [#2261](https://github.com/sifr-lang/sifr/pull/2261) | Adds project residency snapshots, config pending reload state, deduped watch registrations, and verified non-authoritative `.sifrbuildinfo` metadata. |
 | M16 Trace And Status Surfaces | merged | [#2263](https://github.com/sifr-lang/sifr/pull/2263) | Adds deterministic compiler-service trace phases, bounded debug status snapshots, LSP scheduler/cancellation/stale/timing trace events via `sifr/debugTrace`, analysis index-readiness status, and `sifr trace` CLI output. |
-| M17 Editor Corpus And Snapshot Handles | in progress | pending | Adds marker-based multi-file editor query corpus fixtures, internal snapshot-scoped handles, and runtime package diagnostic non-duplication fixtures. |
+| M17 Editor Corpus And Snapshot Handles | merged | [#2265](https://github.com/sifr-lang/sifr/pull/2265) | Adds marker-based multi-file editor query corpus fixtures, internal snapshot-scoped handles, and runtime package diagnostic non-duplication fixtures. |
 
 M2 local validation so far:
 


### PR DESCRIPTION
## Summary
- mark M17 Editor Corpus And Snapshot Handles as merged in the phase tracker
- update the M17 implementation doc status with implementation PR #2265

## Validation
- `git diff --check` -> PASS
