### PR TITLE
milestone_stdlib_boundary_2: centralize stdlib feature deps

### DIFF
--- a/crates/sifr/tests/e2e_support/fixture_compilation.rs
+++ b/crates/sifr/tests/e2e_support/fixture_compilation.rs
@@ -33,9 +33,16 @@ pub(crate) fn compile_source_with_metadata(
         sifr_driver::CompileResultFull::Success {
             rust_source,
             used_stdlib_modules,
-            required_crates,
+            required_features,
             ..
-        } => Ok((rust_source, used_stdlib_modules, required_crates)),
+        } => Ok((
+            rust_source,
+            used_stdlib_modules,
+            required_features
+                .into_iter()
+                .map(|feature| feature.id().to_string())
+                .collect(),
+        )),
         sifr_driver::CompileResultFull::Errors { errors } => {
             Err(errors.iter().map(|error| error.message.clone()).collect())
         }
@@ -57,12 +64,15 @@ pub(crate) fn compile_source_with_metadata_and_stats(
         sifr_driver::CompileResultFull::Success {
             rust_source,
             used_stdlib_modules,
-            required_crates,
+            required_features,
             lowering_stats,
         } => Ok((
             rust_source,
             used_stdlib_modules,
-            required_crates,
+            required_features
+                .into_iter()
+                .map(|feature| feature.id().to_string())
+                .collect(),
             lowering_stats,
         )),
         sifr_driver::CompileResultFull::Errors { errors } => {

--- a/crates/sifr_codegen/Cargo.toml
+++ b/crates/sifr_codegen/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 # Wired early by milestone_diag_1; compiler emission migration starts in milestone_diag_4a.
 sifr_diagnostics = { workspace = true }
 sifr_hir = { workspace = true }
+sifr_stdlib = { workspace = true }
 sifr_type_system = { workspace = true }
 syn = { version = "2.0.117", features = ["full", "visit"] }
 prettyplease = "0.2.37"

--- a/crates/sifr_codegen/src/entrypoints.rs
+++ b/crates/sifr_codegen/src/entrypoints.rs
@@ -144,25 +144,25 @@ pub fn generate_rust_test(module: &HirModule) -> CodegenResult {
         rust_source,
         used_stdlib_modules: emitter.used_stdlib_modules.clone(),
         used_intrinsic_modules: emitter.used_stdlib_modules,
-        required_crates: {
-            let mut crates = emitter.intrinsic_registry_crates;
+        required_features: {
+            let mut features = emitter.intrinsic_registry_features;
             if emitter.runtime_needs.bigint() || import_needs.runtime.numeric.needs_bigint {
-                crates.insert("num-bigint".to_string());
-                crates.insert("num-traits".to_string());
+                features.insert(sifr_stdlib::StdlibFeature::NumBigint);
+                features.insert(sifr_stdlib::StdlibFeature::NumTraits);
             }
             if import_needs.runtime.numeric.needs_decimal {
-                crates.insert("rust_decimal".to_string());
+                features.insert(sifr_stdlib::StdlibFeature::RustDecimal);
             }
             if import_needs.runtime.numeric.needs_bigdecimal {
-                crates.insert("bigdecimal".to_string());
+                features.insert(sifr_stdlib::StdlibFeature::BigDecimal);
             }
             if import_needs.runtime.needs_sifr_int {
-                crates.insert("sifr_runtime".to_string());
+                features.insert(sifr_stdlib::StdlibFeature::SifrRuntime);
             }
             if uses_task_sleep {
-                crates.insert("tokio".to_string());
+                features.insert(sifr_stdlib::StdlibFeature::Tokio);
             }
-            crates
+            features
         },
         constant_mappings: emitter.module_constants,
         lowering_stats: emitter.lowering_stats,

--- a/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
+++ b/crates/sifr_codegen/src/intrinsic_method_emitters/builtin_core_methods.rs
@@ -43,13 +43,11 @@ impl RustEmitter {
                 .require(crate::RuntimeNeed::RandomModuleState);
         }
 
-        if let Some(required_crate) = lowered.required_crate {
-            self.intrinsic_registry_crates
-                .insert(required_crate.to_string());
+        if let Some(feature) = lowered.required_feature {
+            self.intrinsic_registry_features.insert(feature);
         }
-        for required_crate in lowered.additional_required_crates {
-            self.intrinsic_registry_crates
-                .insert((*required_crate).to_string());
+        for required_feature in lowered.additional_required_features {
+            self.intrinsic_registry_features.insert(*required_feature);
         }
     }
 }

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -29,22 +29,23 @@ mod uuid;
 mod zipfile;
 
 use crate::RustExpr;
+use sifr_stdlib::StdlibFeature;
 
 pub(crate) struct LoweredIntrinsic {
     pub(crate) expr: RustExpr,
-    pub(crate) required_crate: Option<&'static str>,
-    pub(crate) additional_required_crates: &'static [&'static str],
+    pub(crate) required_feature: Option<StdlibFeature>,
+    pub(crate) additional_required_features: &'static [StdlibFeature],
 }
 
-pub(crate) fn additional_required_crates(name: &str) -> &'static [&'static str] {
+pub(crate) fn additional_required_features(name: &str) -> &'static [StdlibFeature] {
     match name {
         // random_gauss uses rand_distr::Normal in addition to rand::rng.
-        "random_gauss" => &["rand_distr"],
+        "random_gauss" => &[StdlibFeature::RandDistr],
         "json_loads"
         | "json_validate_integer_digit_limits"
         | "json_dumps_value_exact"
         | "json_dumps_value_web"
-        | "json_dumps_value_string_ints" => &["sifr_runtime"],
+        | "json_dumps_value_string_ints" => &[StdlibFeature::SifrRuntime],
         _ => &[],
     }
 }
@@ -54,7 +55,7 @@ pub(crate) fn lower_intrinsic(name: &str, args: &[RustExpr]) -> Option<LoweredIn
 }
 
 pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<LoweredIntrinsic> {
-    let (expr, required_crate) = match name {
+    let (expr, required_feature) = match name {
         "sqrt" => (math::lower_sqrt(args), None),
         "floor" => (math::lower_floor(args), None),
         "ceil" => (math::lower_ceil(args), None),
@@ -134,8 +135,14 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "touch" => (pathlib::lower_touch(args), None),
         "resolve_path" => (pathlib::lower_resolve_path(args), None),
         "iterdir" => (pathlib::lower_iterdir(args), None),
-        "glob_pattern" => (pathlib::lower_glob_pattern(args), Some("regex")),
-        "rglob_pattern" => (pathlib::lower_rglob_pattern(args), Some("regex")),
+        "glob_pattern" => (
+            pathlib::lower_glob_pattern(args),
+            Some(StdlibFeature::Regex),
+        ),
+        "rglob_pattern" => (
+            pathlib::lower_rglob_pattern(args),
+            Some(StdlibFeature::Regex),
+        ),
         "read_text" => (io::lower_read_text(args), None),
         "write_text" => (io::lower_write_text(args), None),
         "exists" => (io::lower_exists(args), None),
@@ -163,17 +170,26 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "file_close" => (file_handles::lower_file_close(args), None),
         "file_read_bytes" => (file_handles::lower_file_read_bytes(args), None),
         "file_write_bytes" => (file_handles::lower_file_write_bytes(args), None),
-        "json_loads" => (json::lower_json_loads(args), Some("serde_json")),
+        "json_loads" => (json::lower_json_loads(args), Some(StdlibFeature::SerdeJson)),
         "json_validate_integer_digit_limits" => {
             (json::lower_json_validate_integer_digit_limits(args), None)
         }
-        "json_dumps" => (json::lower_json_dumps(args), Some("serde_json")),
-        "json_dumps_value" => (json::lower_json_dumps_value(args), Some("serde_json")),
-        "json_dumps_value_exact" => (json::lower_json_dumps_value_exact(args), Some("serde_json")),
-        "json_dumps_value_web" => (json::lower_json_dumps_value_web(args), Some("serde_json")),
+        "json_dumps" => (json::lower_json_dumps(args), Some(StdlibFeature::SerdeJson)),
+        "json_dumps_value" => (
+            json::lower_json_dumps_value(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "json_dumps_value_exact" => (
+            json::lower_json_dumps_value_exact(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "json_dumps_value_web" => (
+            json::lower_json_dumps_value_web(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
         "json_dumps_value_string_ints" => (
             json::lower_json_dumps_value_string_ints(args),
-            Some("serde_json"),
+            Some(StdlibFeature::SerdeJson),
         ),
         "assert_eq" => (test::lower_assert_eq(args), None),
         "assert_ne" => (test::lower_assert_ne(args), None),
@@ -192,24 +208,45 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "set_intersection" => (collections::lower_set_intersection(args), None),
         "counter_from_list" => (
             collections::lower_counter_from_list(args),
-            Some("serde_json"),
+            Some(StdlibFeature::SerdeJson),
         ),
-        "counter_get" => (collections::lower_counter_get(args), Some("serde_json")),
+        "counter_get" => (
+            collections::lower_counter_get(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
         "counter_most_common" => (
             collections::lower_counter_most_common(args),
-            Some("serde_json"),
+            Some(StdlibFeature::SerdeJson),
         ),
-        "counter_total" => (collections::lower_counter_total(args), Some("serde_json")),
-        "counter_values" => (collections::lower_counter_values(args), Some("serde_json")),
-        "counter_keys" => (collections::lower_counter_keys(args), Some("serde_json")),
-        "counter_items" => (collections::lower_counter_items(args), Some("serde_json")),
+        "counter_total" => (
+            collections::lower_counter_total(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "counter_values" => (
+            collections::lower_counter_values(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "counter_keys" => (
+            collections::lower_counter_keys(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "counter_items" => (
+            collections::lower_counter_items(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
         "counter_increment" => (
             collections::lower_counter_increment(args),
-            Some("serde_json"),
+            Some(StdlibFeature::SerdeJson),
         ),
         "defaultdict_new" => (collections::lower_defaultdict_new(args), None),
-        "defaultdict_get" => (collections::lower_defaultdict_get(args), Some("serde_json")),
-        "defaultdict_set" => (collections::lower_defaultdict_set(args), Some("serde_json")),
+        "defaultdict_get" => (
+            collections::lower_defaultdict_get(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
+        "defaultdict_set" => (
+            collections::lower_defaultdict_set(args),
+            Some(StdlibFeature::SerdeJson),
+        ),
         "encode_utf8" => (bytes::lower_encode_utf8(args), None),
         "str_encode_utf8_result" => (bytes::lower_str_encode_utf8_result(args), None),
         "str_encode_utf8_result_with_encoding" => (
@@ -225,64 +262,88 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "bytes_from_ints" => (bytes::lower_bytes_from_ints(args), None),
         "time_now" => (time::lower_time_now(args), None),
         "sleep" => (time::lower_sleep(args), None),
-        "time_format" => (time::lower_time_format(args), Some("chrono")),
+        "time_format" => (time::lower_time_format(args), Some(StdlibFeature::Chrono)),
         "perf_counter" => (time::lower_perf_counter(args), None),
         "monotonic" => (time::lower_monotonic(args), None),
-        "strptime" => (time::lower_strptime(args), Some("chrono")),
-        "gmtime" => (time::lower_gmtime(args), Some("chrono")),
-        "localtime" => (time::lower_localtime(args), Some("chrono")),
-        "_strptime_intrinsic" => (time::lower_strptime(args), Some("chrono")),
-        "_gmtime_intrinsic" => (time::lower_gmtime(args), Some("chrono")),
-        "_localtime_intrinsic" => (time::lower_localtime(args), Some("chrono")),
-        "time_strptime" => (time::lower_time_strptime_parts(args), Some("chrono")),
-        "time_gmtime" => (time::lower_time_gmtime_parts(args), Some("chrono")),
-        "time_localtime" => (time::lower_time_localtime_parts(args), Some("chrono")),
-        "random_int" => (random::lower_random_int(args), Some("rand")),
-        "random_float" => (random::lower_random_float(args), Some("rand")),
-        "random_choice" => (random::lower_random_choice(args), Some("rand")),
-        "random_uniform" => (random::lower_random_uniform(args), Some("rand")),
-        "random_shuffle" => (random::lower_random_shuffle(args), Some("rand")),
-        "random_sample" => (random::lower_random_sample(args), Some("rand")),
-        "random_randrange" => (random::lower_random_randrange(args), Some("rand")),
-        "random_gauss" => (random::lower_random_gauss(args), Some("rand")),
+        "strptime" => (time::lower_strptime(args), Some(StdlibFeature::Chrono)),
+        "gmtime" => (time::lower_gmtime(args), Some(StdlibFeature::Chrono)),
+        "localtime" => (time::lower_localtime(args), Some(StdlibFeature::Chrono)),
+        "_strptime_intrinsic" => (time::lower_strptime(args), Some(StdlibFeature::Chrono)),
+        "_gmtime_intrinsic" => (time::lower_gmtime(args), Some(StdlibFeature::Chrono)),
+        "_localtime_intrinsic" => (time::lower_localtime(args), Some(StdlibFeature::Chrono)),
+        "time_strptime" => (
+            time::lower_time_strptime_parts(args),
+            Some(StdlibFeature::Chrono),
+        ),
+        "time_gmtime" => (
+            time::lower_time_gmtime_parts(args),
+            Some(StdlibFeature::Chrono),
+        ),
+        "time_localtime" => (
+            time::lower_time_localtime_parts(args),
+            Some(StdlibFeature::Chrono),
+        ),
+        "random_int" => (random::lower_random_int(args), Some(StdlibFeature::Rand)),
+        "random_float" => (random::lower_random_float(args), Some(StdlibFeature::Rand)),
+        "random_choice" => (random::lower_random_choice(args), Some(StdlibFeature::Rand)),
+        "random_uniform" => (
+            random::lower_random_uniform(args),
+            Some(StdlibFeature::Rand),
+        ),
+        "random_shuffle" => (
+            random::lower_random_shuffle(args),
+            Some(StdlibFeature::Rand),
+        ),
+        "random_sample" => (random::lower_random_sample(args), Some(StdlibFeature::Rand)),
+        "random_randrange" => (
+            random::lower_random_randrange(args),
+            Some(StdlibFeature::Rand),
+        ),
+        "random_gauss" => (random::lower_random_gauss(args), Some(StdlibFeature::Rand)),
         "random_module_state_words" => (random::lower_random_module_state_words(args), None),
         "random_module_state_index" => (random::lower_random_module_state_index(args), None),
         "random_module_state_gauss_next" => {
             (random::lower_random_module_state_gauss_next(args), None)
         }
         "random_module_set_state" => (random::lower_random_module_set_state(args), None),
-        "re_match" => (re::lower_re_match(args), Some("regex")),
-        "re_find" => (re::lower_re_find(args), Some("regex")),
-        "re_replace" => (re::lower_re_replace(args), Some("regex")),
-        "re_findall" => (re::lower_re_findall(args), Some("regex")),
-        "re_split" => (re::lower_re_split(args), Some("regex")),
-        "re_find_start" => (re::lower_re_find_start(args), Some("regex")),
-        "re_find_end" => (re::lower_re_find_end(args), Some("regex")),
-        "re_match_flags" => (re::lower_re_match_flags(args), Some("regex")),
-        "re_find_flags" => (re::lower_re_find_flags(args), Some("regex")),
-        "re_replace_flags" => (re::lower_re_replace_flags(args), Some("regex")),
-        "re_findall_flags" => (re::lower_re_findall_flags(args), Some("regex")),
-        "re_split_flags" => (re::lower_re_split_flags(args), Some("regex")),
-        "sha256" => (hash::lower_sha256(args), Some("sha2")),
-        "md5" => (hash::lower_md5(args), Some("md5")),
-        "sha256_bytes" => (hashlib::lower_sha256_bytes(args), Some("sha2")),
-        "md5_bytes" => (hashlib::lower_md5_bytes(args), Some("md5")),
+        "re_match" => (re::lower_re_match(args), Some(StdlibFeature::Regex)),
+        "re_find" => (re::lower_re_find(args), Some(StdlibFeature::Regex)),
+        "re_replace" => (re::lower_re_replace(args), Some(StdlibFeature::Regex)),
+        "re_findall" => (re::lower_re_findall(args), Some(StdlibFeature::Regex)),
+        "re_split" => (re::lower_re_split(args), Some(StdlibFeature::Regex)),
+        "re_find_start" => (re::lower_re_find_start(args), Some(StdlibFeature::Regex)),
+        "re_find_end" => (re::lower_re_find_end(args), Some(StdlibFeature::Regex)),
+        "re_match_flags" => (re::lower_re_match_flags(args), Some(StdlibFeature::Regex)),
+        "re_find_flags" => (re::lower_re_find_flags(args), Some(StdlibFeature::Regex)),
+        "re_replace_flags" => (re::lower_re_replace_flags(args), Some(StdlibFeature::Regex)),
+        "re_findall_flags" => (re::lower_re_findall_flags(args), Some(StdlibFeature::Regex)),
+        "re_split_flags" => (re::lower_re_split_flags(args), Some(StdlibFeature::Regex)),
+        "sha256" => (hash::lower_sha256(args), Some(StdlibFeature::Sha2)),
+        "md5" => (hash::lower_md5(args), Some(StdlibFeature::Md5)),
+        "sha256_bytes" => (hashlib::lower_sha256_bytes(args), Some(StdlibFeature::Sha2)),
+        "md5_bytes" => (hashlib::lower_md5_bytes(args), Some(StdlibFeature::Md5)),
         "platform_system" => (platform::lower_platform_system(args), None),
         "platform_arch" => (platform::lower_platform_arch(args), None),
         "platform_node" => (platform::lower_platform_node(args), None),
         "platform_release" => (platform::lower_platform_release(args), None),
         "platform_version" => (platform::lower_platform_version(args), None),
         "platform_processor" => (platform::lower_platform_processor(args), None),
-        "uuid4" => (uuid::lower_uuid4(args), Some("rand")),
-        "uuid3_text" => (uuid::lower_uuid3(args), Some("uuid")),
-        "uuid5_text" => (uuid::lower_uuid5(args), Some("uuid")),
-        "toml_parse" => (toml::lower_toml_parse(args), Some("toml")),
-        "datetime_now" => (datetime::lower_datetime_now(args), Some("chrono")),
-        "datetime_now_struct" => (datetime::lower_datetime_now_struct(args), Some("chrono")),
+        "uuid4" => (uuid::lower_uuid4(args), Some(StdlibFeature::Rand)),
+        "uuid3_text" => (uuid::lower_uuid3(args), Some(StdlibFeature::Uuid)),
+        "uuid5_text" => (uuid::lower_uuid5(args), Some(StdlibFeature::Uuid)),
+        "toml_parse" => (toml::lower_toml_parse(args), Some(StdlibFeature::Toml)),
+        "datetime_now" => (
+            datetime::lower_datetime_now(args),
+            Some(StdlibFeature::Chrono),
+        ),
+        "datetime_now_struct" => (
+            datetime::lower_datetime_now_struct(args),
+            Some(StdlibFeature::Chrono),
+        ),
         "datetime_format" => (datetime::lower_datetime_format(args), None),
         "datetime_from_timestamp" => (
             datetime::lower_datetime_from_timestamp(args),
-            Some("chrono"),
+            Some(StdlibFeature::Chrono),
         ),
         "sys_exit" => (sys::lower_sys_exit(args), None),
         "sys_version" => (sys::lower_sys_version(args), None),
@@ -296,40 +357,85 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "calendar_isleap" => (calendar::lower_calendar_isleap(args), None),
         "calendar_weekday" => (calendar::lower_calendar_weekday(args), None),
         "calendar_monthrange" => (calendar::lower_calendar_monthrange(args), None),
-        "gzip_compress" => (gzip::lower_gzip_compress(args), Some("flate2")),
-        "gzip_decompress" => (gzip::lower_gzip_decompress(args), Some("flate2")),
-        "zip_create" => (zipfile::lower_zip_create(args), Some("zip")),
-        "zip_add_file" => (zipfile::lower_zip_add_file(args), Some("zip")),
-        "zip_add_file_bytes" => (zipfile::lower_zip_add_file_bytes(args), Some("zip")),
-        "zip_read_file" => (zipfile::lower_zip_read_file(args), Some("zip")),
-        "zip_read_file_bytes" => (zipfile::lower_zip_read_file_bytes(args), Some("zip")),
-        "zip_namelist" => (zipfile::lower_zip_namelist(args), Some("zip")),
-        "base64_encode" => (base64::lower_base64_encode(args), Some("base64")),
-        "base64_decode" => (base64::lower_base64_decode(args), Some("base64")),
-        "base64_encode_bytes" => (base64::lower_base64_encode_bytes(args), Some("base64")),
-        "base64_decode_bytes" => (base64::lower_base64_decode_bytes(args), Some("base64")),
-        "base64_encode_opts" => (base64::lower_base64_encode_opts(args), Some("base64")),
-        "base64_decode_opts" => (base64::lower_base64_decode_opts(args), Some("base64")),
-        "urlsafe_b64encode" => (base64::lower_urlsafe_b64encode(args), Some("base64")),
-        "urlsafe_b64decode" => (base64::lower_urlsafe_b64decode(args), Some("base64")),
-        "urlsafe_b64encode_bytes" => (base64::lower_urlsafe_b64encode_bytes(args), Some("base64")),
-        "urlsafe_b64decode_bytes" => (base64::lower_urlsafe_b64decode_bytes(args), Some("base64")),
+        "gzip_compress" => (gzip::lower_gzip_compress(args), Some(StdlibFeature::Flate2)),
+        "gzip_decompress" => (
+            gzip::lower_gzip_decompress(args),
+            Some(StdlibFeature::Flate2),
+        ),
+        "zip_create" => (zipfile::lower_zip_create(args), Some(StdlibFeature::Zip)),
+        "zip_add_file" => (zipfile::lower_zip_add_file(args), Some(StdlibFeature::Zip)),
+        "zip_add_file_bytes" => (
+            zipfile::lower_zip_add_file_bytes(args),
+            Some(StdlibFeature::Zip),
+        ),
+        "zip_read_file" => (zipfile::lower_zip_read_file(args), Some(StdlibFeature::Zip)),
+        "zip_read_file_bytes" => (
+            zipfile::lower_zip_read_file_bytes(args),
+            Some(StdlibFeature::Zip),
+        ),
+        "zip_namelist" => (zipfile::lower_zip_namelist(args), Some(StdlibFeature::Zip)),
+        "base64_encode" => (
+            base64::lower_base64_encode(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "base64_decode" => (
+            base64::lower_base64_decode(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "base64_encode_bytes" => (
+            base64::lower_base64_encode_bytes(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "base64_decode_bytes" => (
+            base64::lower_base64_decode_bytes(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "base64_encode_opts" => (
+            base64::lower_base64_encode_opts(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "base64_decode_opts" => (
+            base64::lower_base64_decode_opts(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "urlsafe_b64encode" => (
+            base64::lower_urlsafe_b64encode(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "urlsafe_b64decode" => (
+            base64::lower_urlsafe_b64decode(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "urlsafe_b64encode_bytes" => (
+            base64::lower_urlsafe_b64encode_bytes(args),
+            Some(StdlibFeature::Base64),
+        ),
+        "urlsafe_b64decode_bytes" => (
+            base64::lower_urlsafe_b64decode_bytes(args),
+            Some(StdlibFeature::Base64),
+        ),
         "b32encode" => (base32::lower_b32encode(args), None),
         "b32decode" => (base32::lower_b32decode(args), None),
         "b32hexencode" => (base32::lower_b32hexencode(args), None),
         "b32hexdecode" => (base32::lower_b32hexdecode(args), None),
-        "sha1" => (hashlib::lower_sha1(args), Some("sha1")),
-        "sha1_bytes" => (hashlib::lower_sha1_bytes(args), Some("sha1")),
-        "sha512" => (hashlib::lower_sha512(args), Some("sha2")),
-        "sha512_bytes" => (hashlib::lower_sha512_bytes(args), Some("sha2")),
-        "sha224" => (hashlib::lower_sha224(args), Some("sha2")),
-        "sha224_bytes" => (hashlib::lower_sha224_bytes(args), Some("sha2")),
-        "sha384" => (hashlib::lower_sha384(args), Some("sha2")),
-        "sha384_bytes" => (hashlib::lower_sha384_bytes(args), Some("sha2")),
-        "blake2b" => (hashlib::lower_blake2b(args), Some("blake2")),
-        "blake2b_bytes" => (hashlib::lower_blake2b_bytes(args), Some("blake2")),
-        "blake2s" => (hashlib::lower_blake2s(args), Some("blake2")),
-        "blake2s_bytes" => (hashlib::lower_blake2s_bytes(args), Some("blake2")),
+        "sha1" => (hashlib::lower_sha1(args), Some(StdlibFeature::Sha1)),
+        "sha1_bytes" => (hashlib::lower_sha1_bytes(args), Some(StdlibFeature::Sha1)),
+        "sha512" => (hashlib::lower_sha512(args), Some(StdlibFeature::Sha2)),
+        "sha512_bytes" => (hashlib::lower_sha512_bytes(args), Some(StdlibFeature::Sha2)),
+        "sha224" => (hashlib::lower_sha224(args), Some(StdlibFeature::Sha2)),
+        "sha224_bytes" => (hashlib::lower_sha224_bytes(args), Some(StdlibFeature::Sha2)),
+        "sha384" => (hashlib::lower_sha384(args), Some(StdlibFeature::Sha2)),
+        "sha384_bytes" => (hashlib::lower_sha384_bytes(args), Some(StdlibFeature::Sha2)),
+        "blake2b" => (hashlib::lower_blake2b(args), Some(StdlibFeature::Blake2)),
+        "blake2b_bytes" => (
+            hashlib::lower_blake2b_bytes(args),
+            Some(StdlibFeature::Blake2),
+        ),
+        "blake2s" => (hashlib::lower_blake2s(args), Some(StdlibFeature::Blake2)),
+        "blake2s_bytes" => (
+            hashlib::lower_blake2s_bytes(args),
+            Some(StdlibFeature::Blake2),
+        ),
         "set_global_level" => (logging::lower_set_global_level(args), None),
         "get_global_level" => (logging::lower_get_global_level(args), None),
         _ => return None,
@@ -337,7 +443,7 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
 
     Some(LoweredIntrinsic {
         expr: expr?,
-        required_crate,
-        additional_required_crates: additional_required_crates(name),
+        required_feature,
+        additional_required_features: additional_required_features(name),
     })
 }

--- a/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_core_tests.rs
@@ -63,8 +63,13 @@ pub(crate) fn lowers_math_intrinsics_via_registry() {
 pub(crate) fn lowers_json_intrinsics_with_dependency_metadata() {
     let loads =
         lower_intrinsic("json_loads", &["payload".to_string()]).expect("json_loads should lower");
-    assert_eq!(loads.required_crate, Some("serde_json"));
-    assert!(loads.additional_required_crates.contains(&"sifr_runtime"));
+    assert_eq!(
+        loads.required_feature,
+        Some(sifr_stdlib::StdlibFeature::SerdeJson)
+    );
+    assert!(loads
+        .additional_required_features
+        .contains(&sifr_stdlib::StdlibFeature::SifrRuntime));
     let loads_rendered = render_expr(&loads.expr);
     assert!(loads_rendered.contains("serde_json::from_str"));
     assert!(loads_rendered.contains("validate_json_integer_digit_limits"));
@@ -74,15 +79,18 @@ pub(crate) fn lowers_json_intrinsics_with_dependency_metadata() {
         &["payload".to_string()],
     )
     .expect("json_validate_integer_digit_limits should lower");
-    assert_eq!(validate.required_crate, None);
+    assert_eq!(validate.required_feature, None);
     assert!(validate
-        .additional_required_crates
-        .contains(&"sifr_runtime"));
+        .additional_required_features
+        .contains(&sifr_stdlib::StdlibFeature::SifrRuntime));
     assert!(render_expr(&validate.expr).contains("JsonLimitError"));
 
     let dumps =
         lower_intrinsic("json_dumps", &["value".to_string()]).expect("json_dumps should lower");
-    assert_eq!(dumps.required_crate, Some("serde_json"));
+    assert_eq!(
+        dumps.required_feature,
+        Some(sifr_stdlib::StdlibFeature::SerdeJson)
+    );
     assert_eq!(
         render_expr(&dumps.expr),
         "serde_json::to_string(&value).unwrap_or_default()"
@@ -180,13 +188,19 @@ pub(crate) fn lowers_pathlib_intrinsics_via_registry() {
 
     let glob = lower_intrinsic("glob_pattern", &["dir".to_string(), "pat".to_string()])
         .expect("glob_pattern lowers");
-    assert_eq!(glob.required_crate, Some("regex"));
+    assert_eq!(
+        glob.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Regex)
+    );
     assert!(render_expr(&glob.expr).contains("regex::Regex::new"));
     assert!(render_expr(&glob.expr).contains("__re.is_match(&__name)"));
 
     let rglob = lower_intrinsic("rglob_pattern", &["dir".to_string(), "pat".to_string()])
         .expect("rglob_pattern lowers");
-    assert_eq!(rglob.required_crate, Some("regex"));
+    assert_eq!(
+        rglob.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Regex)
+    );
     assert!(render_expr(&rglob.expr).contains("__stack.pop()"));
     assert!(render_expr(&rglob.expr).contains("__re.is_match(&__name)"));
 }
@@ -323,7 +337,10 @@ pub(crate) fn lowers_time_intrinsics_via_registry() {
 
     let fmt = lower_intrinsic("time_format", &["secs".to_string(), "mask".to_string()])
         .expect("time_format");
-    assert_eq!(fmt.required_crate, Some("chrono"));
+    assert_eq!(
+        fmt.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&fmt.expr).contains("DateTime::from_timestamp"));
 
     let perf = lower_intrinsic("perf_counter", &[]).expect("perf_counter");
@@ -333,33 +350,54 @@ pub(crate) fn lowers_time_intrinsics_via_registry() {
     assert!(render_expr(&mono.expr).contains("SystemTime::now()"));
 
     let parse = lower_intrinsic("strptime", &["s".to_string(), "f".to_string()]).expect("strptime");
-    assert_eq!(parse.required_crate, Some("chrono"));
+    assert_eq!(
+        parse.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&parse.expr).contains("NaiveDateTime::parse_from_str"));
 
     let gmt = lower_intrinsic("gmtime", &["ts".to_string()]).expect("gmtime");
-    assert_eq!(gmt.required_crate, Some("chrono"));
+    assert_eq!(
+        gmt.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&gmt.expr).contains("chrono::DateTime::<chrono::Utc>::from_timestamp"));
 
     let local = lower_intrinsic("localtime", &["ts".to_string()]).expect("localtime");
-    assert_eq!(local.required_crate, Some("chrono"));
+    assert_eq!(
+        local.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&local.expr).contains("with_timezone(&chrono::Local)"));
 
     let parse_alias = lower_intrinsic("_strptime_intrinsic", &["s".to_string(), "f".to_string()])
         .expect("_strptime_intrinsic");
-    assert_eq!(parse_alias.required_crate, Some("chrono"));
+    assert_eq!(
+        parse_alias.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&parse_alias.expr).contains("NaiveDateTime::parse_from_str"));
 
     let parsed_parts = lower_intrinsic("time_strptime", &["s".to_string(), "f".to_string()])
         .expect("time_strptime");
-    assert_eq!(parsed_parts.required_crate, Some("chrono"));
+    assert_eq!(
+        parsed_parts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&parsed_parts.expr).contains("Result<Vec<i64>, ValueError>"));
 
     let gmtime_parts = lower_intrinsic("time_gmtime", &[]).expect("time_gmtime");
-    assert_eq!(gmtime_parts.required_crate, Some("chrono"));
+    assert_eq!(
+        gmtime_parts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&gmtime_parts.expr).contains("Utc::now().naive_utc()"));
 
     let localtime_parts = lower_intrinsic("time_localtime", &[]).expect("time_localtime");
-    assert_eq!(localtime_parts.required_crate, Some("chrono"));
+    assert_eq!(
+        localtime_parts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&localtime_parts.expr).contains("Local::now().naive_local()"));
 }
 
@@ -367,11 +405,17 @@ pub(crate) fn lowers_time_intrinsics_via_registry() {
 pub(crate) fn lowers_random_intrinsics_via_registry() {
     let rint =
         lower_intrinsic("random_int", &["1".to_string(), "9".to_string()]).expect("random_int");
-    assert_eq!(rint.required_crate, Some("rand"));
+    assert_eq!(
+        rint.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Rand)
+    );
     assert!(render_expr(&rint.expr).contains("rand::RngExt::random_range"));
 
     let rfloat = lower_intrinsic("random_float", &[]).expect("random_float");
-    assert_eq!(rfloat.required_crate, Some("rand"));
+    assert_eq!(
+        rfloat.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Rand)
+    );
     assert!(render_expr(&rfloat.expr).contains("rand::random::<f64>()"));
 
     let choice = lower_intrinsic("random_choice", &["items".to_string()]).expect("random_choice");
@@ -397,23 +441,25 @@ pub(crate) fn lowers_random_intrinsics_via_registry() {
 
     let gauss = lower_intrinsic("random_gauss", &["0.0".to_string(), "1.0".to_string()])
         .expect("random_gauss");
-    assert!(gauss.additional_required_crates.contains(&"rand_distr"));
+    assert!(gauss
+        .additional_required_features
+        .contains(&sifr_stdlib::StdlibFeature::RandDistr));
     assert!(render_expr(&gauss.expr).contains("rand_distr"));
 
     let state_words =
         lower_intrinsic("random_module_state_words", &[]).expect("random_module_state_words");
-    assert_eq!(state_words.required_crate, None);
+    assert_eq!(state_words.required_feature, None);
     assert!(render_expr(&state_words.expr).contains("__SIFR_RANDOM_MODULE_STATE"));
     assert!(render_expr(&state_words.expr).contains(".words"));
 
     let state_index =
         lower_intrinsic("random_module_state_index", &[]).expect("random_module_state_index");
-    assert_eq!(state_index.required_crate, None);
+    assert_eq!(state_index.required_feature, None);
     assert!(render_expr(&state_index.expr).contains(".index"));
 
     let state_gauss = lower_intrinsic("random_module_state_gauss_next", &[])
         .expect("random_module_state_gauss_next");
-    assert_eq!(state_gauss.required_crate, None);
+    assert_eq!(state_gauss.required_feature, None);
     assert!(render_expr(&state_gauss.expr).contains(".gauss_next"));
 
     let set_state = lower_intrinsic(
@@ -425,7 +471,7 @@ pub(crate) fn lowers_random_intrinsics_via_registry() {
         ],
     )
     .expect("random_module_set_state");
-    assert_eq!(set_state.required_crate, None);
+    assert_eq!(set_state.required_feature, None);
     assert!(render_expr(&set_state.expr).contains("length 624"));
     assert!(render_expr(&set_state.expr).contains("random module state index"));
 }
@@ -433,7 +479,7 @@ pub(crate) fn lowers_random_intrinsics_via_registry() {
 #[test]
 pub(crate) fn lowers_re_intrinsics_via_registry() {
     let m = lower_intrinsic("re_match", &["pat".to_string(), "txt".to_string()]).expect("re_match");
-    assert_eq!(m.required_crate, Some("regex"));
+    assert_eq!(m.required_feature, Some(sifr_stdlib::StdlibFeature::Regex));
     assert!(render_expr(&m.expr).contains("is_match"));
 
     let f = lower_intrinsic("re_find", &["pat".to_string(), "txt".to_string()]).expect("re_find");
@@ -479,29 +525,35 @@ pub(crate) fn lowers_re_intrinsics_via_registry() {
         ],
     )
     .expect("re_replace_flags");
-    assert_eq!(rf.required_crate, Some("regex"));
+    assert_eq!(rf.required_feature, Some(sifr_stdlib::StdlibFeature::Regex));
     assert!(render_expr(&rf.expr).contains("replace_all"));
 }
 
 #[test]
 pub(crate) fn lowers_hash_intrinsics_via_registry() {
     let sha = lower_intrinsic("sha256", &["payload".to_string()]).expect("sha256");
-    assert_eq!(sha.required_crate, Some("sha2"));
+    assert_eq!(sha.required_feature, Some(sifr_stdlib::StdlibFeature::Sha2));
     assert!(render_expr(&sha.expr).contains("<sha2::Sha256 as sha2::Digest>::digest"));
     assert!(render_expr(&sha.expr).contains(".as_bytes()"));
 
     let md5 = lower_intrinsic("md5", &["payload".to_string()]).expect("md5");
-    assert_eq!(md5.required_crate, Some("md5"));
+    assert_eq!(md5.required_feature, Some(sifr_stdlib::StdlibFeature::Md5));
     assert!(render_expr(&md5.expr).contains("md5::compute"));
     assert!(render_expr(&md5.expr).contains(".as_bytes()"));
 
     let sha_bytes =
         lower_intrinsic("sha256_bytes", &["payload".to_string()]).expect("sha256_bytes");
-    assert_eq!(sha_bytes.required_crate, Some("sha2"));
+    assert_eq!(
+        sha_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha_bytes.expr).contains("to_vec"));
 
     let md5_bytes = lower_intrinsic("md5_bytes", &["payload".to_string()]).expect("md5_bytes");
-    assert_eq!(md5_bytes.required_crate, Some("md5"));
+    assert_eq!(
+        md5_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Md5)
+    );
     assert!(render_expr(&md5_bytes.expr).contains("md5::compute"));
     assert!(render_expr(&md5_bytes.expr).contains(".0"));
     assert!(render_expr(&md5_bytes.expr).contains("to_vec"));

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -3,27 +3,39 @@ use crate::{render_expr, RustExpr};
 #[test]
 pub(crate) fn lowers_uuid_intrinsic_via_registry() {
     let uuid = lower_intrinsic("uuid4", &[]).expect("uuid4");
-    assert_eq!(uuid.required_crate, Some("rand"));
+    assert_eq!(
+        uuid.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Rand)
+    );
     assert!(render_expr(&uuid.expr).contains("rand::random::<u32>()"));
     assert!(render_expr(&uuid.expr).contains("format!(\"{:08x}-{:04x}-{:04x}-{:04x}-{:012x}\""));
     assert!(render_expr(&uuid.expr).contains("(rand::random::<u16>() & 4095)"));
 
     let uuid3 =
         lower_intrinsic("uuid3_text", &["ns".to_string(), "name".to_string()]).expect("uuid3");
-    assert_eq!(uuid3.required_crate, Some("uuid"));
+    assert_eq!(
+        uuid3.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Uuid)
+    );
     assert!(render_expr(&uuid3.expr).contains("uuid::Uuid::parse_str"));
     assert!(render_expr(&uuid3.expr).contains("uuid::Uuid::new_v3"));
 
     let uuid5 =
         lower_intrinsic("uuid5_text", &["ns".to_string(), "name".to_string()]).expect("uuid5");
-    assert_eq!(uuid5.required_crate, Some("uuid"));
+    assert_eq!(
+        uuid5.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Uuid)
+    );
     assert!(render_expr(&uuid5.expr).contains("uuid::Uuid::new_v5"));
 }
 
 #[test]
 pub(crate) fn lowers_toml_intrinsic_with_dependency_metadata() {
     let parsed = lower_intrinsic("toml_parse", &["payload".to_string()]).expect("toml_parse");
-    assert_eq!(parsed.required_crate, Some("toml"));
+    assert_eq!(
+        parsed.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Toml)
+    );
     assert!(render_expr(&parsed.expr).contains("parse::<toml::Table>()"));
     assert!(render_expr(&parsed.expr).contains("TOMLDecodeError"));
 }
@@ -31,11 +43,17 @@ pub(crate) fn lowers_toml_intrinsic_with_dependency_metadata() {
 #[test]
 pub(crate) fn lowers_datetime_intrinsics_via_registry() {
     let now = lower_intrinsic("datetime_now", &[]).expect("datetime_now");
-    assert_eq!(now.required_crate, Some("chrono"));
+    assert_eq!(
+        now.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&now.expr).contains("chrono::Local::now()"));
 
     let now_struct = lower_intrinsic("datetime_now_struct", &[]).expect("datetime_now_struct");
-    assert_eq!(now_struct.required_crate, Some("chrono"));
+    assert_eq!(
+        now_struct.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&now_struct.expr).contains("chrono::Datelike::year(&__dt) as i64"));
     assert!(render_expr(&now_struct.expr).contains("chrono::Timelike::second(&__dt) as i64"));
 
@@ -45,7 +63,10 @@ pub(crate) fn lowers_datetime_intrinsics_via_registry() {
 
     let from_ts =
         lower_intrinsic("datetime_from_timestamp", &["ts".to_string()]).expect("from_timestamp");
-    assert_eq!(from_ts.required_crate, Some("chrono"));
+    assert_eq!(
+        from_ts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Chrono)
+    );
     assert!(render_expr(&from_ts.expr).contains("DateTime::from_timestamp"));
     assert!(render_expr(&from_ts.expr).contains("ok_or_else"));
     assert!(render_expr(&from_ts.expr).contains("\"invalid timestamp\".to_string()"));
@@ -123,19 +144,28 @@ pub(crate) fn lowers_calendar_intrinsics_via_registry() {
 #[test]
 pub(crate) fn lowers_gzip_intrinsics_with_dependency_metadata() {
     let compress = lower_intrinsic("gzip_compress", &["data".to_string()]).expect("gzip_compress");
-    assert_eq!(compress.required_crate, Some("flate2"));
+    assert_eq!(
+        compress.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Flate2)
+    );
     assert!(render_expr(&compress.expr).contains("GzEncoder"));
 
     let decompress =
         lower_intrinsic("gzip_decompress", &["bytes".to_string()]).expect("gzip_decompress");
-    assert_eq!(decompress.required_crate, Some("flate2"));
+    assert_eq!(
+        decompress.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Flate2)
+    );
     assert!(render_expr(&decompress.expr).contains("GzDecoder"));
 }
 
 #[test]
 pub(crate) fn lowers_zip_intrinsics_with_dependency_metadata() {
     let create = lower_intrinsic("zip_create", &["path".to_string()]).expect("zip_create");
-    assert_eq!(create.required_crate, Some("zip"));
+    assert_eq!(
+        create.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Zip)
+    );
     assert!(render_expr(&create.expr).contains("ZipWriter::new"));
 
     let add = lower_intrinsic(
@@ -147,7 +177,7 @@ pub(crate) fn lowers_zip_intrinsics_with_dependency_metadata() {
         ],
     )
     .expect("zip_add_file");
-    assert_eq!(add.required_crate, Some("zip"));
+    assert_eq!(add.required_feature, Some(sifr_stdlib::StdlibFeature::Zip));
     assert!(render_expr(&add.expr).contains("start_file"));
 
     let add_bytes = lower_intrinsic(
@@ -159,12 +189,15 @@ pub(crate) fn lowers_zip_intrinsics_with_dependency_metadata() {
         ],
     )
     .expect("zip_add_file_bytes");
-    assert_eq!(add_bytes.required_crate, Some("zip"));
+    assert_eq!(
+        add_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Zip)
+    );
     assert!(render_expr(&add_bytes.expr).contains("write_all"));
 
     let read = lower_intrinsic("zip_read_file", &["path".to_string(), "name".to_string()])
         .expect("zip_read_file");
-    assert_eq!(read.required_crate, Some("zip"));
+    assert_eq!(read.required_feature, Some(sifr_stdlib::StdlibFeature::Zip));
     assert!(render_expr(&read.expr).contains("ZipArchive::new"));
 
     let read_bytes = lower_intrinsic(
@@ -172,34 +205,52 @@ pub(crate) fn lowers_zip_intrinsics_with_dependency_metadata() {
         &["path".to_string(), "name".to_string()],
     )
     .expect("zip_read_file_bytes");
-    assert_eq!(read_bytes.required_crate, Some("zip"));
+    assert_eq!(
+        read_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Zip)
+    );
     assert!(render_expr(&read_bytes.expr).contains("read_to_end"));
 
     let names = lower_intrinsic("zip_namelist", &["path".to_string()]).expect("zip_namelist");
-    assert_eq!(names.required_crate, Some("zip"));
+    assert_eq!(
+        names.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Zip)
+    );
     assert!(render_expr(&names.expr).contains("__zip.by_index"));
 }
 
 #[test]
 pub(crate) fn lowers_base64_intrinsics_with_dependency_metadata() {
     let enc = lower_intrinsic("base64_encode", &["text".to_string()]).expect("base64_encode");
-    assert_eq!(enc.required_crate, Some("base64"));
+    assert_eq!(
+        enc.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&enc.expr).contains("base64::Engine::encode"));
     assert!(render_expr(&enc.expr).contains("general_purpose::STANDARD"));
 
     let dec = lower_intrinsic("base64_decode", &["s".to_string()]).expect("base64_decode");
-    assert_eq!(dec.required_crate, Some("base64"));
+    assert_eq!(
+        dec.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&dec.expr).contains("base64::Engine::decode"));
     assert!(render_expr(&dec.expr).contains("general_purpose::STANDARD"));
 
     let enc_bytes =
         lower_intrinsic("base64_encode_bytes", &["b".to_string()]).expect("base64_encode_bytes");
-    assert_eq!(enc_bytes.required_crate, Some("base64"));
+    assert_eq!(
+        enc_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&enc_bytes.expr).contains("into_bytes"));
 
     let dec_bytes =
         lower_intrinsic("base64_decode_bytes", &["b".to_string()]).expect("base64_decode_bytes");
-    assert_eq!(dec_bytes.required_crate, Some("base64"));
+    assert_eq!(
+        dec_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&dec_bytes.expr).contains("base64::Engine::decode"));
 
     let enc_opts = lower_intrinsic(
@@ -207,7 +258,10 @@ pub(crate) fn lowers_base64_intrinsics_with_dependency_metadata() {
         &["s".to_string(), "alt".to_string(), "wrap".to_string()],
     )
     .expect("base64_encode_opts");
-    assert_eq!(enc_opts.required_crate, Some("base64"));
+    assert_eq!(
+        enc_opts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&enc_opts.expr).contains("wrapcol must be >= 0"));
 
     let dec_opts = lower_intrinsic(
@@ -220,29 +274,44 @@ pub(crate) fn lowers_base64_intrinsics_with_dependency_metadata() {
         ],
     )
     .expect("base64_decode_opts");
-    assert_eq!(dec_opts.required_crate, Some("base64"));
+    assert_eq!(
+        dec_opts.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&dec_opts.expr).contains("invalid base64 character"));
 
     let url_enc =
         lower_intrinsic("urlsafe_b64encode", &["s".to_string()]).expect("urlsafe_b64encode");
-    assert_eq!(url_enc.required_crate, Some("base64"));
+    assert_eq!(
+        url_enc.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&url_enc.expr).contains("base64::Engine::encode"));
     assert!(render_expr(&url_enc.expr).contains("general_purpose::URL_SAFE"));
 
     let url_dec =
         lower_intrinsic("urlsafe_b64decode", &["s".to_string()]).expect("urlsafe_b64decode");
-    assert_eq!(url_dec.required_crate, Some("base64"));
+    assert_eq!(
+        url_dec.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&url_dec.expr).contains("base64::Engine::decode"));
     assert!(render_expr(&url_dec.expr).contains("general_purpose::URL_SAFE"));
 
     let url_enc_bytes = lower_intrinsic("urlsafe_b64encode_bytes", &["b".to_string()])
         .expect("urlsafe_b64encode_bytes");
-    assert_eq!(url_enc_bytes.required_crate, Some("base64"));
+    assert_eq!(
+        url_enc_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&url_enc_bytes.expr).contains("into_bytes"));
 
     let url_dec_bytes = lower_intrinsic("urlsafe_b64decode_bytes", &["b".to_string()])
         .expect("urlsafe_b64decode_bytes");
-    assert_eq!(url_dec_bytes.required_crate, Some("base64"));
+    assert_eq!(
+        url_dec_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Base64)
+    );
     assert!(render_expr(&url_dec_bytes.expr).contains("base64::Engine::decode"));
 }
 
@@ -264,53 +333,89 @@ pub(crate) fn lowers_base32_intrinsics_via_registry() {
 #[test]
 pub(crate) fn lowers_hashlib_intrinsics_with_dependency_metadata() {
     let sha1 = lower_intrinsic("sha1", &["s".to_string()]).expect("sha1");
-    assert_eq!(sha1.required_crate, Some("sha1"));
+    assert_eq!(
+        sha1.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha1)
+    );
     assert!(render_expr(&sha1.expr).contains("<sha1::Sha1 as sha1::Digest>::digest"));
 
     let sha1_bytes = lower_intrinsic("sha1_bytes", &["b".to_string()]).expect("sha1_bytes");
-    assert_eq!(sha1_bytes.required_crate, Some("sha1"));
+    assert_eq!(
+        sha1_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha1)
+    );
     assert!(render_expr(&sha1_bytes.expr).contains("to_vec"));
 
     let sha512 = lower_intrinsic("sha512", &["s".to_string()]).expect("sha512");
-    assert_eq!(sha512.required_crate, Some("sha2"));
+    assert_eq!(
+        sha512.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha512.expr).contains("<sha2::Sha512 as sha2::Digest>::digest"));
 
     let sha512_bytes = lower_intrinsic("sha512_bytes", &["b".to_string()]).expect("sha512_bytes");
-    assert_eq!(sha512_bytes.required_crate, Some("sha2"));
+    assert_eq!(
+        sha512_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha512_bytes.expr).contains("to_vec"));
 
     let sha224 = lower_intrinsic("sha224", &["s".to_string()]).expect("sha224");
-    assert_eq!(sha224.required_crate, Some("sha2"));
+    assert_eq!(
+        sha224.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha224.expr).contains("<sha2::Sha224 as sha2::Digest>::digest"));
 
     let sha224_bytes = lower_intrinsic("sha224_bytes", &["b".to_string()]).expect("sha224_bytes");
-    assert_eq!(sha224_bytes.required_crate, Some("sha2"));
+    assert_eq!(
+        sha224_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha224_bytes.expr).contains("to_vec"));
 
     let sha384 = lower_intrinsic("sha384", &["s".to_string()]).expect("sha384");
-    assert_eq!(sha384.required_crate, Some("sha2"));
+    assert_eq!(
+        sha384.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha384.expr).contains("<sha2::Sha384 as sha2::Digest>::digest"));
 
     let sha384_bytes = lower_intrinsic("sha384_bytes", &["b".to_string()]).expect("sha384_bytes");
-    assert_eq!(sha384_bytes.required_crate, Some("sha2"));
+    assert_eq!(
+        sha384_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Sha2)
+    );
     assert!(render_expr(&sha384_bytes.expr).contains("to_vec"));
 
     let blake2b = lower_intrinsic("blake2b", &["s".to_string()]).expect("blake2b");
-    assert_eq!(blake2b.required_crate, Some("blake2"));
+    assert_eq!(
+        blake2b.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Blake2)
+    );
     assert!(render_expr(&blake2b.expr).contains("Blake2b512"));
 
     let blake2b_bytes =
         lower_intrinsic("blake2b_bytes", &["b".to_string()]).expect("blake2b_bytes");
-    assert_eq!(blake2b_bytes.required_crate, Some("blake2"));
+    assert_eq!(
+        blake2b_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Blake2)
+    );
     assert!(render_expr(&blake2b_bytes.expr).contains("to_vec"));
 
     let blake2s = lower_intrinsic("blake2s", &["s".to_string()]).expect("blake2s");
-    assert_eq!(blake2s.required_crate, Some("blake2"));
+    assert_eq!(
+        blake2s.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Blake2)
+    );
     assert!(render_expr(&blake2s.expr).contains("Blake2s256"));
 
     let blake2s_bytes =
         lower_intrinsic("blake2s_bytes", &["b".to_string()]).expect("blake2s_bytes");
-    assert_eq!(blake2s_bytes.required_crate, Some("blake2"));
+    assert_eq!(
+        blake2s_bytes.required_feature,
+        Some(sifr_stdlib::StdlibFeature::Blake2)
+    );
     assert!(render_expr(&blake2s_bytes.expr).contains("to_vec"));
 }
 
@@ -400,5 +505,5 @@ pub(crate) fn lower_intrinsic_accepts_ir_inputs() {
     .expect("ir file_write");
 
     assert!(render_expr(&ir.expr).contains("TextWrite"));
-    assert_eq!(ir.required_crate, None);
+    assert_eq!(ir.required_feature, None);
 }

--- a/crates/sifr_codegen/src/lib.rs
+++ b/crates/sifr_codegen/src/lib.rs
@@ -54,7 +54,7 @@ pub(crate) use lib_support::{
 pub(crate) use sifr_hir::{HirExpr, HirFunction, HirModule, HirStmt};
 pub(crate) use sifr_type_system::{ParamConvention, Type};
 pub(crate) use std::cell::{Cell, RefCell};
-pub(crate) use std::collections::{BTreeSet, HashMap, HashSet};
+pub(crate) use std::collections::{HashMap, HashSet};
 mod lower_expr;
 pub use lower_expr::*;
 mod lower_item;

--- a/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/async_runtime_codegen_tests.rs
@@ -17,7 +17,9 @@ fn test_task_timeout_context_manager_wraps_awaits() {
     assert!(result.rust_source.contains("match tokio::time::timeout"));
     assert!(result.rust_source.contains("return Err(TimeoutError::new"));
     assert!(result.rust_source.contains("struct TimeoutError"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -143,18 +145,20 @@ fn test_sync_main_does_not_require_tokio() {
     assert!(!result
         .rust_source
         .contains("#[tokio::main(flavor = \"current_thread\")]"));
-    assert!(!result.required_crates.contains("tokio"));
+    assert!(!result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
 fn test_generate_project_emits_tokio_dependency_when_required() {
     let module = empty_module();
-    let required_crates = HashSet::from(["tokio".to_string()]);
+    let required_features = HashSet::from([sifr_stdlib::StdlibFeature::Tokio]);
     let (cargo_toml, _main_rs) = generate_project_with_deps_and_crates(
         &module,
         "sifr_output",
         &HashSet::new(),
-        &required_crates,
+        &required_features,
     );
 
     assert!(cargo_toml.contains(

--- a/crates/sifr_codegen/src/lib_codegen_tests/async_task_runtime_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/async_task_runtime_codegen_tests.rs
@@ -24,7 +24,9 @@ fn test_task_group_basic_lowers_to_scope_runtime_substrate() {
     assert!(result
         .rust_source
         .contains("if let Err(__sifr_scope_failure) = group.__sifr_join_all().await"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -50,7 +52,9 @@ fn test_task_gather_lowers_to_private_gather_helper() {
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<Vec<i64>, std::convert::Infallible>"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -85,7 +89,9 @@ fn test_scope_spawn_fallible_coroutine_lowers_to_result_spawn_helper() {
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<i64, ValueError>"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -143,7 +149,9 @@ fn test_task_race_lowers_to_private_race_helper() {
     assert!(result
         .rust_source
         .contains("let result: __SifrTaskResult<i64, std::convert::Infallible>"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -208,7 +216,9 @@ fn test_task_select_lowers_to_private_select_helper() {
     assert!(result.rust_source.contains(
         "let result: __SifrSelect2<__SifrTaskResult<i64, std::convert::Infallible>, __SifrTaskResult<String, std::convert::Infallible>>"
     ));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/classes_and_basics_codegen_tests.rs
@@ -630,8 +630,12 @@ fn test_generate_rust_multi_with_metadata_aggregates_reachable_dependency_closur
     assert!(result.rust_files.contains_key("helper"));
     assert!(result.used_stdlib_modules.contains("sifr.statistics"));
     assert!(result.used_stdlib_modules.contains("sifr.math"));
-    assert!(result.required_crates.contains("num-bigint"));
-    assert!(result.required_crates.contains("num-traits"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::NumBigint));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::NumTraits));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs
@@ -617,7 +617,7 @@ fn test_generate_rust_multi_assembles_single_rust_file() {
     assert!(generate_block.contains("generate_rust_with_stdlib(module, &project_codegen_code)"));
     assert!(generate_block.contains("render_local_module_imports(module)"));
     assert!(generate_block.contains("publicize_generated_module_source(&rust_source)"));
-    assert!(generate_block.contains("required_crates.extend(codegen_result.required_crates)"));
+    assert!(generate_block.contains("required_features.extend(codegen_result.required_features)"));
     assert!(!generate_block.contains("assert_output_drained("));
     assert!(!generate_block.contains("emitter.output"));
     assert!(!generate_block.contains("module_import_prelude"));
@@ -626,12 +626,12 @@ fn test_generate_rust_multi_assembles_single_rust_file() {
 #[test]
 fn test_generate_project_emits_sifr_runtime_path_dependency_when_required() {
     let module = empty_module();
-    let required_crates = HashSet::from(["sifr_runtime".to_string()]);
+    let required_features = HashSet::from([sifr_stdlib::StdlibFeature::SifrRuntime]);
     let (cargo_toml, _main_rs) = generate_project_with_deps_and_crates(
         &module,
         "sifr_output",
         &HashSet::new(),
-        &required_crates,
+        &required_features,
     );
 
     assert!(cargo_toml.contains("sifr_runtime = { path = "));
@@ -653,7 +653,9 @@ fn test_async_main_entrypoint_gets_tokio_bootstrap_dependency() {
         .rust_source
         .contains("#[tokio::main(flavor = \"current_thread\")]"));
     assert!(result.rust_source.contains("async fn main()"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -677,7 +679,9 @@ fn test_async_result_main_entrypoint_keeps_result_return() {
         .rust_source
         .contains("async fn main() -> Result<(), ValueError>"));
     assert!(result.rust_source.contains("Ok(())"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -696,7 +700,9 @@ fn test_task_sleep_lowers_to_tokio_sleep_and_requires_tokio() {
     assert!(result
         .rust_source
         .contains("std::time::Duration::from_secs_f64"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -716,7 +722,9 @@ fn test_task_sleep_requires_tokio_without_async_main() {
     assert!(!result
         .rust_source
         .contains("#[tokio::main(flavor = \"current_thread\")]"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -741,7 +749,9 @@ fn test_task_scope_context_materializes_runtime_container() {
     assert!(result
         .rust_source
         .contains("scope.__sifr_join_all().await;"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -768,7 +778,9 @@ fn test_scope_spawn_lowers_to_owned_task_handle_substrate() {
     assert!(result
         .rust_source
         .contains("if let Err(__sifr_scope_failure) = scope.__sifr_join_all().await"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -797,7 +809,9 @@ fn test_spawn_blocking_lowers_to_distinct_blocking_task_substrate() {
     assert!(result
         .rust_source
         .contains("__sifr_spawn_blocking_infallible(compute_value);"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]
@@ -823,7 +837,9 @@ fn test_thread_pool_executor_submit_reuses_blocking_task_substrate() {
     assert!(result
         .rust_source
         .contains("__sifr_spawn_blocking_infallible(compute_value);"));
-    assert!(result.required_crates.contains("tokio"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::Tokio));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
+++ b/crates/sifr_codegen/src/lib_codegen_tests/iterators_and_generators_codegen_tests.rs
@@ -389,8 +389,12 @@ fn test_generate_rust_test_collects_imports_from_emitted_code() {
         .rust_source
         .contains("use std::collections::HashSet;"));
     assert!(result.rust_source.contains("use num_bigint::BigInt;"));
-    assert!(result.required_crates.contains("num-bigint"));
-    assert!(result.required_crates.contains("num-traits"));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::NumBigint));
+    assert!(result
+        .required_features
+        .contains(&sifr_stdlib::StdlibFeature::NumTraits));
 }
 
 #[test]

--- a/crates/sifr_codegen/src/lib_emitter_state.rs
+++ b/crates/sifr_codegen/src/lib_emitter_state.rs
@@ -39,8 +39,8 @@ pub struct RustEmitter {
     pub used_stdlib_modules: HashSet<String>,
     /// Set of intrinsic function names (for codegen dispatch)
     pub(crate) intrinsic_functions: HashSet<String>,
-    /// Crates requested by intrinsic registry lowering.
-    pub(crate) intrinsic_registry_crates: HashSet<String>,
+    /// Stdlib/runtime features requested by intrinsic registry lowering.
+    pub(crate) intrinsic_registry_features: HashSet<sifr_stdlib::StdlibFeature>,
     /// Set of (`class_name`, `field_name`) pairs that are self-referential and need Box<T>
     pub(crate) recursive_fields: HashSet<(String, String)>,
     /// Map of (`class_name`, `field_name`) -> concrete Rust type used for recursive field storage.
@@ -210,7 +210,7 @@ impl RustEmitter {
             current_class_name: None,
             used_stdlib_modules: HashSet::new(),
             intrinsic_functions: HashSet::new(),
-            intrinsic_registry_crates: HashSet::new(),
+            intrinsic_registry_features: HashSet::new(),
             recursive_fields: HashSet::new(),
             recursive_field_rust_types: HashMap::new(),
             class_field_order: HashMap::new(),

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -18,11 +18,10 @@ use crate::stdlib_filter::{
     collect_and_strip_shared_prelude, dedup_rust_items, filter_stdlib_ir_to_needed,
 };
 use sifr_hir::HirModule;
+use sifr_stdlib::StdlibFeature;
 use sifr_type_system::{ParamConvention, Type};
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::env;
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
 
 pub(crate) type FuncSignature = (Vec<(Type, ParamConvention)>, Type);
 pub(crate) type ModuleFuncSignatures = HashMap<String, FuncSignature>;
@@ -32,54 +31,6 @@ pub(crate) type IsinstanceUnionMatch = (String, String, String, UnionVariantType
 pub(crate) type IsNoneUnionMatch = (String, String, UnionVariantTypes);
 
 pub use crate::entrypoints::{generate_rust, generate_rust_test, generate_rust_with_metadata};
-
-pub fn sifr_runtime_dependency_spec() -> String {
-    let runtime_path = discover_sifr_runtime_path().unwrap_or_else(compile_time_sifr_runtime_path);
-    let escaped_path = runtime_path
-        .to_string_lossy()
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"");
-    format!("sifr_runtime = {{ path = \"{escaped_path}\" }}")
-}
-
-pub(super) fn tokio_dependency_spec() -> String {
-    "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }"
-        .to_string()
-}
-
-pub(super) fn discover_sifr_runtime_path() -> Option<PathBuf> {
-    env::var_os("SIFR_RUNTIME_PATH")
-        .map(PathBuf::from)
-        .filter(|path| path.join("Cargo.toml").is_file())
-        .or_else(discover_sifr_runtime_path_from_current_dir)
-        .or_else(discover_sifr_runtime_path_from_current_exe)
-}
-
-pub(super) fn discover_sifr_runtime_path_from_current_dir() -> Option<PathBuf> {
-    env::current_dir()
-        .ok()
-        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
-}
-
-pub(super) fn discover_sifr_runtime_path_from_current_exe() -> Option<PathBuf> {
-    env::current_exe()
-        .ok()
-        .and_then(|path| discover_sifr_runtime_path_from_ancestors(&path))
-}
-
-pub(super) fn discover_sifr_runtime_path_from_ancestors(start: &Path) -> Option<PathBuf> {
-    start.ancestors().find_map(|ancestor| {
-        let candidate = ancestor.join("crates").join("sifr_runtime");
-        candidate.join("Cargo.toml").is_file().then_some(candidate)
-    })
-}
-
-pub(super) fn compile_time_sifr_runtime_path() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")))
-        .join("sifr_runtime")
-}
 
 #[derive(Clone)]
 pub(crate) struct NestedFnCapture {
@@ -136,8 +87,8 @@ pub struct CodegenResult {
     pub rust_source: String,
     pub used_stdlib_modules: HashSet<String>,
     pub used_intrinsic_modules: HashSet<String>,
-    /// Required external crates discovered during structured lowering/codegen.
-    pub required_crates: HashSet<String>,
+    /// Required stdlib/runtime features discovered during structured lowering/codegen.
+    pub required_features: HashSet<StdlibFeature>,
     /// Map of `constant_name` -> (type, `rust_name`) for module-level constants
     pub constant_mappings: HashMap<String, (Type, String)>,
     /// Counters for structured lowering usage during emission.
@@ -148,7 +99,7 @@ pub struct CodegenResult {
 pub struct MultiModuleCodegenResult {
     pub rust_files: HashMap<String, String>,
     pub used_stdlib_modules: HashSet<String>,
-    pub required_crates: HashSet<String>,
+    pub required_features: HashSet<StdlibFeature>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -742,29 +693,29 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
         rust_source,
         used_stdlib_modules: all_used_modules.clone(),
         used_intrinsic_modules: emitter.used_stdlib_modules,
-        required_crates: {
-            let mut crates = emitter.intrinsic_registry_crates;
+        required_features: {
+            let mut features = emitter.intrinsic_registry_features;
             if needs_bigint {
-                crates.insert("num-bigint".to_string());
-                crates.insert("num-traits".to_string());
+                features.insert(StdlibFeature::NumBigint);
+                features.insert(StdlibFeature::NumTraits);
             }
             if needs_decimal {
-                crates.insert("rust_decimal".to_string());
+                features.insert(StdlibFeature::RustDecimal);
             }
             if needs_bigdecimal {
-                crates.insert("bigdecimal".to_string());
+                features.insert(StdlibFeature::BigDecimal);
             }
             if needs_sifr_int {
-                crates.insert("sifr_runtime".to_string());
+                features.insert(StdlibFeature::SifrRuntime);
             }
             if has_async_main_entrypoint
                 || uses_task_sleep
                 || module_uses_task_scope(module)
                 || stdlib_preamble.contains("tokio::")
             {
-                crates.insert("tokio".to_string());
+                features.insert(StdlibFeature::Tokio);
             }
-            crates
+            features
         },
         constant_mappings: emitter.module_constants,
         lowering_stats: emitter.lowering_stats,

--- a/crates/sifr_codegen/src/lib_project_codegen.rs
+++ b/crates/sifr_codegen/src/lib_project_codegen.rs
@@ -1,9 +1,9 @@
 use super::{
     generate_rust, generate_rust_with_stdlib, module_class_fields, module_func_signatures,
-    publicize_generated_module_source, sifr_runtime_dependency_spec, tokio_dependency_spec,
-    BTreeSet, HashMap, HashSet, HirModule, MultiModuleCodegenResult, Renderer, RustFile, RustItem,
-    StdlibCode,
+    publicize_generated_module_source, HashMap, HashSet, HirModule, MultiModuleCodegenResult,
+    Renderer, RustFile, RustItem, StdlibCode,
 };
+use sifr_stdlib::{generated_cargo_dependencies, StdlibFeature};
 pub(super) fn render_local_module_imports(module: &HirModule) -> String {
     let mut module_import_items: Vec<RustItem> = Vec::new();
     for import in &module.imports {
@@ -44,7 +44,7 @@ pub fn generate_rust_multi_with_metadata(
 ) -> MultiModuleCodegenResult {
     let mut files = HashMap::new();
     let mut used_stdlib_modules = HashSet::new();
-    let mut required_crates = HashSet::new();
+    let mut required_features = HashSet::new();
     let mut project_codegen_code = stdlib_code.clone();
 
     for (module_name, module) in modules {
@@ -70,13 +70,13 @@ pub fn generate_rust_multi_with_metadata(
 
         files.insert((*module_name).to_string(), rust_source);
         used_stdlib_modules.extend(codegen_result.used_stdlib_modules);
-        required_crates.extend(codegen_result.required_crates);
+        required_features.extend(codegen_result.required_features);
     }
 
     MultiModuleCodegenResult {
         rust_files: files,
         used_stdlib_modules,
-        required_crates,
+        required_features,
     }
 }
 
@@ -108,7 +108,7 @@ pub fn generate_project_with_deps_and_crates(
     module: &HirModule,
     project_name: &str,
     stdlib_modules: &HashSet<String>,
-    required_crates: &HashSet<String>,
+    required_features: &HashSet<StdlibFeature>,
 ) -> (String, String) {
     let mut cargo_toml = format!(
         r#"[package]
@@ -120,240 +120,7 @@ edition = "2021"
 "#
     );
 
-    // Add dependencies based on used stdlib/intrinsic modules
-    let mut deps = Vec::new();
-    for module_name in stdlib_modules
-        .iter()
-        .map(String::as_str)
-        .collect::<BTreeSet<_>>()
-    {
-        match module_name {
-            "sifr.json" | "sifr.collections" | "_sifr.json" | "_sifr.collections" => {
-                if !deps.contains(
-                    &"serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                        .to_string(),
-                ) {
-                    deps.push(
-                        "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                            .to_string(),
-                    );
-                    deps.push(
-                        "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
-                    );
-                }
-            }
-            "sifr.time" | "_sifr.time" => {
-                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
-                    deps.push("chrono = \"0.4.44\"".to_string());
-                }
-            }
-            "sifr.random" | "_sifr.crypto" => {
-                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
-                    deps.push("rand = \"0.10.1\"".to_string());
-                }
-                if !deps.contains(&"rand_distr = \"0.6.0\"".to_string()) {
-                    deps.push("rand_distr = \"0.6.0\"".to_string());
-                }
-            }
-            "sifr.uuid" | "_sifr.uuid" => {
-                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
-                    deps.push("rand = \"0.10.1\"".to_string());
-                }
-                let uuid_dep =
-                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string();
-                if !deps.contains(&uuid_dep) {
-                    deps.push(uuid_dep);
-                }
-            }
-            "sifr.re" | "_sifr.regex" => {
-                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
-                    deps.push("regex = \"1.12.3\"".to_string());
-                }
-            }
-            "sifr.pathlib" => {
-                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
-                    deps.push("regex = \"1.12.3\"".to_string());
-                }
-            }
-            "sifr.hash" | "sifr.hashlib" => {
-                if !deps.contains(&"sha2 = \"0.11.0\"".to_string()) {
-                    deps.push("sha2 = \"0.11.0\"".to_string());
-                    deps.push("md5 = \"0.8.0\"".to_string());
-                    deps.push("sha1 = \"0.11.0\"".to_string());
-                    deps.push("blake2 = \"0.10.6\"".to_string());
-                }
-            }
-            "sifr.encoding" | "sifr.base64" => {
-                if !deps.contains(&"base64 = \"0.22.1\"".to_string()) {
-                    deps.push("base64 = \"0.22.1\"".to_string());
-                }
-            }
-            "sifr.tomllib" | "_sifr.toml" => {
-                let toml_dep =
-                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string();
-                if !deps.contains(&toml_dep) {
-                    deps.push(toml_dep);
-                }
-            }
-            "sifr.datetime" | "_sifr.datetime" => {
-                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
-                    deps.push("chrono = \"0.4.44\"".to_string());
-                }
-            }
-            "sifr.gzip" | "sifr.zipfile" | "_sifr.compress" => {
-                if !deps.contains(&"flate2 = \"1.1.9\"".to_string()) {
-                    deps.push("flate2 = \"1.1.9\"".to_string());
-                }
-                if !deps.contains(&"zip = \"8.6.0\"".to_string()) {
-                    deps.push("zip = \"8.6.0\"".to_string());
-                }
-            }
-            "_bigint" => {
-                if !deps.contains(&"num-bigint = \"0.4.6\"".to_string()) {
-                    deps.push("num-bigint = \"0.4.6\"".to_string());
-                    deps.push("num-traits = \"0.2.19\"".to_string());
-                }
-            }
-            // sifr.io, sifr.env, sifr.os, sifr.math, sifr.test, sifr.bytes, sifr.sys,
-            // sifr.subprocess, sifr.html, sifr.calendar, sifr.operator use only std library
-            _ => {}
-        }
-    }
-
-    for crate_name in required_crates
-        .iter()
-        .map(String::as_str)
-        .collect::<BTreeSet<_>>()
-    {
-        match crate_name {
-            "serde_json" => {
-                if !deps.contains(
-                    &"serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                        .to_string(),
-                ) {
-                    deps.push(
-                        "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                            .to_string(),
-                    );
-                }
-                if !deps
-                    .contains(&"serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string())
-                {
-                    deps.push("serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string());
-                }
-            }
-            "chrono" => {
-                if !deps.contains(&"chrono = \"0.4.44\"".to_string()) {
-                    deps.push("chrono = \"0.4.44\"".to_string());
-                }
-            }
-            "rand" => {
-                if !deps.contains(&"rand = \"0.10.1\"".to_string()) {
-                    deps.push("rand = \"0.10.1\"".to_string());
-                }
-            }
-            "rand_distr" => {
-                if !deps.contains(&"rand_distr = \"0.6.0\"".to_string()) {
-                    deps.push("rand_distr = \"0.6.0\"".to_string());
-                }
-            }
-            "regex" => {
-                if !deps.contains(&"regex = \"1.12.3\"".to_string()) {
-                    deps.push("regex = \"1.12.3\"".to_string());
-                }
-            }
-            "sha2" => {
-                if !deps.contains(&"sha2 = \"0.11.0\"".to_string()) {
-                    deps.push("sha2 = \"0.11.0\"".to_string());
-                }
-            }
-            "md5" => {
-                if !deps.contains(&"md5 = \"0.8.0\"".to_string()) {
-                    deps.push("md5 = \"0.8.0\"".to_string());
-                }
-            }
-            "sha1" => {
-                if !deps.contains(&"sha1 = \"0.11.0\"".to_string()) {
-                    deps.push("sha1 = \"0.11.0\"".to_string());
-                }
-            }
-            "uuid" => {
-                let uuid_dep =
-                    "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }".to_string();
-                if !deps.contains(&uuid_dep) {
-                    deps.push(uuid_dep);
-                }
-            }
-            "blake2" => {
-                if !deps.contains(&"blake2 = \"0.10.6\"".to_string()) {
-                    deps.push("blake2 = \"0.10.6\"".to_string());
-                }
-            }
-            "base64" => {
-                if !deps.contains(&"base64 = \"0.22.1\"".to_string()) {
-                    deps.push("base64 = \"0.22.1\"".to_string());
-                }
-            }
-            "toml" => {
-                let toml_dep =
-                    "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }".to_string();
-                if !deps.contains(&toml_dep) {
-                    deps.push(toml_dep);
-                }
-            }
-            "flate2" => {
-                if !deps.contains(&"flate2 = \"1.1.9\"".to_string()) {
-                    deps.push("flate2 = \"1.1.9\"".to_string());
-                }
-            }
-            "zip" => {
-                if !deps.contains(&"zip = \"8.6.0\"".to_string()) {
-                    deps.push("zip = \"8.6.0\"".to_string());
-                }
-            }
-            "num-bigint" => {
-                if !deps.contains(&"num-bigint = \"0.4.6\"".to_string()) {
-                    deps.push("num-bigint = \"0.4.6\"".to_string());
-                }
-            }
-            "num-traits" => {
-                if !deps.contains(&"num-traits = \"0.2.19\"".to_string()) {
-                    deps.push("num-traits = \"0.2.19\"".to_string());
-                }
-            }
-            "rust_decimal" => {
-                if !deps.contains(
-                    &"rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
-                ) {
-                    deps.push(
-                        "rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }".to_string(),
-                    );
-                }
-            }
-            "bigdecimal" => {
-                if !deps.contains(
-                    &"bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
-                ) {
-                    deps.push(
-                        "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }".to_string(),
-                    );
-                }
-            }
-            "sifr_runtime" | "sifr-runtime" => {
-                let dep = sifr_runtime_dependency_spec();
-                if !deps.contains(&dep) {
-                    deps.push(dep);
-                }
-            }
-            "tokio" => {
-                let dep = tokio_dependency_spec();
-                if !deps.contains(&dep) {
-                    deps.push(dep);
-                }
-            }
-            _ => {}
-        }
-    }
+    let deps = generated_cargo_dependencies(stdlib_modules, required_features);
 
     if !deps.is_empty() {
         cargo_toml.push_str("\n[dependencies]\n");

--- a/crates/sifr_driver/src/build/cargo_manifest.rs
+++ b/crates/sifr_driver/src/build/cargo_manifest.rs
@@ -1,28 +1,29 @@
-use sifr_codegen::generate_project_with_deps_and_crates;
-use sifr_hir::HirModule;
-use std::collections::{HashMap, HashSet};
+use sifr_stdlib::{generated_cargo_dependencies, StdlibFeature};
+use std::collections::HashSet;
 
 pub(crate) fn generate_dependency_cargo_toml(
     project_name: &str,
     stdlib_modules: &HashSet<String>,
-    required_crates: &HashSet<String>,
+    required_features: &HashSet<StdlibFeature>,
 ) -> String {
-    let (cargo_toml, _) = generate_project_with_deps_and_crates(
-        &empty_hir_module(),
-        project_name,
-        stdlib_modules,
-        required_crates,
-    );
-    cargo_toml
-}
+    let mut cargo_toml = format!(
+        r#"[package]
+name = "{project_name}"
+version = "0.1.0"
+edition = "2021"
 
-fn empty_hir_module() -> HirModule {
-    HirModule {
-        functions: vec![],
-        classes: vec![],
-        imports: vec![],
-        constants: vec![],
-        generic_functions: HashMap::new(),
-        type_param_bounds: HashMap::new(),
+[workspace]
+"#
+    );
+
+    let deps = generated_cargo_dependencies(stdlib_modules, required_features);
+    if !deps.is_empty() {
+        cargo_toml.push_str("\n[dependencies]\n");
+        for dep in &deps {
+            cargo_toml.push_str(dep);
+            cargo_toml.push('\n');
+        }
     }
+
+    cargo_toml
 }

--- a/crates/sifr_driver/src/build/entrypoint.rs
+++ b/crates/sifr_driver/src/build/entrypoint.rs
@@ -375,6 +375,7 @@ impl RootedEntrypointPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sifr_stdlib::StdlibFeature;
 
     fn mktemp_dir(name: &str) -> PathBuf {
         let unique = format!(
@@ -405,7 +406,7 @@ mod tests {
         assert!(generated_project.support_modules.is_empty());
         assert!(generated_project.main_rs.contains("fn main"));
         assert!(generated_project.used_stdlib_modules.is_empty());
-        assert!(generated_project.required_crates.is_empty());
+        assert!(generated_project.required_features.is_empty());
     }
 
     #[test]
@@ -502,8 +503,12 @@ def helper() -> bigint:\n    return bigint(1)\n",
             .used_stdlib_modules
             .contains("sifr.statistics"));
         assert!(generated_project.used_stdlib_modules.contains("sifr.math"));
-        assert!(generated_project.required_crates.contains("num-bigint"));
-        assert!(generated_project.required_crates.contains("num-traits"));
+        assert!(generated_project
+            .required_features
+            .contains(&StdlibFeature::NumBigint));
+        assert!(generated_project
+            .required_features
+            .contains(&StdlibFeature::NumTraits));
 
         let _ = std::fs::remove_dir_all(dir);
     }
@@ -537,7 +542,9 @@ def helper() -> bigint:\n    return bigint(1)\n",
             .expect("project metadata aggregation should succeed");
 
         assert!(!generated_project.used_stdlib_modules.contains("sifr.json"));
-        assert!(!generated_project.required_crates.contains("serde_json"));
+        assert!(!generated_project
+            .required_features
+            .contains(&StdlibFeature::SerdeJson));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/crates/sifr_driver/src/build/materialize.rs
+++ b/crates/sifr_driver/src/build/materialize.rs
@@ -4,6 +4,7 @@ use super::{prepare_cached_artifact, CachedArtifactEntry, PreparedArtifactCache}
 use crate::diagnostics::RenderedDiagnostic;
 use crate::project::{namespace_module_files, rust_module_file_path};
 use sifr_diagnostics::DiagnosticCode;
+use sifr_stdlib::StdlibFeature;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -73,7 +74,7 @@ fn materialize_binary_project_at_path(
     let cargo_toml = generate_dependency_cargo_toml(
         project_name,
         &generated_project.used_stdlib_modules,
-        &generated_project.required_crates,
+        &generated_project.required_features,
     );
 
     write_project_file(&project_path.join("Cargo.toml"), cargo_toml, "Cargo.toml")?;
@@ -176,7 +177,7 @@ fn binary_project_cache_key(
     generated_project: &GeneratedBinaryProject,
 ) -> String {
     let stdlib_modules = sorted_lines(&generated_project.used_stdlib_modules);
-    let required_crates = sorted_lines(&generated_project.required_crates);
+    let required_features = sorted_feature_lines(&generated_project.required_features);
     let support_modules = generated_project
         .support_modules
         .iter()
@@ -188,12 +189,12 @@ fn binary_project_cache_key(
         generate_dependency_cargo_toml(
             project_name,
             &generated_project.used_stdlib_modules,
-            &generated_project.required_crates
+            &generated_project.required_features
         ),
         generated_project.main_rs,
         support_modules,
         stdlib_modules.join("\n"),
-        required_crates.join("\n")
+        required_features.join("\n")
     )
 }
 
@@ -201,6 +202,14 @@ fn sorted_lines(values: &std::collections::HashSet<String>) -> Vec<String> {
     let mut ordered: BTreeSet<&str> = BTreeSet::new();
     for value in values {
         ordered.insert(value.as_str());
+    }
+    ordered.into_iter().map(str::to_string).collect()
+}
+
+fn sorted_feature_lines(values: &std::collections::HashSet<StdlibFeature>) -> Vec<String> {
+    let mut ordered: BTreeSet<&str> = BTreeSet::new();
+    for value in values {
+        ordered.insert(value.id());
     }
     ordered.into_iter().map(str::to_string).collect()
 }

--- a/crates/sifr_driver/src/build/project_codegen.rs
+++ b/crates/sifr_driver/src/build/project_codegen.rs
@@ -4,13 +4,14 @@ use crate::project::{
 };
 use sifr_codegen::{generate_rust_multi_with_metadata, StdlibCode};
 use sifr_hir::HirModule;
+use sifr_stdlib::StdlibFeature;
 use std::collections::{BTreeMap, HashSet};
 
 pub(super) struct GeneratedBinaryProject {
     pub(super) main_rs: String,
     pub(super) support_modules: BTreeMap<String, String>,
     pub(super) used_stdlib_modules: HashSet<String>,
-    pub(super) required_crates: HashSet<String>,
+    pub(super) required_features: HashSet<StdlibFeature>,
 }
 
 impl GeneratedBinaryProject {
@@ -41,7 +42,7 @@ pub(super) fn generated_single_file_binary_project(
         main_rs: codegen_result.rust_source,
         support_modules: BTreeMap::new(),
         used_stdlib_modules: codegen_result.used_stdlib_modules,
-        required_crates: codegen_result.required_crates,
+        required_features: codegen_result.required_features,
     }
 }
 
@@ -83,6 +84,6 @@ pub(super) fn generated_project_binary_project(
         main_rs,
         support_modules,
         used_stdlib_modules: codegen_result.used_stdlib_modules,
-        required_crates: codegen_result.required_crates,
+        required_features: codegen_result.required_features,
     })
 }

--- a/crates/sifr_driver/src/diagnostics.rs
+++ b/crates/sifr_driver/src/diagnostics.rs
@@ -2,6 +2,7 @@ use sifr_diagnostics::codes::registry_entry;
 use sifr_diagnostics::{DiagnosticArg, DiagnosticCode};
 pub(crate) use sifr_diagnostics::{DiagnosticSpan, RenderedDiagnostic, Severity};
 use sifr_package::{PackageDiagnostic, PackageDiagnosticOrigin};
+use sifr_stdlib::StdlibFeature;
 use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::io::Write;
@@ -17,7 +18,7 @@ pub enum CompileResultFull {
     Success {
         rust_source: String,
         used_stdlib_modules: HashSet<String>,
-        required_crates: HashSet<String>,
+        required_features: HashSet<StdlibFeature>,
         lowering_stats: sifr_codegen::LoweringStats,
     },
     Errors {

--- a/crates/sifr_driver/src/frontend/api.rs
+++ b/crates/sifr_driver/src/frontend/api.rs
@@ -50,7 +50,7 @@ pub fn compile_with_metadata(source: &str) -> CompileResultFull {
     CompileResultFull::Success {
         rust_source: codegen_result.rust_source,
         used_stdlib_modules: codegen_result.used_stdlib_modules,
-        required_crates: codegen_result.required_crates,
+        required_features: codegen_result.required_features,
         lowering_stats: codegen_result.lowering_stats,
     }
 }

--- a/crates/sifr_driver/src/test_runner/artifacts.rs
+++ b/crates/sifr_driver/src/test_runner/artifacts.rs
@@ -1,5 +1,6 @@
 use crate::build::generate_dependency_cargo_toml;
 use crate::project::top_level_module_declarations;
+use sifr_stdlib::StdlibFeature;
 use std::collections::HashSet;
 
 pub(crate) fn compose_test_runner_lib(
@@ -21,7 +22,7 @@ pub(crate) fn compose_test_runner_lib(
 
 pub(crate) fn generate_test_runner_cargo_toml(
     stdlib_modules: &HashSet<String>,
-    required_crates: &HashSet<String>,
+    required_features: &HashSet<StdlibFeature>,
 ) -> String {
-    generate_dependency_cargo_toml("sifr_tests", stdlib_modules, required_crates)
+    generate_dependency_cargo_toml("sifr_tests", stdlib_modules, required_features)
 }

--- a/crates/sifr_driver/src/test_runner/execution.rs
+++ b/crates/sifr_driver/src/test_runner/execution.rs
@@ -17,7 +17,7 @@ pub(crate) fn execute_test_runner_project(
 ) -> Result<TestRunnerExecutionOutcome, Vec<RenderedDiagnostic>> {
     let cargo_toml = generate_test_runner_cargo_toml(
         &generated_project.all_stdlib_modules,
-        &generated_project.all_required_crates,
+        &generated_project.all_required_features,
     );
     let test_lib = compose_test_runner_lib(
         &generated_project.support_module_names,
@@ -171,16 +171,16 @@ fn test_runner_cache_key(
         .map(String::as_str)
         .collect();
     stdlib_modules.sort_unstable();
-    let mut required_crates: Vec<&str> = generated_project
-        .all_required_crates
+    let mut required_features: Vec<&str> = generated_project
+        .all_required_features
         .iter()
-        .map(String::as_str)
+        .map(|feature| feature.id())
         .collect();
-    required_crates.sort_unstable();
+    required_features.sort_unstable();
     format!(
         "[scope]\n{}\n[Cargo.toml]\n{cargo_toml}\n[src/lib.rs]\n{test_lib}\n[support]\n{support_modules}\n[stdlib]\n{}\n[crates]\n{}",
         generated_project.cache_scope.display(),
         stdlib_modules.join("\n"),
-        required_crates.join("\n")
+        required_features.join("\n")
     )
 }

--- a/crates/sifr_driver/src/test_runner/orchestrator.rs
+++ b/crates/sifr_driver/src/test_runner/orchestrator.rs
@@ -12,6 +12,7 @@ use sifr_frontend::{
     compile_module_hir_with_source, FrontendDiagnosticStyle, FrontendSourceContext,
 };
 use sifr_hir::HirModule;
+use sifr_stdlib::StdlibFeature;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -21,7 +22,7 @@ pub(crate) struct GeneratedTestRunnerProject {
     pub(crate) support_rust_files: HashMap<String, String>,
     pub(crate) all_rust_code: String,
     pub(crate) all_stdlib_modules: HashSet<String>,
-    pub(crate) all_required_crates: HashSet<String>,
+    pub(crate) all_required_features: HashSet<StdlibFeature>,
 }
 
 pub fn run_tests(test_dir: &Path) -> Result<bool, Vec<RenderedDiagnostic>> {
@@ -86,7 +87,7 @@ pub(crate) fn build_test_runner_project(
 
     let mut all_rust_code = String::new();
     let mut all_stdlib_modules = support_codegen.used_stdlib_modules;
-    let mut all_required_crates = support_codegen.required_crates;
+    let mut all_required_features = support_codegen.required_features;
 
     for (module_name, test_file) in test_files_by_module {
         let Some(parsed) = test_modules.get(module_name.as_str()) else {
@@ -141,7 +142,7 @@ pub(crate) fn build_test_runner_project(
         all_rust_code.push_str(&codegen_result.rust_source);
         all_rust_code.push('\n');
         all_stdlib_modules.extend(codegen_result.used_stdlib_modules);
-        all_required_crates.extend(codegen_result.required_crates);
+        all_required_features.extend(codegen_result.required_features);
     }
 
     Ok(GeneratedTestRunnerProject {
@@ -150,6 +151,6 @@ pub(crate) fn build_test_runner_project(
         support_rust_files: support_codegen.rust_files,
         all_rust_code,
         all_stdlib_modules,
-        all_required_crates,
+        all_required_features,
     })
 }

--- a/crates/sifr_driver/src/tests/project_build_check.rs
+++ b/crates/sifr_driver/src/tests/project_build_check.rs
@@ -354,7 +354,7 @@ def broken() -> int:
 }
 
 #[test]
-fn test_build_project_includes_support_module_required_crates_in_manifest() {
+fn test_build_project_includes_support_module_required_features_in_manifest() {
     let dir = mktemp_dir("manifest_positive");
     let main_file = dir.join("main.sifr");
     let build_out = dir.join("build_out");
@@ -382,7 +382,7 @@ fn test_build_project_includes_support_module_required_crates_in_manifest() {
 }
 
 #[test]
-fn test_build_project_manifest_ignores_unreachable_required_crates() {
+fn test_build_project_manifest_ignores_unreachable_required_features() {
     let dir = mktemp_dir("manifest_negative");
     let main_file = dir.join("main.sifr");
     let build_out = dir.join("build_out");

--- a/crates/sifr_driver/src/tests/test_runner.rs
+++ b/crates/sifr_driver/src/tests/test_runner.rs
@@ -397,16 +397,16 @@ fn test_run_tests_frontend_type_errors_use_single_path_prefix() {
 }
 
 #[test]
-fn test_generate_test_runner_cargo_toml_includes_required_crates() {
+fn test_generate_test_runner_cargo_toml_includes_required_features() {
     let stdlib_modules = HashSet::new();
-    let required_crates = HashSet::from([
-        "regex".to_string(),
-        "rand".to_string(),
-        "rand_distr".to_string(),
-        "sifr_runtime".to_string(),
+    let required_features = HashSet::from([
+        sifr_stdlib::StdlibFeature::Regex,
+        sifr_stdlib::StdlibFeature::Rand,
+        sifr_stdlib::StdlibFeature::RandDistr,
+        sifr_stdlib::StdlibFeature::SifrRuntime,
     ]);
 
-    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
+    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_features);
     assert!(cargo_toml.contains("name = \"sifr_tests\""));
     assert!(cargo_toml.contains("regex = \"1.12.3\""));
     assert!(cargo_toml.contains("rand = \"0.10.1\""));
@@ -417,9 +417,9 @@ fn test_generate_test_runner_cargo_toml_includes_required_crates() {
 #[test]
 fn test_generate_test_runner_cargo_toml_preserves_stdlib_deps() {
     let stdlib_modules = HashSet::from(["sifr.json".to_string()]);
-    let required_crates = HashSet::new();
+    let required_features = HashSet::new();
 
-    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
+    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_features);
     assert!(cargo_toml
         .contains("serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"));
     assert!(cargo_toml.contains("serde = { version = \"1.0.228\", features = [\"derive\"] }"));
@@ -428,9 +428,9 @@ fn test_generate_test_runner_cargo_toml_preserves_stdlib_deps() {
 #[test]
 fn test_generate_test_runner_cargo_toml_preserves_tomllib_ordering_deps() {
     let stdlib_modules = HashSet::from(["sifr.tomllib".to_string()]);
-    let required_crates = HashSet::new();
+    let required_features = HashSet::new();
 
-    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_crates);
+    let cargo_toml = generate_test_runner_cargo_toml(&stdlib_modules, &required_features);
     assert!(cargo_toml.contains("toml = { version = \"1.1.2\", features = [\"preserve_order\"] }"));
 }
 

--- a/crates/sifr_stdlib/src/features.rs
+++ b/crates/sifr_stdlib/src/features.rs
@@ -1,0 +1,435 @@
+use std::collections::{BTreeSet, HashSet};
+use std::env;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum StdlibFeature {
+    Base64,
+    BigDecimal,
+    Blake2,
+    Chrono,
+    Flate2,
+    Md5,
+    NumBigint,
+    NumTraits,
+    Rand,
+    RandDistr,
+    Regex,
+    RustDecimal,
+    SerdeJson,
+    Sha1,
+    Sha2,
+    SifrRuntime,
+    Tokio,
+    Toml,
+    Uuid,
+    Zip,
+}
+
+impl StdlibFeature {
+    #[must_use]
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::Base64 => "base64",
+            Self::BigDecimal => "bigdecimal",
+            Self::Blake2 => "blake2",
+            Self::Chrono => "chrono",
+            Self::Flate2 => "flate2",
+            Self::Md5 => "md5",
+            Self::NumBigint => "num-bigint",
+            Self::NumTraits => "num-traits",
+            Self::Rand => "rand",
+            Self::RandDistr => "rand_distr",
+            Self::Regex => "regex",
+            Self::RustDecimal => "rust_decimal",
+            Self::SerdeJson => "serde_json",
+            Self::Sha1 => "sha1",
+            Self::Sha2 => "sha2",
+            Self::SifrRuntime => "sifr_runtime",
+            Self::Tokio => "tokio",
+            Self::Toml => "toml",
+            Self::Uuid => "uuid",
+            Self::Zip => "zip",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GeneratedCargoDependency {
+    pub package: &'static str,
+    pub spec: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StdlibFeatureSpec {
+    pub feature: StdlibFeature,
+    pub cargo_dependencies: &'static [GeneratedCargoDependency],
+}
+
+const BASE64_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "base64",
+    spec: "base64 = \"0.22.1\"",
+}];
+const BIGDECIMAL_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "bigdecimal",
+    spec: "bigdecimal = { version = \"0.4.10\", features = [\"serde\"] }",
+}];
+const BLAKE2_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "blake2",
+    spec: "blake2 = \"0.10.6\"",
+}];
+const CHRONO_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "chrono",
+    spec: "chrono = \"0.4.44\"",
+}];
+const FLATE2_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "flate2",
+    spec: "flate2 = \"1.1.9\"",
+}];
+const MD5_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "md5",
+    spec: "md5 = \"0.8.0\"",
+}];
+const NUM_BIGINT_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "num-bigint",
+    spec: "num-bigint = \"0.4.6\"",
+}];
+const NUM_TRAITS_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "num-traits",
+    spec: "num-traits = \"0.2.19\"",
+}];
+const RAND_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "rand",
+    spec: "rand = \"0.10.1\"",
+}];
+const RAND_DISTR_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "rand_distr",
+    spec: "rand_distr = \"0.6.0\"",
+}];
+const REGEX_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "regex",
+    spec: "regex = \"1.12.3\"",
+}];
+const RUST_DECIMAL_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "rust_decimal",
+    spec: "rust_decimal = { version = \"1.41.0\", features = [\"maths\", \"serde-with-str\"] }",
+}];
+const SERDE_JSON_DEPS: &[GeneratedCargoDependency] = &[
+    GeneratedCargoDependency {
+        package: "serde_json",
+        spec: "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }",
+    },
+    GeneratedCargoDependency {
+        package: "serde",
+        spec: "serde = { version = \"1.0.228\", features = [\"derive\"] }",
+    },
+];
+const SHA1_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "sha1",
+    spec: "sha1 = \"0.11.0\"",
+}];
+const SHA2_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "sha2",
+    spec: "sha2 = \"0.11.0\"",
+}];
+const SIFR_RUNTIME_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "sifr_runtime",
+    spec: "sifr_runtime",
+}];
+const TOKIO_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "tokio",
+    spec: "tokio = { version = \"1.52.3\", features = [\"macros\", \"rt\", \"sync\", \"time\"] }",
+}];
+const TOML_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "toml",
+    spec: "toml = { version = \"1.1.2\", features = [\"preserve_order\"] }",
+}];
+const UUID_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "uuid",
+    spec: "uuid = { version = \"1.23.1\", features = [\"v3\", \"v5\"] }",
+}];
+const ZIP_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
+    package: "zip",
+    spec: "zip = \"8.6.0\"",
+}];
+
+pub const STDLIB_FEATURE_SPECS: &[StdlibFeatureSpec] = &[
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Base64,
+        cargo_dependencies: BASE64_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::BigDecimal,
+        cargo_dependencies: BIGDECIMAL_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Blake2,
+        cargo_dependencies: BLAKE2_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Chrono,
+        cargo_dependencies: CHRONO_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Flate2,
+        cargo_dependencies: FLATE2_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Md5,
+        cargo_dependencies: MD5_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::NumBigint,
+        cargo_dependencies: NUM_BIGINT_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::NumTraits,
+        cargo_dependencies: NUM_TRAITS_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Rand,
+        cargo_dependencies: RAND_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::RandDistr,
+        cargo_dependencies: RAND_DISTR_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Regex,
+        cargo_dependencies: REGEX_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::RustDecimal,
+        cargo_dependencies: RUST_DECIMAL_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::SerdeJson,
+        cargo_dependencies: SERDE_JSON_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Sha1,
+        cargo_dependencies: SHA1_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Sha2,
+        cargo_dependencies: SHA2_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::SifrRuntime,
+        cargo_dependencies: SIFR_RUNTIME_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Tokio,
+        cargo_dependencies: TOKIO_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Toml,
+        cargo_dependencies: TOML_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Uuid,
+        cargo_dependencies: UUID_DEPS,
+    },
+    StdlibFeatureSpec {
+        feature: StdlibFeature::Zip,
+        cargo_dependencies: ZIP_DEPS,
+    },
+];
+
+#[must_use]
+pub fn feature_for_codegen_requirement(name: &str) -> Option<StdlibFeature> {
+    match name {
+        "base64" => Some(StdlibFeature::Base64),
+        "bigdecimal" => Some(StdlibFeature::BigDecimal),
+        "blake2" => Some(StdlibFeature::Blake2),
+        "chrono" => Some(StdlibFeature::Chrono),
+        "flate2" => Some(StdlibFeature::Flate2),
+        "md5" => Some(StdlibFeature::Md5),
+        "num-bigint" => Some(StdlibFeature::NumBigint),
+        "num-traits" => Some(StdlibFeature::NumTraits),
+        "rand" => Some(StdlibFeature::Rand),
+        "rand_distr" => Some(StdlibFeature::RandDistr),
+        "regex" => Some(StdlibFeature::Regex),
+        "rust_decimal" => Some(StdlibFeature::RustDecimal),
+        "serde_json" => Some(StdlibFeature::SerdeJson),
+        "sha1" => Some(StdlibFeature::Sha1),
+        "sha2" => Some(StdlibFeature::Sha2),
+        "sifr_runtime" | "sifr-runtime" => Some(StdlibFeature::SifrRuntime),
+        "tokio" => Some(StdlibFeature::Tokio),
+        "toml" => Some(StdlibFeature::Toml),
+        "uuid" => Some(StdlibFeature::Uuid),
+        "zip" => Some(StdlibFeature::Zip),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub fn features_for_stdlib_module(module_name: &str) -> &'static [StdlibFeature] {
+    match module_name {
+        "sifr.json" | "sifr.collections" | "_sifr.json" | "_sifr.collections" => {
+            &[StdlibFeature::SerdeJson]
+        }
+        "sifr.time" | "_sifr.time" => &[StdlibFeature::Chrono],
+        "sifr.random" | "_sifr.crypto" => &[StdlibFeature::Rand, StdlibFeature::RandDistr],
+        "sifr.uuid" | "_sifr.uuid" => &[StdlibFeature::Rand, StdlibFeature::Uuid],
+        "sifr.re" | "_sifr.regex" | "sifr.pathlib" => &[StdlibFeature::Regex],
+        "sifr.hash" | "sifr.hashlib" => &[
+            StdlibFeature::Sha2,
+            StdlibFeature::Md5,
+            StdlibFeature::Sha1,
+            StdlibFeature::Blake2,
+        ],
+        "sifr.encoding" | "sifr.base64" => &[StdlibFeature::Base64],
+        "sifr.tomllib" | "_sifr.toml" => &[StdlibFeature::Toml],
+        "sifr.datetime" | "_sifr.datetime" => &[StdlibFeature::Chrono],
+        "sifr.gzip" | "sifr.zipfile" | "_sifr.compress" => {
+            &[StdlibFeature::Flate2, StdlibFeature::Zip]
+        }
+        "_bigint" => &[StdlibFeature::NumBigint, StdlibFeature::NumTraits],
+        _ => &[],
+    }
+}
+
+#[must_use]
+pub fn generated_cargo_dependencies(
+    stdlib_modules: &HashSet<String>,
+    required_features: &HashSet<StdlibFeature>,
+) -> Vec<String> {
+    let mut deps = Vec::new();
+    let mut packages = BTreeSet::new();
+
+    for module_name in stdlib_modules
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>()
+    {
+        for feature in features_for_stdlib_module(module_name) {
+            push_feature_dependencies(&mut deps, &mut packages, *feature);
+        }
+    }
+
+    for feature in required_features.iter().copied().collect::<BTreeSet<_>>() {
+        push_feature_dependencies(&mut deps, &mut packages, feature);
+    }
+
+    deps
+}
+
+fn push_feature_dependencies(
+    deps: &mut Vec<String>,
+    packages: &mut BTreeSet<&'static str>,
+    feature: StdlibFeature,
+) {
+    if let Some(spec) = STDLIB_FEATURE_SPECS
+        .iter()
+        .find(|spec| spec.feature == feature)
+    {
+        for dependency in spec.cargo_dependencies {
+            if packages.insert(dependency.package) {
+                deps.push(render_dependency_spec(dependency));
+            }
+        }
+    }
+}
+
+fn render_dependency_spec(dependency: &GeneratedCargoDependency) -> String {
+    if dependency.package == "sifr_runtime" {
+        return sifr_runtime_dependency_spec();
+    }
+    dependency.spec.to_string()
+}
+
+fn sifr_runtime_dependency_spec() -> String {
+    let runtime_path = discover_sifr_runtime_path().unwrap_or_else(compile_time_sifr_runtime_path);
+    let escaped_path = runtime_path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("sifr_runtime = {{ path = \"{escaped_path}\" }}")
+}
+
+fn discover_sifr_runtime_path() -> Option<PathBuf> {
+    env::var_os("SIFR_RUNTIME_PATH")
+        .map(PathBuf::from)
+        .filter(|path| path.join("Cargo.toml").is_file())
+        .or_else(discover_sifr_runtime_path_from_current_dir)
+        .or_else(discover_sifr_runtime_path_from_current_exe)
+}
+
+fn discover_sifr_runtime_path_from_current_dir() -> Option<PathBuf> {
+    env::current_dir()
+        .ok()
+        .and_then(|dir| find_sifr_runtime_ancestor(&dir))
+}
+
+fn discover_sifr_runtime_path_from_current_exe() -> Option<PathBuf> {
+    env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+        .and_then(|dir| find_sifr_runtime_ancestor(&dir))
+}
+
+fn find_sifr_runtime_ancestor(start: &Path) -> Option<PathBuf> {
+    for ancestor in start.ancestors() {
+        let candidate = ancestor.join("crates").join("sifr_runtime");
+        if candidate.join("Cargo.toml").is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn compile_time_sifr_runtime_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    match manifest_dir.parent() {
+        Some(parent) => parent.join("sifr_runtime"),
+        None => manifest_dir.join("../sifr_runtime"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generated_cargo_dependencies, StdlibFeature};
+    use std::collections::HashSet;
+
+    #[test]
+    fn stdlib_module_dependencies_are_deterministic_and_deduplicated() {
+        let stdlib_modules = HashSet::from([
+            "sifr.json".to_string(),
+            "_sifr.json".to_string(),
+            "sifr.random".to_string(),
+        ]);
+        let required_features = HashSet::from([StdlibFeature::SerdeJson, StdlibFeature::Rand]);
+
+        let deps = generated_cargo_dependencies(&stdlib_modules, &required_features);
+
+        assert_eq!(
+            deps,
+            vec![
+                "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }",
+                "serde = { version = \"1.0.228\", features = [\"derive\"] }",
+                "rand = \"0.10.1\"",
+                "rand_distr = \"0.6.0\"",
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_modules_and_empty_features_do_not_emit_dependencies() {
+        let stdlib_modules = HashSet::from(["sifr.io".to_string()]);
+        let required_features = HashSet::new();
+
+        assert!(generated_cargo_dependencies(&stdlib_modules, &required_features).is_empty());
+    }
+
+    #[test]
+    fn runtime_and_tokio_features_render_owned_dependency_specs() {
+        let deps = generated_cargo_dependencies(
+            &HashSet::new(),
+            &HashSet::from([StdlibFeature::SifrRuntime, StdlibFeature::Tokio]),
+        );
+
+        assert!(deps.iter().any(|dep| dep.starts_with("sifr_runtime = ")));
+        assert!(deps.iter().any(|dep| dep.starts_with("tokio = ")));
+    }
+}

--- a/crates/sifr_stdlib/src/lib.rs
+++ b/crates/sifr_stdlib/src/lib.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 mod collections_bytes_time;
 mod crypto_regex_uuid;
+mod features;
 mod io_json;
 mod math_test;
 mod platform_misc;
@@ -17,6 +18,10 @@ mod sys_fs;
 
 use collections_bytes_time::{intrinsic_bytes, intrinsic_collections, intrinsic_time};
 use crypto_regex_uuid::{intrinsic_crypto, intrinsic_regex, intrinsic_uuid};
+pub use features::{
+    feature_for_codegen_requirement, features_for_stdlib_module, generated_cargo_dependencies,
+    GeneratedCargoDependency, StdlibFeature, StdlibFeatureSpec, STDLIB_FEATURE_SPECS,
+};
 use io_json::{intrinsic_io, intrinsic_json};
 use math_test::{intrinsic_math, intrinsic_test};
 use platform_misc::{

--- a/issues/ad-hoc-stdlib-ir-lowering-boundary-refactor-execution.md
+++ b/issues/ad-hoc-stdlib-ir-lowering-boundary-refactor-execution.md
@@ -2,11 +2,11 @@
 
 Phase contract: [ad-hoc-stdlib-ir-lowering-boundary-refactor.md](./ad-hoc-stdlib-ir-lowering-boundary-refactor.md)
 
-Status: planned
+Status: in progress
 
 ## Checklist
 
-- [ ] `milestone_stdlib_boundary_1`: Create `sifr_stdlib` Contract Crate
+- [x] `milestone_stdlib_boundary_1`: Create `sifr_stdlib` Contract Crate
 - [ ] `milestone_stdlib_boundary_2`: Centralize Stdlib Feature And Dependency Manifest
 - [ ] `milestone_ir_boundary_1`: Extract `sifr_ir` Data Crate
 - [ ] `milestone_ir_boundary_2`: Rename Remainder To `sifr_lowering`
@@ -21,6 +21,7 @@ Record planning and implementation reviews here.
 - Follow-up planning review: `reviews/ad-hoc-stdlib-ir-lowering-boundary-refactor-review-pass-2.md` -> `CHANGES_REQUESTED`; aligned `sifr_stdlib` locked dependency rules with the guardrail forbidden set and added a direct-lowering dependency guard for `sifr_analysis`.
 - Final planning review: `reviews/ad-hoc-stdlib-ir-lowering-boundary-refactor-review-pass-3.md` -> `READY`; reviewer confirmed the contract is implementation-ready with precise crate ownership, acyclic dependency direction, enumerable exit gates, and milestone validation coverage.
 - M1 implementation review: `reviews/ad-hoc-stdlib-boundary-m1-review-1.md` -> `READY`; reviewer confirmed the `sifr_stdlib` contract crate owns intrinsic signatures and embedded source inventory, driver still owns bootstrap compilation, no `sifr_hir` stdlib shim remains, and dependency direction is clean.
+- M2 implementation review: `reviews/ad-hoc-stdlib-boundary-m2-review-4.md` -> `READY`; reviewer found no blockers and confirmed the stdlib feature/dependency manifest boundary is mergeable.
 
 ## Validation Ledger
 
@@ -36,7 +37,20 @@ Record local validation for each milestone before opening the corresponding PR.
   - `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/import_intrinsic.sifr` -> expected `SIFR-IMPORT-0001` failure.
   - `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/stdlib_io_consolidated.sifr` -> PASS.
   - `scripts/run_all_tests.sh --profile create-pr` -> PASS (`target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded).
-- M2: pending.
+- M2: local validation passed.
+  - `cargo check -p sifr_stdlib` -> PASS.
+  - `cargo check -p sifr_codegen` -> PASS.
+  - `cargo check -p sifr_driver` -> PASS.
+  - `cargo test -p sifr_stdlib` -> PASS.
+  - `cargo test -p sifr_driver` -> PASS.
+  - `cargo test -p sifr_codegen generate_project_emits -- --nocapture` -> PASS.
+  - `cargo test -p sifr_codegen lowers_json_intrinsics_with_dependency_metadata -- --nocapture` -> PASS.
+  - `cargo test -p sifr_codegen lowers_random_intrinsics_via_registry -- --nocapture` -> PASS.
+  - `cargo test -p sifr --test e2e --no-run` -> PASS.
+  - `python3 scripts/check_file_size_guardrails.py` -> PASS.
+  - `scripts/run_all_tests.sh --profile create-pr` -> PASS (`target/validation_lane_reports/create-pr.latest.json`; wall time 77.93s, advisories: none).
+  - `scripts/check_codegen_binary_size.sh origin/main HEAD` -> PASS (`baseline_size_bytes=522640`, `candidate_size_bytes=522640`, `delta_bytes=0`).
+  - `cargo test -p sifr_codegen` -> FAILS with 54 pre-existing codegen/render expectation failures; verified representative failure on clean `origin/main` before M2 implementation. Focused M2 dependency/metadata tests above pass.
 - M3: pending.
 - M4: pending.
 - M5: pending.
@@ -46,7 +60,7 @@ Record local validation for each milestone before opening the corresponding PR.
 
 Record merged PR links here as each milestone lands.
 
-- M1: pending.
+- M1: https://github.com/sifr-lang/sifr/pull/2284
 - M2: pending.
 - M3: pending.
 - M4: pending.

--- a/reviews/ad-hoc-stdlib-boundary-m2-review-4.md
+++ b/reviews/ad-hoc-stdlib-boundary-m2-review-4.md
@@ -1,0 +1,10 @@
+Verdict: READY
+
+Findings: None
+
+Non-blocking notes:
+- `sifr_codegen::generate_project_with_deps_and_crates` (crates/sifr_codegen/src/lib_project_codegen.rs) still assembles its own `[package]`/`[dependencies]` Cargo.toml header by hand and now only delegates the deps body to `sifr_stdlib::generated_cargo_dependencies`. The driver's `generate_dependency_cargo_toml` (crates/sifr_driver/src/build/cargo_manifest.rs) duplicates the same header logic. If the codegen-side helper has no remaining callers, consider removing it; otherwise either path should be the single owner of manifest assembly to keep the boundary clean.
+- `sifr_stdlib::feature_for_codegen_requirement` (crates/sifr_stdlib/src/features.rs) is publicly exported but not referenced in this packet. If it is reserved for upcoming milestones (e.g. M3), that's fine; otherwise it's effectively dead surface area.
+- `features_for_stdlib_module` returns `&'static [StdlibFeature]`, so callers can't differentiate "unknown module" from "module with no deps". The current single call site doesn't care, but a richer return (e.g. `Option<&[…]>`) would be friendlier if future code grows around it.
+- `scripts/check_codegen_binary_size.sh` now symlinks `third_party/ruff` and pre-creates `audits/leetcode/src`. The symlink is harmless because both worktrees treat the path identically, but it means the size run no longer reflects a truly clean checkout of either ref. Worth a comment in the script noting that intent.
+- Pre-existing 54 `cargo test -p sifr_codegen` expectation failures reproduce on `origin/main`, as stated — not a regression here.

--- a/scripts/check_codegen_binary_size.sh
+++ b/scripts/check_codegen_binary_size.sh
@@ -49,6 +49,39 @@ trap cleanup EXIT
 git -C "$REPO_ROOT" worktree add --detach "$BASE_WT" "$BASE_REF" >/dev/null
 git -C "$REPO_ROOT" worktree add --detach "$CAND_WT" "$CANDIDATE_REF" >/dev/null
 
+materialize_ruff_submodule() {
+  local worktree="$1"
+  local ruff_path="$worktree/third_party/ruff"
+  local local_ruff_path="$REPO_ROOT/third_party/ruff"
+
+  if [[ -f "$ruff_path/crates/ruff_text_size/Cargo.toml" ]]; then
+    return
+  fi
+
+  if [[ -f "$local_ruff_path/crates/ruff_text_size/Cargo.toml" ]]; then
+    mkdir -p "$worktree/third_party"
+    rm -rf "$ruff_path"
+    ln -s "$local_ruff_path" "$ruff_path"
+    return
+  fi
+
+  git -C "$worktree" submodule update --init --recursive third_party/ruff >/dev/null
+}
+
+materialize_ruff_submodule "$BASE_WT"
+materialize_ruff_submodule "$CAND_WT"
+
+materialize_local_workspace_roots() {
+  local worktree="$1"
+
+  # This local audit corpus is intentionally not required for the size demo,
+  # but the repository sifr.toml names the directory as a workspace source root.
+  mkdir -p "$worktree/audits/leetcode/src"
+}
+
+materialize_local_workspace_roots "$BASE_WT"
+materialize_local_workspace_roots "$CAND_WT"
+
 measure_size() {
   local worktree="$1"
   local label="$2"


### PR DESCRIPTION
## Summary
- centralize generated Cargo dependency policy in sifr_stdlib feature specs
- change codegen/driver metadata plumbing from required crate strings to typed StdlibFeature values
- keep E2E harness dependency-name model by converting features back to stable ids at that boundary
- make the binary-size helper materialize local temp-worktree prerequisites

## Validation
- cargo check -p sifr_stdlib
- cargo check -p sifr_codegen
- cargo check -p sifr_driver
- cargo test -p sifr_stdlib
- cargo test -p sifr_driver
- cargo test -p sifr_codegen generate_project_emits -- --nocapture
- cargo test -p sifr_codegen lowers_json_intrinsics_with_dependency_metadata -- --nocapture
- cargo test -p sifr_codegen lowers_random_intrinsics_via_registry -- --nocapture
- cargo test -p sifr --test e2e --no-run
- python3 scripts/check_file_size_guardrails.py
- scripts/run_all_tests.sh --profile create-pr
- scripts/check_codegen_binary_size.sh origin/main HEAD

Reviewer: reviews/ad-hoc-stdlib-boundary-m2-review-4.md -> READY