### PR TITLE
Add self-update distribution drift guardrails

### DIFF
--- a/internal_docs/distribution_pipeline.md
+++ b/internal_docs/distribution_pipeline.md
@@ -204,6 +204,16 @@ verification/distribution/artifact_target_mismatch_rejected.sh
 verification/distribution/stable_entrypoints_unchanged_by_preview_release.sh
 ```
 
+The self-update metadata drift checks validate that `metadata/channels.json`, preview dispatchers, and immutable installer `APP_VERSION` values are generated from one release plan:
+
+```bash
+scripts/distribution/validate_self_update_metadata.sh --install-root <install-root>
+verification/distribution/channel_metadata_installer_agreement.sh
+verification/distribution/channel_metadata_dispatcher_drift_rejected.sh
+verification/distribution/channel_metadata_installer_drift_rejected.sh
+verification/distribution/channel_metadata_stable_rejected.sh
+```
+
 ## Preview Release Command
 
 The `/create-new-version` workflow is backed by:

--- a/issues/ad-hoc-sifr-self-update.md
+++ b/issues/ad-hoc-sifr-self-update.md
@@ -9,7 +9,7 @@ Status: in progress
 - [x] `milestone_self_update_1` Metadata And Receipt Contract — merged in [PR #2274](https://github.com/sifr-lang/sifr/pull/2274); review artifacts: `reviews/self-update-m1-review-pass-1.md`, `reviews/self-update-m1-review-pass-2.md`, `reviews/self-update-m1-review-pass-3.md`.
 - [x] `milestone_self_update_2` CLI Eligibility And Dry Run — merged in [PR #2275](https://github.com/sifr-lang/sifr/pull/2275); review artifacts: `reviews/self-update-m2-review-pass-1.md`, `reviews/self-update-m2-review-pass-2.md`.
 - [x] `milestone_self_update_3` Installer Delegation — ready in [PR #2276](https://github.com/sifr-lang/sifr/pull/2276); review artifacts: `reviews/self-update-m3-review-pass-1.md`, `reviews/self-update-m3-review-pass-2.md`.
-- [ ] `milestone_self_update_4` Distribution Drift Guardrails.
+- [ ] `milestone_self_update_4` Distribution Drift Guardrails — implementation in progress on `ad-hoc-self-update-m4`.
 - [ ] `milestone_self_update_5` Docs And Release Readiness.
 
 ## Objective

--- a/issues/ad-hoc-sifr-self-update.md
+++ b/issues/ad-hoc-sifr-self-update.md
@@ -9,7 +9,7 @@ Status: in progress
 - [x] `milestone_self_update_1` Metadata And Receipt Contract — merged in [PR #2274](https://github.com/sifr-lang/sifr/pull/2274); review artifacts: `reviews/self-update-m1-review-pass-1.md`, `reviews/self-update-m1-review-pass-2.md`, `reviews/self-update-m1-review-pass-3.md`.
 - [x] `milestone_self_update_2` CLI Eligibility And Dry Run — merged in [PR #2275](https://github.com/sifr-lang/sifr/pull/2275); review artifacts: `reviews/self-update-m2-review-pass-1.md`, `reviews/self-update-m2-review-pass-2.md`.
 - [x] `milestone_self_update_3` Installer Delegation — ready in [PR #2276](https://github.com/sifr-lang/sifr/pull/2276); review artifacts: `reviews/self-update-m3-review-pass-1.md`, `reviews/self-update-m3-review-pass-2.md`.
-- [ ] `milestone_self_update_4` Distribution Drift Guardrails — implementation in progress on `ad-hoc-self-update-m4`.
+- [x] `milestone_self_update_4` Distribution Drift Guardrails — ready in [PR #2277](https://github.com/sifr-lang/sifr/pull/2277); review artifacts: `reviews/self-update-m4-review-pass-1.md`, `reviews/self-update-m4-review-pass-2.md`, `reviews/self-update-m4-review-pass-3.md`.
 - [ ] `milestone_self_update_5` Docs And Release Readiness.
 
 ## Objective

--- a/reviews/self-update-m4-review-pass-1.md
+++ b/reviews/self-update-m4-review-pass-1.md
@@ -1,0 +1,28 @@
+I've reviewed all the new and changed files against the M4 contract. Here is my assessment.
+
+# READY (with non-blocking polish notes)
+
+The M4 implementation satisfies every "definition of done" item in the contract:
+
+- ✅ Distribution validation wired in through the existing `verification/distribution/*.sh` glob in `scripts/run_distribution_validation.sh`.
+- ✅ Validator (`scripts/distribution/validate_self_update_metadata.sh`) checks schema, channel allowlist, ordering, semver prerelease label per channel, dispatcher↔dispatcher cross-consistency, metadata↔dispatcher agreement, and immutable installer `APP_VERSION`.
+- ✅ One-plan flow: `create_new_version.sh` real-run calls `generate_version_installer.sh` then `generate_dispatchers.sh` (which writes both dispatchers and `metadata/channels.json`).
+- ✅ Dry-run prints `channel_metadata=…` and `channel_metadata_update=alpha:…,beta:…` mutation lines; asserted by `create_new_version_alpha_dry_run.sh`.
+- ✅ Real-run fixture validates dispatcher, metadata, and immutable installer agreement end-to-end and then runs the new validator against the mutated install root.
+- ✅ Stable metadata rejected at validation time (`channel_metadata_stable_rejected.sh`) and at dispatcher generation (`generate_dispatchers.sh`/`create_new_version.sh` reject stable-looking versions).
+- ✅ APP_VERSION extracted from immutable installer and cross-checked vs metadata (and transitively vs dispatcher, since metadata↔dispatcher is asserted in the same run).
+- ✅ `internal_docs/distribution_pipeline.md` updated with the new drift validation surface.
+
+## Non-blocking polish notes
+
+1. **Validator's Python error diagnostics get clipped on stderr.** `scripts/distribution/validate_self_update_metadata.sh:59-100` captures only stdout from the heredoc, so when `SystemExit("…")` fires, the message lands on stderr while `metadata_values` is empty — then `|| fail "${metadata_values}"` prints an empty `self-update metadata validation:` line. The tests still pass because `require_failure_contains` reads `2>&1`, but the bash wrapper line is dead noise. Consider running python without command substitution (e.g., `python3 - "${metadata_path}" <<'PY' … PY || fail "channel metadata validation failed"`) so the Python message stands alone.
+
+2. **Redundant prerelease label check.** `validate_installer` re-runs `preview_channel_for_version` against the metadata version (`validate_self_update_metadata.sh:142`) even though the Python regex already enforces the prerelease label for that channel. Harmless but dead code; consider removing or relocating it to validate the *installer*'s embedded version against the channel label rather than the metadata's.
+
+3. **`schema_version != 1` accepts `True`.** Python's `True == 1` means `{"schema_version": true}` would slip past `validate_self_update_metadata.sh:76`. Edge case unlikely in practice (your generator only writes the literal `1`), but `if metadata.get("schema_version") is not 1 or isinstance(metadata["schema_version"], bool)` (or a `type(…) is int` check) would close it.
+
+4. **Seeded drift coverage is intentionally narrow.** The 4 fixtures cover (dispatcher drift, installer drift, stable, agreement). The validator catches more cases (missing file, unknown non-stable channel, schema mismatch, ordering, label-vs-channel mismatch), but those branches are exercised only by reading the code. Contract just says "every seeded drift class" — what you seed is caught — so this is in spec, but you may want a fifth seeded test covering "metadata file missing" or "unknown channel `rc` in metadata" for completeness in M5 if/when other drift classes appear.
+
+5. **`make_self_update_install_root_fixture` deletes its artifact dir.** `verification/distribution/common.sh:157` removes `${artifact_dir}` after generating installers, but the immutable installer at `${install_root}/versions/<v>` has `ARTIFACT_BASE_URL=file://${artifact_dir}/<channel>` baked in. Drift validation doesn't run the installer so this is intentional and fine, but a one-line comment in `common.sh` would save the next maintainer from puzzling over the dangling URL.
+
+None of the above blocks merge. Recommend READY.

--- a/reviews/self-update-m4-review-pass-2.md
+++ b/reviews/self-update-m4-review-pass-2.md
@@ -1,0 +1,49 @@
+I ran the full distribution validation suite and inspected each polish fix. Here's the verdict.
+
+# READY (one polish note recurs)
+
+All M4 obligations remain met after the pass-2 fixes:
+
+- **Drift coverage intact** — `channel_metadata_dispatcher_drift_rejected.sh`, `channel_metadata_installer_drift_rejected.sh`, `channel_metadata_stable_rejected.sh`, and `channel_metadata_installer_agreement.sh` all pass via `scripts/run_distribution_validation.sh`.
+- **Create-new-version fixtures still prove mutation** — `create_new_version_alpha_dry_run.sh` asserts `channel_metadata=…` and `channel_metadata_update=…`; `create_new_version_real_run_plan_reuse.sh` asserts the metadata write and re-invokes the validator on the populated install root.
+- **Wiring** — `scripts/run_distribution_validation.sh` globs `verification/distribution/*.sh` (excluding `common.sh`), so the four new drift fixtures are discovered without changes.
+- **Validator branches** — `validate_self_update_metadata.sh` still rejects malformed JSON, unsupported fields, stable channel, unknown channels, ordering drift, mismatched prerelease labels, dispatcher↔dispatcher drift, metadata↔dispatcher drift, missing installer, and APP_VERSION drift.
+
+## Polish fix audit
+
+| Pass-1 note | Pass-2 claim | Actual state |
+|---|---|---|
+| #1 capture python stderr into wrapper | "captures Python stderr into the wrapper failure message" | **Not landed as described** — see below |
+| #2 `schema_version != 1` accepts `True` | exact int type + value | ✅ `type(schema_version) is not int or schema_version != 1` at `scripts/distribution/validate_self_update_metadata.sh:69` — verified by mutating fixture metadata to `true` and observing rejection |
+| #3 redundant prerelease shell recheck | removed | ✅ `validate_installer` (`scripts/distribution/validate_self_update_metadata.sh:127-136`) no longer re-derives the channel label; Python regex at line 89 is the sole check |
+| #4 comment on artifact_dir deletion | added | ✅ `verification/distribution/common.sh:157` |
+
+## Recurring issue — non-blocking
+
+Fix #1 doesn't actually work. The `2>&1` placement at `scripts/distribution/validate_self_update_metadata.sh:93` (on its own line *after* the heredoc terminator `PY`) is parsed as a standalone redirection, not as a redirection on `python3`. I confirmed with a minimal reproduction:
+
+```bash
+out="$( python3 - <<'PY'
+...
+raise SystemExit("msg")
+PY
+  2>&1
+)"
+# → substitution exit status: 0   (python's exit 1 is lost)
+# → stderr leaks to parent; out captures only stdout
+```
+
+Consequence: when Python rejects metadata, the substitution exits 0 with empty `metadata_values`, so `|| fail "${metadata_values}"` never fires. Execution falls through to `[[ -n "${metadata_alpha}" && -n "${metadata_beta}" ]] || fail "metadata versions could not be extracted"` at line 109. Combined with the leaked-but-uncaptured Python stderr, the user sees:
+
+```
+channel metadata schema_version must be 1
+self-update metadata validation: metadata versions could not be extracted
+```
+
+Tests still pass because `require_failure_contains` captures combined stderr+stdout via `2>&1`, so the leaked Python message is matched at the test layer. But the wrapper has not been improved over the pass-1 state — and it's now arguably *more* misleading because line 109 prints a misattribution ("could not be extracted" when the real reason is a Python-level rejection).
+
+The minimal correct placement is `python3 - "${metadata_path}" 2>&1 <<'PY'` (redirection before the heredoc on the command line), which I verified yields substitution status 1 and captures stderr into the substitution. Suggested for a follow-up — not blocking M4.
+
+## Recommendation
+
+**READY.** M4 definition-of-done items are all met; all seeded drift, agreement, mutation-line, and write-assertion fixtures pass. The Python-stderr capture polish is still imperfect but the validator behaves correctly for every contract obligation, so this should not block merge. Worth a one-line follow-up to actually land fix #1 by moving `2>&1` to the same line as `python3 -`.

--- a/reviews/self-update-m4-review-pass-3.md
+++ b/reviews/self-update-m4-review-pass-3.md
@@ -1,0 +1,17 @@
+Distribution validation: exit 0. Fix verified end-to-end.
+
+# READY
+
+The pass-2 polish note is resolved. Verified at `scripts/distribution/validate_self_update_metadata.sh:52`:
+
+```bash
+python3 - "${metadata_path}" 2>&1 <<'PY'
+```
+
+The `2>&1` is now on the python3 command line *before* the heredoc, not on its own line after the `PY` terminator. Behavioral verification:
+
+- **Isolated repro** — `out="$( python3 - 2>&1 <<'PY' ... raise SystemExit("...") PY )" || ...` captures the SystemExit message into `out` *and* the substitution exits non-zero, so `|| fail` fires.
+- **End-to-end probe** — mutating `schema_version` to `true` now produces a single, correctly-attributed failure: `self-update metadata validation: channel metadata schema_version must be 1` (exit 2). The misleading "metadata versions could not be extracted" fall-through that pass-2 flagged is gone.
+- **Full suite** — `scripts/run_distribution_validation.sh` exits 0, including all four M4 drift/agreement fixtures.
+
+No blocking issues. M4 remains **READY**.

--- a/scripts/distribution/validate_self_update_metadata.sh
+++ b/scripts/distribution/validate_self_update_metadata.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/distribution/validate_self_update_metadata.sh --install-root <dir>
+
+Validate that self-update channel metadata, preview dispatchers, and immutable
+version installers agree.
+EOF
+}
+
+INSTALL_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-root)
+      INSTALL_ROOT="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+fail() {
+  echo "self-update metadata validation: $*" >&2
+  exit 2
+}
+
+[[ -n "${INSTALL_ROOT}" ]] || fail "--install-root is required"
+[[ -d "${INSTALL_ROOT}" ]] || fail "install root not found: ${INSTALL_ROOT}"
+
+extract_var() {
+  local file="$1"
+  local name="$2"
+  sed -n "s/^${name}=\"\\(.*\\)\"$/\\1/p" "${file}" | head -n 1
+}
+
+metadata_path="${INSTALL_ROOT}/metadata/channels.json"
+[[ -f "${metadata_path}" ]] || fail "channel metadata missing: ${metadata_path}"
+
+metadata_values="$(
+  python3 - "${metadata_path}" 2>&1 <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+metadata_path = pathlib.Path(sys.argv[1])
+try:
+    metadata = json.loads(metadata_path.read_text())
+except json.JSONDecodeError as error:
+    raise SystemExit(f"channel metadata is malformed: {error}")
+
+if not isinstance(metadata, dict):
+    raise SystemExit("channel metadata must be a JSON object")
+if set(metadata) != {"schema_version", "channels"}:
+    raise SystemExit("channel metadata contains unsupported fields")
+schema_version = metadata.get("schema_version")
+if type(schema_version) is not int or schema_version != 1:
+    raise SystemExit("channel metadata schema_version must be 1")
+
+channels = metadata.get("channels")
+if not isinstance(channels, dict):
+    raise SystemExit("channel metadata channels must be an object")
+if "stable" in channels:
+    raise SystemExit("stable channel metadata is disabled until Phase 39")
+if set(channels) != {"alpha", "beta"}:
+    unknown = sorted(set(channels) - {"alpha", "beta"})
+    if unknown:
+        raise SystemExit(f"unknown self-update channel in metadata: {unknown[0]}")
+    raise SystemExit("channel metadata must contain alpha and beta channels")
+if list(channels) != ["alpha", "beta"]:
+    raise SystemExit("channel metadata ordering drifted")
+
+for channel in ("alpha", "beta"):
+    version = channels[channel]
+    if not isinstance(version, str):
+        raise SystemExit(f"metadata channel {channel} must map to a version")
+    if not re.fullmatch(rf"[0-9]+\.[0-9]+\.[0-9]+-{channel}\.[0-9]+", version):
+        raise SystemExit(f"metadata channel {channel} points at {version}")
+    print(f"{channel}={version}")
+PY
+)" || fail "${metadata_values}"
+
+metadata_alpha=""
+metadata_beta=""
+while IFS='=' read -r key value; do
+  case "${key}" in
+    alpha)
+      metadata_alpha="${value}"
+      ;;
+    beta)
+      metadata_beta="${value}"
+      ;;
+  esac
+done <<<"${metadata_values}"
+
+[[ -n "${metadata_alpha}" && -n "${metadata_beta}" ]] || fail "metadata versions could not be extracted"
+
+for dispatcher in index alpha beta; do
+  [[ -f "${INSTALL_ROOT}/${dispatcher}" ]] || fail "dispatcher missing: ${INSTALL_ROOT}/${dispatcher}"
+done
+
+index_alpha="$(extract_var "${INSTALL_ROOT}/index" ALPHA_VERSION)"
+index_beta="$(extract_var "${INSTALL_ROOT}/index" BETA_VERSION)"
+alpha_alpha="$(extract_var "${INSTALL_ROOT}/alpha" ALPHA_VERSION)"
+alpha_beta="$(extract_var "${INSTALL_ROOT}/alpha" BETA_VERSION)"
+beta_alpha="$(extract_var "${INSTALL_ROOT}/beta" ALPHA_VERSION)"
+beta_beta="$(extract_var "${INSTALL_ROOT}/beta" BETA_VERSION)"
+
+[[ "${index_alpha}" == "${alpha_alpha}" && "${index_alpha}" == "${beta_alpha}" ]] || fail "dispatcher ALPHA_VERSION drift"
+[[ "${index_beta}" == "${alpha_beta}" && "${index_beta}" == "${beta_beta}" ]] || fail "dispatcher BETA_VERSION drift"
+[[ "${metadata_alpha}" == "${index_alpha}" ]] || fail "metadata alpha version drift: metadata=${metadata_alpha} dispatcher=${index_alpha}"
+[[ "${metadata_beta}" == "${index_beta}" ]] || fail "metadata beta version drift: metadata=${metadata_beta} dispatcher=${index_beta}"
+
+validate_installer() {
+  local channel="$1"
+  local version="$2"
+  local installer="${INSTALL_ROOT}/versions/${version}"
+  [[ -f "${installer}" ]] || fail "immutable installer missing for ${channel}: ${installer}"
+  local installer_version
+  installer_version="$(extract_var "${installer}" APP_VERSION)"
+  [[ -n "${installer_version}" ]] || fail "immutable installer missing APP_VERSION for ${channel}: ${installer}"
+  [[ "${installer_version}" == "${version}" ]] || fail "immutable installer APP_VERSION drift for ${channel}: metadata=${version} installer=${installer_version}"
+}
+
+validate_installer alpha "${metadata_alpha}"
+validate_installer beta "${metadata_beta}"

--- a/verification/distribution/channel_metadata_dispatcher_drift_rejected.sh
+++ b/verification/distribution/channel_metadata_dispatcher_drift_rejected.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-channel-dispatcher-drift.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+install_root="${tmp_dir}/install"
+make_self_update_install_root_fixture "${install_root}" "0.1.0-alpha.4" "0.1.0-beta.7"
+sed -i.bak 's/"beta": "0.1.0-beta.7"/"beta": "0.1.0-beta.6"/' \
+  "${install_root}/metadata/channels.json"
+
+require_failure_contains \
+  "metadata beta version drift" \
+  "${REPO_ROOT}/scripts/distribution/validate_self_update_metadata.sh" \
+    --install-root "${install_root}"

--- a/verification/distribution/channel_metadata_installer_agreement.sh
+++ b/verification/distribution/channel_metadata_installer_agreement.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-channel-agreement.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+install_root="${tmp_dir}/install"
+make_self_update_install_root_fixture "${install_root}" "0.1.0-alpha.4" "0.1.0-beta.7"
+
+"${REPO_ROOT}/scripts/distribution/validate_self_update_metadata.sh" \
+  --install-root "${install_root}"

--- a/verification/distribution/channel_metadata_installer_drift_rejected.sh
+++ b/verification/distribution/channel_metadata_installer_drift_rejected.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-channel-installer-drift.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+install_root="${tmp_dir}/install"
+make_self_update_install_root_fixture "${install_root}" "0.1.0-alpha.4" "0.1.0-beta.7"
+sed -i.bak 's/APP_VERSION="0.1.0-beta.7"/APP_VERSION="0.1.0-beta.6"/' \
+  "${install_root}/versions/0.1.0-beta.7"
+
+require_failure_contains \
+  "immutable installer APP_VERSION drift for beta" \
+  "${REPO_ROOT}/scripts/distribution/validate_self_update_metadata.sh" \
+    --install-root "${install_root}"

--- a/verification/distribution/channel_metadata_stable_rejected.sh
+++ b/verification/distribution/channel_metadata_stable_rejected.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-channel-stable.XXXXXX")"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+install_root="${tmp_dir}/install"
+make_self_update_install_root_fixture "${install_root}" "0.1.0-alpha.4" "0.1.0-beta.7"
+
+python3 - "${install_root}/metadata/channels.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+metadata = json.loads(path.read_text())
+metadata["channels"]["stable"] = "1.0.0"
+path.write_text(json.dumps(metadata, indent=2) + "\n")
+PY
+
+require_failure_contains \
+  "stable channel metadata is disabled until Phase 39" \
+  "${REPO_ROOT}/scripts/distribution/validate_self_update_metadata.sh" \
+    --install-root "${install_root}"

--- a/verification/distribution/common.sh
+++ b/verification/distribution/common.sh
@@ -130,6 +130,34 @@ make_target_specific_artifacts() {
   done
 }
 
+make_self_update_install_root_fixture() {
+  local install_root="$1"
+  local alpha_version="${2:-0.1.0-alpha.4}"
+  local beta_version="${3:-0.1.0-beta.7}"
+  local artifact_dir
+  mkdir -p "${install_root}/versions"
+  artifact_dir="$(mktemp -d "${TMPDIR:-/tmp}/sifr-self-update-artifacts.XXXXXX")"
+  make_target_specific_artifacts "${alpha_version}" "${artifact_dir}/alpha"
+  make_target_specific_artifacts "${beta_version}" "${artifact_dir}/beta"
+  "${REPO_ROOT}/scripts/distribution/generate_dispatchers.sh" \
+    --install-root "${install_root}" \
+    --alpha-version "${alpha_version}" \
+    --beta-version "${beta_version}" \
+    --base-url "file://${install_root}" >/dev/null
+  "${REPO_ROOT}/scripts/distribution/generate_version_installer.sh" \
+    --version "${alpha_version}" \
+    --artifact-dir "${artifact_dir}/alpha" \
+    --out "${install_root}/versions/${alpha_version}" \
+    --artifact-base-url "file://${artifact_dir}/alpha" >/dev/null
+  "${REPO_ROOT}/scripts/distribution/generate_version_installer.sh" \
+    --version "${beta_version}" \
+    --artifact-dir "${artifact_dir}/beta" \
+    --out "${install_root}/versions/${beta_version}" \
+    --artifact-base-url "file://${artifact_dir}/beta" >/dev/null
+  # Drift fixtures inspect embedded installer metadata; they do not execute these installers.
+  rm -rf "${artifact_dir}"
+}
+
 make_site_repo_fixture() {
   local target_repo="$1"
   mkdir -p "${target_repo}/apps/sifr-site/public"

--- a/verification/distribution/create_new_version_alpha_dry_run.sh
+++ b/verification/distribution/create_new_version_alpha_dry_run.sh
@@ -23,5 +23,7 @@ output="$("${REPO_ROOT}/scripts/distribution/create_new_version.sh" \
 [[ "${output}" == *"channel=alpha"* ]] || { echo "${output}" >&2; exit 1; }
 [[ "${output}" == *"version=0.1.0-alpha.2"* ]] || { echo "${output}" >&2; exit 1; }
 [[ "${output}" == *"new_alpha=0.1.0-alpha.2"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"channel_metadata="*"metadata/channels.json"* ]] || { echo "${output}" >&2; exit 1; }
+[[ "${output}" == *"channel_metadata_update=alpha:0.1.0-alpha.2,beta:"* ]] || { echo "${output}" >&2; exit 1; }
 [[ "${output}" == *"dry_run_side_effects=none"* ]] || { echo "${output}" >&2; exit 1; }
 [[ ! -e "${site_repo}/apps/sifr-site/public/install/versions/0.1.0-alpha.2" ]] || exit 1

--- a/verification/distribution/create_new_version_real_run_plan_reuse.sh
+++ b/verification/distribution/create_new_version_real_run_plan_reuse.sh
@@ -44,7 +44,11 @@ real_sha="$(printf '%s\n' "${real_output}" | sed -n 's/^plan_sha256=//p')"
 }
 
 grep -q "BETA_VERSION=\"${version}\"" "${site_repo}/apps/sifr-site/public/install/index"
+grep -q "\"beta\": \"${version}\"" "${site_repo}/apps/sifr-site/public/install/metadata/channels.json"
+grep -q "APP_VERSION=\"${version}\"" "${site_repo}/apps/sifr-site/public/install/versions/${version}"
 test -x "${site_repo}/apps/sifr-site/public/install/versions/${version}"
 test -f "${work_dir}/plan.txt"
 test -f "${work_dir}/release-checklist.md"
 test -f "${work_dir}/recovery-note.md"
+"${REPO_ROOT}/scripts/distribution/validate_self_update_metadata.sh" \
+  --install-root "${site_repo}/apps/sifr-site/public/install"


### PR DESCRIPTION
## Summary
- add self-update metadata validator that cross-checks channel metadata, dispatchers, and immutable installer APP_VERSION values
- add distribution fixtures for agreement, dispatcher drift, installer drift, and stable metadata rejection
- assert create-new-version dry-run metadata mutation lines and real-run metadata/installer writes

## Validation
- bash -n for new/updated shell scripts
- new M4 drift fixtures individually
- scripts/run_distribution_validation.sh
- cargo fmt --check
- python3 scripts/check_file_size_guardrails.py
- explicit schema_version=true rejection probe
- scripts/run_all_tests.sh --profile quick (advisories only: warm wall-time exceeded; e2e group skew high)

## Review
- reviews/self-update-m4-review-pass-1.md: READY
- reviews/self-update-m4-review-pass-2.md: READY with one polish fix requested
- reviews/self-update-m4-review-pass-3.md: READY