### PR TITLE
milestone_ir_boundary_3: enforce dependency guardrails

### DIFF
--- a/issues/ad-hoc-stdlib-ir-lowering-boundary-refactor-execution.md
+++ b/issues/ad-hoc-stdlib-ir-lowering-boundary-refactor-execution.md
@@ -9,7 +9,7 @@ Status: in progress
 - [x] `milestone_stdlib_boundary_1`: Create `sifr_stdlib` Contract Crate
 - [x] `milestone_stdlib_boundary_2`: Centralize Stdlib Feature And Dependency Manifest
 - [x] `milestone_ir_boundary_1`: Extract `sifr_ir` Data Crate
-- [ ] `milestone_ir_boundary_2`: Rename Remainder To `sifr_lowering`
+- [x] `milestone_ir_boundary_2`: Rename Remainder To `sifr_lowering`
 - [ ] `milestone_ir_boundary_3`: Dependency Direction Guardrails
 - [ ] `milestone_ir_boundary_4`: Documentation And Phase Closeout
 
@@ -24,6 +24,7 @@ Record planning and implementation reviews here.
 - M2 implementation review: `reviews/ad-hoc-stdlib-boundary-m2-review-4.md` -> `READY`; reviewer found no blockers and confirmed the stdlib feature/dependency manifest boundary is mergeable.
 - M3 implementation review: `reviews/ad-hoc-stdlib-boundary-m3-review-2.md` -> `READY`; reviewer found no blockers and confirmed the `sifr_ir` data boundary, codegen/lint dependency direction, and retained HIR CFG/flow-graph construction match the M3 contract.
 - M4 implementation review: `reviews/ad-hoc-stdlib-boundary-m4-review-2.md` -> `READY`; reviewer found no blockers and confirmed the `sifr_hir` crate is retired, codegen/lint dependency direction stays on `sifr_ir`, and remaining old-name references are migration-plan history.
+- M5 implementation review: `reviews/ad-hoc-stdlib-boundary-m5-review-3.md` -> `READY`; reviewer confirmed the guardrail covers parser crate edges, production source references, direct normal dependency edges, generated dependency spec ownership, allowed downstream spec reads, and test-only codegen lowering helpers.
 
 ## Validation Ledger
 
@@ -86,7 +87,14 @@ Record local validation for each milestone before opening the corresponding PR.
   - `cargo fmt --check` -> PASS.
   - `git diff --check` -> PASS.
   - `scripts/run_all_tests.sh --profile create-pr` -> PASS (`target/validation_lane_reports/create-pr.latest.json`; wall time 76.78s, advisories: none).
-- M5: pending.
+- M5: local validation passed.
+  - `python3 scripts/check_source_crate_dependency_direction.py` -> PASS.
+  - `python3 scripts/check_source_crate_dependency_direction.py --self-test` -> PASS; seeded positive and negative cases cover `sifr_source`, `sifr_ir`, parser-crate edges, production source references, test-only codegen lowering references, `sifr_stdlib`, `sifr_codegen`, `sifr_lint`, `sifr_analysis`, and generated dependency spec ownership.
+  - `python3 scripts/check_file_size_guardrails.py` -> PASS.
+  - `cargo fmt --check` -> PASS.
+  - `cargo clippy --workspace -- -D warnings` -> PASS.
+  - `git diff --check` -> PASS.
+  - `scripts/run_all_tests.sh --profile create-pr` -> PASS (`target/validation_lane_reports/create-pr.latest.json`; wall time 78.63s, advisories: none).
 - M6: pending.
 
 ## Merged PRs
@@ -96,6 +104,6 @@ Record merged PR links here as each milestone lands.
 - M1: https://github.com/sifr-lang/sifr/pull/2284
 - M2: https://github.com/sifr-lang/sifr/pull/2285
 - M3: https://github.com/sifr-lang/sifr/pull/2286
-- M4: pending.
+- M4: https://github.com/sifr-lang/sifr/pull/2287
 - M5: pending.
 - M6: pending.

--- a/reviews/ad-hoc-stdlib-boundary-m5-review-1.md
+++ b/reviews/ad-hoc-stdlib-boundary-m5-review-1.md
@@ -1,0 +1,14 @@
+Verdict: READY
+
+Findings:
+- None blocking. Some lower-confidence observations worth noting but not blockers:
+  - `scripts/check_source_crate_dependency_direction.py:46-58` (`IR_FORBIDDEN_DEPENDENCIES`): the milestone scope lists "parser" alongside "syntax". The guardrail forbids `sifr_syntax` for `sifr_ir` but does not include `sifr_python_parser` / `sifr_python_ast` (the Ruff-fork submodule crates named in `AGENTS.md`'s pipeline). If those crates are reachable as workspace path-deps, future regressions onto them would not be caught. Worth confirming with the M6 doc pass whether "parser" is intended to alias `sifr_syntax` here or whether the submodule crates need an explicit listing.
+  - `scripts/check_source_crate_dependency_direction.py:53-61` (`GENERATED_DEPENDENCY_SPEC_TOKENS`): the ownership check is a substring match. Tokens like `STDLIB_FEATURE_SPECS`, `GeneratedCargoDependency {`, and `StdlibFeatureSpec {` will trigger on any consumer that reads or pattern-matches the spec via `sifr_stdlib::STDLIB_FEATURE_SPECS`, even though such consumption is legitimate (ownership ≠ no read access). Currently passes only because no other crate touches the spec by name yet — a forward false-positive risk for downstream consumers.
+
+Validation Gaps / Residual Risks:
+- Self-tests exercise manifest-edge mutations only; the source-reference scanning path (`use sifr_x` / `sifr_x::`) and the `is_test_source` skip heuristic are not seeded with positive/negative fixtures, so regressions in that branch could go undetected.
+- Manifest scan covers `[dependencies]` and `[build-dependencies]` plus their target-cfg variants but skips `[dev-dependencies]` intentionally. That matches the "test-only codegen lowering helpers" allowance, but leaves no rail against accidentally moving a real prod dep into `[dev-dependencies]` to bypass the guard.
+- The "advisory: warm wall-time budget exceeded" on the create-pr run (148.33s) is informational; the self-test does add tempdir churn under `target/` but is not the dominant cost — flagging only in case the budget tightens.
+
+Summary:
+- M5 extends the existing source-crate dependency-direction script into a multi-rule guardrail (sifr_ir / sifr_stdlib / sifr_codegen / sifr_lint / sifr_analysis), enforces generated-spec ownership in `sifr_stdlib`, ships a self-test with positive plus six targeted negative cases, and wires both the check and the self-test into `run_core_guardrails`, which is reached by `--profile create-pr`. Definition-of-done (codegen/lint/analysis → lowering edges fail before PR review) is met. No blockers; the parser-naming and substring-token observations should be revisited in M6's documentation/closeout pass.

--- a/reviews/ad-hoc-stdlib-boundary-m5-review-2.md
+++ b/reviews/ad-hoc-stdlib-boundary-m5-review-2.md
@@ -1,0 +1,12 @@
+Verdict: READY
+
+Findings:
+- None. The round 1 concerns are addressed substantively, not cosmetically: parser crates are explicitly forbidden for both `sifr_ir` and `sifr_stdlib` (`scripts/check_source_crate_dependency_direction.py:64-71, 105-127`); the generated-spec scan now uses definition-anchored regexes that require `struct`/`const`/`fn` keywords before the symbol (lines 73-82), so legitimate downstream reads like `sifr_stdlib::STDLIB_FEATURE_SPECS` cannot trip the guardrail; and the self-test fixture seeds exactly that downstream read alongside a test-only `sifr_lowering` reference in `lib_codegen_tests.rs` to lock in both behaviors (lines 235-244, 312-320). The "production source reference" negative case for codegen (lines 304-310) confirms non-test code is still caught.
+
+Validation Gaps / Residual Risks:
+- `is_test_source` hardcodes the filename `lib_codegen_tests.rs` next to the `_tests.rs` suffix check. If future codegen-side test helpers don't follow that naming, contributors will need to extend this list rather than relying on a convention. Minor.
+- The generated-spec definition patterns are an enumerated allowlist of known symbols/functions (e.g., `GeneratedCargoDependency`, `STDLIB_FEATURE_SPECS`, `render_dependency_spec`). New spec abstractions added to `sifr_stdlib` will need a corresponding pattern entry, otherwise duplication outside the crate could slip through. Acceptable but worth noting in M6 closeout docs.
+- The self-test runs inside `target/` via `tempfile.TemporaryDirectory(dir=REPO_ROOT / "target")`; harmless given `.gitignore`, but assumes `target/` exists when the script runs in isolation. Create-pr wiring already builds the workspace so this is fine in practice.
+
+Summary:
+- Round 2 closes the round 1 gaps with targeted changes: parser-crate forbids on `sifr_ir`/`sifr_stdlib`, regex-anchored generated-spec ownership detection, and self-test coverage that exercises both positive downstream reads and negative production-source/test-only edge cases. Create-pr wiring invokes both the live scan and the self-test inside `run_core_guardrails`, and local validation (create-pr 83.60s, advisories none) is recorded in the issue ledger. Ready to merge.

--- a/reviews/ad-hoc-stdlib-boundary-m5-review-3.md
+++ b/reviews/ad-hoc-stdlib-boundary-m5-review-3.md
@@ -1,0 +1,11 @@
+Verdict: READY
+
+Findings:
+- None.
+
+Validation Gaps / Residual Risks:
+- Self-test tempdirs now nest under `target/`, which is gitignored and conventional for build artifacts; no risk introduced.
+- Self-test still depends on `target/` being creatable from CWD=repo root; acceptable since the script resolves `REPO_ROOT` from its own path.
+
+Summary:
+- Delta only relocates self-test temp directories under `target/` (created on demand) and reruns validation. Create-pr profile passes in 78.63s with no advisories; round 2 READY verdict still holds.

--- a/scripts/check_source_crate_dependency_direction.py
+++ b/scripts/check_source_crate_dependency_direction.py
@@ -1,58 +1,406 @@
 #!/usr/bin/env python3
-"""Guard the bottom-of-graph dependency contract for `sifr_source`."""
+"""Guard source, IR, stdlib, and lowering-boundary dependency direction."""
 
 from __future__ import annotations
 
-import pathlib
+import argparse
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+import re
 import sys
+import tempfile
 import tomllib
 
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-SOURCE_CRATE = REPO_ROOT / "crates" / "sifr_source"
-ALLOWED_DEPENDENCIES = {"ruff_text_size"}
-FORBIDDEN_CRATES = {
-    "sifr_diagnostics",
-    "sifr_syntax",
-    "sifr_frontend",
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SELF_TEST_TMP_ROOT = REPO_ROOT / "target"
+
+NORMAL_DEP_SECTIONS = ("dependencies", "build-dependencies")
+TARGET_DEP_SECTIONS = ("dependencies", "build-dependencies")
+
+ALL_SIFR_CRATES = {
+    "sifr",
     "sifr_analysis",
-    "sifr_lsp",
-    "sifr_lint",
+    "sifr_codegen",
+    "sifr_diagnostics",
+    "sifr_driver",
     "sifr_format",
-    "sifr_package",
+    "sifr_frontend",
+    "sifr_ir",
+    "sifr_lint",
     "sifr_lowering",
+    "sifr_lsp",
+    "sifr_package",
+    "sifr_runtime",
+    "sifr_source",
+    "sifr_stdlib",
+    "sifr_syntax",
     "sifr_type_system",
+}
+
+IR_FORBIDDEN_DEPENDENCIES = {
+    "sifr",
+    "sifr_analysis",
     "sifr_codegen",
     "sifr_driver",
-    "sifr",
+    "sifr_frontend",
+    "sifr_lint",
+    "sifr_lowering",
+    "sifr_lsp",
+    "sifr_package",
+    "sifr_stdlib",
+    "sifr_syntax",
 }
+
+STDLIB_FORBIDDEN_DEPENDENCIES = {
+    "sifr",
+    "sifr_analysis",
+    "sifr_codegen",
+    "sifr_driver",
+    "sifr_frontend",
+    "sifr_lint",
+    "sifr_lowering",
+    "sifr_lsp",
+    "sifr_package",
+}
+
+PARSER_CRATES = {
+    "sifr_python_ast",
+    "sifr_python_parser",
+}
+
+GENERATED_DEPENDENCY_SPEC_DEFINITION_PATTERNS = (
+    re.compile(r"\b(?:pub\s+)?struct\s+GeneratedCargoDependency\b"),
+    re.compile(r"\b(?:pub\s+)?struct\s+StdlibFeatureSpec\b"),
+    re.compile(r"\b(?:pub\s+)?const\s+STDLIB_FEATURE_SPECS\b"),
+    re.compile(r"\bconst\s+[A-Z0-9_]+_DEPS\s*:\s*&\s*\[GeneratedCargoDependency\]"),
+    re.compile(r"\bfn\s+generated_cargo_dependencies\b"),
+    re.compile(r"\bfn\s+render_dependency_spec\b"),
+)
+
+
+@dataclass(frozen=True)
+class CrateRule:
+    crate: str
+    allowed_normal_dependencies: frozenset[str] | None = None
+    forbidden_normal_dependencies: frozenset[str] = frozenset()
+    forbidden_source_references: frozenset[str] = frozenset()
+    skip_test_sources: bool = False
+
+
+RULES = (
+    CrateRule(
+        crate="sifr_source",
+        allowed_normal_dependencies=frozenset({"ruff_text_size"}),
+        forbidden_source_references=frozenset(ALL_SIFR_CRATES - {"sifr_source"}),
+    ),
+    CrateRule(
+        crate="sifr_ir",
+        forbidden_normal_dependencies=frozenset(
+            IR_FORBIDDEN_DEPENDENCIES | PARSER_CRATES
+        ),
+        forbidden_source_references=frozenset(IR_FORBIDDEN_DEPENDENCIES | PARSER_CRATES),
+    ),
+    CrateRule(
+        crate="sifr_stdlib",
+        forbidden_normal_dependencies=frozenset(
+            STDLIB_FORBIDDEN_DEPENDENCIES | PARSER_CRATES | {"sifr_syntax"}
+        ),
+        forbidden_source_references=frozenset(
+            STDLIB_FORBIDDEN_DEPENDENCIES | PARSER_CRATES | {"sifr_syntax"}
+        ),
+    ),
+    CrateRule(
+        crate="sifr_codegen",
+        forbidden_normal_dependencies=frozenset({"sifr_lowering"}),
+        forbidden_source_references=frozenset({"sifr_lowering"}),
+        skip_test_sources=True,
+    ),
+    CrateRule(
+        crate="sifr_lint",
+        forbidden_normal_dependencies=frozenset({"sifr_lowering"}),
+        forbidden_source_references=frozenset({"sifr_lowering"}),
+        skip_test_sources=True,
+    ),
+    CrateRule(
+        crate="sifr_analysis",
+        forbidden_normal_dependencies=frozenset({"sifr_lowering"}),
+        forbidden_source_references=frozenset({"sifr_lowering"}),
+        skip_test_sources=True,
+    ),
+)
+
+
+def load_manifest(root: Path, crate: str) -> dict:
+    manifest_path = root / "crates" / crate / "Cargo.toml"
+    if not manifest_path.exists():
+        return {}
+    return tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def normal_dependencies(manifest: dict) -> set[str]:
+    dependencies: set[str] = set()
+    for section in NORMAL_DEP_SECTIONS:
+        dependencies.update(manifest.get(section, {}))
+    for target in manifest.get("target", {}).values():
+        for section in TARGET_DEP_SECTIONS:
+            dependencies.update(target.get(section, {}))
+    return dependencies
+
+
+def is_test_source(path: Path) -> bool:
+    name = path.name
+    return (
+        "tests" in path.parts
+        or name == "lib_codegen_tests.rs"
+        or name.endswith("_tests.rs")
+        or name == "tests.rs"
+    )
+
+
+def crate_source_files(root: Path, crate: str, *, skip_test_sources: bool) -> list[Path]:
+    src = root / "crates" / crate / "src"
+    if not src.exists():
+        return []
+    files = sorted(src.rglob("*.rs"))
+    if skip_test_sources:
+        files = [path for path in files if not is_test_source(path.relative_to(src))]
+    return files
+
+
+def references_crate(text: str, crate: str) -> bool:
+    return re.search(rf"\buse\s+{re.escape(crate)}\b", text) is not None or re.search(
+        rf"\b{re.escape(crate)}::", text
+    ) is not None
+
+
+def validate_crate_rule(root: Path, rule: CrateRule) -> list[str]:
+    failures: list[str] = []
+    manifest = load_manifest(root, rule.crate)
+    if not manifest:
+        failures.append(f"{rule.crate}: missing Cargo.toml")
+        return failures
+
+    dependencies = normal_dependencies(manifest)
+    if rule.allowed_normal_dependencies is not None:
+        unexpected = sorted(dependencies - rule.allowed_normal_dependencies)
+        if unexpected:
+            failures.append(
+                f"{rule.crate}: unexpected normal dependency/dependencies: "
+                + ", ".join(unexpected)
+            )
+
+    forbidden_dependencies = sorted(dependencies & rule.forbidden_normal_dependencies)
+    if forbidden_dependencies:
+        failures.append(
+            f"{rule.crate}: forbidden normal dependency/dependencies: "
+            + ", ".join(forbidden_dependencies)
+        )
+
+    for path in crate_source_files(
+        root, rule.crate, skip_test_sources=rule.skip_test_sources
+    ):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for crate in sorted(rule.forbidden_source_references):
+            if references_crate(text, crate):
+                rel = path.relative_to(root)
+                failures.append(f"{rule.crate}: {rel} references {crate}")
+    return failures
+
+
+def generated_dependency_spec_violations(root: Path) -> list[str]:
+    failures: list[str] = []
+    crates_root = root / "crates"
+    for path in sorted(crates_root.rglob("*.rs")):
+        rel = path.relative_to(root)
+        if rel.parts[:2] == ("crates", "sifr_stdlib"):
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for pattern in GENERATED_DEPENDENCY_SPEC_DEFINITION_PATTERNS:
+            if pattern.search(text):
+                failures.append(
+                    f"{rel} defines generated dependency spec pattern {pattern.pattern!r}"
+                )
+                break
+    return failures
+
+
+def validate(root: Path) -> list[str]:
+    failures: list[str] = []
+    for rule in RULES:
+        failures.extend(validate_crate_rule(root, rule))
+    failures.extend(generated_dependency_spec_violations(root))
+    return failures
+
+
+def write_manifest(crate_root: Path, name: str, deps: list[str] | None = None) -> None:
+    crate_root.mkdir(parents=True, exist_ok=True)
+    dependency_lines = ""
+    for dependency in deps or []:
+        dependency_lines += f'{dependency} = {{ path = "../{dependency}" }}\n'
+    crate_root.joinpath("Cargo.toml").write_text(
+        f"""[package]
+name = "{name}"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+{dependency_lines}""",
+        encoding="utf-8",
+    )
+    src = crate_root / "src"
+    src.mkdir(exist_ok=True)
+    src.joinpath("lib.rs").write_text("", encoding="utf-8")
+
+
+def seed_valid_repo(root: Path) -> None:
+    allowed_deps = {
+        "sifr_source": ["ruff_text_size"],
+        "sifr_ir": ["sifr_diagnostics", "sifr_type_system"],
+        "sifr_stdlib": ["sifr_type_system"],
+        "sifr_codegen": ["sifr_ir", "sifr_stdlib"],
+        "sifr_lint": ["sifr_frontend", "sifr_ir"],
+        "sifr_analysis": ["sifr_frontend", "sifr_lint"],
+    }
+    for crate in ALL_SIFR_CRATES | {"ruff_text_size"}:
+        write_manifest(root / "crates" / crate, crate, allowed_deps.get(crate, []))
+    stdlib_src = root / "crates" / "sifr_stdlib" / "src" / "features.rs"
+    stdlib_src.write_text("pub struct GeneratedCargoDependency;\n", encoding="utf-8")
+    codegen_src = root / "crates" / "sifr_codegen" / "src"
+    codegen_src.joinpath("lib.rs").write_text(
+        "pub fn read_specs() { let _ = sifr_stdlib::STDLIB_FEATURE_SPECS; }\n",
+        encoding="utf-8",
+    )
+    codegen_src.joinpath("lib_codegen_tests.rs").write_text(
+        "use sifr_lowering::lower_module;\n",
+        encoding="utf-8",
+    )
+
+
+def assert_self_test_case(
+    label: str, mutate: Callable[[Path], object], expected_fragment: str, failures: list[str]
+) -> None:
+    SELF_TEST_TMP_ROOT.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=SELF_TEST_TMP_ROOT) as tmp:
+        root = Path(tmp)
+        seed_valid_repo(root)
+        mutate(root)
+        found = validate(root)
+    if not any(expected_fragment in failure for failure in found):
+        failures.append(f"{label}: seeded violation was not detected; found={found!r}")
+
+
+def run_self_test() -> int:
+    failures: list[str] = []
+    SELF_TEST_TMP_ROOT.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=SELF_TEST_TMP_ROOT) as tmp:
+        root = Path(tmp)
+        seed_valid_repo(root)
+        found = validate(root)
+    if found:
+        failures.append(f"positive fixture unexpectedly failed: {found!r}")
+
+    assert_self_test_case(
+        "sifr_source upward dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_source", "sifr_source", ["sifr_diagnostics"]
+        ),
+        "sifr_source: unexpected normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_ir parser dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_ir", "sifr_ir", ["sifr_python_parser"]
+        ),
+        "sifr_ir: forbidden normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_ir source reference",
+        lambda root: (
+            root / "crates" / "sifr_ir" / "src" / "lib.rs"
+        ).write_text("use sifr_lowering::LoweringResult;\n", encoding="utf-8"),
+        "sifr_ir: crates/sifr_ir/src/lib.rs references sifr_lowering",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_stdlib codegen dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_stdlib", "sifr_stdlib", ["sifr_codegen"]
+        ),
+        "sifr_stdlib: forbidden normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_codegen lowering dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_codegen", "sifr_codegen", ["sifr_lowering"]
+        ),
+        "sifr_codegen: forbidden normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_codegen production source reference",
+        lambda root: (
+            root / "crates" / "sifr_codegen" / "src" / "lib.rs"
+        ).write_text("pub fn leak() { sifr_lowering::lower_module(); }\n", encoding="utf-8"),
+        "sifr_codegen: crates/sifr_codegen/src/lib.rs references sifr_lowering",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_lint lowering dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_lint", "sifr_lint", ["sifr_lowering"]
+        ),
+        "sifr_lint: forbidden normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "sifr_analysis lowering dependency",
+        lambda root: write_manifest(
+            root / "crates" / "sifr_analysis", "sifr_analysis", ["sifr_lowering"]
+        ),
+        "sifr_analysis: forbidden normal dependency",
+        failures,
+    )
+    assert_self_test_case(
+        "generated dependency spec outside stdlib",
+        lambda root: (
+            root
+            / "crates"
+            / "sifr_codegen"
+            / "src"
+            / "lib.rs"
+        ).write_text("pub struct GeneratedCargoDependency;\n", encoding="utf-8"),
+        "generated dependency spec pattern",
+        failures,
+    )
+
+    if failures:
+        print("source crate dependency-direction self-test: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("source crate dependency-direction self-test: PASS")
+    return 0
 
 
 def main() -> int:
-    manifest = tomllib.loads((SOURCE_CRATE / "Cargo.toml").read_text())
-    dependencies = set(manifest.get("dependencies", {}))
-    unexpected = sorted(dependencies - ALLOWED_DEPENDENCIES)
-    if unexpected:
-        print(
-            "sifr_source has non-bottom dependency/dependencies: "
-            + ", ".join(unexpected),
-            file=sys.stderr,
-        )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return run_self_test()
+
+    failures = validate(REPO_ROOT)
+    if failures:
+        print("source crate dependency-direction guardrail: FAIL", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
         return 1
-
-    violations: list[str] = []
-    for path in sorted((SOURCE_CRATE / "src").rglob("*.rs")):
-        text = path.read_text()
-        for crate in sorted(FORBIDDEN_CRATES):
-            if f"use {crate}" in text or f"{crate}::" in text:
-                violations.append(f"{path.relative_to(REPO_ROOT)} references {crate}")
-
-    if violations:
-        print("sifr_source depends upward in source code:", file=sys.stderr)
-        for violation in violations:
-            print(f"  - {violation}", file=sys.stderr)
-        return 1
-
+    print("source crate dependency-direction guardrail: PASS")
     return 0
 
 

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -122,6 +122,7 @@ run_core_guardrails() {
 
   echo "Running source crate dependency-direction guardrail"
   python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py"
+  python3 "${SCRIPT_DIR}/check_source_crate_dependency_direction.py" --self-test
 
   echo "Running TypeScript-Go architecture transfer M1 guardrails"
   python3 "${SCRIPT_DIR}/../verification/tooling/check_typescript_go_m1_guardrails.py"


### PR DESCRIPTION
## Summary

- expand `scripts/check_source_crate_dependency_direction.py` from a `sifr_source`-only guardrail into the phase dependency-boundary guardrail
- enforce protected normal dependency/source-reference rules for `sifr_ir`, `sifr_stdlib`, `sifr_codegen`, `sifr_lint`, and `sifr_analysis`
- add generated dependency spec ownership checks so specs remain defined in `sifr_stdlib`
- add self-tests with positive and seeded negative cases, including parser crate edges, production source references, allowed codegen test-only lowering references, and allowed downstream reads of stdlib specs
- wire the self-test into create-pr core guardrails

## Validation

- `python3 scripts/check_source_crate_dependency_direction.py` -> PASS
- `python3 scripts/check_source_crate_dependency_direction.py --self-test` -> PASS
- `python3 scripts/check_file_size_guardrails.py` -> PASS
- `cargo fmt --check` -> PASS
- `cargo clippy --workspace -- -D warnings` -> PASS
- `git diff --check` -> PASS
- `scripts/run_all_tests.sh --profile create-pr` -> PASS (`target/validation_lane_reports/create-pr.latest.json`; wall time 78.63s, advisories: none)

## Review

- `reviews/ad-hoc-stdlib-boundary-m5-review-1.md` -> `READY` with hardening observations
- `reviews/ad-hoc-stdlib-boundary-m5-review-2.md` -> `READY` after parser/spec/source-scan hardening
- `reviews/ad-hoc-stdlib-boundary-m5-review-3.md` -> `READY` after final self-test tempdir fix
