### PR TITLE
[codex] Rebalance validation lanes

### DIFF
--- a/crates/sifr/tests/e2e_support/fixture_compilation.rs
+++ b/crates/sifr/tests/e2e_support/fixture_compilation.rs
@@ -567,22 +567,32 @@ pub(crate) fn plan_batches(
 
     let mut groups = Vec::with_capacity(buckets.len());
     let mut planning_failures = Vec::new();
+    let max_group_fixtures = std::env::var("SIFR_E2E_MAX_GROUP_FIXTURES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(usize::MAX);
     for (_, cases) in buckets {
-        let fixture_names = cases
-            .iter()
-            .map(|case| case.fixture.name.clone())
-            .collect::<Vec<_>>();
-        match build_group_sources(cases) {
-            Ok(group) => groups.push(group),
-            Err(err) => {
-                for fixture_name in fixture_names {
-                    planning_failures.push(FixtureExecution {
-                        name: fixture_name.clone(),
-                        status: Err(format!(
-                            "FAIL [{}]: failed to generate grouped crate source: {}",
-                            fixture_name, err
-                        )),
-                    });
+        let mut cases = cases;
+        cases.sort_by(|left, right| left.fixture.name.cmp(&right.fixture.name));
+        for chunk in cases.chunks(max_group_fixtures) {
+            let chunk_cases = chunk.to_vec();
+            let fixture_names = chunk_cases
+                .iter()
+                .map(|case| case.fixture.name.clone())
+                .collect::<Vec<_>>();
+            match build_group_sources(chunk_cases) {
+                Ok(group) => groups.push(group),
+                Err(err) => {
+                    for fixture_name in fixture_names {
+                        planning_failures.push(FixtureExecution {
+                            name: fixture_name.clone(),
+                            status: Err(format!(
+                                "FAIL [{}]: failed to generate grouped crate source: {}",
+                                fixture_name, err
+                            )),
+                        });
+                    }
                 }
             }
         }

--- a/crates/sifr/tests/validation_contract_support/runner.rs
+++ b/crates/sifr/tests/validation_contract_support/runner.rs
@@ -59,13 +59,29 @@ fn repo_root() -> PathBuf {
 
 fn run_suite(repo_root: &Path, suite: &Suite) -> Result<(), String> {
     for row in &suite.rows {
+        let row_started = Instant::now();
+        let mut row_status = "pass";
         println!("  row={}", row.id);
         let tmp_dir = temp_root(repo_root, &suite.name, &row.id)?;
-        let results = run_row_commands(repo_root, &tmp_dir, &row.commands)?;
-        for assertion in &row.assertions {
-            apply_assertion(assertion, &results)?;
-        }
+        let result = (|| {
+            let results = run_row_commands(repo_root, &tmp_dir, &row.commands)?;
+            for assertion in &row.assertions {
+                apply_assertion(assertion, &results)?;
+            }
+            Ok::<(), String>(())
+        })();
         let _ = std::fs::remove_dir_all(&tmp_dir);
+        if result.is_err() {
+            row_status = "fail";
+        }
+        println!(
+            "[sifr-case-timing] bucket=validation_contract case={}/{} elapsed_ms={} status={}",
+            suite.name,
+            row.id,
+            row_started.elapsed().as_millis(),
+            row_status
+        );
+        result?;
     }
     println!("{}: PASS", suite.label);
     Ok(())

--- a/crates/sifr_driver/src/bin/diagnostic_contract_harness.rs
+++ b/crates/sifr_driver/src/bin/diagnostic_contract_harness.rs
@@ -1,0 +1,375 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use serde_json::Value;
+use sifr_diagnostics::RenderedDiagnostic;
+use sifr_driver::{check_package_project, check_project, check_single_file, PackageEntrypoint};
+use sifr_package::{
+    derive_package_graph, parse_metadata_json, CargoCommandPlan, CargoLockMode, PackageSourceMap,
+};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LEGACY_WORKSPACE_IMPORT_CODES: &[&str] = &[
+    "SIFR-WORKSPACE-0101",
+    "SIFR-WORKSPACE-0102",
+    "SIFR-WORKSPACE-0103",
+    "SIFR-WORKSPACE-0104",
+];
+
+const PARSER_FIXTURES: &[(&str, &str)] = &[
+    ("parser_bad_indent", "SIFR-PARSE-0002"),
+    ("parser_unterminated_string", "SIFR-PARSE-0003"),
+    ("parser_invalid_call_order", "SIFR-PARSE-0006"),
+    ("parser_empty_declaration", "SIFR-PARSE-0007"),
+    ("parser_invalid_declaration", "SIFR-PARSE-0002"),
+    ("parser_invalid_match_pattern", "SIFR-PARSE-0008"),
+    ("parser_unsupported_syntax", "SIFR-PARSE-0009"),
+];
+
+const PROJECT_FIXTURES: &[(&str, &str, &[&str])] = &[
+    (
+        "workspace_missing_import_canonical",
+        "SIFR-IMPORT-0002",
+        &["resolution_scope", "tried_paths"],
+    ),
+    (
+        "workspace_ambiguous_import_canonical",
+        "SIFR-IMPORT-0005",
+        &["resolution_scope", "candidate_paths"],
+    ),
+    (
+        "workspace_namespace_collision_canonical",
+        "SIFR-IMPORT-0006",
+        &["resolved_path", "parent_path"],
+    ),
+];
+
+const CYCLE_FIXTURES: &[(&str, &str, &[&str])] = &[(
+    "import_cycle_source_spans",
+    "SIFR-IMPORT-0007",
+    &["cycle", "cycle_edges"],
+)];
+
+const PACKAGE_FIXTURES: &[(&str, &str, &[&str])] = &[
+    (
+        "package_missing_import_canonical",
+        "SIFR-IMPORT-0002",
+        &[
+            "resolution_scope",
+            "tried_paths",
+            "written_module_path",
+            "package_import_origin",
+        ],
+    ),
+    (
+        "package_ambiguous_import_canonical",
+        "SIFR-IMPORT-0005",
+        &[
+            "resolution_scope",
+            "candidate_paths",
+            "written_module_path",
+            "package_import_origin",
+        ],
+    ),
+];
+
+const PACKAGE_FATAL_FIXTURES: &[(&str, &str, &[&str])] = &[(
+    "package_fatal_source_map_no_import_ambiguity",
+    "SIFR-PACKAGE-0713",
+    &["origin_kind", "manifest_path", "manifest_key"],
+)];
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("diagnostic contract harness: FAIL: {error}");
+        std::process::exit(1);
+    }
+    println!("diagnostic contract harness: PASS");
+}
+
+fn run() -> Result<(), String> {
+    let repo_root = repo_root()?;
+    check_parser_runtime_contract(&repo_root)?;
+    check_project_runtime_contract(&repo_root)?;
+    check_cycle_runtime_contract(&repo_root)?;
+    check_package_runtime_contract(&repo_root)?;
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "sifr_driver should live under repo_root/crates/sifr_driver".to_string())
+}
+
+fn check_parser_runtime_contract(root: &Path) -> Result<(), String> {
+    let base = root.join("crates/sifr/tests/verification/diagnostics");
+    for (fixture, code) in PARSER_FIXTURES {
+        let entry = base.join(fixture).join("main.sifr");
+        let source = std::fs::read_to_string(&entry)
+            .map_err(|err| format!("failed to read {}: {err}", entry.display()))?;
+        let diagnostics = check_single_file(&source, &entry);
+        assert_contract(&diagnostics, code, fixture, &[], &[], true, true)?;
+        assert_text_formats(&diagnostics, code, &entry)?;
+    }
+    Ok(())
+}
+
+fn check_project_runtime_contract(root: &Path) -> Result<(), String> {
+    let base = root.join("crates/sifr/tests/verification/project");
+    for (fixture, code, required_args) in PROJECT_FIXTURES {
+        let entry = base.join(fixture).join("main.sifr");
+        let diagnostics = check_project(&entry);
+        assert_contract(
+            &diagnostics,
+            code,
+            fixture,
+            LEGACY_WORKSPACE_IMPORT_CODES,
+            required_args,
+            true,
+            true,
+        )?;
+        assert_text_formats(&diagnostics, code, &entry)?;
+    }
+    Ok(())
+}
+
+fn check_cycle_runtime_contract(root: &Path) -> Result<(), String> {
+    let base = root.join("crates/sifr/tests/verification/project");
+    for (fixture, code, required_args) in CYCLE_FIXTURES {
+        let entry = base.join(fixture).join("main.sifr");
+        let diagnostics = check_project(&entry);
+        assert_contract(
+            &diagnostics,
+            code,
+            fixture,
+            LEGACY_WORKSPACE_IMPORT_CODES,
+            required_args,
+            true,
+            true,
+        )?;
+        assert_text_formats(&diagnostics, code, &entry)?;
+    }
+    Ok(())
+}
+
+fn check_package_runtime_contract(root: &Path) -> Result<(), String> {
+    let base = root.join("crates/sifr/tests/verification/package");
+    for (fixture, code, required_args) in PACKAGE_FIXTURES {
+        let package = base.join(fixture);
+        let diagnostics = package_diagnostics(&package)?;
+        assert_contract(
+            &diagnostics,
+            code,
+            fixture,
+            LEGACY_WORKSPACE_IMPORT_CODES,
+            required_args,
+            true,
+            true,
+        )?;
+        assert_no_prefix(&diagnostics, fixture, "SIFR-PACKAGE-")?;
+        assert_text_formats(&diagnostics, code, &package)?;
+    }
+    for (fixture, code, required_args) in PACKAGE_FATAL_FIXTURES {
+        let package = base.join(fixture);
+        let diagnostics = package_diagnostics(&package)?;
+        assert_contract(&diagnostics, code, fixture, &[], required_args, false, true)?;
+        assert_no_prefix(&diagnostics, fixture, "SIFR-IMPORT-")?;
+    }
+    Ok(())
+}
+
+fn package_diagnostics(package: &Path) -> Result<Vec<RenderedDiagnostic>, String> {
+    let plan = CargoCommandPlan::metadata(package.to_path_buf(), CargoLockMode::Normal);
+    let output = Command::new(&plan.program)
+        .args(&plan.args)
+        .current_dir(&plan.current_dir)
+        .output()
+        .map_err(|err| {
+            format!(
+                "failed to run cargo metadata for {}: {err}",
+                package.display()
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed for {}: {}",
+            package.display(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let metadata = parse_metadata_json(&stdout).map_err(|err| {
+        format!(
+            "failed to parse cargo metadata for {}: {err:?}",
+            package.display()
+        )
+    })?;
+    let graph = match derive_package_graph(metadata) {
+        Ok(graph) => graph,
+        Err(errors) => {
+            return Ok(errors
+                .into_iter()
+                .map(sifr_driver::render_package_diagnostic)
+                .collect());
+        }
+    };
+    let source_map = match PackageSourceMap::build(&graph) {
+        Ok(source_map) => source_map,
+        Err(errors) => {
+            return Ok(errors
+                .into_iter()
+                .map(sifr_driver::render_package_diagnostic)
+                .collect());
+        }
+    };
+    let package_id = graph
+        .packages
+        .iter()
+        .find(|(_, metadata)| metadata.package_root == package)
+        .map(|(id, _)| id.clone())
+        .ok_or_else(|| format!("could not find package id for {}", package.display()))?;
+    let entry = find_package_entry(package)?;
+    let entrypoint = PackageEntrypoint {
+        main_file: entry,
+        package_id,
+        graph,
+        source_map,
+    };
+    Ok(check_package_project(&entrypoint))
+}
+
+fn find_package_entry(package: &Path) -> Result<PathBuf, String> {
+    for candidate in ["src/main.sifr", "src1/main.sifr", "src_a/main.sifr"] {
+        let path = package.join(candidate);
+        if path.is_file() {
+            return Ok(path);
+        }
+    }
+    Err(format!(
+        "package fixture missing main.sifr under {}",
+        package.display()
+    ))
+}
+
+fn assert_contract(
+    diagnostics: &[RenderedDiagnostic],
+    expected_code: &str,
+    case_id: &str,
+    forbidden_codes: &[&str],
+    required_args: &[&str],
+    require_span: bool,
+    render_json: bool,
+) -> Result<(), String> {
+    if diagnostics.is_empty() {
+        return Err(format!("{case_id}: diagnostic payload is empty"));
+    }
+    let codes = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code.as_str())
+        .collect::<BTreeSet<_>>();
+    if !codes.contains(expected_code) {
+        return Err(format!(
+            "{case_id}: expected {expected_code}, got {codes:?}"
+        ));
+    }
+    for code in forbidden_codes {
+        if codes.contains(code) {
+            return Err(format!(
+                "{case_id}: retired workspace import code leaked: {code}"
+            ));
+        }
+    }
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == expected_code)
+        .ok_or_else(|| format!("{case_id}: expected diagnostic disappeared"))?;
+    if require_span {
+        assert_primary_span(diagnostic)?;
+    }
+    for arg in required_args {
+        if !diagnostic.args.contains_key(*arg) {
+            return Err(format!("{expected_code} missing JSON arg: {arg}"));
+        }
+    }
+    if render_json {
+        let json = sifr_diagnostics::render_json_diagnostics(diagnostics)
+            .map_err(|err| format!("{case_id}: JSON rendering failed: {err}"))?;
+        let payload: Value =
+            serde_json::from_str(&json).map_err(|err| format!("{case_id}: invalid JSON: {err}"))?;
+        if payload.as_array().is_none_or(std::vec::Vec::is_empty) {
+            return Err(format!("{case_id}: rendered JSON payload is empty"));
+        }
+    }
+    Ok(())
+}
+
+fn assert_primary_span(diagnostic: &RenderedDiagnostic) -> Result<(), String> {
+    let span = diagnostic
+        .spans
+        .iter()
+        .find(|span| span.is_primary)
+        .or_else(|| diagnostic.spans.first())
+        .ok_or_else(|| format!("{} has no spans", diagnostic.code))?;
+    if span.file.as_deref().is_none_or(|file| file == "<unknown>") {
+        return Err(format!(
+            "{} primary span file is <unknown>",
+            diagnostic.code
+        ));
+    }
+    if span.line.is_none_or(|line| line < 1) || span.column.is_none_or(|column| column < 1) {
+        return Err(format!(
+            "{} primary span location is not 1-based",
+            diagnostic.code
+        ));
+    }
+    if span.lines.is_empty() {
+        return Err(format!(
+            "{} primary span missing snippet lines",
+            diagnostic.code
+        ));
+    }
+    Ok(())
+}
+
+fn assert_text_formats(
+    diagnostics: &[RenderedDiagnostic],
+    expected_code: &str,
+    entry: &Path,
+) -> Result<(), String> {
+    let human = sifr_diagnostics::render_human_diagnostics(diagnostics);
+    if !human.contains(expected_code) || !human.contains("-->") || human.contains("<unknown>") {
+        return Err(format!(
+            "human output failed source contract for {}",
+            entry.display()
+        ));
+    }
+    let compact = sifr_diagnostics::render_compact_diagnostics(diagnostics);
+    if !compact.contains(&format!("E {expected_code} ")) || compact.contains("<unknown>") {
+        return Err(format!(
+            "compact output failed source contract for {}",
+            entry.display()
+        ));
+    }
+    Ok(())
+}
+
+fn assert_no_prefix(
+    diagnostics: &[RenderedDiagnostic],
+    case_id: &str,
+    forbidden_prefix: &str,
+) -> Result<(), String> {
+    for diagnostic in diagnostics {
+        if diagnostic.code.starts_with(forbidden_prefix) {
+            return Err(format!(
+                "{case_id}: forbidden diagnostic family leaked: {}",
+                diagnostic.code
+            ));
+        }
+    }
+    Ok(())
+}

--- a/internal_docs/validation_lane_policy.md
+++ b/internal_docs/validation_lane_policy.md
@@ -1,0 +1,52 @@
+# Validation Lane Policy
+
+Status: active
+
+Sifr local validation uses four canonical lanes. Legacy names remain aliases so existing local and CI commands keep working:
+
+- `create-pr` (`quick` alias): fast local create-PR signal, target <=120s warm and <=300s cold.
+- `merge` (`pr` and `full` aliases): authoritative merge gate for compiler correctness.
+- `nightly`: broad hardening, full generated-code quality, and full e2e pass corpus.
+- `release` (`stress` alias): highest-confidence release qualification lane.
+
+The lane manifest is `verification/validation_lanes/manifest.json`. `scripts/validation_lane.py` is the primary shell-facing resolver for lane metadata. Helper scripts that keep standalone defaults for compatibility must preserve the same alias semantics as the manifest.
+
+## Create-PR Lane
+
+`scripts/run_all_tests.sh --profile create-pr` proves fast compiler-relevant behavior:
+
+- static guardrails and diagnostic registry/docs contracts
+- parser/frontend cache and split-brain guardrails
+- static tooling contracts and LSP protocol smoke
+- smoke performance budgets
+- generated-code quality smoke over a bounded fixture subset
+- library crate unit tests, CLI unit tests, and representative e2e pass fixtures
+
+It intentionally excludes editor packaging, editor asset release checks, distribution/self-update checks, LSP stress, LSP large-session smoke, broad verification hardening, broad project-mode matrices, full generated clippy/corpus, full performance budgets, and the slower `sifr` integration/e2e-support crate tests.
+
+## Merge Lane
+
+`scripts/run_all_tests.sh --profile merge` is the authoritative merge gate. It preserves broader compiler coverage through:
+
+- full core contract matrices listed in the manifest
+- representative hardening suites
+- representative performance budget subset
+- representative generated-code quality checks with shared generated artifacts and Cargo target reuse
+- distribution representative checks
+- formatter, analysis, static tooling, and LSP smoke checks
+- full crate tests, including the slower `sifr` integration/e2e-support tests
+
+## Change-Aware Ownership
+
+Use the broader lane or targeted family command when touching these surfaces:
+
+- Generated-code quality: codegen, runtime dependency selection, generated project layout, or emitted Rust quality.
+- LSP stress and large-session checks: `crates/sifr_lsp`, `crates/sifr_analysis`, frontend query scheduling/cancellation, LSP protocol scripts, or editor integration behavior.
+- Developer tooling/editor release: formatter, linter, editor assets, VS Code packaging, analysis snapshots, or editor query behavior.
+- Distribution/self-update: installer scripts, self-update metadata, release channel scripts, or stable/preview channel behavior.
+- Performance budgets: compiler performance-sensitive paths, frontend cache, formatter, LSP latency, or build/run/check workflows.
+- Verification hardening: diagnostics, project graph, regression corpus, crash fixtures, and OSS-curated validation.
+
+## Timing Evidence
+
+`scripts/run_all_tests.sh` emits `[sifr-lane-step]` records for every top-level bucket. Slow sub-tools emit `[sifr-case-timing]` records. `scripts/validation_lane_report.py` writes `target/validation_lane_reports/<profile>.latest.json` with wall time, step timings, slowest cases, e2e cache/group stats, generated artifact cache hits, and advisories.

--- a/issues/ad-hoc-pr-gate-speed-and-validation-lane-rebalancing.md
+++ b/issues/ad-hoc-pr-gate-speed-and-validation-lane-rebalancing.md
@@ -1,6 +1,11 @@
 # Ad Hoc PR Gate Speed and Validation Lane Rebalancing
 
-status: draft
+status: implemented
+
+Implementation note: lane policy is now documented in
+`internal_docs/validation_lane_policy.md`. Canonical lanes are `create-pr`,
+`merge`, `nightly`, and `release`; legacy `quick`, `pr`, `full`, and `stress`
+remain aliases.
 
 ## Objective
 
@@ -97,42 +102,42 @@ TypeScript-Go keeps regular `go test ./...` usable, relies on Go test caching, a
 
 ### milestone_gate_speed_1: Timing And Lane Taxonomy
 
-- Add first-class timing output to `scripts/run_all_tests.sh` for every top-level bucket.
-- Add per-case timing to generated-code quality, performance budgets, contract matrix rows, hardening variants, and distribution scripts.
-- Define lane taxonomy: `create-pr`, `merge`, `nightly`, and `release`.
-- Acceptance: one run produces a machine-readable breakdown that identifies the slowest case in every bucket.
+- [x] Add first-class timing output to `scripts/run_all_tests.sh` for every top-level bucket.
+- [x] Add per-case timing to generated-code quality, performance budgets, contract matrix rows, hardening variants, and distribution scripts.
+- [x] Define lane taxonomy: `create-pr`, `merge`, `nightly`, and `release`.
+- [x] Acceptance: one run produces a machine-readable breakdown that identifies the slowest case in every bucket.
 
 ### milestone_gate_speed_2: Diagnostic Contract Harness
 
-- Replace repeated Cargo-launched diagnostic source canonicalization checks with an in-process harness or one built-binary invocation model.
-- Keep JSON/human/compact renderer coverage, source-span assertions, and package/project cases.
-- Acceptance: the same semantic assertions run in under 10s warm on the local benchmark machine.
+- [x] Replace repeated Cargo-launched diagnostic source canonicalization checks with an in-process harness or one built-binary invocation model.
+- [x] Keep JSON/human/compact renderer coverage, source-span assertions, and package/project cases.
+- [x] Acceptance: the same semantic assertions run in under 10s warm on the local benchmark machine.
 
 ### milestone_gate_speed_3: Tooling And LSP Gate Isolation
 
-- Split editor packaging/assets, formatter full contract, LSP protocol stress, and LSP large-session checks into change-aware tooling lanes.
-- Make `lsp_protocol_stress.py` emit stderr, process lifecycle, and last protocol event evidence on failure.
-- Acceptance: create-PR lane keeps compiler/tooling smoke only; full tooling lane remains available and deterministic.
+- [x] Split editor packaging/assets, formatter full contract, LSP protocol stress, and LSP large-session checks into change-aware tooling lanes.
+- [x] Make `lsp_protocol_stress.py` emit stderr, process lifecycle, and last protocol event evidence on failure.
+- [x] Acceptance: create-PR lane keeps compiler/tooling smoke only; full tooling lane remains available and deterministic.
 
 ### milestone_gate_speed_4: Generated-Code Quality Reuse
 
-- Generate the corpus once per run and reuse artifacts across panic scan, rustfmt, clippy, determinism, and demo checks.
-- Share or intentionally scope Cargo target directories so dependency builds are not repeated unnecessarily.
-- Introduce a small generated-code smoke subset for create-PR and keep full corpus for codegen-facing merge/nightly gates.
-- Acceptance: generated-code smoke is under 30s warm; full corpus reports per-fixture timings and does not silently rebuild duplicate release dependencies without justification.
+- [x] Generate the corpus once per run and reuse artifacts across panic scan, rustfmt, clippy, determinism, and demo checks.
+- [x] Share or intentionally scope Cargo target directories so dependency builds are not repeated unnecessarily.
+- [x] Introduce a small generated-code smoke subset for create-PR and keep full corpus for codegen-facing merge/nightly gates.
+- [x] Acceptance: generated-code smoke is under 30s warm; full corpus reports per-fixture timings and does not silently rebuild duplicate release dependencies without justification.
 
 ### milestone_gate_speed_5: Compiler Contract Rebalancing
 
-- Reduce create-PR contract matrix to unique compiler invariants not already covered by unit/e2e tests.
-- Move broad project-mode matrices and hardening breadth to merge or nightly lanes unless touched paths require them.
-- Keep representative e2e pass warm-cache behavior and add group-skew rebalancing for cold runs.
-- Acceptance: create-PR lane stays under 120s warm and under 300s cold, while merge lane preserves documented coverage.
+- [x] Reduce create-PR contract matrix to unique compiler invariants not already covered by unit/e2e tests.
+- [x] Move broad project-mode matrices and hardening breadth to merge or nightly lanes unless touched paths require them.
+- [x] Keep representative e2e pass warm-cache behavior and add group-skew rebalancing for cold runs.
+- [x] Acceptance: create-PR lane stays under 120s warm and under 300s cold, while merge lane preserves documented coverage.
 
 ### milestone_gate_speed_6: Policy And Validation
 
-- Update `scripts/run_all_tests.sh`, `verification/validation_lanes/manifest.json`, and docs to make the lane policy explicit.
-- Document which paths trigger change-aware tooling, distribution, generated-code, performance, and hardening lanes.
-- Acceptance: local validation and CI use the same commands; no CI-only gate behavior is introduced.
+- [x] Update `scripts/run_all_tests.sh`, `verification/validation_lanes/manifest.json`, and docs to make the lane policy explicit.
+- [x] Document which paths trigger change-aware tooling, distribution, generated-code, performance, and hardening lanes.
+- [x] Acceptance: local validation and CI use the same commands; no CI-only gate behavior is introduced.
 
 ## Required Validation
 
@@ -146,3 +151,58 @@ Before closing this ad hoc phase:
 - file-size guardrail
 
 The final report must include warm and cold wall-clock times, per-bucket timings, and a before/after comparison against the initial benchmark table above.
+
+## Implementation Measurements
+
+Measured locally after implementation on 2026-06-05 from `/Users/yaseralnajjar/work/sifr/codebase`.
+
+| Lane or bucket | Before | After | Status |
+|---|---:|---:|---|
+| create-PR lane cold (`scripts/run_all_tests.sh --profile quick`) | 367.18s reported, 375.36s wrapper | 206.74s reported | Under 300s cold target. |
+| create-PR lane warm (`scripts/run_all_tests.sh --profile quick`) | 309.43s reported | 74.82s reported | Under 120s warm target. |
+| merge lane warm/cold-local (`scripts/run_all_tests.sh --profile merge`) | `pr` failed before completion at 225.36s | 595.66s reported | Under 15-minute warm target; e2e cache was cold for this run. |
+| Diagnostic source canonicalization contract | 80.48s | 3.18s | Under 10s warm target. |
+| Generated-code smoke | PR grouped bucket interrupted after >11m | 18.11s in create-PR lane | Under 30s warm target. |
+| quick e2e cold | 57.34s lane bucket, `cache_hits=0/12`, largest group 19, median 2 | 55.12s test body, `cache_hits=0/18`, largest group 8, median 2 | Group skew capped. |
+| quick e2e warm | 2.87s direct | 1.66s test body, `cache_hits=18/18` | Warm cache preserved. |
+
+Latest create-PR per-bucket timings from `target/validation_lane_reports/quick.latest.json`:
+
+| Bucket | Wall time |
+|---|---:|
+| core guardrails | 5.91s |
+| diagnostic contracts | 7.97s |
+| frontend/syntax guardrails | 1.77s |
+| developer tooling smoke | 9.29s |
+| performance budget smoke | 7.06s |
+| verification hardening self-tests | 0.49s |
+| distribution validation | 0.23s skipped by lane policy |
+| generated-code quality smoke | 18.11s |
+| crate tests | 17.04s |
+| validation contract matrix | 0.36s no-op by lane policy |
+| e2e pass suite | 2.43s |
+| verification hardening suites | 0.25s no-op by lane policy |
+| extra e2e checks | 0.25s no-op by lane policy |
+
+Latest merge-lane per-bucket timings from `target/validation_lane_reports/merge.latest.json`:
+
+| Bucket | Wall time |
+|---|---:|
+| core guardrails | 5.82s |
+| diagnostic contracts | 15.37s |
+| frontend/syntax guardrails | 1.73s |
+| developer tooling representative | 35.36s |
+| performance budget representative | 138.51s |
+| verification hardening self-tests | 0.51s |
+| distribution representative | 28.27s |
+| generated-code quality representative | 127.12s |
+| crate tests full | 67.01s |
+| validation contract matrix | 81.44s |
+| e2e pass suite | 38.22s |
+| verification hardening suites | 52.44s |
+| extra e2e checks | 0.35s |
+
+Merge e2e used a cold cache for this run: `cache_hits=0/22`,
+`largest_group_fixtures=12`, `median_group_fixtures=1`. The lane passed with
+the non-blocking advisory `group skew is high; investigate batching balance or
+fixture clustering`.

--- a/reviews/gate-speed-phase-review-1.md
+++ b/reviews/gate-speed-phase-review-1.md
@@ -1,0 +1,101 @@
+# Code Review: Validation Lane Rebalancing
+
+## Findings (ordered by severity)
+
+### 1. CRITICAL — Performance budget retry hides legitimate failures
+`scripts/run_all_tests.sh:280-294` retries the performance budget subset up to **5 times with unchanged thresholds**:
+
+```bash
+for attempt in 2 3 4 5; do
+  echo "performance budget subset failed; retrying attempt ${attempt}/5 with unchanged thresholds"
+  if run_performance_budget_subset "${RETRY_PERF_RESULTS}"; then
+    PERFORMANCE_PASSED=1
+    break
+  fi
+done
+```
+
+This is a direct regression against the issue's stated goal of "deterministic, actionable failure evidence" (root cause #6) and against the broader "compiler-relevant" gate posture. A budget that fails once and passes on retry-3 is a flake, not a pass — silently masking it short‑circuits the entire purpose of the budget. Either move retries behind an explicit `--allow-perf-retries` flag, halve the count to a justified value with rationale, or remove entirely.
+
+### 2. CRITICAL — Policy doc and manifest disagree on create-pr contract matrix
+`internal_docs/validation_lane_policy.md:14-25` lists "frontend-mode validation contract matrix" as part of the create-PR lane. But `verification/validation_lanes/manifest.json:17` sets `"matrix_suites": []` for `create-pr`, and `scripts/run_all_tests.sh:393-405` `run_validation_contract_suites` no-ops when `CONTRACT_SUITES` is empty.
+
+Result: the documented "fast compiler-relevant" gate ships **zero** contract-matrix coverage, contradicting the policy doc that just landed in the same PR. Either add `frontend_mode_parity` to the manifest's create-pr `matrix_suites`, or strike the bullet from the policy doc.
+
+### 3. CRITICAL — Issue marked `status: implemented` with acceptance items unchecked
+`issues/ad-hoc-pr-gate-speed-and-validation-lane-rebalancing.md:3` states `status: implemented`, but two acceptance criteria are still `[ ]`:
+- L127 (milestone 4): "generated-code smoke is under 30s warm; full corpus reports per-fixture timings…"
+- L134 (milestone 5): "create-PR lane stays under 120s warm and under 300s cold, while merge lane preserves documented coverage."
+
+The measured warm 94.89s and smoke 17.57s appear to satisfy these, but the issue is internally inconsistent and the "Required Validation" closing section (L142-153) is missing the warm/cold before/after table the issue itself mandates. Don't ship `implemented` without checking the boxes and providing the table.
+
+### 4. HIGH — Lane policy duplication contradicts the policy doc's own claim
+`internal_docs/validation_lane_policy.md:12` says: *"`scripts/validation_lane.py` is the only shell-facing resolver for lane metadata; scripts should not duplicate profile policy."* Yet:
+
+- `scripts/run_verification_hardening/core.py:91-98` reimplements `canonicalize_profile` (now hardcoding `quick→create-pr`, `pr|full→merge`).
+- `scripts/run_verification_hardening/core.py:145-157` hardcodes the merge-lane suite list (`diagnostics, project, fixedbugs, crashes, oss-curated`) — which is also in `manifest.json:69-75`. Two sources of truth.
+- `scripts/run_e2e_pass.sh:50-83` `set_profile_defaults` reimplements worker counts that already live in `manifest.json` `e2e.*_jobs`.
+
+Either route all of these through `validation_lane.py` (the stated single resolver) or weaken the doc claim. Right now the doc is enforceable in spirit but provably false in code.
+
+### 5. HIGH — `exit 1` inside `timed_step` bypasses lane-step status emission
+`scripts/run_all_tests.sh:292` uses `exit 1` from `run_performance_budget_checks`. `timed_step` (L100-120) wraps the call with `set +e; "$@"; status=$?` — but `exit` terminates the shell **before** the closing `echo "[sifr-lane-step] … status=fail"` runs. The whole purpose of milestone 1 was machine-readable per-bucket timing including failures (issue L108). On a real perf failure, the JSON report loses the `performance_budget_checks` step entirely. Change to `return 1`.
+
+### 6. HIGH — `runner.rs` silently leaks the temp dir on failure
+`crates/sifr/tests/validation_contract_support/runner.rs:60-87`: the `let _ = std::fs::remove_dir_all(&tmp_dir);` was moved **inside** the inner closure. Now any failure in `temp_root`, `run_row_commands`, or `apply_assertion` returns `Err` before cleanup, leaking the directory under `target/`. The old code cleaned up unconditionally.
+
+If the intent is "preserve evidence on failure," say so with a comment **and** print the preserved path (like `generated_code_quality.py:543-544` does). Otherwise restore the unconditional cleanup. As written, it's an accidental behavior change.
+
+### 7. MEDIUM — `nightly` and `release` lanes are nearly identical
+`verification/validation_lanes/manifest.json:79-164`: every field except `extra_checks` is byte-identical between `nightly` and `release` (same matrix_suites, tooling_suites, distribution, generated_code_quality, performance_budget, e2e, hardening_suites). The only release-only signal is `e2e_report_determinism` and `e2e_sequential_parallel_equivalence`. That's a thin justification for a 4th lane and contradicts the policy doc's "highest-confidence release qualification" framing. Either widen the release lane (additional cold/thermal coverage, longer-running fuzz, larger sample-scale) or collapse `release` into `nightly` with a `--extra-checks` opt-in.
+
+### 8. MEDIUM — Dead exports in `validation_lane.py`
+`scripts/validation_lane.py:126-129` emits `RUN_FRONTEND_MODE_PARITY`, `RUN_PHASE23_GRAPH_ISOLATION`, `RUN_PHASE24_HIR_ANALYSIS`, `RUN_PHASE25_CFG_FLOW`. `grep` confirms these are read **nowhere** (`grep` returns the source file only). Either consume them in `run_all_tests.sh` for fine-grained per-suite gating, or delete to avoid drift.
+
+### 9. MEDIUM — Hardening JSON `profile` field semantics changed
+`scripts/run_verification_hardening/core.py:91-98` now canonicalizes `pr→merge`. `main_flow.py:218` writes `args.profile` into `target/verification/hardening-results.json`. Any consumer that previously matched on `"profile": "pr"` now needs `"profile": "merge"`. There's no schema version bump or migration note. If you intend to keep this, bump `schema_version` and call it out in the policy doc.
+
+### 10. MEDIUM — `e2e_metrics` dict carries both `groups` and `group_count`
+`scripts/validation_lane_report.py:243-261`: `E2E_TIMING_RE` writes `group_count` (the denominator after `cache_hits=`), then `E2E_GROUP_RE` overlays `groups`, `largest_group_fixtures`, `median_group_fixtures`. Two keys for the same concept. The display at L408 uses `group_count`; the advisory at L164 uses `group_count` and `largest_group_fixtures`. If `E2E_GROUP_RE` ever lands without `E2E_TIMING_RE` (regex change, log truncation), `cache_hit_rate` silently goes to None. Normalize to one key and assert the regex still matches the e2e bucket's actual output.
+
+### 11. MEDIUM — Generated-code cache key only hashes the entry file
+`verification/generated_code_quality/generated_code_quality.py:327-334` builds the cache key from `entry.id || source_path || absolute_source.read_bytes()`. Multi-module fixtures (`multi-module-projects` group, REQUIRED_GROUP_COUNTS:35) have **secondary modules** that aren't in the hash. The shared root is wiped at the top of `run_generated_code_quality_checks` (`run_all_tests.sh:323`) so within a single lane invocation this is benign, but if anyone ever points `SIFR_GCQ_SHARED_ROOT` at a persistent dir (e.g. for fast iteration), a stale secondary module produces a false cache hit. At minimum, document the cache-key contract; better, hash the whole entry directory.
+
+### 12. LOW — `gate_demos` mutates the parsed `args`
+`verification/generated_code_quality/generated_code_quality.py:696-698`:
+```python
+def gate_demos(entries, args):
+    args.group = ["demos-required"]
+    gate_corpus(entries, args)
+```
+Today each mode is its own process so this is harmless, but it's a footgun if anyone ever calls multiple gates in-process. Pass a fresh `argparse.Namespace` or a small kwarg instead.
+
+### 13. LOW — `/usr/bin/time -l` is macOS-only
+`scripts/run_all_tests.sh:64`: `-l` is BSD/macOS. On Linux, GNU time uses `-v` and the `BSD_TIME_*` regexes in `validation_lane_report.py` won't match. AGENTS.md says "CI mirrors these exact scripts — no CI-only behavior." If CI runs on Linux, max_rss/swaps parsing silently produces no advisories. Detect platform or use a Python `resource` helper.
+
+### 14. LOW — `set_profile_defaults` in `run_e2e_pass.sh` duplicates manifest jobs
+`scripts/run_e2e_pass.sh:50-83`: per-profile job counts duplicate `manifest.json` `e2e.{sifr,rust,run}_jobs`. Drift risk if someone tunes one and not the other. Make `run_e2e_pass.sh` read the manifest via `validation_lane.py shell` when invoked standalone.
+
+### 15. LOW — `scripts/run_distribution_validation.sh:31` exits on first failure but skips the rest of the loop
+`exit "${status}"` halts the loop after the first failing distribution script. The per-case timing records that would be useful for diagnosing fan-out failure are lost. Consider accumulating failures and exiting at the end of the loop (matches the spirit of milestone 1's per-case timing visibility).
+
+## Lane composition coherence
+
+The four-lane split is **structurally sound**: create-pr is genuinely a smoke profile, merge is representative, nightly is full corpus, release adds determinism/equivalence. Aliases (`quick→create-pr`, `pr→merge`, `full→merge`, `stress→release`) preserve backward compatibility cleanly.
+
+But two coherence concerns survive:
+- **Boundary blurring** (finding #7): `nightly` and `release` are too close to justify two lanes.
+- **Doc/manifest skew** (finding #2): the create-PR coverage claim in the policy doc is not honored by the manifest.
+
+## Measured-evidence sanity check
+
+- 94.89s warm < 120s warm target → milestone 5 acceptance is satisfiable; tick the box.
+- 17.57s generated-code smoke < 30s → milestone 4 acceptance is satisfiable; tick the box.
+- 3.18s warm for the diagnostic source canonicalization wrapper, against the ≤10s milestone-2 target → comfortably met.
+- 18/18 cache_hits warm and 0/18 cold with median group 2, largest 8 → group skew advisory should not trigger (ratio 4.0, abs delta 6 < 8). Good.
+
+## Verdict
+
+**Request another revision round.** The structural design is solid and the measured numbers hit their warm targets, but findings #1–#3 are blockers — a performance gate that retries 5× silently, a policy doc that contradicts its own manifest, and an `implemented` status with unchecked acceptance items together undermine the very "deterministic, actionable" posture this phase was meant to establish. Findings #4–#6 are also non-optional before merge: the policy doc states a "single resolver" invariant that the code violates, `exit 1` defeats the new lane-step instrumentation, and the runner.rs cleanup regression is silent.
+
+Once those six are addressed, the remaining items are reasonable follow-ups.

--- a/reviews/gate-speed-phase-review-2.md
+++ b/reviews/gate-speed-phase-review-2.md
@@ -1,0 +1,1 @@
+Round-2 review complete. Verdict: **REQUEST CHANGES**. Two new blocker-class findings — `set +e` propagation inside `timed_step` (silently swallows mid-bucket failures across 6 runner functions) and a missed `exit 2` twin at `run_all_tests.sh:345` matching round-1 #5's anti-pattern. The six listed round-1 blocker fixes all verified clean.

--- a/reviews/gate-speed-phase-review-3.md
+++ b/reviews/gate-speed-phase-review-3.md
@@ -1,0 +1,47 @@
+# Code Review — Gate Speed Phase, Round 3
+
+## Prior blockers — verified clean
+
+1. **Perf retry removed.** `scripts/run_all_tests.sh:245-284` `run_performance_budget_checks` has no retry loop; `verification/performance/run_benchmarks.py` and `check_budgets.py` contain no retry/attempt logic. Round-1 #1 resolved.
+
+2. **Create-PR manifest ↔ policy doc alignment.** `internal_docs/validation_lane_policy.md:16-26` lists smoke-only bullets and explicitly excludes "broad project-mode matrices"; `verification/validation_lanes/manifest.json:17` `matrix_suites: []` matches. Round-1 #2 resolved.
+
+3. **Phase evidence + acceptance ticks.** `issues/ad-hoc-pr-gate-speed-and-validation-lane-rebalancing.md:159-184` carries the before/after table the issue mandated, all milestone checkboxes are `[x]`. Round-1 #3 resolved.
+
+4. **Resolver doc claim weakened.** `internal_docs/validation_lane_policy.md:12` now says "*primary* shell-facing resolver" and acknowledges helper scripts may keep standalone defaults with the same alias semantics. Round-1 #4 resolved.
+
+5. **`exit` → `return` inside `timed_step` callees.** `scripts/run_all_tests.sh:346` (GCQ default arm) and `:384` (crate-test default arm) both use `return 2`; no other `exit` survives inside a `timed_step` callee. Round-1 #5 + Round-2 follow-up resolved.
+
+6. **`runner.rs` temp cleanup.** `crates/sifr/tests/validation_contract_support/runner.rs:66-84` — work is wrapped in an inner closure, `let _ = std::fs::remove_dir_all(&tmp_dir);` runs unconditionally at line 73 *after* the closure result is captured, then `result?` propagates the error. Cleanup happens on both pass and fail paths. Round-1 #6 resolved.
+
+7. **`timed_step` errexit preservation.** `scripts/run_all_tests.sh:108-112`:
+   ```
+   set +e
+   (set -euo pipefail; "$@")
+   status=$?
+   set -e
+   ```
+   The subshell re-enables `errexit`/`pipefail` inside each bucket so mid-bucket failures still abort, the outer `set +e` keeps the wrapper alive long enough to emit `[sifr-lane-step] … status=fail`, and `return "${status}"` propagates. Round-2 blocker resolved.
+
+8. **Unsupported-mode returns.** Both `scripts/run_all_tests.sh:343-346` (`generated-code quality mode`) and `:381-384` (`crate test mode`) write to stderr and `return 2`, which `timed_step` will surface as `status=fail` rather than terminating the shell silently. Verified.
+
+## New surface — lane-aware `crate_tests=smoke/full`
+
+- **Manifest** (`verification/validation_lanes/manifest.json:25,61,100,143`): only `create-pr` → `"crate_tests": "smoke"`; `merge`, `nightly`, `release` → `"full"`.
+- **Resolver** (`scripts/validation_lane.py:134`): exported as `CRATE_TEST_MODE`.
+- **Shell** (`scripts/run_all_tests.sh:375-388`): `smoke` runs only `cargo test -p sifr --bin sifr` (CLI unit tests). `full` runs `cargo test -p sifr -- --skip test_e2e_pass`. Common crates (`sifr_diagnostics`, `sifr_hir`, `sifr_syntax`, `sifr_frontend`, `sifr_analysis`, `sifr_lsp`, `sifr_package`, `sifr_driver --lib`) run in both modes. Unknown mode → `return 2`.
+- **Policy doc** (`internal_docs/validation_lane_policy.md:23,25`): create-PR includes "library crate unit tests, CLI unit tests, and representative e2e pass fixtures" and explicitly excludes "the slower `sifr` integration/e2e-support crate tests". Manifest, shell, and doc agree.
+
+## Latest create-PR pass
+
+`target/validation_lane_reports/quick.latest.json`: `profile=create-pr`, `real_seconds=74.82`, `within_warm_budget=true`, advisories=`[]`. All 13 lane_steps pass; bucket timings exactly match `issues/.../*:169-184`. Generated-code smoke at 18.11s (target ≤30s), diagnostic contracts at 7.97s (target ≤10s), crate_tests at 17.04s under the new smoke split.
+
+## Pre-existing minors (not in this round's scope, flagging only)
+
+- `scripts/run_distribution_validation.sh:32` still `exit "${status}"` inside the per-script loop — Round-1 #15 untouched. Distribution lane is "none" on create-PR so it doesn't affect the gate today.
+- `scripts/run_verification_hardening/main_flow.py:218` writes the canonicalized profile (e.g. `"merge"` for `pr`) into `target/verification/hardening-results.json` with `schema_version: 1` — Round-1 #9 untouched. Internal artifact; document or bump when external consumers appear.
+- `runner.rs:65` `temp_root()?` early-returns before the `[sifr-case-timing]` log on tmp-dir creation failure. Cleanup is moot (nothing was created), but the timing line is lost. Cosmetic.
+
+## Verdict
+
+**SATISFIED.** All eight named prior blockers are properly fixed, the new `crate_tests=smoke/full` split is consistent across manifest, resolver, shell, and policy doc, and the measured 74.82s warm pass with no advisories matches the documented evidence. The two minor pre-existing items above are appropriate follow-ups, not gate-blockers.

--- a/reviews/gate-speed-phase-review-4.md
+++ b/reviews/gate-speed-phase-review-4.md
@@ -1,0 +1,43 @@
+## Findings
+
+### Round 3 follow-ups verified
+
+1. **Distribution per-script timing.** `scripts/run_distribution_validation.sh:8-34` now wraps each `verification/distribution/*.sh` in start/stop monotonic measurement and emits `[sifr-case-timing] bucket=distribution case=<name> status=pass|fail` before the loop-terminating `exit`. The round-1 #15 / round-3 follow-up about the bare `exit "${status}"` is properly mitigated — the failure record is logged before the loop bails.
+
+2. **Hardening profile aliases.** `scripts/run_verification_hardening/core.py:40, 88-93` widens `--profile` choices to `create-pr|merge|quick|pr|nightly|release|full|stress` and canonicalizes `pr|full → merge`, `quick → create-pr`, `stress → release`, matching `verification/validation_lanes/manifest.json:3-8`. `should_run_suite` (line 144-156) returns `False` for `create-pr` and runs the `diagnostics|project|fixedbugs|crashes|oss-curated` set for `merge`. `schema_version: 1` in the hardening JSON is unchanged; round-3's pre-existing minor about the canonicalized name leaking into the artifact is still cosmetic.
+
+3. **Validation-contract row timing.** `crates/sifr/tests/validation_contract_support/runner.rs:62-84` wraps each row body in a closure, removes the temp dir unconditionally at line 73, then emits `[sifr-case-timing] bucket=validation_contract` before `result?`. The round-3 cosmetic about losing the timing line on `temp_root(...)?` failure (line 65) is still present but the failure is genuinely catastrophic (cannot create `${TMPDIR}/sifr-validation-contracts-…`), so no real evidence is lost.
+
+### New surface — `diagnostic_contract_harness` binary
+
+4. **Binary builds and exists.** `crates/sifr_driver/src/bin/diagnostic_contract_harness.rs` (375 lines, under 900 cap) is invoked via `verification/tooling/check_diagnostic_source_canonicalization_contract.py:186-218` (`cargo build -q -p sifr_driver --bin diagnostic_contract_harness` → run). `target/debug/diagnostic_contract_harness` exists at ~30 MB, confirming it compiles. All imports (`check_single_file`, `check_project`, `check_package_project`, `PackageEntrypoint`, `render_package_diagnostic`) are publicly re-exported from `crates/sifr_driver/src/lib.rs:19-27`.
+
+5. **Harness decomposition is clean.** One function per fixture family (`check_parser_runtime_contract:109`, `check_project_runtime_contract:122`, `check_cycle_runtime_contract:141`, `check_package_runtime_contract:160`). `process::exit(1)` lives only in `main` (lines 83-89); all internal paths return `Result<(), String>`. `assert_contract` (line 259) takes 7 parameters which is at the clippy pedantic threshold, but the user's `cargo clippy --workspace -- -D warnings` validation passed.
+
+6. **Package path still uses one `cargo metadata`** (`crates/sifr_driver/src/bin/diagnostic_contract_harness.rs:186-204`). That's necessary to derive the package graph and is one external invocation per package fixture (~3 fixtures) rather than the ~42 `cargo run` invocations the Python harness was making. The 80.48s → 3.18s measurement in `issues/…:164` is consistent.
+
+### Other touched files
+
+7. **`crates/sifr/tests/e2e_support/fixture_compilation.rs:570-599`.** `max_group_fixtures` resolves `SIFR_E2E_MAX_GROUP_FIXTURES`, parses to `usize`, filters `> 0`, defaults to `usize::MAX`. Cases are sorted before chunking and each chunk goes through `build_group_sources` with proper planning-failure attribution per fixture. Group-skew acceptance for milestone_gate_speed_5 is met (largest group `19→8` quick lane, `43→12` merge lane).
+
+8. **`verification/generated_code_quality/generated_code_quality.py:320-405`.** `shared_artifact_root()` resolves `SIFR_GCQ_SHARED_ROOT` (set in `scripts/run_all_tests.sh:308-310` and wiped each run). `entry_cache_key` hashes id + source_path + source bytes. `materialize_entry` checks for `Cargo.toml` and emits `[sifr-artifact-cache] cache_hit=true|false` lines parsed by `scripts/validation_lane_report.py:30-32`. `CARGO_TARGET_DIR=<shared>/cargo-target` is set only for `cargo check` / `cargo clippy` (line 343-350), correctly excluding `cargo run -p sifr -- build` (which uses the workspace target) and `cargo fmt` (no compilation). Per-mode reuse within one lane run is what milestone_gate_speed_4 asks for.
+
+9. **`verification/tooling/lsp_protocol.py:43-48, 111-175`.** `events` ring buffer kept to last 20; `_diagnostic_context` returns `lifecycle{pid,returncode,args}` + last-10 events + `stderr_tail[:-4000]`. Wired into `close()` (line 96, 99), `_read_message()` (line 127), satisfying milestone_gate_speed_3's "emit stderr, process lifecycle, and last protocol event evidence on failure".
+
+10. **`verification/performance/run_benchmarks.py:253-272`.** Per-case `[sifr-case-timing] bucket=performance case=<id>` emission added via `try/except/finally`. `status=fail` only set in the `except Exception` arm before re-raise; status defaults to `pass` if no exception fires.
+
+11. **`scripts/run_verification_hardening/main_flow.py:22-42, 167-170`.** `timing_token` sanitizes case/variant names to match `validation_lane_report.py:40-43`'s `[A-Za-z0-9_.:/+-]+` pattern. `emit_case_timings` runs after `execute_suite_once` for each selected suite.
+
+### Issue / docs
+
+12. **`issues/ad-hoc-pr-gate-speed-and-validation-lane-rebalancing.md:3,103-140,159-208`.** Status flipped to `implemented`, all 6 milestone checkboxes `[x]`, Implementation Measurements table covers both warm and cold create-PR runs (74.82s / 206.74s), merge lane (595.66s under 15-min target), and the per-bucket breakdowns for both lanes. The merge-lane group-skew advisory is documented at lines 205-208 with `cache_hits=0/22`, explaining the cold-cache caveat.
+
+13. **`internal_docs/validation_lane_policy.md`.** Aligned with manifest: `create-pr` excludes "broad project-mode matrices, full generated clippy/corpus, full performance budgets, and the slower `sifr` integration/e2e-support crate tests" (line 25), matching `verification/validation_lanes/manifest.json` and `scripts/run_all_tests.sh:375-388`'s `crate_tests=smoke` split.
+
+### Phase-closure obligation (not a code defect)
+
+14. **`crates/sifr_driver/src/bin/` is untracked in git.** `git status` lists `crates/sifr_driver/src/bin/` as untracked, so the new harness file (and its containing directory) is **not yet committed**. The Python validation harness at `verification/tooling/check_diagnostic_source_canonicalization_contract.py:188` issues `cargo build -p sifr_driver --bin diagnostic_contract_harness`, which would fail on any fresh clone or CI environment until this directory is staged into the closure PR. Round-3 SATISFIED with this same state, so the prior reviewer evidently expected the user to `git add` before opening the closure PR — flagging it here so the closure commit doesn't accidentally omit it.
+
+## Verdict
+
+**SATISFIED.** The implementation is sound and matches every milestone's stated acceptance criterion: harness collapses the ~42-invocation Python check to a single binary (3.18s warm, well under the 10s target), generated-code smoke at 18.11s (under 30s target), create-PR lane at 74.82s warm (under 120s), merge lane at 595.66s (under 15m), group skew capped via `max_group_fixtures`, LSP error reporting includes lifecycle + events + stderr tail, distribution and hardening buckets emit per-case timing, lane manifest / resolver / shell / hardening alias map / policy doc are all consistent. Round-3 follow-ups are addressed. The only obligation outside the code itself is staging `crates/sifr_driver/src/bin/` in the closure PR — without that, the source-canonicalization contract breaks on a fresh tree.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -12,17 +12,19 @@ Usage: scripts/run_all_tests.sh [options]
 Run local-first validation for the selected lane.
 
 Lanes:
-  quick   Fast local signal.
-  pr      Authoritative merge gate (default).
+  create-pr Fast local create-PR signal.
+  merge     Authoritative merge gate (default via `pr` alias).
   nightly Broad hardening and full-corpus signal.
   release Highest-confidence local qualification gate.
 
 Legacy aliases:
-  full    Alias for `pr`
+  quick   Alias for `create-pr`
+  pr      Alias for `merge`
+  full    Alias for `merge`
   stress  Alias for `release`
 
 Options:
-  --profile <quick|pr|nightly|release|full|stress>  Validation lane (default: pr)
+  --profile <create-pr|merge|nightly|release|quick|pr|full|stress>  Validation lane (default: pr)
   --help                         Show this help
 
 Any remaining arguments are forwarded to scripts/run_e2e_pass.sh.
@@ -90,240 +92,379 @@ echo "  profile=${PROFILE}"
 echo "  lane=${LANE_NAME}"
 echo "  budget=warm<=${WARM_TARGET_MINUTES}m cold<=${COLD_TARGET_MINUTES}m"
 echo "  policy=thermal:${THERMAL_POLICY} memory:${MEMORY_POLICY}"
-echo "Running HIR maintainability guardrails"
-python3 "${SCRIPT_DIR}/check_hir_maintainability_guardrails.py"
 
-echo "Running file-size guardrails"
-python3 "${SCRIPT_DIR}/check_file_size_guardrails.py"
-
-echo "Running source crate dependency-direction guardrail"
-python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py"
-
-echo "Running TypeScript-Go architecture transfer M1 guardrails"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py" --self-test
-
-echo "Running sifr_driver maintainability guardrails"
-python3 "${SCRIPT_DIR}/check_sifr_driver_maintainability_guardrails.py"
-
-echo "Running package-manager guardrails"
-python3 "${SCRIPT_DIR}/check_package_manager_guardrails.py"
-
-echo "Running diagnostic schema sync check"
-python3 "${SCRIPT_DIR}/check_diagnostic_schema_sync.py"
-
-echo "Running diagnostic docs sync check"
-python3 "${SCRIPT_DIR}/check_diagnostic_docs_sync.py"
-
-echo "Running diagnostic code coverage check"
-python3 "${SCRIPT_DIR}/check_diagnostic_code_coverage.py"
-
-echo "Running diagnostic baseline hygiene check"
-python3 "${SCRIPT_DIR}/check_diagnostic_baseline_hygiene.py"
-
-echo "Running diagnostic cancel usage check"
-python3 "${SCRIPT_DIR}/check_diagnostic_cancel_usage.py"
-
-echo "Running diagnostic transport cleanup check"
-python3 "${SCRIPT_DIR}/check_diagnostic_transport_cleanup.py"
-
-echo "Running diagnostic presentation contract check"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_presentation_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_presentation_contract.py" --self-test
-
-echo "Running diagnostic source canonicalization contract check"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_source_canonicalization_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_source_canonicalization_contract.py" --self-test
-
-echo "Running Phase 35 frontend and syntax guardrails"
-python3 "${SCRIPT_DIR}/../verification/performance/check_ruff_fork_update_contract.py"
-python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.py"
-python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/performance/check_frontend_cache_contract.py"
-
-echo "Running Developer Tooling Checks"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_contract_lock.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_contract_lock.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_dependency_boundaries.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_dependency_boundaries.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_lsp_split_brain.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_lsp_split_brain.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_linter_diagnostic_class.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_linter_diagnostic_class.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension_contract.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_contract.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_phase_manifests.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_phase_manifests.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_ast_coverage.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_ast_coverage.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_rule_suppression_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_rule_suppression_contract.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_contract.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_contract.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_coherence.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_coherence.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_split_brain.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_split_brain.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/run_tooling_parity.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/run_tooling_parity.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_completion_quality.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_completion_quality.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py" --self-test
-git submodule update --init verification/sifr-large-lsp-verification
-python3 "${SCRIPT_DIR}/../verification/sifr-large-lsp-verification/tools/generate_corpus.py" check
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --mode smoke --require-submodule
-python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/tooling/check_phase36_closeout.py"
-python3 "${SCRIPT_DIR}/../verification/tooling/check_phase36_closeout.py" --self-test
-
-echo "Running Performance Budget Checks"
-python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --validate-only
-python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --self-test
-python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py"
-python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" --self-test
-run_performance_budget_subset() {
-  local perf_results="$1"
-  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
-    --case check-single-file-001-arithmetic \
-    --case check-project-004-project-graph \
-    --case build-single-file-001-break-continue \
-    --case build-project-001-additional-modules \
-    --case formatter-corpus-001-project-check \
-    --case formatter-large-file-001-check \
-    --case incremental-local-loop-001-unchanged-file-update \
-    --case interactive-tooling-foundation-002-warm-diagnostics-query \
-    --case lsp-query-003-diagnostics \
-    --case phase27-non-regression-002-json-diagnostic-schema \
-    --json-out "${perf_results}"
-  python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" \
-    --results "${perf_results}" \
-    --allow-subset
+now_ms() {
+  python3 -c 'import time; print(time.monotonic_ns() // 1_000_000)'
 }
-if [[ "${PROFILE}" == "quick" ]]; then
-  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
-    --sample-scale smoke \
-    --case formatter-corpus-001-project-check \
-    --case formatter-large-file-001-check \
-    --case incremental-local-loop-001-unchanged-file-update \
-    --case interactive-tooling-foundation-002-warm-diagnostics-query \
-    --case lsp-query-003-diagnostics
-else
-  PERF_RESULTS="target/performance/${PROFILE}.budget.latest.json"
-  if ! run_performance_budget_subset "${PERF_RESULTS}"; then
-    PERFORMANCE_PASSED=0
-    for attempt in 2 3 4 5; do
-      RETRY_PERF_RESULTS="target/performance/${PROFILE}.budget.retry-${attempt}.latest.json"
-      echo "performance budget subset failed; retrying attempt ${attempt}/5 with unchanged thresholds"
-      if run_performance_budget_subset "${RETRY_PERF_RESULTS}"; then
-        PERFORMANCE_PASSED=1
-        break
+
+timed_step() {
+  local name="$1"
+  shift
+  local start_ms
+  local end_ms
+  local elapsed_ms
+  local status
+  start_ms="$(now_ms)"
+  set +e
+  (set -euo pipefail; "$@")
+  status=$?
+  set -e
+  end_ms="$(now_ms)"
+  elapsed_ms=$((end_ms - start_ms))
+  if [[ "${status}" -eq 0 ]]; then
+    echo "[sifr-lane-step] name=${name} elapsed_ms=${elapsed_ms} status=pass"
+  else
+    echo "[sifr-lane-step] name=${name} elapsed_ms=${elapsed_ms} status=fail"
+  fi
+  return "${status}"
+}
+
+run_core_guardrails() {
+  echo "Running HIR maintainability guardrails"
+  python3 "${SCRIPT_DIR}/check_hir_maintainability_guardrails.py"
+
+  echo "Running file-size guardrails"
+  python3 "${SCRIPT_DIR}/check_file_size_guardrails.py"
+
+  echo "Running source crate dependency-direction guardrail"
+  python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py"
+
+  echo "Running TypeScript-Go architecture transfer M1 guardrails"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py" --self-test
+
+  echo "Running sifr_driver maintainability guardrails"
+  python3 "${SCRIPT_DIR}/check_sifr_driver_maintainability_guardrails.py"
+
+  echo "Running package-manager guardrails"
+  python3 "${SCRIPT_DIR}/check_package_manager_guardrails.py"
+}
+
+run_diagnostic_contracts() {
+  echo "Running diagnostic schema sync check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_schema_sync.py"
+
+  echo "Running diagnostic docs sync check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_docs_sync.py"
+
+  echo "Running diagnostic code coverage check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_code_coverage.py"
+
+  echo "Running diagnostic baseline hygiene check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_baseline_hygiene.py"
+
+  echo "Running diagnostic cancel usage check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_cancel_usage.py"
+
+  echo "Running diagnostic transport cleanup check"
+  python3 "${SCRIPT_DIR}/check_diagnostic_transport_cleanup.py"
+
+  echo "Running diagnostic presentation contract check"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_presentation_contract.py"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_presentation_contract.py" --self-test
+
+  echo "Running diagnostic source canonicalization contract check"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_source_canonicalization_contract.py"
+  python3 "${SCRIPT_DIR}/../verification/tooling/check_diagnostic_source_canonicalization_contract.py" --self-test
+}
+
+run_frontend_syntax_guardrails() {
+  echo "Running Phase 35 frontend and syntax guardrails"
+  python3 "${SCRIPT_DIR}/../verification/performance/check_ruff_fork_update_contract.py"
+  python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.py"
+  python3 "${SCRIPT_DIR}/../verification/performance/check_split_brain_guardrail.py" --self-test
+  python3 "${SCRIPT_DIR}/../verification/performance/check_frontend_cache_contract.py"
+}
+
+tooling_enabled() {
+  local suite="$1"
+  [[ ",${TOOLING_SUITES}," == *",full,"* || ",${TOOLING_SUITES}," == *",${suite},"* ]]
+}
+
+run_developer_tooling_checks() {
+  echo "Running Developer Tooling Checks"
+  echo "  suites=${TOOLING_SUITES:-none}"
+  if tooling_enabled static; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_contract_lock.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_contract_lock.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_dependency_boundaries.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_tooling_dependency_boundaries.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_lsp_split_brain.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_lsp_split_brain.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_linter_diagnostic_class.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_linter_diagnostic_class.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_rule_suppression_contract.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_rule_suppression_contract.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_completion_quality.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_completion_quality.py" --self-test
+  fi
+  if tooling_enabled formatter; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_contract.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_contract.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_phase_manifests.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_phase_manifests.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_ast_coverage.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_formatter_ast_coverage.py" --self-test
+  fi
+  if tooling_enabled analysis; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_contract.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_contract.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_coherence.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_snapshot_coherence.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_split_brain.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_analysis_split_brain.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/run_tooling_parity.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/run_tooling_parity.py" --self-test
+  fi
+  if tooling_enabled lsp-smoke; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_smoke.py" --self-test
+  fi
+  if tooling_enabled editor-release; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension_contract.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension_contract.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_vscode_extension.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_editor_assets.py" --self-test
+  fi
+  if tooling_enabled lsp-stress; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_protocol_stress.py" --self-test
+    git submodule update --init verification/sifr-large-lsp-verification
+    python3 "${SCRIPT_DIR}/../verification/sifr-large-lsp-verification/tools/generate_corpus.py" check
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --self-test
+    python3 "${SCRIPT_DIR}/../verification/tooling/lsp_large_session.py" --mode smoke --require-submodule
+  fi
+  if tooling_enabled phase-closeout; then
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_phase36_closeout.py"
+    python3 "${SCRIPT_DIR}/../verification/tooling/check_phase36_closeout.py" --self-test
+  fi
+}
+
+run_performance_budget_checks() {
+  echo "Running Performance Budget Checks"
+  echo "  mode=${PERFORMANCE_BUDGET_MODE}"
+  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --validate-only
+  python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" --self-test
+  python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py"
+  python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" --self-test
+  run_performance_budget_subset() {
+    local perf_results="$1"
+    python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
+      --case check-single-file-001-arithmetic \
+      --case check-project-004-project-graph \
+      --case build-single-file-001-break-continue \
+      --case build-project-001-additional-modules \
+      --case formatter-corpus-001-project-check \
+      --case formatter-large-file-001-check \
+      --case incremental-local-loop-001-unchanged-file-update \
+      --case interactive-tooling-foundation-002-warm-diagnostics-query \
+      --case lsp-query-003-diagnostics \
+      --case phase27-non-regression-002-json-diagnostic-schema \
+      --json-out "${perf_results}"
+    python3 "${SCRIPT_DIR}/../verification/performance/check_budgets.py" \
+      --results "${perf_results}" \
+      --allow-subset
+  }
+  if [[ "${PERFORMANCE_BUDGET_MODE}" == "smoke" ]]; then
+    python3 "${SCRIPT_DIR}/../verification/performance/run_benchmarks.py" \
+      --sample-scale smoke \
+      --case formatter-corpus-001-project-check \
+      --case formatter-large-file-001-check \
+      --case incremental-local-loop-001-unchanged-file-update \
+      --case interactive-tooling-foundation-002-warm-diagnostics-query \
+      --case lsp-query-003-diagnostics
+  elif [[ "${PERFORMANCE_BUDGET_MODE}" == "representative" || "${PERFORMANCE_BUDGET_MODE}" == "full" ]]; then
+    PERF_RESULTS="target/performance/${PROFILE}.budget.latest.json"
+    run_performance_budget_subset "${PERF_RESULTS}"
+  else
+    echo "Skipping performance benchmark execution for lane ${PROFILE}"
+  fi
+}
+
+run_verification_hardening_self_tests() {
+  echo "Running verification hardening script self-tests"
+  python3 "${SCRIPT_DIR}/run_verification_hardening.py" --self-test
+}
+
+run_distribution_checks() {
+  if [[ "${DISTRIBUTION_MODE}" == "none" ]]; then
+    echo "Skipping distribution validation for lane ${PROFILE}"
+    return 0
+  fi
+  echo "Running distribution validation"
+  echo "  mode=${DISTRIBUTION_MODE}"
+  bash "${SCRIPT_DIR}/run_distribution_validation.sh"
+}
+
+run_generated_code_quality_checks() {
+  if [[ "${GENERATED_CODE_QUALITY_MODE}" == "none" ]]; then
+    echo "Skipping Generated Code Quality Checks for lane ${PROFILE}"
+    return 0
+  fi
+  echo "Running Generated Code Quality Checks"
+  echo "  mode=${GENERATED_CODE_QUALITY_MODE}"
+  local shared_root="target/sifr_generated_code_quality/${PROFILE}.shared"
+  rm -rf "${shared_root}"
+  export SIFR_GCQ_SHARED_ROOT="${shared_root}"
+  case "${GENERATED_CODE_QUALITY_MODE}" in
+    smoke)
+      SIFR_GCQ_MAX_ENTRIES=2 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_corpus.sh"
+      SIFR_GCQ_MAX_ENTRIES=2 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_panic_scan.sh"
+      SIFR_GCQ_MAX_ENTRIES=2 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_rustfmt.sh"
+      SIFR_GCQ_MAX_ENTRIES=2 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_determinism.sh"
+      ;;
+    representative)
+      SIFR_GCQ_MAX_ENTRIES=12 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_corpus.sh"
+      SIFR_GCQ_MAX_ENTRIES=12 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_panic_scan.sh"
+      SIFR_GCQ_MAX_ENTRIES=12 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_rustfmt.sh"
+      SIFR_GCQ_MAX_ENTRIES=12 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_clippy.sh"
+      SIFR_GCQ_MAX_ENTRIES=12 \
+        bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_determinism.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_demos.sh"
+      ;;
+    full)
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_corpus.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_panic_scan.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_rustfmt.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_clippy.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_determinism.sh"
+      bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_demos.sh"
+      ;;
+    *)
+      echo "unsupported generated-code quality mode: ${GENERATED_CODE_QUALITY_MODE}" >&2
+      return 2
+      ;;
+  esac
+}
+
+run_crate_tests() {
+  echo "Running crate tests"
+  echo "  mode=${CRATE_TEST_MODE}"
+
+  echo "Running sifr_diagnostics tests"
+  cargo test -p sifr_diagnostics
+
+  echo "Running sifr_hir tests"
+  cargo test -p sifr_hir -- --skip test_e2e_pass
+
+  echo "Running sifr_syntax tests"
+  cargo test -p sifr_syntax
+
+  echo "Running sifr_frontend tests"
+  cargo test -p sifr_frontend
+
+  echo "Running sifr_analysis tests"
+  cargo test -p sifr_analysis
+
+  echo "Running sifr_lsp tests"
+  cargo test -p sifr_lsp
+
+  echo "Running sifr_package tests"
+  cargo test -p sifr_package
+
+  if [[ "${CRATE_TEST_MODE}" == "smoke" ]]; then
+    echo "Running sifr CLI unit tests"
+    cargo test -p sifr --bin sifr
+  elif [[ "${CRATE_TEST_MODE}" == "full" ]]; then
+    echo "Running unit tests and non-pass e2e tests (cargo test -p sifr -- --skip test_e2e_pass)"
+    cargo test -p sifr -- --skip test_e2e_pass
+  else
+    echo "unsupported crate test mode: ${CRATE_TEST_MODE}" >&2
+    return 2
+  fi
+
+  echo "Running sifr_driver library tests"
+  cargo test -p sifr_driver --lib
+}
+
+run_validation_contract_suites() {
+  if [[ -n "${CONTRACT_SUITES}" ]]; then
+    echo "Running validation contract matrix suites"
+    CONTRACT_ARGS=()
+    IFS=',' read -r -a CONTRACT_SUITE_ARRAY <<< "${CONTRACT_SUITES}"
+    for suite in "${CONTRACT_SUITE_ARRAY[@]}"; do
+      if [[ -n "${suite}" ]]; then
+        CONTRACT_ARGS+=(--suite "${suite}")
       fi
     done
-    if [[ "${PERFORMANCE_PASSED}" != "1" ]]; then
-      echo "performance budget subset failed after 5 attempts with unchanged thresholds" >&2
-      exit 1
-    fi
+    bash "${SCRIPT_DIR}/run_validation_contract_matrix.sh" "${CONTRACT_ARGS[@]}"
   fi
+}
+
+run_e2e_pass_suite() {
+  echo "Running e2e pass suite"
+  E2E_ARGS=(
+    --profile "${E2E_PROFILE}"
+    --sifr-jobs "${E2E_SIFR_JOBS}"
+    --rust-jobs "${E2E_RUST_JOBS}"
+    --run-jobs "${E2E_RUN_JOBS}"
+    --cargo-build-jobs "${E2E_CARGO_BUILD_JOBS}"
+  )
+  if [[ -n "${E2E_MAX_GROUP_FIXTURES}" ]]; then
+    E2E_ARGS+=(--max-group-fixtures "${E2E_MAX_GROUP_FIXTURES}")
+  fi
+  if [[ -n "${E2E_FIXTURE_MANIFEST}" ]]; then
+    E2E_ARGS+=(--fixture-manifest "${E2E_FIXTURE_MANIFEST}")
+  fi
+  if [[ "${E2E_DISABLE_CACHE}" == "1" ]]; then
+    E2E_ARGS+=(--no-cache)
+  fi
+  bash "${SCRIPT_DIR}/run_e2e_pass.sh" "${E2E_ARGS[@]}" ${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}
+}
+
+run_hardening_suites() {
+  if [[ "${RUN_HARDENING}" == "1" ]]; then
+    echo "Running phase 29 verification hardening suites"
+    HARDENING_ARGS=(--profile "${PROFILE}")
+    IFS=',' read -r -a HARDENING_SUITE_ARRAY <<< "${HARDENING_SUITES}"
+    for suite in "${HARDENING_SUITE_ARRAY[@]}"; do
+      if [[ -n "${suite}" ]]; then
+        HARDENING_ARGS+=(--suite "${suite}")
+      fi
+    done
+    python3 "${SCRIPT_DIR}/run_verification_hardening.py" "${HARDENING_ARGS[@]}"
+  fi
+}
+
+run_extra_e2e_checks() {
+  if [[ "${RUN_E2E_REPORT_DETERMINISM}" == "1" ]]; then
+    echo "Running e2e report determinism check"
+    bash "${SCRIPT_DIR}/check_e2e_report_determinism.sh" --profile "${PROFILE}"
+  fi
+
+  if [[ "${RUN_E2E_SEQUENTIAL_PARALLEL_EQUIVALENCE}" == "1" ]]; then
+    echo "Running e2e sequential-vs-parallel equivalence check"
+    bash "${SCRIPT_DIR}/check_e2e_sequential_parallel_equivalence.sh" --profile "${PROFILE}"
+  fi
+}
+
+timed_step core_guardrails run_core_guardrails
+timed_step diagnostic_contracts run_diagnostic_contracts
+timed_step frontend_syntax_guardrails run_frontend_syntax_guardrails
+timed_step developer_tooling_checks run_developer_tooling_checks
+timed_step performance_budget_checks run_performance_budget_checks
+timed_step verification_hardening_self_tests run_verification_hardening_self_tests
+timed_step distribution_validation run_distribution_checks
+
+if [[ "${GENERATED_CODE_QUALITY_MODE}" != "none" ]]; then
+  timed_step generated_code_quality_checks run_generated_code_quality_checks
 fi
 
-echo "Running verification hardening script self-tests"
-python3 "${SCRIPT_DIR}/run_verification_hardening.py" --self-test
+timed_step crate_tests run_crate_tests
 
-echo "Running distribution validation"
-bash "${SCRIPT_DIR}/run_distribution_validation.sh"
+timed_step validation_contract_matrix run_validation_contract_suites
 
-if [[ "${PROFILE}" == "pr" || "${PROFILE}" == "nightly" || "${PROFILE}" == "release" ]]; then
-  echo "Running Generated Code Quality Checks"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_corpus.sh"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_panic_scan.sh"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_rustfmt.sh"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_clippy.sh"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_determinism.sh"
-  bash "${SCRIPT_DIR}/../verification/generated_code_quality/generated_code_quality_demos.sh"
-fi
+timed_step e2e_pass_suite run_e2e_pass_suite
 
-echo "Running sifr_diagnostics tests"
-cargo test -p sifr_diagnostics
-
-echo "Running sifr_hir tests"
-cargo test -p sifr_hir -- --skip test_e2e_pass
-
-echo "Running sifr_syntax tests"
-cargo test -p sifr_syntax
-
-echo "Running sifr_frontend tests"
-cargo test -p sifr_frontend
-
-echo "Running sifr_analysis tests"
-cargo test -p sifr_analysis
-
-echo "Running sifr_lsp tests"
-cargo test -p sifr_lsp
-
-echo "Running sifr_package tests"
-cargo test -p sifr_package
-
-echo "Running unit tests and non-pass e2e tests (cargo test -p sifr -- --skip test_e2e_pass)"
-cargo test -p sifr -- --skip test_e2e_pass
-
-echo "Running sifr_driver library tests"
-cargo test -p sifr_driver --lib
-
-if [[ -n "${CONTRACT_SUITES}" ]]; then
-  echo "Running validation contract matrix suites"
-  CONTRACT_ARGS=()
-  IFS=',' read -r -a CONTRACT_SUITE_ARRAY <<< "${CONTRACT_SUITES}"
-  for suite in "${CONTRACT_SUITE_ARRAY[@]}"; do
-    if [[ -n "${suite}" ]]; then
-      CONTRACT_ARGS+=(--suite "${suite}")
-    fi
-  done
-  bash "${SCRIPT_DIR}/run_validation_contract_matrix.sh" "${CONTRACT_ARGS[@]}"
-fi
-
-echo "Running e2e pass suite"
-E2E_ARGS=(
-  --profile "${E2E_PROFILE}"
-  --sifr-jobs "${E2E_SIFR_JOBS}"
-  --rust-jobs "${E2E_RUST_JOBS}"
-  --run-jobs "${E2E_RUN_JOBS}"
-  --cargo-build-jobs "${E2E_CARGO_BUILD_JOBS}"
-)
-if [[ -n "${E2E_FIXTURE_MANIFEST}" ]]; then
-  E2E_ARGS+=(--fixture-manifest "${E2E_FIXTURE_MANIFEST}")
-fi
-if [[ "${E2E_DISABLE_CACHE}" == "1" ]]; then
-  E2E_ARGS+=(--no-cache)
-fi
-bash "${SCRIPT_DIR}/run_e2e_pass.sh" "${E2E_ARGS[@]}" ${FORWARD_ARGS[@]+"${FORWARD_ARGS[@]}"}
-
-if [[ "${RUN_HARDENING}" == "1" ]]; then
-  echo "Running phase 29 verification hardening suites"
-  HARDENING_ARGS=(--profile "${PROFILE}")
-  IFS=',' read -r -a HARDENING_SUITE_ARRAY <<< "${HARDENING_SUITES}"
-  for suite in "${HARDENING_SUITE_ARRAY[@]}"; do
-    if [[ -n "${suite}" ]]; then
-      HARDENING_ARGS+=(--suite "${suite}")
-    fi
-  done
-  python3 "${SCRIPT_DIR}/run_verification_hardening.py" "${HARDENING_ARGS[@]}"
-fi
-
-if [[ "${RUN_E2E_REPORT_DETERMINISM}" == "1" ]]; then
-  echo "Running e2e report determinism check"
-  bash "${SCRIPT_DIR}/check_e2e_report_determinism.sh" --profile "${PROFILE}"
-fi
-
-if [[ "${RUN_E2E_SEQUENTIAL_PARALLEL_EQUIVALENCE}" == "1" ]]; then
-  echo "Running e2e sequential-vs-parallel equivalence check"
-  bash "${SCRIPT_DIR}/check_e2e_sequential_parallel_equivalence.sh" --profile "${PROFILE}"
-fi
+timed_step verification_hardening_suites run_hardening_suites
+timed_step extra_e2e_checks run_extra_e2e_checks

--- a/scripts/run_distribution_validation.sh
+++ b/scripts/run_distribution_validation.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 
+now_ms() {
+  python3 -c 'import time; print(time.monotonic_ns() // 1_000_000)'
+}
+
 for script in "${REPO_ROOT}"/verification/distribution/*.sh; do
   case "${script}" in
     */common.sh)
@@ -12,5 +16,19 @@ for script in "${REPO_ROOT}"/verification/distribution/*.sh; do
       ;;
   esac
   echo "Running ${script#${REPO_ROOT}/}"
+  start_ms="$(now_ms)"
+  set +e
   "${script}"
+  status=$?
+  set -e
+  end_ms="$(now_ms)"
+  elapsed_ms=$((end_ms - start_ms))
+  case_name="${script#${REPO_ROOT}/verification/distribution/}"
+  case_name="${case_name%.sh}"
+  if [[ "${status}" -eq 0 ]]; then
+    echo "[sifr-case-timing] bucket=distribution case=${case_name} elapsed_ms=${elapsed_ms} status=pass"
+  else
+    echo "[sifr-case-timing] bucket=distribution case=${case_name} elapsed_ms=${elapsed_ms} status=fail"
+    exit "${status}"
+  fi
 done

--- a/scripts/run_e2e_pass.sh
+++ b/scripts/run_e2e_pass.sh
@@ -7,6 +7,7 @@ SIFR_JOBS_OVERRIDE=""
 RUST_JOBS_OVERRIDE=""
 RUN_JOBS_OVERRIDE=""
 CARGO_BUILD_JOBS_OVERRIDE=""
+MAX_GROUP_FIXTURES_OVERRIDE=""
 DISABLE_CACHE_OVERRIDE=""
 CACHE_DIR_OVERRIDE=""
 FIXTURE_MANIFEST_OVERRIDE=""
@@ -17,21 +18,24 @@ usage() {
 Usage: scripts/run_e2e_pass.sh [options]
 
 Profiles:
-  quick   Fast local signal; bounded parallel workers; cache enabled.
-  pr      Authoritative merge gate; representative corpus; cache enabled.
+  create-pr Fast local signal; bounded parallel workers; cache enabled.
+  merge     Authoritative merge gate; representative corpus; cache enabled.
   nightly Broad pass-corpus lane; cache enabled.
   release Highest-confidence local gate; cache enabled.
 
 Legacy aliases:
-  full    Alias for `pr`
+  quick   Alias for `create-pr`
+  pr      Alias for `merge`
+  full    Alias for `merge`
   stress  Alias for `release`
 
 Options:
-  --profile <quick|pr|nightly|release|full|stress> Local execution profile (default: pr)
+  --profile <create-pr|merge|nightly|release|quick|pr|full|stress> Local execution profile (default: pr)
   --sifr-jobs <n>              Parallel Sifr compile workers
   --rust-jobs <n>              Parallel group build workers
   --run-jobs <n>               Parallel group run workers
   --cargo-build-jobs <n>       Cargo jobs per generated group build
+  --max-group-fixtures <n>     Maximum fixtures per generated Rust batch group
   --cache-dir <path>           e2e cache directory (default: target/sifr_e2e_cache/<profile>)
   --fixture-manifest <path>    JSON manifest listing the selected e2e pass fixtures
   --no-cache                   Disable the e2e cache for this run
@@ -46,7 +50,7 @@ canonicalize_profile() {
 set_profile_defaults() {
   local profile="$1"
   case "${profile}" in
-    quick)
+    create-pr)
       SIFR_JOBS="2"
       RUST_JOBS="2"
       RUN_JOBS="2"
@@ -54,7 +58,7 @@ set_profile_defaults() {
       DISABLE_CACHE="0"
       FIXTURE_MANIFEST_DEFAULT="verification/validation_lanes/quick_e2e_manifest.json"
       ;;
-    pr)
+    merge)
       SIFR_JOBS="4"
       RUST_JOBS="3"
       RUN_JOBS="3"
@@ -100,6 +104,10 @@ while [[ $# -gt 0 ]]; do
       CARGO_BUILD_JOBS_OVERRIDE="${2:-}"
       shift 2
       ;;
+    --max-group-fixtures)
+      MAX_GROUP_FIXTURES_OVERRIDE="${2:-}"
+      shift 2
+      ;;
     --cache-dir)
       CACHE_DIR_OVERRIDE="${2:-}"
       shift 2
@@ -132,6 +140,7 @@ SIFR_JOBS="${SIFR_E2E_SIFR_JOBS:-${SIFR_JOBS}}"
 RUST_JOBS="${SIFR_E2E_RUST_JOBS:-${RUST_JOBS}}"
 RUN_JOBS="${SIFR_E2E_RUN_JOBS:-${RUN_JOBS}}"
 CARGO_BUILD_JOBS="${SIFR_E2E_CARGO_BUILD_JOBS:-${CARGO_BUILD_JOBS}}"
+MAX_GROUP_FIXTURES="${SIFR_E2E_MAX_GROUP_FIXTURES:-}"
 DISABLE_CACHE="${SIFR_E2E_DISABLE_CACHE:-${DISABLE_CACHE}}"
 CACHE_DIR="${SIFR_E2E_CACHE_DIR:-target/sifr_e2e_cache/${PROFILE}}"
 FIXTURE_MANIFEST="${SIFR_E2E_FIXTURE_MANIFEST:-${FIXTURE_MANIFEST_DEFAULT}}"
@@ -147,6 +156,9 @@ if [[ -n "${RUN_JOBS_OVERRIDE}" ]]; then
 fi
 if [[ -n "${CARGO_BUILD_JOBS_OVERRIDE}" ]]; then
   CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS_OVERRIDE}"
+fi
+if [[ -n "${MAX_GROUP_FIXTURES_OVERRIDE}" ]]; then
+  MAX_GROUP_FIXTURES="${MAX_GROUP_FIXTURES_OVERRIDE}"
 fi
 if [[ -n "${DISABLE_CACHE_OVERRIDE}" ]]; then
   DISABLE_CACHE="${DISABLE_CACHE_OVERRIDE}"
@@ -170,6 +182,9 @@ echo "  sifr_jobs=${SIFR_JOBS}"
 echo "  rust_jobs=${RUST_JOBS}"
 echo "  run_jobs=${RUN_JOBS}"
 echo "  cargo_build_jobs=${CARGO_BUILD_JOBS}"
+if [[ -n "${MAX_GROUP_FIXTURES}" ]]; then
+  echo "  max_group_fixtures=${MAX_GROUP_FIXTURES}"
+fi
 echo "  disable_cache=${DISABLE_CACHE}"
 echo "  cache_dir=${CACHE_DIR}"
 if [[ -n "${FIXTURE_MANIFEST}" ]]; then
@@ -181,6 +196,7 @@ SIFR_E2E_SIFR_JOBS="${SIFR_JOBS}" \
 SIFR_E2E_RUST_JOBS="${RUST_JOBS}" \
 SIFR_E2E_RUN_JOBS="${RUN_JOBS}" \
 SIFR_E2E_CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS}" \
+SIFR_E2E_MAX_GROUP_FIXTURES="${MAX_GROUP_FIXTURES}" \
 SIFR_E2E_DISABLE_CACHE="${DISABLE_CACHE}" \
 SIFR_E2E_CACHE_DIR="${CACHE_DIR}" \
 SIFR_E2E_FIXTURE_MANIFEST="${FIXTURE_MANIFEST}" \

--- a/scripts/run_verification_hardening/core.py
+++ b/scripts/run_verification_hardening/core.py
@@ -37,7 +37,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--profile",
-        choices=("pr", "nightly", "release", "full", "stress"),
+        choices=("create-pr", "merge", "quick", "pr", "nightly", "release", "full", "stress"),
         default="pr",
         help="Execution profile.",
     )
@@ -89,8 +89,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def canonicalize_profile(profile: str) -> str:
-    if profile == "full":
-        return "pr"
+    if profile == "quick":
+        return "create-pr"
+    if profile == "pr" or profile == "full":
+        return "merge"
     if profile == "stress":
         return "release"
     return profile
@@ -142,7 +144,9 @@ def load_text(path: Path) -> str:
 
 def should_run_suite(profile: str, suite_name: str) -> bool:
     canonical_profile = canonicalize_profile(profile)
-    if canonical_profile == "pr":
+    if canonical_profile == "create-pr":
+        return False
+    if canonical_profile == "merge":
         return suite_name in {
             "diagnostics",
             "project",
@@ -350,5 +354,3 @@ def assert_self_test_failure(description: str, expected: str, callback: Any) -> 
             ) from error
         return
     raise AssertionError(f"{description}: expected SystemExit")
-
-

--- a/scripts/run_verification_hardening/main_flow.py
+++ b/scripts/run_verification_hardening/main_flow.py
@@ -19,6 +19,28 @@ from .property_and_fuzz import run_fuzz_smoke_suite, run_property_suite
 from .self_tests_and_baselines import run_baseline_suite, run_self_tests
 
 
+def timing_token(value: object) -> str:
+    return "".join(char if char.isalnum() or char in "_.:/+-" else "_" for char in str(value))
+
+
+def emit_case_timings(suite_name: str, suite_result: dict[str, Any]) -> None:
+    for case in suite_result.get("cases", []):
+        if not isinstance(case, dict):
+            continue
+        case_id = timing_token(case.get("id", "unknown"))
+        for variant in case.get("variants", []):
+            if not isinstance(variant, dict) or "duration_ms" not in variant:
+                continue
+            label = timing_token(variant.get("label", "variant"))
+            status = "pass" if variant.get("status") == "pass" else "fail"
+            elapsed_ms = int(float(variant["duration_ms"]))
+            print(
+                f"[sifr-case-timing] bucket=verification_hardening "
+                f"case={timing_token(suite_name)}/{case_id}/{label} "
+                f"elapsed_ms={elapsed_ms} status={status}"
+            )
+
+
 def main() -> int:
     args = parse_args()
     args.profile = canonicalize_profile(args.profile)
@@ -145,6 +167,7 @@ def main() -> int:
     for suite in selected_suites:
         suite_result = execute_suite_once(suite)
         suite_name = str(suite.get("name"))
+        emit_case_timings(suite_name, suite_result)
         suite_quarantine = [entry for entry in quarantine_entries if entry.get("suite") == suite_name]
         if suite_quarantine:
             suite_result["quarantine_entries"] = suite_quarantine

--- a/scripts/validation_lane.py
+++ b/scripts/validation_lane.py
@@ -99,6 +99,9 @@ def emit_shell(profile: str, lane: dict[str, Any], manifest_path: Path) -> None:
     hardening_suites = lane.get("hardening_suites", [])
     if not isinstance(hardening_suites, list):
         raise SystemExit("invalid lane manifest: 'hardening_suites' must be a list")
+    tooling_suites = lane.get("tooling_suites", [])
+    if not isinstance(tooling_suites, list):
+        raise SystemExit("invalid lane manifest: 'tooling_suites' must be a list")
     extra_checks = lane.get("extra_checks", [])
     if not isinstance(extra_checks, list):
         raise SystemExit("invalid lane manifest: 'extra_checks' must be a list")
@@ -124,6 +127,11 @@ def emit_shell(profile: str, lane: dict[str, Any], manifest_path: Path) -> None:
         "RUN_PHASE23_GRAPH_ISOLATION": "1" if "phase23_graph_isolation" in matrix_suites else "0",
         "RUN_PHASE24_HIR_ANALYSIS": "1" if "phase24_hir_analysis" in matrix_suites else "0",
         "RUN_PHASE25_CFG_FLOW": "1" if "phase25_cfg_flow" in matrix_suites else "0",
+        "TOOLING_SUITES": ",".join(tooling_suites),
+        "DISTRIBUTION_MODE": lane.get("distribution", "none"),
+        "GENERATED_CODE_QUALITY_MODE": lane.get("generated_code_quality", "none"),
+        "PERFORMANCE_BUDGET_MODE": lane.get("performance_budget", "none"),
+        "CRATE_TEST_MODE": lane.get("crate_tests", "full"),
         "RUN_HARDENING": "1" if hardening_suites else "0",
         "HARDENING_SUITES": ",".join(hardening_suites),
         "RUN_E2E_REPORT_DETERMINISM": "1" if "e2e_report_determinism" in extra_checks else "0",
@@ -136,6 +144,7 @@ def emit_shell(profile: str, lane: dict[str, Any], manifest_path: Path) -> None:
         "E2E_RUST_JOBS": e2e.get("rust_jobs", 1),
         "E2E_RUN_JOBS": e2e.get("run_jobs", 1),
         "E2E_CARGO_BUILD_JOBS": e2e.get("cargo_build_jobs", 1),
+        "E2E_MAX_GROUP_FIXTURES": e2e.get("max_group_fixtures", ""),
         "E2E_DISABLE_CACHE": "1" if e2e.get("disable_cache", False) else "0",
         "LANE_MANIFEST_DIR": str(lane_dir),
     }
@@ -155,6 +164,7 @@ def emit_summary(requested_profile: str, canonical_profile: str, lane: dict[str,
 
     matrix_suites = lane.get("matrix_suites", [])
     hardening_suites = lane.get("hardening_suites", [])
+    tooling_suites = lane.get("tooling_suites", [])
     extra_checks = lane.get("extra_checks", [])
 
     print("Validation lane summary")
@@ -185,6 +195,11 @@ def emit_summary(requested_profile: str, canonical_profile: str, lane: dict[str,
         "  hardening_suites="
         + (", ".join(hardening_suites) if hardening_suites else "none")
     )
+    print("  tooling_suites=" + (", ".join(tooling_suites) if tooling_suites else "none"))
+    print(f"  distribution={lane.get('distribution', 'none')}")
+    print(f"  generated_code_quality={lane.get('generated_code_quality', 'none')}")
+    print(f"  performance_budget={lane.get('performance_budget', 'none')}")
+    print(f"  crate_tests={lane.get('crate_tests', 'full')}")
     print("  extra_checks=" + (", ".join(extra_checks) if extra_checks else "none"))
     print(f"  manifest={manifest_path.relative_to(REPO_ROOT)}")
 

--- a/scripts/validation_lane_report.py
+++ b/scripts/validation_lane_report.py
@@ -34,6 +34,13 @@ HARDENING_OK_RE = re.compile(
     r"^verification ok:\s+variants=(\d+),\s+failures=(\d+),\s+blocking_failures=(\d+),\s+non_blocking_failures=(\d+)$"
 )
 CACHE_DIR_RE = re.compile(r"^\s*cache_dir=(.+)$")
+LANE_STEP_RE = re.compile(
+    r"^\[sifr-lane-step\]\s+name=([A-Za-z0-9_-]+)\s+elapsed_ms=(\d+)\s+status=(pass|fail)$"
+)
+CASE_TIMING_RE = re.compile(
+    r"^\[sifr-case-timing\]\s+bucket=([A-Za-z0-9_-]+)\s+case=([A-Za-z0-9_.:/+-]+)"
+    r"\s+elapsed_ms=(\d+)\s+status=(pass|fail)$"
+)
 WARM_CACHE_HIT_TARGET = 0.90
 GROUP_SKEW_ADVISORY_RATIO = 4.0
 GROUP_SKEW_ABSOLUTE_DELTA = 8
@@ -148,7 +155,7 @@ def build_advisories(
         advisories.append("swap activity observed; lower worker counts or rebalance groups")
 
     max_rss_bytes = int(time_metrics.get("max_rss_bytes", 0))
-    if profile in {"quick", "pr"} and max_rss_bytes > DEFAULT_LANE_RSS_ADVISORY_BYTES:
+    if profile in {"create-pr", "merge"} and max_rss_bytes > DEFAULT_LANE_RSS_ADVISORY_BYTES:
         advisories.append("peak RSS exceeded low-single-digit GiB guidance for the default lane")
 
     if isinstance(e2e_metrics, dict):
@@ -184,6 +191,8 @@ def directory_stats(path: Path) -> dict[str, int | str]:
 
 def parse_log(path: Path) -> dict[str, Any]:
     contract_suites: list[dict[str, int | str]] = []
+    lane_steps: list[dict[str, int | str]] = []
+    case_timings: list[dict[str, int | str]] = []
     artifact_cache: dict[str, dict[str, int]] = {}
     hardening_summary: dict[str, int] | None = None
     e2e_metrics: dict[str, int] | None = None
@@ -192,6 +201,25 @@ def parse_log(path: Path) -> dict[str, Any]:
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line:
+            continue
+        if match := LANE_STEP_RE.match(line):
+            lane_steps.append(
+                {
+                    "name": match.group(1),
+                    "elapsed_ms": int(match.group(2)),
+                    "status": match.group(3),
+                }
+            )
+            continue
+        if match := CASE_TIMING_RE.match(line):
+            case_timings.append(
+                {
+                    "bucket": match.group(1),
+                    "case": match.group(2),
+                    "elapsed_ms": int(match.group(3)),
+                    "status": match.group(4),
+                }
+            )
             continue
         if match := CONTRACT_SUITE_RE.match(line):
             contract_suites.append(
@@ -252,6 +280,8 @@ def parse_log(path: Path) -> dict[str, Any]:
             cache_dir = match.group(1).strip()
 
     return {
+        "lane_steps": lane_steps,
+        "case_timings": case_timings,
         "contract_suites": contract_suites,
         "artifact_cache": artifact_cache,
         "hardening_summary": hardening_summary,
@@ -326,6 +356,8 @@ def summarize(args: argparse.Namespace) -> int:
             "group_skew_ratio": group_skew_ratio,
         },
         "advisories": advisories,
+        "lane_steps": parsed_log["lane_steps"],
+        "case_timings": parsed_log["case_timings"],
         "contract_suites": parsed_log["contract_suites"],
         "artifact_cache": parsed_log["artifact_cache"],
         "hardening_summary": parsed_log["hardening_summary"],
@@ -385,6 +417,27 @@ def summarize(args: argparse.Namespace) -> int:
         f"run={workers['run_jobs']} "
         f"cargo_build={workers['cargo_build_jobs']}"
     )
+    lane_steps = parsed_log["lane_steps"]
+    if lane_steps:
+        slowest_step = max(lane_steps, key=lambda step: int(step["elapsed_ms"]))
+        print(
+            "  slowest_step="
+            f"{slowest_step['name']} {int(slowest_step['elapsed_ms'])}ms "
+            f"status={slowest_step['status']}"
+        )
+    case_timings = parsed_log["case_timings"]
+    if case_timings:
+        by_bucket: dict[str, dict[str, int | str]] = {}
+        for timing in case_timings:
+            bucket = str(timing["bucket"])
+            current = by_bucket.get(bucket)
+            if current is None or int(timing["elapsed_ms"]) > int(current["elapsed_ms"]):
+                by_bucket[bucket] = timing
+        slowest_cases = [
+            f"{bucket}:{timing['case']}={int(timing['elapsed_ms'])}ms"
+            for bucket, timing in sorted(by_bucket.items())
+        ]
+        print("  slowest_cases=" + " ".join(slowest_cases))
     if parsed_log["artifact_cache"]:
         summaries = []
         for namespace, stats in sorted(parsed_log["artifact_cache"].items()):

--- a/verification/generated_code_quality/generated_code_quality.py
+++ b/verification/generated_code_quality/generated_code_quality.py
@@ -317,16 +317,42 @@ def command_env() -> dict[str, str]:
     return os.environ.copy()
 
 
+def shared_artifact_root() -> Path | None:
+    raw = os.environ.get("SIFR_GCQ_SHARED_ROOT")
+    if not raw:
+        return None
+    return (REPO_ROOT / raw).resolve() if not Path(raw).is_absolute() else Path(raw)
+
+
+def entry_cache_key(entry: Entry) -> str:
+    digest = hashlib.sha256()
+    digest.update(entry.id.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(entry.source_path.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(entry.absolute_source.read_bytes())
+    return digest.hexdigest()[:16]
+
+
 def run_command(
     args: list[str],
     *,
     cwd: Path = REPO_ROOT,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    env = command_env()
+    shared_root = shared_artifact_root()
+    if (
+        shared_root is not None
+        and len(args) >= 2
+        and args[0] == "cargo"
+        and args[1] in {"check", "clippy"}
+    ):
+        env["CARGO_TARGET_DIR"] = str(shared_root / "cargo-target")
     result = subprocess.run(
         args,
         cwd=cwd,
-        env=command_env(),
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -342,23 +368,39 @@ def run_command(
 
 
 def materialize_entry(entry: Entry, run_root: Path) -> Path:
-    entry_root = run_root / entry.id
-    entry_root.mkdir(parents=True, exist_ok=True)
-    run_command(
-        [
-            "cargo",
-            "run",
-            "-q",
-            "-p",
-            "sifr",
-            "--",
-            "build",
-            entry.source_path,
-            "-o",
-            str(entry_root),
-        ]
+    shared_root = shared_artifact_root()
+    cache_key = entry_cache_key(entry)
+    entry_root = (
+        shared_root / "entries" / f"{entry.id}-{cache_key}"
+        if shared_root is not None
+        else run_root / entry.id
     )
+    entry_root.mkdir(parents=True, exist_ok=True)
     crate_root = entry_root / "sifr_output"
+    if (crate_root / "Cargo.toml").is_file():
+        print(
+            f"[sifr-artifact-cache] namespace=generated-code-quality key={cache_key} "
+            f"cache_hit=true workspace={crate_root}"
+        )
+    else:
+        print(
+            f"[sifr-artifact-cache] namespace=generated-code-quality key={cache_key} "
+            f"cache_hit=false workspace={crate_root} miss_reason=not_materialized"
+        )
+        run_command(
+            [
+                "cargo",
+                "run",
+                "-q",
+                "-p",
+                "sifr",
+                "--",
+                "build",
+                entry.source_path,
+                "-o",
+                str(entry_root),
+            ]
+        )
     cargo_toml = crate_root / "Cargo.toml"
     if not cargo_toml.is_file():
         raise RuntimeError(f"{entry.id}: generated crate missing Cargo.toml at {cargo_toml}")
@@ -467,14 +509,34 @@ def record_for_entry(entry: Entry, crate_root: Path | None, status: str) -> dict
     return record
 
 
+def timed_case(bucket: str, case_id: str, action: Any) -> Any:
+    started = time.perf_counter()
+    status = "pass"
+    try:
+        return action()
+    except Exception:
+        status = "fail"
+        raise
+    finally:
+        elapsed_ms = int((time.perf_counter() - started) * 1000.0)
+        print(
+            f"[sifr-case-timing] bucket={bucket} case={case_id} "
+            f"elapsed_ms={elapsed_ms} status={status}"
+        )
+
+
 def gate_corpus(entries: list[Entry], args: argparse.Namespace) -> None:
     run = run_id("corpus")
     run_root = TARGET_ROOT / run
     records = []
     try:
         for entry in selected_positive_entries(entries, args.group):
-            crate_root = materialize_entry(entry, run_root)
-            run_command(["cargo", "check", "--manifest-path", str(crate_root / "Cargo.toml")])
+            def check_entry() -> Path:
+                crate_root_inner = materialize_entry(entry, run_root)
+                run_command(["cargo", "check", "--manifest-path", str(crate_root_inner / "Cargo.toml")])
+                return crate_root_inner
+
+            crate_root = timed_case("generated_code_quality", f"corpus/{entry.id}", check_entry)
             records.append(record_for_entry(entry, crate_root, "passed"))
         evidence = record_evidence("corpus", run, records)
         print(f"generated-code corpus passed; evidence={evidence.relative_to(REPO_ROOT)}")
@@ -491,12 +553,20 @@ def gate_panic_scan(entries: list[Entry], args: argparse.Namespace) -> None:
     run_root = TARGET_ROOT / run
     records = []
     try:
-        assert_negative_scan(GCQ_ROOT / "negative_seeds" / "forbidden_unwrap.rs")
+        timed_case(
+            "generated_code_quality",
+            "panic-scan/negative-forbidden-unwrap",
+            lambda: assert_negative_scan(GCQ_ROOT / "negative_seeds" / "forbidden_unwrap.rs"),
+        )
         for entry in selected_positive_entries(entries, args.group):
-            crate_root = materialize_entry(entry, run_root)
-            violations = scan_files(rust_files(crate_root))
-            if violations:
-                raise RuntimeError("\n".join([f"{entry.id}: forbidden constructs found", *violations]))
+            def scan_entry() -> Path:
+                crate_root_inner = materialize_entry(entry, run_root)
+                violations = scan_files(rust_files(crate_root_inner))
+                if violations:
+                    raise RuntimeError("\n".join([f"{entry.id}: forbidden constructs found", *violations]))
+                return crate_root_inner
+
+            crate_root = timed_case("generated_code_quality", f"panic-scan/{entry.id}", scan_entry)
             records.append(record_for_entry(entry, crate_root, "passed"))
         evidence = record_evidence("panic-scan", run, records)
         print(f"generated-code panic scan passed; evidence={evidence.relative_to(REPO_ROOT)}")
@@ -513,11 +583,19 @@ def gate_rustfmt(entries: list[Entry], args: argparse.Namespace) -> None:
     run_root = TARGET_ROOT / run
     records = []
     try:
-        assert_negative_rustfmt(GCQ_ROOT / "negative_seeds" / "format_violation.rs", run_root)
+        timed_case(
+            "generated_code_quality",
+            "rustfmt/negative-format-violation",
+            lambda: assert_negative_rustfmt(GCQ_ROOT / "negative_seeds" / "format_violation.rs", run_root),
+        )
         for entry in selected_positive_entries(entries, args.group):
-            crate_root = materialize_entry(entry, run_root)
-            run_command(["cargo", "fmt", "--manifest-path", str(crate_root / "Cargo.toml")])
-            run_command(["cargo", "fmt", "--manifest-path", str(crate_root / "Cargo.toml"), "--", "--check"])
+            def format_entry() -> Path:
+                crate_root_inner = materialize_entry(entry, run_root)
+                run_command(["cargo", "fmt", "--manifest-path", str(crate_root_inner / "Cargo.toml")])
+                run_command(["cargo", "fmt", "--manifest-path", str(crate_root_inner / "Cargo.toml"), "--", "--check"])
+                return crate_root_inner
+
+            crate_root = timed_case("generated_code_quality", f"rustfmt/{entry.id}", format_entry)
             records.append(record_for_entry(entry, crate_root, "passed"))
         evidence = record_evidence("rustfmt", run, records)
         print(f"generated-code rustfmt passed; evidence={evidence.relative_to(REPO_ROOT)}")
@@ -534,20 +612,28 @@ def gate_clippy(entries: list[Entry], args: argparse.Namespace) -> None:
     run_root = TARGET_ROOT / run
     records = []
     try:
-        assert_negative_clippy(GCQ_ROOT / "negative_seeds" / "clippy_warning.rs", run_root)
+        timed_case(
+            "generated_code_quality",
+            "clippy/negative-clippy-warning",
+            lambda: assert_negative_clippy(GCQ_ROOT / "negative_seeds" / "clippy_warning.rs", run_root),
+        )
         for entry in selected_positive_entries(entries, args.group):
-            crate_root = materialize_entry(entry, run_root)
-            run_command(["cargo", "fmt", "--manifest-path", str(crate_root / "Cargo.toml")])
-            run_command(
-                [
-                    "cargo",
-                    "clippy",
-                    "--manifest-path",
-                    str(crate_root / "Cargo.toml"),
-                    "--",
-                    *GENERATED_CLIPPY_ARGS,
-                ],
-            )
+            def clippy_entry() -> Path:
+                crate_root_inner = materialize_entry(entry, run_root)
+                run_command(["cargo", "fmt", "--manifest-path", str(crate_root_inner / "Cargo.toml")])
+                run_command(
+                    [
+                        "cargo",
+                        "clippy",
+                        "--manifest-path",
+                        str(crate_root_inner / "Cargo.toml"),
+                        "--",
+                        *GENERATED_CLIPPY_ARGS,
+                    ],
+                )
+                return crate_root_inner
+
+            crate_root = timed_case("generated_code_quality", f"clippy/{entry.id}", clippy_entry)
             records.append(record_for_entry(entry, crate_root, "passed"))
         evidence = record_evidence("clippy", run, records)
         print(f"generated-code clippy passed; evidence={evidence.relative_to(REPO_ROOT)}")
@@ -565,19 +651,27 @@ def gate_determinism(entries: list[Entry], args: argparse.Namespace) -> None:
     run_root.mkdir(parents=True, exist_ok=True)
     records = []
     try:
-        assert_negative_determinism(
-            GCQ_ROOT / "negative_seeds" / "determinism_a.rs",
-            GCQ_ROOT / "negative_seeds" / "determinism_b.rs",
+        timed_case(
+            "generated_code_quality",
+            "determinism/negative-byte-drift",
+            lambda: assert_negative_determinism(
+                GCQ_ROOT / "negative_seeds" / "determinism_a.rs",
+                GCQ_ROOT / "negative_seeds" / "determinism_b.rs",
+            ),
         )
         for entry in selected_positive_entries(entries, args.group):
-            first = emit_source(entry)
-            second = emit_source(entry)
-            if not compare_bytes(first, second):
-                first_path = run_root / f"{entry.id}.first.rs"
-                second_path = run_root / f"{entry.id}.second.rs"
-                first_path.write_bytes(first)
-                second_path.write_bytes(second)
-                raise RuntimeError(f"{entry.id}: repeated emission was not byte-stable")
+            def deterministic_entry() -> bytes:
+                first_inner = emit_source(entry)
+                second = emit_source(entry)
+                if not compare_bytes(first_inner, second):
+                    first_path = run_root / f"{entry.id}.first.rs"
+                    second_path = run_root / f"{entry.id}.second.rs"
+                    first_path.write_bytes(first_inner)
+                    second_path.write_bytes(second)
+                    raise RuntimeError(f"{entry.id}: repeated emission was not byte-stable")
+                return first_inner
+
+            first = timed_case("generated_code_quality", f"determinism/{entry.id}", deterministic_entry)
             digest = hashlib.sha256(first).hexdigest()
             records.append(
                 {

--- a/verification/performance/run_benchmarks.py
+++ b/verification/performance/run_benchmarks.py
@@ -253,7 +253,20 @@ def run_cases(cases: list[BenchmarkCase], output_root: Path, sample_scale: str) 
     run_root.mkdir(parents=True, exist_ok=True)
     results = []
     for case in cases:
-        results.append(run_case(case, run_root, sample_scale))
+        started = time.perf_counter()
+        status = "pass"
+        try:
+            result = run_case(case, run_root, sample_scale)
+        except Exception:
+            status = "fail"
+            raise
+        finally:
+            elapsed_ms = int((time.perf_counter() - started) * 1000.0)
+            print(
+                f"[sifr-case-timing] bucket=performance case={case.id} "
+                f"elapsed_ms={elapsed_ms} status={status}"
+            )
+        results.append(result)
     return {
         "schema_version": 1,
         "runner_version": RUNNER_VERSION,

--- a/verification/tooling/check_diagnostic_source_canonicalization_contract.py
+++ b/verification/tooling/check_diagnostic_source_canonicalization_contract.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
 
@@ -161,11 +162,64 @@ def check_legacy_code_docs(root: Path) -> None:
         )
 
 
+@lru_cache(maxsize=1)
+def sifr_binary() -> Path:
+    proc = subprocess.run(
+        ["cargo", "build", "-q", "-p", "sifr"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=300,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "failed to build sifr diagnostic-contract binary:\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+    binary = REPO_ROOT / "target" / "debug" / "sifr"
+    require(binary.is_file(), f"sifr binary missing after build: {binary}")
+    return binary
+
+
+@lru_cache(maxsize=1)
+def diagnostic_contract_harness_binary() -> Path:
+    proc = subprocess.run(
+        ["cargo", "build", "-q", "-p", "sifr_driver", "--bin", "diagnostic_contract_harness"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=300,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "failed to build diagnostic contract harness:\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+    binary = REPO_ROOT / "target" / "debug" / "diagnostic_contract_harness"
+    require(binary.is_file(), f"diagnostic contract harness missing after build: {binary}")
+    return binary
+
+
+def run_runtime_harness() -> None:
+    proc = subprocess.run(
+        [str(diagnostic_contract_harness_binary())],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "diagnostic contract harness failed:\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        )
+
+
 def run_sifr(args: list[str], cwd: Path = REPO_ROOT) -> CommandResult:
-    argv = ["cargo", "run", "-q"]
-    if cwd != REPO_ROOT:
-        argv.extend(["--manifest-path", str(REPO_ROOT / "Cargo.toml")])
-    argv.extend(["-p", "sifr", "--", *args])
+    argv = [str(sifr_binary()), *args]
     proc = subprocess.run(
         argv,
         cwd=cwd,
@@ -402,10 +456,7 @@ def run_static_checks(root: Path) -> None:
 
 def run_checks(root: Path) -> None:
     run_static_checks(root)
-    check_parser_runtime_contract(root)
-    check_project_runtime_contract(root)
-    check_package_runtime_contract(root)
-    check_cycle_runtime_contract(root)
+    run_runtime_harness()
     check_package_help_contract(root)
 
 

--- a/verification/tooling/lsp_protocol.py
+++ b/verification/tooling/lsp_protocol.py
@@ -40,9 +40,12 @@ class LspClient:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        self.args = args
         self.timeout = timeout
         self.next_id = 1
         self.notifications: list[dict[str, Any]] = []
+        self.events: list[dict[str, Any]] = []
+        self._record_event("spawn", {"pid": self.process.pid, "args": args})
 
     def request(self, method: str, params: dict[str, Any] | None = None) -> Any:
         request_id = self.next_id
@@ -90,10 +93,10 @@ class LspClient:
             self.process.kill()
             self.process.wait(timeout=10)
             stderr = self.process.stderr.read().decode("utf-8", errors="replace") if self.process.stderr else ""
-            raise LspProtocolError(f"LSP did not exit after stdin close: {stderr[-1000:]}")
+            raise LspProtocolError(self._diagnostic_context("LSP did not exit after stdin close", stderr))
         if self.process.returncode not in {0, None}:
             stderr = self.process.stderr.read().decode("utf-8", errors="replace") if self.process.stderr else ""
-            raise LspProtocolError(f"LSP exited {self.process.returncode}: {stderr[-1000:]}")
+            raise LspProtocolError(self._diagnostic_context(f"LSP exited {self.process.returncode}", stderr))
 
     def _wait_for_response(self, request_id: int) -> dict[str, Any]:
         deadline = time.monotonic() + self.timeout
@@ -108,6 +111,7 @@ class LspClient:
     def _send(self, payload: dict[str, Any]) -> None:
         if self.process.stdin is None:
             raise LspProtocolError("LSP stdin is closed")
+        self._record_event("send", payload)
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
         self.process.stdin.write(header + body)
@@ -119,7 +123,9 @@ class LspClient:
         while True:
             if self.process.poll() is not None:
                 stderr = self.process.stderr.read().decode("utf-8", errors="replace") if self.process.stderr else ""
-                raise LspProtocolError(f"LSP exited before response: {self.process.returncode}: {stderr[-1000:]}")
+                raise LspProtocolError(
+                    self._diagnostic_context(f"LSP exited before response: {self.process.returncode}", stderr)
+                )
             remaining = max(deadline - time.monotonic(), 0.0)
             if remaining == 0:
                 raise LspProtocolError("timed out waiting for LSP output")
@@ -142,11 +148,61 @@ class LspClient:
         body = self.process.stdout.read(length)
         if len(body) != length:
             raise LspProtocolError("LSP closed stdout while reading body")
-        return json.loads(body.decode("utf-8"))
+        message = json.loads(body.decode("utf-8"))
+        self._record_event("recv", message)
+        return message
+
+    def _record_event(self, kind: str, payload: dict[str, Any]) -> None:
+        event = {
+            "kind": kind,
+            "at_unix": round(time.time(), 3),
+            "summary": protocol_summary(payload),
+        }
+        self.events.append(event)
+        self.events = self.events[-20:]
+
+    def _diagnostic_context(self, reason: str, stderr: str) -> str:
+        lifecycle = {
+            "pid": self.process.pid,
+            "returncode": self.process.returncode,
+            "args": self.args,
+        }
+        return (
+            f"{reason}\n"
+            f"lifecycle={json.dumps(lifecycle, sort_keys=True)}\n"
+            f"last_protocol_events={json.dumps(self.events[-10:], sort_keys=True)}\n"
+            f"stderr_tail={stderr[-4000:]}"
+        )
 
 
 def file_uri(path: Path) -> str:
     return path.resolve().as_uri()
+
+
+def protocol_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    if "id" in payload:
+        summary["id"] = payload.get("id")
+    if "method" in payload:
+        summary["method"] = payload.get("method")
+    if "error" in payload:
+        error = payload.get("error")
+        if isinstance(error, dict):
+            summary["error"] = {
+                "code": error.get("code"),
+                "message": error.get("message"),
+            }
+    if "result" in payload:
+        summary["result_type"] = type(payload.get("result")).__name__
+    params = payload.get("params")
+    if isinstance(params, dict):
+        if isinstance(params.get("textDocument"), dict):
+            summary["uri"] = params["textDocument"].get("uri")
+            if "version" in params["textDocument"]:
+                summary["version"] = params["textDocument"].get("version")
+        if "uri" in params:
+            summary["uri"] = params.get("uri")
+    return summary
 
 
 def assert_has_keys(value: dict[str, Any], keys: set[str], label: str) -> None:

--- a/verification/validation_lanes/manifest.json
+++ b/verification/validation_lanes/manifest.json
@@ -1,35 +1,42 @@
 {
   "schema_version": 1,
   "aliases": {
-    "full": "pr",
+    "quick": "create-pr",
+    "pr": "merge",
+    "full": "merge",
     "stress": "release"
   },
   "lanes": [
     {
-      "name": "quick",
+      "name": "create-pr",
       "description": "Fast local developer confidence with bounded contract coverage and representative e2e only.",
-      "warm_wall_time_target_minutes": 5,
-      "cold_wall_time_target_minutes": 10,
+      "warm_wall_time_target_minutes": 2,
+      "cold_wall_time_target_minutes": 5,
       "thermal_policy": "bounded-local-defaults",
       "memory_policy": "avoid-swap-defaults",
-      "matrix_suites": [
-        "frontend_mode_parity",
-        "phase23_graph_isolation",
-        "integer_dtype_contract"
+      "matrix_suites": [],
+      "tooling_suites": [
+        "static",
+        "lsp-smoke"
       ],
+      "distribution": "none",
+      "generated_code_quality": "smoke",
+      "performance_budget": "smoke",
+      "crate_tests": "smoke",
       "e2e": {
         "fixture_manifest": "verification/validation_lanes/quick_e2e_manifest.json",
         "sifr_jobs": 2,
         "rust_jobs": 2,
         "run_jobs": 2,
         "cargo_build_jobs": 1,
+        "max_group_fixtures": 8,
         "disable_cache": false
       },
       "hardening_suites": [],
       "extra_checks": []
     },
     {
-      "name": "pr",
+      "name": "merge",
       "description": "Authoritative merge gate with full contract matrices, representative e2e, and selected hardening.",
       "warm_wall_time_target_minutes": 15,
       "cold_wall_time_target_minutes": 25,
@@ -42,12 +49,23 @@
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],
+      "tooling_suites": [
+        "static",
+        "formatter",
+        "analysis",
+        "lsp-smoke"
+      ],
+      "distribution": "representative",
+      "generated_code_quality": "representative",
+      "performance_budget": "representative",
+      "crate_tests": "full",
       "e2e": {
         "fixture_manifest": "verification/validation_lanes/pr_e2e_manifest.json",
         "sifr_jobs": 4,
         "rust_jobs": 3,
         "run_jobs": 3,
         "cargo_build_jobs": 1,
+        "max_group_fixtures": 12,
         "disable_cache": false
       },
       "hardening_suites": [
@@ -73,12 +91,20 @@
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],
+      "tooling_suites": [
+        "full"
+      ],
+      "distribution": "full",
+      "generated_code_quality": "full",
+      "performance_budget": "full",
+      "crate_tests": "full",
       "e2e": {
         "fixture_manifest": null,
         "sifr_jobs": 6,
         "rust_jobs": 4,
         "run_jobs": 4,
         "cargo_build_jobs": 1,
+        "max_group_fixtures": 16,
         "disable_cache": false
       },
       "hardening_suites": [
@@ -108,12 +134,20 @@
         "phase24_hir_analysis",
         "phase25_cfg_flow"
       ],
+      "tooling_suites": [
+        "full"
+      ],
+      "distribution": "full",
+      "generated_code_quality": "full",
+      "performance_budget": "full",
+      "crate_tests": "full",
       "e2e": {
         "fixture_manifest": null,
         "sifr_jobs": 6,
         "rust_jobs": 4,
         "run_jobs": 4,
         "cargo_build_jobs": 1,
+        "max_group_fixtures": 16,
         "disable_cache": false
       },
       "hardening_suites": [


### PR DESCRIPTION
## Summary

- Defines canonical validation lanes (`create-pr`, `merge`, `nightly`, `release`) with legacy aliases preserved in the lane manifest and resolver.
- Rebalances create-PR vs merge coverage: smoke generated-code quality, performance budgets, tooling, and crate tests in create-PR; broader representative/full checks remain in merge/nightly/release.
- Replaces the repeated Cargo-launched diagnostic source canonicalization script with an in-process Rust harness binary.
- Adds lane step timing, per-case timing, generated artifact cache reporting, e2e group caps, and validation lane policy documentation.
- Records reviewer rounds and phase closure evidence in the issue.

## Validation

- `scripts/run_all_tests.sh --profile quick` passed in 74.82s, no advisories.
- `scripts/run_all_tests.sh --profile merge` passed in 595.66s, under the 15-minute warm target; non-blocking e2e group-skew advisory documented in the issue.
- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `python3 scripts/check_file_size_guardrails.py`
- shell syntax checks for touched shell runners
- Python compile checks for touched Python validation scripts
- Reviewer rounds through `reviews/gate-speed-phase-review-4.md`; final verdict: SATISFIED.

## Notes

Draft PR for phase closure. The merge-lane e2e cache was cold for the recorded run (`cache_hits=0/22`), and the remaining group-skew advisory is documented as follow-up evidence rather than hidden.