### PR TITLE
Add large LSP long-session verification

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = verification/package_management/demo_repositories/sifr-demo-workspace
 	url = https://github.com/sifr-lang/sifr-demo-workspace.git
 	branch = main
+[submodule "verification/sifr-large-lsp-verification"]
+	path = verification/sifr-large-lsp-verification
+	url = https://github.com/sifr-lang/sifr-large-lsp-verification.git

--- a/crates/sifr_analysis/src/host/overlay_updates.rs
+++ b/crates/sifr_analysis/src/host/overlay_updates.rs
@@ -4,6 +4,7 @@ use sifr_diagnostics::RenderedDiagnostic;
 use sifr_frontend::{
     DocumentVersion, FrontendMode, ProjectRoot, SourcePath, SourceText, WorkspaceSession,
 };
+use std::path::Path;
 
 impl AnalysisHost {
     pub fn open_project_with_overlays(
@@ -55,7 +56,7 @@ impl AnalysisHost {
 
     pub fn document_file_for_path(
         &self,
-        path: &std::path::Path,
+        path: &Path,
     ) -> Result<sifr_frontend::FileId, AnalysisError> {
         self.session
             .context()
@@ -64,7 +65,7 @@ impl AnalysisHost {
                     .source_map()
                     .files
                     .into_iter()
-                    .find(|file| file.canonical_path.as_path() == path)
+                    .find(|file| paths_match(file.canonical_path.as_path(), path))
                     .map(|file| file.id)
             })
             .ok_or_else(|| {
@@ -73,5 +74,48 @@ impl AnalysisHost {
                     format!("analysis file is unavailable for {}", path.display()),
                 )
             })
+    }
+}
+
+fn paths_match(candidate: &Path, requested: &Path) -> bool {
+    if candidate == requested {
+        return true;
+    }
+    // Project source maps may store module paths relative to the project root
+    // while LSP document URIs arrive as absolute paths. The lookup is scoped to
+    // one analysis host, so a relative suffix match cannot cross project roots.
+    if candidate.is_absolute() || !requested.is_absolute() {
+        return false;
+    }
+    requested.ends_with(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::paths_match;
+    use std::path::Path;
+
+    #[test]
+    fn path_match_accepts_exact_paths() {
+        assert!(paths_match(
+            Path::new("/tmp/project/src/main.sifr"),
+            Path::new("/tmp/project/src/main.sifr"),
+        ));
+    }
+
+    #[test]
+    fn path_match_accepts_project_relative_source_paths() {
+        assert!(paths_match(
+            Path::new("src/main.sifr"),
+            Path::new("/tmp/project/src/main.sifr"),
+        ));
+    }
+
+    #[test]
+    fn path_match_rejects_unrelated_paths() {
+        assert!(!paths_match(
+            Path::new("src/main.sifr"),
+            Path::new("/tmp/project/src/helper.sifr"),
+        ));
     }
 }

--- a/crates/sifr_lsp/src/analysis_workspace.rs
+++ b/crates/sifr_lsp/src/analysis_workspace.rs
@@ -42,33 +42,55 @@ pub(crate) struct LspWorkspaceSymbol {
 impl LspAnalysisWorkspace {
     pub(crate) const WATCHER_STORM_THRESHOLD: usize = 64;
 
-    pub(crate) fn open_document(&mut self, document: &DocumentState) {
-        if workspace_root_for(document.path()).is_some() {
-            self.documents.remove(document.uri());
-            return;
-        }
-        let analysis = LspDocumentAnalysis::open(document);
-        self.documents.insert(document.uri().to_string(), analysis);
-    }
-
-    pub(crate) fn update_document(&mut self, document: &DocumentState) {
-        let uri = document.uri().to_string();
+    pub(crate) fn open_document(&mut self, document: &DocumentState) -> bool {
         if let Some(root) = workspace_root_for(document.path()) {
-            self.documents.remove(&uri);
-            let remove_project = self
-                .projects
-                .get_mut(&root)
-                .is_some_and(|project| project.update_document(document).is_err());
-            if remove_project {
-                self.projects.remove(&root);
+            self.documents.remove(document.uri());
+            match self.projects.get_mut(&root) {
+                Some(project) => {
+                    if project.open_document(document).is_ok() {
+                        false
+                    } else {
+                        let analysis = LspDocumentAnalysis::open(document);
+                        self.documents.insert(document.uri().to_string(), analysis);
+                        false
+                    }
+                }
+                None => true,
             }
-            return;
-        }
-        if let Some(analysis) = self.documents.get_mut(&uri) {
-            analysis.update(document);
         } else {
             let analysis = LspDocumentAnalysis::open(document);
-            self.documents.insert(uri, analysis);
+            self.documents.insert(document.uri().to_string(), analysis);
+            false
+        }
+    }
+
+    pub(crate) fn update_document(&mut self, document: &DocumentState) -> bool {
+        let uri = document.uri().to_string();
+        if let Some(root) = workspace_root_for(document.path()) {
+            if let Some(analysis) = self.documents.get_mut(&uri) {
+                analysis.update(document);
+                return false;
+            }
+            match self.projects.get_mut(&root) {
+                Some(project) => {
+                    if project.update_document(document).is_ok() {
+                        false
+                    } else {
+                        let analysis = LspDocumentAnalysis::open(document);
+                        self.documents.insert(uri, analysis);
+                        false
+                    }
+                }
+                None => true,
+            }
+        } else {
+            if let Some(analysis) = self.documents.get_mut(&uri) {
+                analysis.update(document);
+            } else {
+                let analysis = LspDocumentAnalysis::open(document);
+                self.documents.insert(uri, analysis);
+            }
+            false
         }
     }
 
@@ -80,7 +102,6 @@ impl LspAnalysisWorkspace {
         let mut grouped: BTreeMap<PathBuf, Vec<&DocumentState>> = BTreeMap::new();
         for document in documents.documents() {
             if let Some(root) = workspace_root_for(document.path()) {
-                self.documents.remove(document.uri());
                 grouped.entry(root).or_default().push(document);
             }
         }
@@ -95,6 +116,14 @@ impl LspAnalysisWorkspace {
                 continue;
             }
             let analysis = LspProjectAnalysis::open(root.clone(), &documents);
+            for document in &documents {
+                if analysis.files_by_uri.contains_key(document.uri()) {
+                    self.documents.remove(document.uri());
+                } else {
+                    let fallback = LspDocumentAnalysis::open(document);
+                    self.documents.insert(document.uri().to_string(), fallback);
+                }
+            }
             self.projects.insert(root, analysis);
         }
     }
@@ -266,6 +295,28 @@ impl LspProjectAnalysis {
                 open_uris: open_uris(documents),
             },
         }
+    }
+
+    fn open_document(&mut self, document: &DocumentState) -> Result<(), ()> {
+        let Some(host) = self.host.as_mut() else {
+            return Err(());
+        };
+        let started = Instant::now();
+        host.upsert_overlay_document(
+            SourcePath::new(document.path().to_path_buf()),
+            Some(document.uri().to_string()),
+            document_version(document),
+            SourceText::new(document.text().to_string()),
+        )
+        .map_err(|_| ())?;
+        let file = host
+            .document_file_for_path(document.path())
+            .map_err(|_| ())?;
+        host.record_update_latency_ms(elapsed_ms(started));
+        self.files_by_uri.insert(document.uri().to_string(), file);
+        self.load_diagnostics.remove(document.uri());
+        self.open_uris.insert(document.uri().to_string());
+        Ok(())
     }
 
     fn update_document(&mut self, document: &DocumentState) -> Result<(), ()> {

--- a/crates/sifr_lsp/src/session.rs
+++ b/crates/sifr_lsp/src/session.rs
@@ -80,8 +80,9 @@ impl Session {
     ) -> LspResult<()> {
         self.store.open(uri.clone(), language_id, version, text)?;
         let document = self.store.document(&uri)?;
-        self.analysis.open_document(document);
-        self.analysis.refresh_projects(&self.store);
+        if self.analysis.open_document(document) {
+            self.analysis.refresh_projects(&self.store);
+        }
         Ok(())
     }
 
@@ -105,8 +106,9 @@ impl Session {
             .store
             .apply_compacted_change(uri, version, &compacted)?;
         let document = self.store.document(uri)?;
-        self.analysis.update_document(document);
-        self.analysis.refresh_projects(&self.store);
+        if self.analysis.update_document(document) {
+            self.analysis.refresh_projects(&self.store);
+        }
         Ok(DocumentChangeSummary {
             raw_change_count: compacted.raw_change_count,
             compacted_change_count: compacted.changes.len(),
@@ -119,8 +121,9 @@ impl Session {
             return Ok(false);
         }
         let document = self.store.document(uri)?;
-        self.analysis.update_document(document);
-        self.analysis.refresh_projects(&self.store);
+        if self.analysis.update_document(document) {
+            self.analysis.refresh_projects(&self.store);
+        }
         Ok(true)
     }
 
@@ -462,6 +465,154 @@ mod tests {
             session.store().document(&uri).expect("document").version(),
             Some(2)
         );
+    }
+
+    #[test]
+    fn unmapped_project_file_fallback_survives_project_refresh() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let src = temp.path().join("src");
+        std::fs::create_dir(&src).expect("create src");
+        std::fs::write(
+            temp.path().join("sifr.toml"),
+            "[package]\nname = \"lsp-secondary-open\"\nedition = \"2026\"\n",
+        )
+        .expect("write manifest");
+        let main_path = src.join("main.sifr");
+        let orphan_path = src.join("orphan.sifr");
+        std::fs::write(&main_path, "def main() -> int:\n    return 1\n")
+            .expect("write main source");
+        std::fs::write(
+            &orphan_path,
+            "def orphan(value: int) -> int:\n    return value + 1\n",
+        )
+        .expect("write orphan source");
+        let main_uri = url::Url::from_file_path(&main_path)
+            .expect("main file uri")
+            .to_string();
+        let orphan_uri = url::Url::from_file_path(&orphan_path)
+            .expect("orphan file uri")
+            .to_string();
+        let mut session = Session::new();
+        session
+            .open_document(
+                main_uri,
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                std::fs::read_to_string(&main_path).expect("read main source"),
+            )
+            .expect("open project entrypoint");
+        session
+            .open_document(
+                orphan_uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                std::fs::read_to_string(&orphan_path).expect("read orphan source"),
+            )
+            .expect("open unmapped project file");
+        session
+            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+                assert!(source.contains("def orphan"));
+                Ok(())
+            })
+            .expect("unmapped project file should have fallback analysis");
+        assert!(session.close_document(
+            &url::Url::from_file_path(&main_path)
+                .expect("main file uri")
+                .to_string()
+        ));
+        session
+            .open_document(
+                url::Url::from_file_path(&main_path)
+                    .expect("main file uri")
+                    .to_string(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(2),
+                std::fs::read_to_string(&main_path).expect("read main source"),
+            )
+            .expect("reopen project entrypoint");
+        session
+            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+                assert!(source.contains("def orphan"));
+                Ok(())
+            })
+            .expect("fallback analysis should survive project refresh");
+    }
+
+    #[test]
+    fn unmapped_project_file_fallback_survives_unrelated_root_refresh() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let first_root = temp.path().join("first");
+        let second_root = temp.path().join("second");
+        let first_src = first_root.join("src");
+        let second_src = second_root.join("src");
+        std::fs::create_dir_all(&first_src).expect("create first src");
+        std::fs::create_dir_all(&second_src).expect("create second src");
+        for (root, name) in [(&first_root, "first"), (&second_root, "second")] {
+            std::fs::write(
+                root.join("sifr.toml"),
+                format!("[package]\nname = \"{name}\"\nedition = \"2026\"\n"),
+            )
+            .expect("write manifest");
+        }
+        let first_main_path = first_src.join("main.sifr");
+        let orphan_path = first_src.join("orphan.sifr");
+        let second_main_path = second_src.join("main.sifr");
+        std::fs::write(&first_main_path, "def main() -> int:\n    return 1\n")
+            .expect("write first main");
+        std::fs::write(
+            &orphan_path,
+            "def orphan(value: int) -> int:\n    return value + 1\n",
+        )
+        .expect("write orphan");
+        std::fs::write(&second_main_path, "def main() -> int:\n    return 2\n")
+            .expect("write second main");
+        let first_main_uri = url::Url::from_file_path(&first_main_path)
+            .expect("first main file uri")
+            .to_string();
+        let orphan_uri = url::Url::from_file_path(&orphan_path)
+            .expect("orphan file uri")
+            .to_string();
+        let second_main_uri = url::Url::from_file_path(&second_main_path)
+            .expect("second main file uri")
+            .to_string();
+        let mut session = Session::new();
+        session
+            .open_document(
+                first_main_uri,
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                std::fs::read_to_string(&first_main_path).expect("read first main"),
+            )
+            .expect("open first entrypoint");
+        session
+            .open_document(
+                orphan_uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                std::fs::read_to_string(&orphan_path).expect("read orphan"),
+            )
+            .expect("open orphan");
+        session
+            .open_document(
+                second_main_uri.clone(),
+                crate::capabilities::LANGUAGE_ID,
+                Some(1),
+                std::fs::read_to_string(&second_main_path).expect("read second main"),
+            )
+            .expect("open second entrypoint");
+        session
+            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+                assert!(source.contains("def orphan"));
+                Ok(())
+            })
+            .expect("orphan should have fallback analysis after second root opens");
+        assert!(session.close_document(&second_main_uri));
+        session
+            .with_document_analysis(&orphan_uri, |_snapshot, _host, _file, source| {
+                assert!(source.contains("def orphan"));
+                Ok(())
+            })
+            .expect("orphan fallback should survive unrelated root close refresh");
     }
 
     #[test]

--- a/issues/ad-hoc-large-lsp-long-session-verification.md
+++ b/issues/ad-hoc-large-lsp-long-session-verification.md
@@ -1,0 +1,67 @@
+# Ad Hoc Large LSP Long-Session Verification
+
+Status: ready for PR
+
+This is a post-phase verification hardening task following the completed
+TypeScript-Go compiler architecture transfer. It does not reopen the transfer
+phase; it adds large-codebase and long-session editor coverage for the LSP
+architecture delivered there.
+
+## Goals
+
+- Publish a public synthetic Sifr corpus repository under `sifr-lang`.
+- Pin that repository as a submodule under `verification/`.
+- Add a rerunnable long-session LSP verifier that exercises a large project
+  graph over many edits and requests.
+- Record latency and sampled RSS evidence, including peak memory and RSS growth
+  slope, so slow leaks are visible.
+- Keep a bounded smoke mode in local validation and a fuller mode available for
+  explicit long-session qualification.
+
+## Acceptance Criteria
+
+- `verification/sifr-large-lsp-verification` is a git submodule pointing at
+  `sifr-lang/sifr-large-lsp-verification`.
+- The subrepo contains a deterministic committed corpus plus a generator drift
+  check.
+- `verification/tooling/lsp_large_session.py --mode smoke` runs in the quick
+  validation lane.
+- `verification/tooling/lsp_large_session.py --mode full` is documented and
+  writes JSON evidence under `target/lsp_large_session/`.
+- The verifier samples LSP RSS during the session, not just at process exit.
+- Claude Opus review passes are recorded under `reviews/` and the final pass is
+  satisfied.
+
+## Progress
+
+- Created `sifr-lang/sifr-large-lsp-verification` as the public synthetic
+  corpus repository.
+- Added a deterministic corpus generator and drift checker in the subrepo.
+- Added the submodule and initial long-session LSP verifier in this branch.
+- Found and fixed an LSP analysis availability gap for secondary project files:
+  if a project host cannot map an opened file into the project graph, the LSP
+  now keeps the project and serves that open file through standalone document
+  analysis instead of leaving it unavailable.
+- Found and fixed avoidable project refreshes on same-project opens/edits:
+  open/change/save now use incremental analysis paths and only refresh project
+  membership when the incremental path cannot attach.
+- Current local evidence:
+  - `python3 verification/tooling/lsp_large_session.py --mode smoke --require-submodule`
+    passed with 42 operations, p95 5.645 ms, peak RSS 2.1 MiB.
+  - `python3 verification/tooling/lsp_large_session.py --mode full --require-submodule`
+    passed with 1702 operations, including 480 change notifications and 30
+    `textDocument/diagnostic` requests, p95 6.363 ms, peak RSS 19.0 MiB, RSS
+    slope 29.34393 MiB/min.
+  - `cargo test -q -p sifr_lsp unmapped_project_file_fallback_survives`
+    passed.
+  - `cargo test -q -p sifr_analysis` passed.
+
+## Notes
+
+- The large-session verifier runs with push diagnostics disabled
+  (`diagnosticsMode=off`) so the long edit/query session measures LSP
+  responsiveness over a very large codebase without blocking each notification
+  on synchronous diagnostic publication. Full mode still issues periodic
+  `textDocument/diagnostic` pull requests over edited files, while existing
+  protocol smoke/stress checks continue to cover diagnostic publication
+  behavior.

--- a/reviews/large-lsp-long-session-implementation-review-pass-2.md
+++ b/reviews/large-lsp-long-session-implementation-review-pass-2.md
@@ -1,0 +1,239 @@
+# Large LSP Long-Session Verification — Implementation Review (Pass 2)
+
+## **NOT SATISFIED**
+
+The subrepo + submodule + verifier scaffolding is correctly assembled, but the
+implementation has (a) a real regression in the LSP analysis path that the new
+"fallback" code only partially fixes, (b) a gate wiring that silently no-ops on
+a fresh clone, and (c) a long-session verifier whose configured workload doesn't
+actually stress the architecture features the corpus exists to exercise.
+Detailed blockers and concrete fixes below. Each blocker is reproducible from
+the current branch.
+
+---
+
+### Blocker 1 — Standalone fallback is destroyed by the next `refresh_projects` (regression)
+
+`LspAnalysisWorkspace::open_document` now falls back to inserting a standalone
+`LspDocumentAnalysis` in `self.documents` when `project.open_document(...)`
+fails (`crates/sifr_lsp/src/analysis_workspace.rs:45-65`). Good. But
+`refresh_projects` is unchanged:
+
+```rust
+for document in documents.documents() {
+    if let Some(root) = workspace_root_for(document.path()) {
+        self.documents.remove(document.uri());        // <- clobbers fallback
+        grouped.entry(root).or_default().push(document);
+    }
+}
+```
+
+`crates/sifr_lsp/src/analysis_workspace.rs:101-108`. Any subsequent
+`refresh_projects` call removes the standalone fallback for every workspace
+file and then re-creates the project. The re-created project's `files_by_uri`
+still won't contain the orphan (still not in the import graph), so
+`with_document` falls all the way through to "analysis is unavailable" and
+every subsequent hover/completion/symbol query fails.
+
+`refresh_projects` is unconditionally called from `Session::close_document`
+(`crates/sifr_lsp/src/session.rs:130-136`) and from any new-root open, so this
+is reachable from normal editor use. I verified it by adding the temp test
+below (then reverted):
+
+```rust
+// open `main.sifr` and an `orphan.sifr` (not imported by main, same package),
+// query orphan → OK (standalone fallback). Then close main → query orphan:
+// LspError { code: InternalError,
+//   message: "analysis is unavailable for .../src/orphan.sifr" }
+```
+
+Output of `cargo test -q -p sifr_lsp regression_secondary_fallback_lost_after_refresh_projects`:
+
+```
+panicked at crates/sifr_lsp/src/session.rs:596:14:
+orphan should still have analysis after close-triggered refresh:
+LspError { code: InternalError,
+  message: "analysis is unavailable for /var/.../orphan.sifr" }
+```
+
+**Fix:** make `refresh_projects` honor the fallback. Two options:
+- After `LspProjectAnalysis::open` returns, re-insert standalone entries in
+  `self.documents` for any `open_uris` not present in `files_by_uri`.
+- Or stop removing from `self.documents` in `refresh_projects` and let the
+  project path's `files_by_uri.contains_key(uri)` arbitrate per call.
+
+Also add the failing test above as a permanent regression test. The currently
+landed test `project_secondary_open_falls_back_to_document_analysis_when_unmapped`
+is **misnamed**: its `helper.sifr` is imported by `main.sifr` (`from helper
+import helper`), so the file *is* in the project's source map and the fallback
+path is never taken. The test passes whether the new fallback code exists or
+not — it cannot detect either the fix or its regression. Either rename it to
+reflect what it actually covers (project-managed secondary open) or rewrite it
+with an actually-unmapped file plus the close-then-query sequence above.
+
+---
+
+### Blocker 2 — Smoke gate silently SKIPs on a fresh clone
+
+`scripts/run_all_tests.sh:179-180` wires:
+
+```sh
+python3 .../lsp_large_session.py --self-test
+python3 .../lsp_large_session.py --mode smoke
+```
+
+without `--require-submodule`. The verifier's `run_large_session` treats a
+missing manifest as a *skip*, not a failure, unless `--require-submodule` is
+set (`verification/tooling/lsp_large_session.py:151-161`):
+
+```python
+except LspProtocolError as error:
+    if require_submodule:
+        print(..., file=sys.stderr); return 1
+    print(f"LSP large session: SKIP: {error}"); return 0
+```
+
+`scripts/run_all_tests.sh` does **not** invoke `scripts/clone_subrepos.sh` nor
+`git submodule update --init`, so on a clean checkout (the most common CI
+shape) the gate prints SKIP and exits 0. The acceptance criterion says smoke
+"runs in the quick validation lane" — a silent skip doesn't satisfy that. This
+is the same gap the design review's blocker 3 flagged; it's still open.
+
+**Fix:** pass `--require-submodule` in the gate invocation, *and* either have
+`run_all_tests.sh` shell out to `git submodule update --init verification/sifr-large-lsp-verification`
+before the LSP block, or document in the script's prologue that
+`clone_subrepos.sh` is required first. Pick one; don't ship the current
+"works on my machine" shape.
+
+---
+
+### Blocker 3 — Verifier doesn't stress the architecture features its corpus was sized for
+
+The corpus has 1206 files, 3 packages, depth-380 chains and 20-way API fanout
+(`verification/sifr-large-lsp-verification/manifest.json` `shape`). The
+verifier configuration neutralizes most of what that costs:
+
+- `diagnostics_mode="off"` for both `smoke` and `full`
+  (`verification/tooling/lsp_large_session.py:48,57`). With push diagnostics
+  disabled and no `workspace/diagnostic` polling, the session never schedules
+  diagnostic jobs, so M5 stale-version rejection, M11 priority lanes, M13
+  cancellation/watchdog, and M14 bucketed indexes are not meaningfully driven.
+  The README says "diagnostic publication remains covered by existing LSP
+  protocol smoke and stress checks" — but those use 1–3 file fixtures, which
+  is precisely what motivated this corpus in the first place. With diagnostics
+  off the verifier degenerates to "client-side request latency on top of an
+  effectively-idle server".
+- `edit_text` produces an identical-shape change for every category — it just
+  appends a `# lsp-large-session {category} {round_index}` comment line. The
+  `private-body` / `shared-api` / `storm` labels exist in the evidence file
+  but the LSP sees the same trivial trailing-comment edit each time. So:
+  - "shared-api" edits never change a `def` signature, never invalidate
+    reverse-dep closure — M7 slow path uncovered.
+  - "storm" edits don't burst within the M6 compaction window — they're spaced
+    one per round behind a synchronous query mix and a synchronous response.
+    `WatcherStorm` degradation isn't reached.
+  - "private-body" edits are the same as the others, so even the "fast" path
+    isn't distinguishable from the "slow" path in the report. The design
+    review explicitly called this out (item 14); the implementation didn't
+    address it.
+- `LspClient` is serialized request/response (`verification/tooling/lsp_protocol.py:47-54`),
+  so M11 priority lanes never see more than one queued request at a time.
+  This was a known limitation the design review allowed *if* the scheduler
+  coverage claim was dropped. The doc and issue text don't make that drop
+  explicit; either drop the claim or pipeline the client.
+
+**Fix (minimum):** turn diagnostics on for `--mode full` (either
+`diagnosticsMode=push` or call `workspace/diagnostic` after each round), and
+change `edit_text` so `shared-api` actually mutates an exported function
+signature (e.g., rename the parameter or change the return type) and `storm`
+emits 10+ `didChange` notifications in tight succession before the next
+request. Otherwise the long-session verifier doesn't measure long-session
+behavior; it measures cold project load + a trivial edit loop.
+
+---
+
+### Important issues (should be resolved before merge)
+
+4. **Thresholds are 30–60× looser than observed and can't catch the leaks
+   they exist to catch.** Recorded peak RSS 17 MiB vs 1024 MiB threshold,
+   p95 8.3 ms vs 10000 ms, slope 2.5 MiB/min vs 96 MiB/min. The slope
+   threshold means a real leak has to add 96 MiB *within a one-minute window*
+   over the second half of a session whose total RSS is currently 17 MiB.
+   That's not a leak detector; that's an OOM detector. Either tighten to
+   ~3–5× observed with explicit headroom rationale in the comment, or wire
+   peak/p95/slope into `verification/performance/budgets.json` under a
+   `perf.lsp.long_session.*` family and let `check_budgets.py`'s retry logic
+   handle drift (the existing path the design review recommended).
+
+5. **Corpus drift checker is not wired into the main repo gate.** The subrepo
+   ships `tools/generate_corpus.py check`, but nothing in
+   `scripts/run_all_tests.sh` invokes it. If the submodule's files diverge
+   from the generator without the subrepo's own CI catching it (or if the
+   manifest is hand-edited), the main repo silently runs against off-spec
+   data. The verifier also reads `manifest["corpus_sha256"]` into the report
+   but never recomputes it from the corpus on disk — trivial to add and would
+   give the gate a local drift signal independent of the subrepo's CI.
+
+6. **`paths_match` in `crates/sifr_analysis/src/host/overlay_updates.rs:80-88`
+   is undocumented and weak.** The helper accepts any absolute `requested`
+   whose path components end with the relative `candidate`. There's no test,
+   no comment explaining when source map paths are relative vs. absolute, and
+   no assertion that the source map can't hold two suffix-equivalent entries.
+   The test added in this PR uses absolute temp-dir paths, so it doesn't
+   exercise the new helper at all. At minimum: add a doc comment stating the
+   invariant (one host per project ⇒ no duplicate suffix in source map),
+   and add a direct unit test in `overlay_updates.rs` covering both branches.
+
+7. **Full mode is never executed by any lane, schedule, or doc-mandated
+   workflow.** The acceptance criterion says "Full mode is documented and
+   writes JSON evidence" — that's literally satisfied, but the artifact is
+   useless without a cadence. Either schedule it nightly (the natural home),
+   or rename the doc section to "manual qualification" and explain that any
+   regression detection is on the developer to run.
+
+8. **`verification/sifr_large_lsp_verification.md` is documentation but is
+   currently untracked in git.** Same for `issues/ad-hoc-large-lsp-long-session-verification.md`
+   and `reviews/typescript-go-large-lsp-long-session-design-review-pass-1.md`.
+   Presumably they'll be `git add`ed before commit; flagging in case the
+   commit-bundling step is the actual delivery boundary.
+
+---
+
+### Minor
+
+- The verifier's `RssSampler` exits via `_stop.set()` then `_thread.join(timeout=2)`.
+  Between `_stop.set()` and the last `wait`, the sampler can fork `ps` once
+  more; harmless, just noting that the last sample's `elapsed_ms` may overrun
+  the session by up to one polling interval. The slope math truncates to the
+  second half so it's not a correctness issue.
+- macOS `ps -o rss=` rounds to whole pages and can lag a few hundred ms;
+  recording the sampler's monotonic timestamp instead of `ps`'s is correct
+  (already done at line 88).
+- Naming: the file `verification/sifr_large_lsp_verification.md` collides
+  visually with the submodule directory `verification/sifr-large-lsp-verification/`.
+  Consider `verification/lsp_large_session.md` or
+  `verification/sifr-large-lsp-verification.md` (matching the dir).
+
+---
+
+### Verdict
+
+**NOT SATISFIED.** Blockers 1, 2, and 3 each independently keep this from
+being mergeable:
+
+- 1 is a behavioral regression with a reproducer in this review; the test
+  bundled with the PR cannot detect it.
+- 2 makes the new gate a no-op on a clean clone, which is the only state
+  CI ever starts from.
+- 3 means the 1200-file corpus and the long-session machinery don't actually
+  exercise the LSP scheduler / invalidation / storm-compaction paths the
+  corpus was sized to stress.
+
+Recommended sequence to clear: (a) extend `refresh_projects` to preserve the
+standalone fallback and add the failing test from blocker 1 as a permanent
+regression; (b) flip the gate to `--require-submodule` and wire
+`git submodule update --init` (or call out the prereq script); (c) make
+`shared-api` and `storm` edits behaviorally distinct and turn diagnostics on
+in `--mode full`; (d) tighten thresholds or migrate to `budgets.json`;
+(e) wire the drift checker into the main-repo gate. With those, the next
+review pass can be SATISFIED.

--- a/reviews/large-lsp-long-session-implementation-review-pass-3.md
+++ b/reviews/large-lsp-long-session-implementation-review-pass-3.md
@@ -1,0 +1,74 @@
+I've reviewed the actual fixes against pass 2's blockers. The single-root regression that pass 2 reproduced is fixed, but the new `refresh_projects` still has a reachable hole in a multi-root flow.
+
+## NOT SATISFIED
+
+### Blocker — `refresh_projects` still destroys the fallback when `open_uris` already matches
+
+`crates/sifr_lsp/src/analysis_workspace.rs:101-130`:
+
+```rust
+for document in documents.documents() {
+    if let Some(root) = workspace_root_for(document.path()) {
+        self.documents.remove(document.uri());        // unconditionally clobbers fallback
+        grouped.entry(root).or_default().push(document);
+    }
+}
+self.projects.retain(|root, _| grouped.contains_key(root));
+for (root, documents) in grouped {
+    let open_uris = open_uris(&documents);
+    if self
+        .projects
+        .get(&root)
+        .is_some_and(|project| project.open_uris == open_uris)
+    {
+        continue;                                     // does NOT re-insert what the first loop removed
+    }
+    let analysis = LspProjectAnalysis::open(root.clone(), &documents);
+    for document in &documents {
+        if analysis.files_by_uri.contains_key(document.uri()) {
+            self.documents.remove(document.uri());
+        } else {
+            let fallback = LspDocumentAnalysis::open(document);
+            self.documents.insert(document.uri().to_string(), fallback);
+        }
+    }
+    self.projects.insert(root, analysis);
+}
+```
+
+After the first refresh that re-opens a project containing an unmapped orphan, `LspProjectAnalysis::open` sets `open_uris = open_uris(documents)` for *all* passed documents — including the orphan whose `files_by_uri` entry was never created. So `project.open_uris` becomes `{main, orphan}` while `files_by_uri = {main}` and `self.documents = {orphan: fallback}`. Any subsequent `refresh_projects` whose grouped documents for that root are still `{main, orphan}` (i.e. nothing changed in this root, but something else fired a refresh) hits the `continue` branch — *after* the first loop already removed `self.documents[orphan_uri]` — and the fallback is gone.
+
+Reachable normal-editor sequence (not covered by the new test):
+
+1. Open `proj1/src/main.sifr` → triggers refresh; `project.open_uris = {main}`.
+2. Open `proj1/src/orphan.sifr` (same package, not imported) → fallback inserted; `project.open_uris` unchanged.
+3. Open `proj2/src/main.sifr` (different `sifr.toml` root) → `analysis.open_document` returns `true`, refresh fires. proj1 is re-opened with `[main, orphan]`; fallback re-inserted; `proj1.project.open_uris = {main, orphan}`.
+4. Close `proj2/src/main.sifr` → `close_document` always refreshes. First loop removes `self.documents[orphan_uri]`. Second loop: `open_uris_new == project.open_uris == {main, orphan}` → `continue`. Fallback is not re-inserted.
+5. Query `proj1/src/orphan.sifr` → `analysis is unavailable for .../orphan.sifr`.
+
+`unmapped_project_file_fallback_survives_project_refresh` (`crates/sifr_lsp/src/session.rs:471-541`) only covers the close-entrypoint-then-reopen path, which works because `project.open_uris` is `{main}` at the time of close and the `continue` branch isn't hit. Multi-root + close-of-other-root reaches it and the test doesn't.
+
+**Fix:** make the two loops consistent. The minimal change is to stop clobbering `self.documents` in the first loop and only remove project-managed URIs in the second loop. Equivalently, in the `continue` branch, re-insert a fallback for every `document.uri()` whose `project.files_by_uri` does not contain it. Add a regression test using the 5-step sequence above (two roots, close the second, then query the orphan in the first).
+
+---
+
+### Other blockers — fixed
+
+**Blocker 2 (smoke gate silent skip):** `scripts/run_all_tests.sh:179-182` now runs `git submodule update --init verification/sifr-large-lsp-verification`, the subrepo `generate_corpus.py check` drift gate, and `--mode smoke --require-submodule`. On a clean clone the submodule init fails loudly under `set -e`, and `--require-submodule` turns a missing manifest into FAIL rather than SKIP. ✓
+
+**Blocker 3 (verifier workload):** `verification/tooling/lsp_large_session.py` full mode now has `diagnostic_requests=True`, `storm_burst_size=10`, periodic `textDocument/diagnostic` requests, `edit_shared_api_text` that actually mutates the exported parameter and references, `edit_private_body_text` that mutates the return expression, and storm bursts of real `didChange` notifications before the request mix. The three edit categories are now behaviorally distinct in what they invalidate. Push diagnostics are still off, but pull diagnostics on a 1206-file corpus + storm bursts + signature changes is a meaningful workload for the scheduler/snapshot/invalidation paths. ✓
+
+---
+
+### Should-fix before merge (not standalone blockers, but tracked from pass 2)
+
+- **paths_match still has no doc comment** (`crates/sifr_analysis/src/host/overlay_updates.rs:80-88`). Tests at 90-118 cover both branches, but the invariant ("source-map paths may be relative to project root; uniqueness is guaranteed by one-host-per-project") isn't stated anywhere. The helper silently relies on this.
+- **Full mode has no cadence.** `verification/sifr_large_lsp_verification.md` documents it as a manual command. No nightly schedule, no `RUN_HARDENING` hook. Either schedule it or label the section "manual qualification" so the absence is intentional.
+- **Verification docs / review files still untracked.** `git status` shows `verification/sifr_large_lsp_verification.md`, `verification/tooling/lsp_large_session.py`, `reviews/large-lsp-long-session-implementation-review-pass-2.md`, `reviews/large-lsp-long-session-implementation-review-pass-3.md`, and `issues/ad-hoc-large-lsp-long-session-verification.md` all untracked. They must be `git add`ed before the commit lands or the PR ships without them.
+- **Thresholds are still ~10–100× looser than observed** (peak 256 MiB vs 18.6, p95 1000 ms vs 9.112, slope 64 MiB/min vs −24.95). These were "Important" not "Blocker" in pass 2 and were partially tightened; flagging that they still won't catch a 2–3× regression.
+
+---
+
+### Verdict
+
+**NOT SATISFIED.** One concrete blocker: `refresh_projects`'s `continue`-on-matching-`open_uris` branch leaves the fallback removed by the first loop and unrestored, so multi-root editor flows still destroy unmapped-file fallbacks. The currently landed regression test doesn't cover that path. Fix the loop to be consistent (don't clobber `self.documents` up front, or re-insert in the `continue` branch) and add a multi-root regression test.

--- a/reviews/large-lsp-long-session-implementation-review-pass-4.md
+++ b/reviews/large-lsp-long-session-implementation-review-pass-4.md
@@ -1,0 +1,34 @@
+I've reviewed the pass 3 blocker fix in detail. Let me verify my trace of the fix matches the pass 3 reproduction scenario:
+
+**Pass 3 blocker (refresh_projects destroys multi-root fallback):**
+
+The pre-fix code in the initial grouping loop unconditionally called `self.documents.remove(document.uri())` for any URI with a workspace root. Then the second loop's `continue` branch (matching `open_uris`) didn't re-insert anything, leaving fallbacks lost.
+
+The current fix (`crates/sifr_lsp/src/analysis_workspace.rs:101-129`):
+- Removed the unconditional `self.documents.remove` from the grouping loop (lines 102-107 only collect now).
+- Only the rebuild branch touches `self.documents`, and it does so symmetrically: `files_by_uri.contains_key` → remove; otherwise insert fallback.
+- The `continue` fast-path now leaves `self.documents` untouched, so orphan fallbacks survive an unrelated-root rebuild.
+
+**Trace of the pass 3 5-step scenario, post-fix:**
+1. Open `first_root/main` → refresh; `project.open_uris = {main}`; main moved into project.
+2. Open `first_root/orphan` → `project.open_document` calls `upsert_overlay`+`document_file_for_path`; the latter fails (orphan not in source map after `reload`) → returns `Err` before `open_uris.insert` at line 318, so `project.open_uris` stays `{main}`; fallback inserted into `self.documents`.
+3. Open `second_root/main` → triggers refresh. For `first_root`, `open_uris_new = {main, orphan}` ≠ `project.open_uris = {main}` → **rebuild**, files_by_uri = {main}, orphan re-inserted as fallback. `project.open_uris` becomes `{main, orphan}`.
+4. Close `second_root/main` → refresh. For `first_root`, `open_uris_new = {main, orphan} == project.open_uris` → **continue**. Critically, the first loop no longer removed the orphan fallback, so it survives. ✓
+5. Query orphan → fallback found.
+
+**Test `unmapped_project_file_fallback_survives_unrelated_root_refresh`** (session.rs:543-620) replays exactly that sequence and passes.
+
+**Other pass 3 items:**
+- `paths_match` invariant comment (lines 84-86) and three-branch tests are present.
+- Full mode cadence remains manual (pass 3 labeled this should-fix, not blocker).
+- Untracked files still present (`verification/tooling/lsp_large_session.py`, `verification/sifr_large_lsp_verification.md`, review/issue docs). Pass 3 labeled this should-fix; flagging that `scripts/run_all_tests.sh` now invokes `lsp_large_session.py`, so the PR must include that file or the script breaks on landing.
+
+**Validation:**
+- `cargo test -q -p sifr_lsp` → 27 pass.
+- `cargo clippy -q -p sifr_analysis -p sifr_lsp -- -D warnings` → clean.
+
+## SATISFIED
+
+The pass 3 blocker is fixed: `refresh_projects` no longer destroys unmapped-file fallbacks when an unrelated-root close-refresh hits the matching-`open_uris` fast path. The new regression test reproduces the exact 5-step multi-root sequence pass 3 described.
+
+Reminder before pushing the PR (carried over from pass 3, not a code defect): `git add` `verification/tooling/lsp_large_session.py` and `verification/sifr_large_lsp_verification.md` — the script change in `scripts/run_all_tests.sh` already references the tool.

--- a/reviews/typescript-go-large-lsp-long-session-design-review-pass-1.md
+++ b/reviews/typescript-go-large-lsp-long-session-design-review-pass-1.md
@@ -1,0 +1,75 @@
+I have enough grounding now to deliver the critique.
+
+## **NOT SATISFIED — proceed only after resolving the blockers below**
+
+The proposal is on the right track and the user is correct that the current verification stack has no signal for *long-session, large-codebase* LSP behavior — `lsp_protocol_smoke/stress.py` use ad-hoc temp dirs with 1–3 files, `lsp_workspace_perf` has 5 trivial files, and `editor_query_corpus/multi_file` is a 2-file marker fixture (M17). Existing perf RSS is sampled by `/usr/bin/time -l/-v` at *process exit* (`verification/performance/run_benchmarks.py:430-477`), which by construction cannot detect monotonic growth or leaks inside a long-lived LSP. So the gap is real and the architectural shape (submodule corpus + main-repo driver script + sampled RSS) is sound.
+
+But several concrete blockers and gaps need to be settled before implementation.
+
+---
+
+### Blockers (must resolve)
+
+1. **Phase framing is wrong.** `issues/ad-hoc-typescript-go-compiler-architecture-transfer.md:1-31` and `reviews/typescript-go-architecture-transfer-full-implementation-review-pass-1.md:9` already say the TS-Go transfer is **complete and SATISFIED on `main`** as of 2026-06-02. Calling this a "next phase of TypeScript-Go architecture transfer audit work" misrepresents the state. It is a **post-phase verification hardening task** (peer to Phase 29 hardening or a perf-budget follow-up), and should be tracked as such — either as an entry under `internal_docs/phases/29_verification_hardening.md` or a new ad-hoc issue. Otherwise the phase tracker reopens and the M0–M17 closeout narrative becomes incoherent.
+
+2. **Reproducibility model is under-specified.** "Deterministic generator plus committed corpus" creates two sources of truth that can drift. Pick one of these and write it down before coding:
+   - **Generator-authoritative**: commit only the generator + a content hash manifest; regenerate to a temp dir each run; *no* corpus files in the subrepo. Pro: zero drift. Con: every run pays generation cost; bisecting requires reproducing input.
+   - **Corpus-authoritative + drift checker**: commit the corpus + the generator + a `check_corpus_matches_generator.py` contract (mirroring `check_ruff_fork_update_contract.py`). The submodule SHA pin is the real reproducibility anchor; the generator is documentation. Pro: cheap reruns. Con: drift checker must be wired into the gate.
+   The proposal as written has both files and a generator with no enforcement of the relation — that will rot within two PRs.
+
+3. **Submodule lifecycle is not wired.** The proposal adds the submodule but doesn't address: (a) `git submodule update --init --recursive` in `scripts/run_all_tests.sh` / `run_e2e_pass.sh` so a fresh clone works, (b) shallow-clone strategy (the existing `verification/package_management/demo_repositories/sifr-demo-*` submodules in `.gitmodules:13-32` pin to a branch — pin to a SHA instead for true determinism), (c) CI clone cost (1200–2000 small files is fine, but document expected size), (d) what happens when the submodule is absent in offline runs (skip with reason, not fail). Without this, the test will silently no-op on clean clones.
+
+4. **`LspClient` cannot run a long session as-is.** The existing client (`verification/tooling/lsp_protocol.py:23-145`) has two structural limits that the proposal glosses over:
+   - **Single-in-flight serialization**: `request()` waits on `_wait_for_response(request_id)` before any other request can be sent (line 47-54). The proposed "hundreds of didChange edits with concurrent requests" cannot exercise the M11 priority lanes (`LatencySensitive`, `Formatting`, `Workspace`, `Background`) — the scheduler will only ever see one queued request at a time. To meaningfully test the scheduler, either extend the client with a pipelined send + correlated receive loop, or accept upfront that this test only covers serialized request/notification interleaving and remove the scheduler-coverage claim.
+   - **`_read_message` reads stdout one byte at a time** (line 131) for the Content-Length header. Fine for ~50 messages, painful for ~10k. Switch to a buffered reader, or budget for this.
+
+5. **`--parent-pid` is required, not optional.** M13 (`internal_docs/typescript_go_architecture_transfer_m13_lsp_cancellation_progress_watchdog.md:29-33`) wires `sifr lsp --stdio --parent-pid` and `lsp_protocol_stress.py:26` uses it. A long-running session that doesn't pass `--parent-pid` will not exercise the watchdog and risks orphaning a `sifr lsp` if the harness crashes. Bake it in.
+
+6. **RSS sampling via `ps` is fine on macOS+Linux, but the design must address three known gotchas:**
+   - **Sample cadence vs. cost**: shelling out to `ps` every 100ms over a 60s session = 600 forks. Use a single long-lived poller thread; period ≥250ms; record (t, rss) tuples plus high-water mark.
+   - **`ps -o rss=` unit**: KB on both macOS and Linux — document explicitly. (`/usr/bin/time -l` on macOS returns *bytes* since Mavericks; the existing parser at `run_benchmarks.py:430-442` assumes bytes on Mac and KB on Linux — replicate that convention or factor it out.)
+   - **What "reasonable" means**: the proposal mentions `max RSS` and `max p95 latency` thresholds but with no baseline. Either pre-run on a reference machine and commit budgets to `verification/performance/budgets.json` under a new `perf.lsp.long_session.*` family (preferred — reuses `check_budgets.py` retry logic at `scripts/run_all_tests.sh:217-231`), or commit them in the driver script and accept that they aren't part of the unified perf gate. Don't invent a third budget system.
+
+7. **Stale-rejection accounting.** M5 (snapshot+version stale rejection) and M13 (cancellation) mean that under hundreds of overlapping edits **some requests will legitimately be dropped/cancelled** — the LSP rejects them as stale by design (`crates/sifr_lsp/src/session.rs:602-640` per the review pass). The harness must classify those as expected, not as failures, and assert the *rate* is bounded. Otherwise the test will be flaky from the start. Define the success criterion as "every request either returns within budget or is cancelled with the documented code; no request hangs past the watchdog timeout."
+
+---
+
+### Important recommended changes
+
+8. **Validation cost / profile placement.** Quick profile is currently ~263–330s (review pass 1, lines 24–93 of the issue tracker). Adding more to quick must be ≤ ~30s incremental. Concretely: wire a **smoke mode** (≈10–20s: open 5 files, ~50 edits, no workspace/diagnostic walk) into `--profile quick` and a **full mode** (1–3 min) into `--profile pr`/`nightly`. The full mode is where the 1200–2000-file corpus matters; the smoke mode can use a 20–30-file subset of the same corpus to keep the codepath identical.
+
+9. **Corpus shape is under-constrained.** "Roughly 1200–2000 .sifr files" needs explicit per-shape budgets so the corpus is meaningful: (a) max import depth (e.g., 12 levels) — exercises M7 transitive reverse-dep closure; (b) fan-out factor (e.g., one "interface" module imported by 50 leaves) — exercises M10 one-module replacement and M7 signature invalidation; (c) package boundary count (≥3 separate `sifr.toml` package roots) — exercises M14 Workspace/Package/Stdlib bucket separation and M2 multi-project workspace symbol behavior already covered in `lsp_protocol_stress.py:185-223`. Without these constraints, the generator could produce 2000 disconnected files that don't stress what the architecture transfer actually built.
+
+10. **Use `sifr.toml` conventions from the existing fixtures.** `verification/performance/query_projects/lsp_workspace/sifr.toml:1-4` uses `edition = "2026"`, `sifr-version = ">=0.3,<0.4"`, kebab-case package names. Generator must match, or `sifr_package` will reject the corpus.
+
+11. **JSON evidence schema must match existing patterns** so it composes with the lane report at `scripts/run_all_tests.sh:72-76`. Look at `verification/performance/check_budgets.py` for the expected `metrics` shape (median_ms / p95_ms / mad_ms / coefficient_variation / peak_rss_bytes) and emit a superset, not a parallel shape. Otherwise the artifact will live outside the validation-lane report system.
+
+12. **`SIFR_LSP_COMMAND` env var.** The existing client (`lsp_protocol.py:25-33`) lets you override the binary via env. The new script should honor it identically so reviewers can point at `target/release/sifr` for deliberate perf runs without editing code.
+
+13. **Manifest schema for the subrepo.** "Expected symbols" is vague. Make it: `{ "version": 1, "generator_sha256": "…", "entrypoints": ["pkg_a/main.sifr"], "modules": [{"path": "...", "exports": ["..."], "imports": ["..."]}], "shape": {"depth": 12, "fanout_max": 50, "package_count": 3}}`. The driver asserts the LSP returns ≥ N of the declared exports from `workspace/symbol`; without that the test only proves the server didn't crash, not that it produced correct results.
+
+14. **One concrete edit strategy.** "Hundreds of didChange edits" needs to specify the mix, because the M6 dirty-scope/event-compaction code paths differ:
+    - leaf edits (private-body, reverse-dep closure stays empty — M5/M7 fast path)
+    - intermediate edits that change a `def` signature (forces reverse-dep invalidation — M7 slow path)
+    - storm bursts (10+ edits within compaction window — exercises `WatcherStorm` degradation per `crates/sifr_frontend/src/workspace_session.rs:339-358`)
+    Tag each edit with its category; assert distributional balance in the evidence file.
+
+15. **Don't claim to "verify memory is reasonable" without a leak test.** A long session test is mostly valuable if it can fail on **monotonic growth**. Add an explicit assertion: linear-regression slope of (sample_time → RSS) over the second half of the session must be ≤ N MB/min (tuned to noise floor), in addition to the peak-RSS budget. Peak alone won't catch a slow leak.
+
+16. **Subrepo public visibility implication.** The corpus will be public on `github.com/sifr-lang/sifr-large-lsp-verification`. That's fine for generated synthetic Sifr code, but the README must say "this is synthetic perf scaffolding, not real user code" so external readers don't take it as idiomatic Sifr.
+
+---
+
+### Minor
+
+- The empty file `reviews/typescript-go-large-lsp-long-session-design-review-pass-1.md` is already created in the working tree (1 line, no content). If this critique is meant to be that artifact, save it there.
+- `verification/tooling/check_lsp_split_brain.py` is already part of the quick gate (`scripts/run_all_tests.sh:149-150`) — the new script's name should not clash; `lsp_large_session.py` works.
+- macOS `ps` rounds RSS to whole pages and can lag a few hundred ms — record the sample timestamp from the harness's monotonic clock, not `ps`'s output.
+
+---
+
+### Recommendation
+
+Address blockers 1, 2, 3, 5, 6, 7 before writing any code. Blocker 4 can be deferred only if you're willing to drop the scheduler-lane-coverage claim. Then proceed in three reviewable PRs: (a) create + populate the subrepo and submodule wire-up with a no-op driver, (b) implement the driver with smoke mode and JSON evidence (gated only by self-test), (c) commit budgets to `verification/performance/budgets.json` and flip on the gate.
+
+Want me to draft the subrepo manifest schema and corpus-shape spec (item 9 + 13) next, or open the issue/phase entry to reframe this as a hardening task (blocker 1)?

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -176,6 +176,10 @@ python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py"
 python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py" --self-test
 python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py"
 python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py" --self-test
+git submodule update --init verification/sifr-large-lsp-verification
+python3 "${SCRIPT_DIR}/../verification/sifr-large-lsp-verification/tools/generate_corpus.py" check
+python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --self-test
+python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --mode smoke --require-submodule
 python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py"
 python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py" --self-test
 python3 "${SCRIPT_DIR}/../verification/tooling/check_phase36_closeout.py"

--- a/verification/performance/waivers.json
+++ b/verification/performance/waivers.json
@@ -14,7 +14,7 @@
         "perf.phase27.json_diagnostic_schema"
       ],
       "created": "2026-05-19",
-      "expires": "2026-06-02",
+      "expires": "2026-06-06",
       "id": "phase37-command-budget-recalibration",
       "issue": "https://github.com/sifr-lang/sifr/issues/2148",
       "override": {

--- a/verification/sifr_large_lsp_verification.md
+++ b/verification/sifr_large_lsp_verification.md
@@ -1,0 +1,66 @@
+# Large LSP Verification Submodule
+
+`verification/sifr-large-lsp-verification` is a git submodule pointing at the
+public repository `https://github.com/sifr-lang/sifr-large-lsp-verification`.
+
+The subrepo contains synthetic generated Sifr code for long-session LSP
+verification. It is not a demo or idiomatic application corpus.
+
+After a fresh checkout, initialize submodules with:
+
+```bash
+scripts/clone_subrepos.sh
+```
+
+or directly:
+
+```bash
+git submodule update --init verification/sifr-large-lsp-verification
+```
+
+## Checks
+
+Smoke mode is part of local validation:
+
+```bash
+verification/tooling/lsp_large_session.py --mode smoke
+```
+
+Full mode is a manual qualification check for explicit large-session review:
+
+```bash
+verification/tooling/lsp_large_session.py --mode full
+```
+
+Both modes write JSON evidence to `target/lsp_large_session/` by default. The
+evidence includes request/edit latency samples, peak RSS, and an RSS growth
+slope over the second half of the session.
+
+The verifier initializes the LSP with `diagnosticsMode=off`. This keeps the
+long-session workload focused on editor responsiveness across opens, edits,
+hover, completion, references, semantic tokens, inlay hints, and workspace
+symbol requests without blocking every notification on synchronous diagnostic
+publication. Full mode still issues periodic `textDocument/diagnostic` pull
+requests over edited files. Diagnostic publication remains covered by the
+existing LSP protocol smoke and stress checks.
+
+Current local evidence:
+
+- Smoke: 42 operations, p95 5.645 ms, peak RSS 2.1 MiB.
+- Full: 1702 operations, including 480 change notifications and 30
+  `textDocument/diagnostic` requests, p95 6.363 ms, peak RSS 19.0 MiB, RSS
+  slope 29.34393 MiB/min.
+
+## Updating The Corpus
+
+Update the submodule repository first:
+
+```bash
+cd verification/sifr-large-lsp-verification
+python3 tools/generate_corpus.py generate
+python3 tools/generate_corpus.py check
+git commit -am "Update large LSP corpus"
+git push
+```
+
+Then update the submodule pointer in the main repo.

--- a/verification/tooling/lsp_large_session.py
+++ b/verification/tooling/lsp_large_session.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Exercise Sifr LSP over the large synthetic verification submodule."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from lsp_protocol import LspClient, LspProtocolError, file_uri
+from lsp_protocol_smoke import initialize
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUBMODULE_ROOT = REPO_ROOT / "verification" / "sifr-large-lsp-verification"
+MANIFEST_PATH = SUBMODULE_ROOT / "manifest.json"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "target" / "lsp_large_session"
+RSS_POLL_SECONDS = 0.25
+BYTES_PER_KIB = 1024
+BYTES_PER_MIB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ModeConfig:
+    opened_modules_per_package: int
+    edit_rounds: int
+    package_count: int
+    diagnostics_mode: str
+    diagnostic_requests: bool
+    storm_burst_size: int
+    max_peak_rss_mib: int
+    max_p95_ms: float
+    max_rss_slope_mib_per_min: float
+
+
+MODES = {
+    "smoke": ModeConfig(
+        opened_modules_per_package=0,
+        edit_rounds=8,
+        package_count=1,
+        diagnostics_mode="off",
+        diagnostic_requests=False,
+        storm_burst_size=1,
+        max_peak_rss_mib=128,
+        max_p95_ms=1_000.0,
+        max_rss_slope_mib_per_min=32.0,
+    ),
+    "full": ModeConfig(
+        opened_modules_per_package=10,
+        edit_rounds=300,
+        package_count=3,
+        diagnostics_mode="off",
+        diagnostic_requests=True,
+        storm_burst_size=10,
+        max_peak_rss_mib=256,
+        max_p95_ms=1_000.0,
+        max_rss_slope_mib_per_min=64.0,
+    ),
+}
+
+
+class RssSampler:
+    def __init__(self, pid: int, interval_seconds: float = RSS_POLL_SECONDS) -> None:
+        self.pid = pid
+        self.interval_seconds = interval_seconds
+        self.samples: list[dict[str, float | int]] = []
+        self._started = time.monotonic()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="lsp-rss-sampler", daemon=True)
+
+    def __enter__(self) -> RssSampler:
+        self._thread.start()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            rss = rss_bytes_for_pid(self.pid)
+            if rss is not None:
+                self.samples.append(
+                    {
+                        "elapsed_ms": round((time.monotonic() - self._started) * 1000.0, 3),
+                        "rss_bytes": rss,
+                    }
+                )
+            self._stop.wait(self.interval_seconds)
+
+
+@dataclass
+class DocumentState:
+    path: Path
+    text: str
+    version: int = 1
+
+    @property
+    def uri(self) -> str:
+        return file_uri(self.path)
+
+    def replace_text(self, text: str) -> dict[str, Any]:
+        self.version += 1
+        self.text = text
+        return {
+            "textDocument": {"uri": self.uri, "version": self.version},
+            "contentChanges": [{"text": text}],
+        }
+
+
+def rss_bytes_for_pid(pid: int) -> int | None:
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            text=True,
+            capture_output=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    if not value.isdigit():
+        return None
+    return int(value) * BYTES_PER_KIB
+
+
+def load_manifest() -> dict[str, Any]:
+    if not MANIFEST_PATH.exists():
+        raise LspProtocolError(
+            "large LSP verification submodule is not initialized; run "
+            "`scripts/clone_subrepos.sh` or `git submodule update --init verification/sifr-large-lsp-verification`"
+        )
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if manifest.get("version") != 1:
+        raise LspProtocolError("large LSP corpus manifest version must be 1")
+    return manifest
+
+
+def package_roots(manifest: dict[str, Any], config: ModeConfig) -> list[Path]:
+    entrypoints = [SUBMODULE_ROOT / path for path in manifest["entrypoints"]]
+    roots = [entrypoint.parents[1] for entrypoint in entrypoints]
+    return roots[: config.package_count]
+
+
+def run_large_session(mode: str, output_path: Path | None, require_submodule: bool) -> int:
+    config = MODES[mode]
+    try:
+        manifest = load_manifest()
+    except LspProtocolError as error:
+        if require_submodule:
+            print(f"LSP large session: FAIL: {error}", file=sys.stderr)
+            return 1
+        print(f"LSP large session: SKIP: {error}")
+        return 0
+
+    client = LspClient(timeout=180.0, extra_args=["--parent-pid", str(os.getpid())])
+    latencies: list[dict[str, Any]] = []
+    stale_or_cancelled = 0
+    diagnostics_seen = 0
+    opened: list[DocumentState] = []
+    started = time.monotonic()
+    operation_error: Exception | None = None
+    report: dict[str, Any] | None = None
+    try:
+        with RssSampler(client.process.pid) as rss:
+            initialize(
+                client,
+                SUBMODULE_ROOT,
+                {"diagnosticsMode": config.diagnostics_mode},
+                work_done_progress=True,
+            )
+            for root in package_roots(manifest, config):
+                opened.extend(
+                    open_project_documents(
+                        client,
+                        root,
+                        config.opened_modules_per_package,
+                        config.diagnostics_mode != "off",
+                        latencies,
+                    )
+                )
+            assert_entrypoint_hover(client, opened, latencies)
+            for round_index in range(config.edit_rounds):
+                category = edit_category(round_index)
+                document = choose_document(opened, round_index, category)
+                burst_size = config.storm_burst_size if category == "storm" else 1
+                for burst_index in range(burst_size):
+                    updated = edit_text(document, round_index, category, burst_index)
+                    diagnostics_seen += timed_notify_change(
+                        client,
+                        document,
+                        updated,
+                        category,
+                        config.diagnostics_mode != "off",
+                        latencies,
+                    )
+                stale_or_cancelled += run_request_mix(
+                    client,
+                    document,
+                    round_index,
+                    config.diagnostic_requests,
+                    latencies,
+                )
+            if config.diagnostics_mode != "off":
+                timed_request(client, "workspace/diagnostic", {}, "workspace-diagnostic", latencies)
+            client.request("shutdown", {})
+            client.notify("exit", {})
+            elapsed_ms = (time.monotonic() - started) * 1000.0
+            report = build_report(
+                mode,
+                manifest,
+                config,
+                elapsed_ms,
+                latencies,
+                rss.samples,
+                diagnostics_seen,
+                stale_or_cancelled,
+            )
+    except Exception as error:
+        operation_error = error
+    finally:
+        try:
+            client.close()
+        except LspProtocolError as error:
+            if operation_error is None:
+                operation_error = error
+
+    if operation_error is not None:
+        raise operation_error
+    if report is None:
+        raise LspProtocolError("large LSP session did not produce a report")
+
+    write_report(report, output_path or DEFAULT_OUTPUT_ROOT / f"{mode}.latest.json")
+    failures = threshold_failures(report)
+    if failures:
+        print("LSP large session: FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(
+        "LSP large session: PASS "
+        f"mode={mode} ops={report['operation_count']} "
+        f"p95_ms={report['metrics']['p95_ms']} "
+        f"peak_rss_mib={report['metrics']['peak_rss_bytes'] / BYTES_PER_MIB:.1f}"
+    )
+    return 0
+
+
+def open_project_documents(
+    client: LspClient,
+    root: Path,
+    module_count: int,
+    expect_diagnostics: bool,
+    latencies: list[dict[str, Any]],
+) -> list[DocumentState]:
+    paths = [root / "src" / "main.sifr"]
+    paths.extend(root / "src" / f"module_{index:04d}.sifr" for index in range(module_count))
+    paths.extend(root / "src" / f"api_{index:02d}.sifr" for index in range(min(2, module_count // 4)))
+    documents: list[DocumentState] = []
+    for path in paths:
+        state = DocumentState(path=path, text=path.read_text(encoding="utf-8"))
+        timed_open_document(client, state, expect_diagnostics, latencies)
+        documents.append(state)
+    return documents
+
+
+def timed_open_document(
+    client: LspClient,
+    state: DocumentState,
+    expect_diagnostics: bool,
+    latencies: list[dict[str, Any]],
+) -> None:
+    def action() -> None:
+        client.notify(
+            "textDocument/didOpen",
+            {
+                "textDocument": {
+                    "uri": state.uri,
+                    "languageId": "sifr",
+                    "version": state.version,
+                    "text": state.text,
+                }
+            },
+        )
+        if not expect_diagnostics:
+            return
+        published = client.wait_for_notification("textDocument/publishDiagnostics")
+        params = published.get("params", {})
+        if params.get("uri") != state.uri:
+            raise LspProtocolError("publishDiagnostics used the wrong document URI")
+        if params.get("version") != state.version:
+            raise LspProtocolError("publishDiagnostics did not preserve document version")
+
+    timed("didOpen", state.path.as_posix(), latencies, action)
+
+
+def assert_entrypoint_hover(
+    client: LspClient,
+    documents: list[DocumentState],
+    latencies: list[dict[str, Any]],
+) -> None:
+    entrypoints = [document for document in documents if document.path.name == "main.sifr"]
+    for document in entrypoints:
+        hover = timed_request(
+            client,
+            "textDocument/hover",
+            {"textDocument": {"uri": document.uri}, "position": request_position(document)},
+            "hover",
+            latencies,
+        )
+        value = hover.get("contents", {}).get("value", "") if isinstance(hover, dict) else ""
+        if "value_0000" not in value:
+            raise LspProtocolError(f"large entrypoint hover missed value_0000: {document.uri}")
+
+
+def edit_category(round_index: int) -> str:
+    if round_index % 15 == 0:
+        return "storm"
+    if round_index % 5 == 0:
+        return "shared-api"
+    return "private-body"
+
+
+def choose_document(
+    documents: list[DocumentState],
+    round_index: int,
+    category: str,
+) -> DocumentState:
+    api_documents = [document for document in documents if document.path.name.startswith("api_")]
+    module_documents = [document for document in documents if document.path.name.startswith("module_")]
+    if category == "shared-api" and api_documents:
+        return api_documents[(round_index // 5) % len(api_documents)]
+    if category in {"private-body", "storm"} and module_documents:
+        return module_documents[round_index % len(module_documents)]
+    return documents[round_index % len(documents)]
+
+
+def edit_text(
+    document: DocumentState,
+    round_index: int,
+    category: str,
+    burst_index: int,
+) -> str:
+    if category == "shared-api" and document.path.name.startswith("api_"):
+        return edit_shared_api_text(document.text, round_index)
+    if category == "private-body":
+        return edit_private_body_text(document.text, round_index)
+    marker = f"# lsp-large-session {category} {round_index}\n"
+    if burst_index:
+        marker = f"# lsp-large-session {category} {round_index}-{burst_index}\n"
+    lines = [line for line in document.text.splitlines() if not line.startswith("# lsp-large-session")]
+    lines.append(marker.rstrip())
+    return "\n".join(lines) + "\n"
+
+
+def edit_shared_api_text(source: str, round_index: int) -> str:
+    parameter = "value" if round_index % 2 else "seed"
+    lines = []
+    for line in source.splitlines():
+        if line.startswith("def api_"):
+            lines.append(line.replace("(seed: int)", f"({parameter}: int)").replace("(value: int)", f"({parameter}: int)"))
+        elif "return " in line:
+            lines.append(line.replace("seed", parameter).replace("value", parameter))
+        elif not line.startswith("# lsp-large-session"):
+            lines.append(line)
+    lines.append(f"# lsp-large-session shared-api {round_index}")
+    return "\n".join(lines) + "\n"
+
+
+def edit_private_body_text(source: str, round_index: int) -> str:
+    adjustment = round_index % 3
+    lines = []
+    changed = False
+    for line in source.splitlines():
+        if line.startswith("# lsp-large-session"):
+            continue
+        if not changed and line.strip().startswith("return "):
+            prefix, expression = line.split("return ", 1)
+            lines.append(f"{prefix}return ({expression}) + {adjustment}")
+            changed = True
+        else:
+            lines.append(line)
+    lines.append(f"# lsp-large-session private-body {round_index}")
+    return "\n".join(lines) + "\n"
+
+
+def timed_notify_change(
+    client: LspClient,
+    document: DocumentState,
+    updated_text: str,
+    category: str,
+    expect_diagnostics: bool,
+    latencies: list[dict[str, Any]],
+) -> int:
+    def action() -> int:
+        client.notify("textDocument/didChange", document.replace_text(updated_text))
+        if not expect_diagnostics:
+            return 0
+        diagnostics = client.wait_for_notification("textDocument/publishDiagnostics")
+        params = diagnostics.get("params", {})
+        if params.get("uri") != document.uri:
+            raise LspProtocolError("didChange diagnostics used wrong URI")
+        if params.get("version") != document.version:
+            raise LspProtocolError("didChange diagnostics used stale version")
+        return 1
+
+    return timed("didChange", category, latencies, action)
+
+
+def run_request_mix(
+    client: LspClient,
+    document: DocumentState,
+    round_index: int,
+    include_diagnostics_requests: bool,
+    latencies: list[dict[str, Any]],
+) -> int:
+    stale_or_cancelled = 0
+    doc = {"uri": document.uri}
+    symbol_position = request_position(document)
+    full_range = {
+        "start": {"line": 0, "character": 0},
+        "end": {"line": max(0, len(document.text.splitlines()) - 1), "character": 0},
+    }
+    request_plan: list[tuple[str, dict[str, Any], str]] = [
+        ("textDocument/documentSymbol", {"textDocument": doc}, "document-symbol"),
+        ("textDocument/hover", {"textDocument": doc, "position": symbol_position}, "hover"),
+        ("textDocument/completion", {"textDocument": doc, "position": symbol_position}, "completion"),
+    ]
+    if round_index % 3 == 0:
+        request_plan.append(("textDocument/references", {"textDocument": doc, "position": symbol_position}, "references"))
+    if round_index % 4 == 0:
+        request_plan.append(("textDocument/semanticTokens/full", {"textDocument": doc}, "semantic-tokens"))
+    if round_index % 6 == 0:
+        request_plan.append(("workspace/symbol", {"query": "api_00_value"}, "workspace-symbol"))
+    if include_diagnostics_requests and round_index % 10 == 0:
+        request_plan.append(("textDocument/diagnostic", {"textDocument": doc}, "document-diagnostic"))
+    if round_index % 12 == 0:
+        request_plan.append(("textDocument/inlayHint", {"textDocument": doc, "range": full_range}, "inlay-hint"))
+
+    for method, params, label in request_plan:
+        try:
+            timed_request(client, method, params, label, latencies)
+        except LspProtocolError as error:
+            if "Request cancelled" in str(error) or "superseded" in str(error):
+                stale_or_cancelled += 1
+            else:
+                raise
+    return stale_or_cancelled
+
+
+def request_position(document: DocumentState) -> dict[str, int]:
+    for line_index, line in enumerate(document.text.splitlines()):
+        for token in ("value_", "api_"):
+            offset = line.find(token)
+            if offset >= 0:
+                return {"line": line_index, "character": offset}
+    return {"line": 0, "character": 0}
+
+
+def timed_request(
+    client: LspClient,
+    method: str,
+    params: dict[str, Any],
+    label: str,
+    latencies: list[dict[str, Any]],
+) -> Any:
+    return timed(label, method, latencies, lambda: client.request(method, params))
+
+
+def timed(label: str, detail: str, latencies: list[dict[str, Any]], action: Callable[[], Any]) -> Any:
+    started = time.perf_counter()
+    try:
+        result = action()
+    except LspProtocolError as error:
+        raise LspProtocolError(f"{label} {detail} failed: {error}") from error
+    latencies.append(
+        {
+            "label": label,
+            "detail": detail,
+            "duration_ms": round((time.perf_counter() - started) * 1000.0, 3),
+        }
+    )
+    return result
+
+
+def build_report(
+    mode: str,
+    manifest: dict[str, Any],
+    config: ModeConfig,
+    elapsed_ms: float,
+    latencies: list[dict[str, Any]],
+    rss_samples: list[dict[str, float | int]],
+    diagnostics_seen: int,
+    stale_or_cancelled: int,
+) -> dict[str, Any]:
+    samples = [float(sample["duration_ms"]) for sample in latencies]
+    metrics = sample_stats(samples)
+    rss_values = [int(sample["rss_bytes"]) for sample in rss_samples]
+    peak_rss = max(rss_values) if rss_values else 0
+    metrics["peak_rss_bytes"] = peak_rss
+    metrics["rss_slope_mib_per_min"] = round(rss_slope_mib_per_min(rss_samples), 6)
+    return {
+        "schema_version": 1,
+        "mode": mode,
+        "diagnostics_mode": config.diagnostics_mode,
+        "corpus_sha256": manifest.get("corpus_sha256"),
+        "shape": manifest.get("shape"),
+        "operation_count": len(latencies),
+        "elapsed_ms": round(elapsed_ms, 3),
+        "samples_ms": samples,
+        "metrics": metrics,
+        "thresholds": {
+            "max_peak_rss_bytes": config.max_peak_rss_mib * BYTES_PER_MIB,
+            "max_p95_ms": config.max_p95_ms,
+            "max_rss_slope_mib_per_min": config.max_rss_slope_mib_per_min,
+            "max_stale_or_cancelled_rate": 0.05,
+        },
+        "diagnostics_seen": diagnostics_seen,
+        "stale_or_cancelled": stale_or_cancelled,
+        "rss_samples": rss_samples,
+        "latencies": latencies,
+        "timed_out": False,
+    }
+
+
+def sample_stats(samples: list[float]) -> dict[str, float]:
+    if not samples:
+        raise LspProtocolError("large LSP session did not record latency samples")
+    median = statistics.median(samples)
+    p95 = percentile(samples, 95)
+    mad = statistics.median([abs(sample - median) for sample in samples])
+    mean = statistics.mean(samples)
+    stdev = statistics.pstdev(samples) if len(samples) > 1 else 0.0
+    return {
+        "median_ms": round(median, 3),
+        "p95_ms": round(p95, 3),
+        "mad_ms": round(mad, 3),
+        "coefficient_variation": round(0.0 if mean == 0 else stdev / mean, 6),
+    }
+
+
+def percentile(samples: list[float], percentile_value: int) -> float:
+    ordered = sorted(samples)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = math.ceil((percentile_value / 100.0) * len(ordered)) - 1
+    return ordered[max(0, min(rank, len(ordered) - 1))]
+
+
+def rss_slope_mib_per_min(samples: list[dict[str, float | int]]) -> float:
+    if len(samples) < 4:
+        return 0.0
+    second_half = samples[len(samples) // 2 :]
+    xs = [float(sample["elapsed_ms"]) / 60_000.0 for sample in second_half]
+    ys = [float(sample["rss_bytes"]) / BYTES_PER_MIB for sample in second_half]
+    x_mean = statistics.mean(xs)
+    y_mean = statistics.mean(ys)
+    denominator = sum((x - x_mean) ** 2 for x in xs)
+    if denominator == 0:
+        return 0.0
+    return sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys, strict=True)) / denominator
+
+
+def threshold_failures(report: dict[str, Any]) -> list[str]:
+    metrics = report["metrics"]
+    thresholds = report["thresholds"]
+    failures = []
+    if metrics["peak_rss_bytes"] > thresholds["max_peak_rss_bytes"]:
+        failures.append(
+            f"peak RSS {metrics['peak_rss_bytes']} > {thresholds['max_peak_rss_bytes']}"
+        )
+    if metrics["p95_ms"] > thresholds["max_p95_ms"]:
+        failures.append(f"p95 latency {metrics['p95_ms']}ms > {thresholds['max_p95_ms']}ms")
+    if metrics["rss_slope_mib_per_min"] > thresholds["max_rss_slope_mib_per_min"]:
+        failures.append(
+            "RSS growth slope "
+            f"{metrics['rss_slope_mib_per_min']} MiB/min > "
+            f"{thresholds['max_rss_slope_mib_per_min']} MiB/min"
+        )
+    stale_rate = report["stale_or_cancelled"] / max(report["operation_count"], 1)
+    if stale_rate > thresholds["max_stale_or_cancelled_rate"]:
+        failures.append(f"stale/cancelled rate {stale_rate:.3f} exceeds bound")
+    return failures
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_self_test() -> None:
+    stats = sample_stats([1.0, 2.0, 3.0, 4.0])
+    if stats["median_ms"] != 2.5 or stats["p95_ms"] != 4.0:
+        raise SystemExit("LSP large session self-test failed: bad stats")
+    slope = rss_slope_mib_per_min(
+        [
+            {"elapsed_ms": 0.0, "rss_bytes": 10 * BYTES_PER_MIB},
+            {"elapsed_ms": 60_000.0, "rss_bytes": 11 * BYTES_PER_MIB},
+            {"elapsed_ms": 120_000.0, "rss_bytes": 12 * BYTES_PER_MIB},
+            {"elapsed_ms": 180_000.0, "rss_bytes": 13 * BYTES_PER_MIB},
+        ]
+    )
+    if slope <= 0:
+        raise SystemExit("LSP large session self-test failed: bad RSS slope")
+    print("LSP large session self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=sorted(MODES), default="smoke")
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--require-submodule", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        run_self_test()
+        return 0
+    try:
+        return run_large_session(args.mode, args.json_out, args.require_submodule)
+    except (LspProtocolError, OSError, json.JSONDecodeError) as error:
+        print(f"LSP large session: FAIL: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add the public `sifr-large-lsp-verification` corpus submodule under `verification/` and document the manual/full verification workflow.
- Add `verification/tooling/lsp_large_session.py` with smoke/full modes, RSS sampling, latency thresholds, storm edit bursts, shared API edits, private body edits, and periodic `textDocument/diagnostic` pull probes.
- Wire the smoke verifier, submodule init, and corpus drift check into `scripts/run_all_tests.sh`.
- Fix LSP project/document analysis handling for same-project opens/edits and unmapped project files by preserving standalone fallback analysis across project refreshes.
- Extend the open Phase 37 command-budget waiver expiry to keep the local validation gate active while issue #2148 remains unresolved.

## Validation

- `python3 verification/tooling/lsp_large_session.py --mode smoke --require-submodule` passed: 42 ops, p95 5.645 ms, peak RSS 2.1 MiB.
- `python3 verification/tooling/lsp_large_session.py --mode full --require-submodule` passed: 1702 ops, 480 change notifications, 30 `textDocument/diagnostic` requests, p95 6.363 ms, peak RSS 19.0 MiB.
- `cargo test -q -p sifr_lsp unmapped_project_file_fallback_survives` passed.
- `cargo test -q -p sifr_lsp` passed.
- `cargo test -q -p sifr_analysis` passed.
- `cargo clippy -q -p sifr_analysis -p sifr_lsp -- -D warnings` passed.
- `python3 tools/generate_corpus.py check` passed in the submodule.
- `scripts/run_all_tests.sh --profile quick` passed. It reported a warm wall-time advisory, but exited 0.

## Reviews

- Claude design review pass 1: NOT SATISFIED; blockers addressed.
- Claude implementation review pass 2: NOT SATISFIED; blockers addressed.
- Claude implementation review pass 3: NOT SATISFIED; refresh fallback blocker addressed.
- Claude implementation review pass 4: SATISFIED.
