### PR TITLE
[codex] Add stdlib planning review records

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md
@@ -1,0 +1,210 @@
+# Ad Hoc Phase Execution: Production Concurrency And Runtime Stdlib Parity
+
+Phase contract: [ad-hoc-production-concurrency-runtime-stdlib-parity.md](./ad-hoc-production-concurrency-runtime-stdlib-parity.md)
+
+Status: draft
+
+## Scope Split
+
+This ledger tracks:
+
+- `queue`, `asyncio.Queue`
+- `subprocess`, `asyncio.subprocess`
+- `concurrent.futures`, `multiprocessing`
+- `contextlib`, `warnings`, `signal`
+
+Network/web parity remains in [ad-hoc-production-stdlib-platform-parity-execution.md](./ad-hoc-production-stdlib-platform-parity-execution.md). Text and internationalization parity remains in [ad-hoc-production-text-i18n-stdlib-parity-execution.md](./ad-hoc-production-text-i18n-stdlib-parity-execution.md).
+
+## Milestone Checklist
+
+- [ ] `milestone_concurrency_runtime_0`: CPython Inventory, Error Mapping, And Effect Classification
+- [ ] `milestone_concurrency_runtime_1`: Asyncio Core, Queue, And Async Queue Parity
+- [ ] `milestone_concurrency_runtime_2`: Subprocess, Popen, Async Subprocess, And Signals
+- [ ] `milestone_concurrency_runtime_3`: Concurrent Futures And Thread Executors
+- [ ] `milestone_concurrency_runtime_4`: Typed IPC, Process Pools, And Multiprocessing
+- [ ] `milestone_concurrency_runtime_5`: Contextlib, Warnings, And Runtime Ergonomics
+- [ ] `milestone_concurrency_runtime_6`: Integration, Documentation, And Production Gate
+
+## Planning Reviews
+
+- Inherited from the original combined stdlib parity planning review:
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-1d.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-2.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-3.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-4.md`
+- Final combined review result before split: `PASS`.
+- Split-phase Claude review:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-1-constrained.md`
+  - Result: `FAIL`; cross-phase dependency and ownership gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-2-constrained.md`
+  - Result: `FAIL`; remaining ownership/disposition gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-3-constrained.md`
+  - Result: `FAIL`; remaining sequencing/error-surface gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-4-constrained.md`
+  - Result: `FAIL`; remaining async-context/file/default-encoding/thread-error gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-5-constrained.md`
+  - Result: `FAIL`; remaining contextvars/future-cancellation/open-policy/worker-typing gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-6-constrained.md`
+  - Result: `FAIL`; remaining executor map/timeout/cancellation/heterogeneous-future gaps and text-wrapper gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-7-constrained.md`
+  - Result: `FAIL`; remaining executor state-machine, `StringIO`, `threading.local`, and codec error-handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-8-constrained.md`
+  - Result: `FAIL`; remaining Future.cancel, wait partition, executor.map timeout, and text handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-9-constrained.md`
+  - Result: `FAIL`; remaining executor deadline/cancellation/wait fallback and codec handler classification gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-10-constrained.md`
+  - Result: `FAIL`; remaining handler enforcement, partial iteration, FIRST_EXCEPTION trigger, and shutdown pending/running gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-11-constrained.md`
+  - Result: `FAIL`; remaining future ownership/lifecycle and shutdown observability gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-12-constrained.md`
+  - Result: `FAIL`; remaining `wait()` ownership, cancelled result typing, and incremental codec finalization gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-13-constrained.md`
+  - Result: `FAIL`; remaining `gather()` ownership/result typing, `as_completed()` timeout signaling, codec recoverable-error, and `TaskGroup` aggregation gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-14-constrained.md`
+  - Result: `FAIL`; remaining network error hierarchy, TLS socket ownership, workload classification, handler model, concurrency gate, text decision, and review-gate gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-15-constrained.md`
+  - Result: `FAIL`; remaining TLS wrap failure-state, `signal.pause`, and text-i18n dependency milestone gaps were remediated.
+- Final split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-16-constrained.md`
+  - Result: `PASS`; no material implementation-blocking gaps remained.
+- Final implementation-readiness scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-17-final-readiness.md`
+  - Result: `PASS`; all three phases were implementation-ready, with one editorial ledger-title mismatch remediated in this ledger.
+- No-legacy readiness scans:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-18-no-legacy-readiness.md`
+  - Result: `FAIL`; text/i18n stale dynamic-handler and implicit-open wording were remediated.
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-19-no-legacy-readiness.md`
+  - Result: `PASS`; no remaining backward-compatibility, legacy-support, deprecated-behavior, shim, bridge-alias, or fallback decisions remained.
+- Namespace consistency scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-20-sifr-namespace-readiness.md`
+  - Result: `PASS`; all three phase docs consistently use canonical `sifr.*` stdlib imports and reject bare CPython stdlib aliases.
+- Required follow-up: run a dedicated external review after M0 inventory and before M1 implementation, because this phase is now independently scoped.
+
+## Planning Review Remediation Retained In This Phase
+
+- [x] Define multiprocessing start-method, typed IPC, shared-memory, and ownership constraints.
+- [x] Narrow unsafe signal handler registration to `unsupported` for this phase.
+- [x] Add milestone dependency graph.
+- [x] Add shared concurrency/runtime error mapping requirement.
+- [x] Expand `concurrent.futures`, multiprocessing, warnings, and global-state requirements.
+- [x] Name Tokio as the backing async runtime for this phase and require concrete feature expansion in M0.
+- [x] Tie `multiprocessing.Pool` to the same typed IPC gate as `ProcessPoolExecutor`.
+- [x] Clarify that class-based context managers are independent APIs, not fallback implementations for generator decorators.
+- [x] Mark `contextmanager` and `asynccontextmanager` unsupported in this phase, with a revisit rule for a future CPython-compatible generator semantics phase.
+- [x] Add explicit cross-phase dependency contract for text/i18n and network/web consumers.
+- [x] Clarify that core `asyncio` scheduler/task helpers are prior async-model infrastructure and this phase owns only `asyncio.Queue`/`asyncio.subprocess` compatibility additions.
+- [x] Assign private thread-pool substrate for `ThreadPoolExecutor` to this phase while keeping public `threading` module parity out of scope.
+- [x] Add explicit terminal expectations for `signal.getsignal`, `signal.pause`, and `pthread_sigmask`.
+- [x] Assign the `asyncio` task/wait/timeout/synchronization parity closure audit consumed by queues/subprocesses to `milestone_concurrency_runtime_1`.
+- [x] Add concrete `ThreadPoolExecutor` behavior dispositions for `max_workers`, `submit`, `map`, `shutdown(cancel_futures)`, `thread_name_prefix`, `initializer`, `initargs`, and public worker-thread inspection.
+- [x] Require M1's asyncio closure audit to finish before `asyncio.Queue` or `asyncio.subprocess` fixtures are marked conformant.
+- [x] Mark `ThreadPoolExecutor` `initializer`/`initargs` unsupported until Sifr has a formal user-visible cross-thread callable sendability contract.
+- [x] Add rationale that `TaskGroup` maps to Sifr's fixed structured-concurrency executor without exposing event-loop policies or callback transports.
+- [x] Mark `contextvars` parity and implicit per-task context propagation out of scope, with M1 fixtures proving unsupported context propagation is diagnosed or waived rather than silently ignored.
+- [x] Add ThreadPoolExecutor worker error propagation contract: worker failures return typed `ExecutorError` evidence and never panic or disappear.
+- [x] Mark all `contextvars` usage unsupported in this phase, including single-task reads/writes and cross-task propagation.
+- [x] Add `Future.cancel` and cancelled futures as a distinct typed terminal state.
+- [x] Replace ambiguous worker failure wording with a compiler contract: worker callables must type-check as `Callable[..., T]` or `Callable[..., Result[T, E]]`; other user-visible fallible paths are compile-time errors and runtime boundary failures become typed `ExecutorError::WorkerRuntime`.
+- [x] Specify `Executor.map` as an ordered iterator of typed item results for homogeneous callable result types.
+- [x] Add typed timeout terminal state for `Future.result(timeout=...)`.
+- [x] Specify `shutdown(cancel_futures=True)` marks pending futures with the same cancelled terminal state as `Future.cancel`.
+- [x] Restrict `wait` and `as_completed` to homogeneous future collections unless users define an explicit sum type.
+- [x] Add typed `Future.cancel()` return outcome for cancelled versus already-running futures.
+- [x] Add typed timeout behavior for `Executor.map(..., timeout=...)` and `as_completed(..., timeout=...)`.
+- [x] Define `wait(return_when=FIRST_EXCEPTION)` as first future with typed worker failure `Err(_)`.
+- [x] Mark `threading.local` unsupported in this phase with diagnostics.
+- [x] Add `Future.cancel()` `AlreadyDone` outcome.
+- [x] Specify `wait(return_when=FIRST_EXCEPTION)` returns the full `(done, not_done)` partition.
+- [x] Specify `Executor.map(..., timeout=...)` uses one absolute deadline from map-call time, not a per-item timeout reset.
+- [x] Specify `as_completed(..., timeout=...)` uses one absolute deadline from call time, not a per-yield timeout reset.
+- [x] Specify `wait(return_when=FIRST_EXCEPTION)` falls back to `ALL_COMPLETED` semantics when no worker failure occurs.
+- [x] Specify `shutdown(cancel_futures=True)` routes pending futures through the same typed `Cancelled` outcome path as `Future.cancel`.
+- [x] Specify `as_completed(..., timeout=...)` partial-result ownership: previously yielded futures remain valid, timeout is terminal, pending futures remain live/cancellable.
+- [x] Define `FIRST_EXCEPTION` trigger as ordinary typed `Result::Err` worker outcomes plus executor/runtime worker failures.
+- [x] Specify `shutdown(cancel_futures=True)` cancels only pending not-yet-started futures; running futures continue to typed completion.
+- [x] Specify `as_completed` borrows or clones observation handles and does not consume caller-owned future handles.
+- [x] Define `not_done` futures from `wait(FIRST_EXCEPTION)` as still scheduled; caller is responsible for cancellation or executor shutdown.
+- [x] Specify `shutdown(wait=True)` stores running-future results before returning and `shutdown(wait=False)` keeps result channels alive for future observation.
+- [x] Specify `wait()` borrows or clones observation handles and returns valid `done`/`not_done` views without consuming caller-owned futures.
+- [x] Define future result observation as `Result[T, FutureError[E]]` or equivalent with dedicated `Cancelled`, `TimedOut`, `Worker(E)`, and `WorkerRuntime` variants.
+- [x] Specify `gather()` borrows or clones task/future observation handles and does not consume caller-owned cancellation handles.
+- [x] Define `gather(return_exceptions=True)` as per-element typed results and `gather(return_exceptions=False)` as Sifr structured typed aggregate/cancellation behavior rather than exceptions.
+- [x] Specify `as_completed()` yields typed completed-future results, reports timeout as a terminal typed error, and leaves pending futures live/cancellable through original handles.
+- [x] Define `TaskGroup` child failure aggregation as `TaskGroupError[E]` or equivalent containing all observed child `FutureError[E]` values.
+- [x] Add binary pass/fail criteria for the M1 asyncio closure audit and make failed audit items block M1/M2 conformance claims.
+- [x] Convert `contextmanager` and `asynccontextmanager` from vague generator-phase blockers into formal unsupported/waived surfaces with a future-generator-semantics revisit rule.
+- [x] Make typed IPC design explicitly owned by M4, with no unnamed external prerequisite for `ProcessPoolExecutor` or `multiprocessing.Pool`.
+- [x] Replace the conditional `signal.pause()` adoption path with an explicit unsupported/waived terminal state for this phase.
+- [x] Resolve `signal.pause()` to unsupported/waived in this phase with diagnostics and a future safe signal-handler or structured signal-stream revisit rule.
+- [x] Add external-review owner and five-working-day fallback rule.
+- [x] Pin subprocess text mode, warning text encoding, and text-open demos to text/i18n `milestone_text_i18n_1` completion.
+- [x] Add no-backward-compatibility policy: current-CPython API shape under canonical `sifr.*` imports only, no bare CPython stdlib aliases, no legacy aliases, no deprecated behavior, no pickle-style fallbacks, and no compatibility shims; only inventory-recorded current adapters with Sifr-safe semantics are allowed.
+- [x] Align the phase with the stdlib namespace cleanup: `sifr.*` remains the permanent public stdlib namespace and bare CPython stdlib import attempts get namespace-contract diagnostics.
+- [x] Mark `subprocess.getoutput` and `subprocess.getstatusoutput` unsupported as legacy shell-invocation helpers; typed `run(..., shell=...)` remains the explicit shell path where allowed.
+
+## Implementation PRs
+
+- M0: pending.
+- M1: pending.
+- M2: pending.
+- M3: pending.
+- M4: pending.
+- M5: pending.
+- M6: pending.
+
+## Validation Evidence
+
+Record local validation for each milestone before opening its PR.
+
+Required baseline commands:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+python3 scripts/check_hir_maintainability_guardrails.py
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Required merge-gate command before milestone closure:
+
+```bash
+scripts/run_all_tests.sh
+```
+
+## CPython Scan Evidence
+
+Each milestone must record:
+
+- CPython source files scanned.
+- CPython docs files scanned.
+- CPython tests scanned.
+- Public APIs adopted, adapted, waived.
+- Unsupported/intentional-diff/host-limited surfaces.
+- Sifr e2e pass/fail fixtures added.
+
+## Waiver Index
+
+No waivers recorded yet.
+
+Every waiver must include:
+
+- surface
+- terminal state: `intentional-diff`, `unsupported`, or `host-limited`
+- rationale
+- revisit rule
+- CPython evidence
+- Sifr regression fixture

--- a/issues/ad-hoc-production-concurrency-runtime-stdlib-parity.md
+++ b/issues/ad-hoc-production-concurrency-runtime-stdlib-parity.md
@@ -1,0 +1,551 @@
+# Ad Hoc Phase: Production Concurrency And Runtime Stdlib Parity
+
+Status: draft
+Phase placement: ad hoc expansion phase after the stdlib boundary refactor and after the async workload/effect model is stable enough to enforce blocking-process diagnostics.
+Phase owner: stdlib/runtime implementation with compiler effect, ownership, import, and codegen support
+
+## Objective
+
+Close the production stdlib gaps for queues, subprocesses, process-backed concurrency, and runtime ergonomics:
+
+- asyncio control/synchronization compatibility needed by this phase: selected `asyncio` task, wait, timeout, and synchronization primitives
+- queues and async queues: `queue`, `asyncio.Queue`
+- subprocess and async subprocess: `subprocess`, `asyncio.subprocess`
+- executors and process concurrency: `concurrent.futures`, `multiprocessing`
+- runtime ergonomics and shutdown behavior: `contextlib`, `warnings`, `signal`
+
+This phase is complete when each target surface has either:
+
+- current-CPython-shaped source parity with Sifr-safe semantics,
+- a native Sifr runtime implementation that backs that compatibility surface,
+- or an explicit, tested waiver with rationale, revisit rule, and CPython test-family evidence.
+
+This phase does not add backward-compatibility or legacy support. Parity means the current supported CPython stdlib API shape and behavior adapted under Sifr's canonical `sifr.*` namespace with Sifr's static, typed, ownership-safe model. Bare CPython stdlib imports, historical aliases, deprecated APIs, compatibility shims, fake generator paths, pickle-style fallbacks, and hidden bridge names are not implemented; they receive diagnostics or waivers.
+
+## Related Phases
+
+- Network/web stdlib parity remains in [ad-hoc-production-stdlib-platform-parity.md](./ad-hoc-production-stdlib-platform-parity.md).
+- Text and internationalization parity is tracked in [ad-hoc-production-text-i18n-stdlib-parity.md](./ad-hoc-production-text-i18n-stdlib-parity.md).
+- Subprocess `text=True`, `encoding=...`, `errors=...`, locale-aware formatting, and warning text encoding depend on text/i18n `milestone_text_i18n_1: Codecs Registry, Encodings, And Text I/O Integration`. Until that milestone closes, this phase implements binary pipe semantics and records text-mode APIs as `blocked-on-text-i18n-m1`/adapted.
+- This phase assumes [ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md](./ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md) is complete: Sifr stdlib remains publicly imported through `sifr.*`, and bare CPython stdlib names are not aliases.
+
+## Cross-Phase Dependency Contract
+
+The three split phases are not an implied ship order. This phase may implement binary/process/queue/runtime behavior independently, but cross-phase consumer features are blocked until their provider phase is complete:
+
+- Text/i18n `milestone_text_i18n_1` is the hard prerequisite for subprocess text mode, warning output encodings, locale-sensitive warning formatting, and demos that rely on `open(..., encoding=...)`.
+- Network/web owns network stream compatibility entry points such as `asyncio.open_connection`; this phase owns the `asyncio` control/synchronization closure audit plus `asyncio.Queue` and `asyncio.subprocess` additions.
+- Async scheduler/task primitives are prior runtime infrastructure, but this phase owns their CPython compatibility closure states for the primitives consumed by queue/process APIs.
+- This phase owns the private thread-pool substrate needed by `ThreadPoolExecutor`, but it does not add a public `threading` module. If a CPython `concurrent.futures` behavior requires public `threading.Thread` semantics, that behavior is `unsupported` or `adapted` with explicit evidence.
+
+## Source Of Truth
+
+The authoritative CPython source tree for this phase is:
+
+- `/Users/yaseralnajjar/work/sifr/cpython`
+
+The implementation must scan and classify these CPython files before each milestone implementation PR:
+
+| Domain | CPython library sources | CPython test sources | Native backing sources |
+| --- | --- | --- | --- |
+| subprocess/process | `Lib/subprocess.py`, `Lib/asyncio/subprocess.py`, `Doc/library/subprocess.rst`, `Doc/library/asyncio-subprocess.rst` | `Lib/test/test_subprocess.py`, `Lib/test/test_asyncio/test_subprocess.py` | `Modules/_posixsubprocess.c`, `Modules/clinic/_posixsubprocess.c.h` |
+| queue/concurrency | `Lib/queue.py`, `Lib/asyncio/*.py`, `Lib/concurrent/futures/*.py`, `Lib/multiprocessing/*.py`, `Doc/library/queue.rst`, `Doc/library/asyncio.rst`, `Doc/library/concurrent.futures.rst`, `Doc/library/multiprocessing*.rst` | `Lib/test/test_queue.py`, `Lib/test/test_asyncio/test_queues.py`, `Lib/test/test_asyncio/test_tasks.py`, `Lib/test/test_asyncio/test_taskgroups.py`, `Lib/test/test_asyncio/test_waitfor.py`, `Lib/test/test_asyncio/test_timeouts.py`, `Lib/test/test_asyncio/test_locks.py`, `Lib/test/test_asyncio/test_runners.py`, `Lib/test/test_concurrent_futures/`, `Lib/test/_test_multiprocessing.py`, `Lib/test/test_multiprocessing_main_handling.py`, `Lib/test/test_multiprocessing_spawn/`, `Lib/test/test_multiprocessing_fork/`, `Lib/test/test_multiprocessing_forkserver/` | `Modules/_queuemodule.c`, `Modules/_multiprocessing/*`, `Modules/clinic/_queuemodule.c.h` |
+| context/warnings/signal | `Lib/contextlib.py`, `Lib/warnings.py`, `Doc/library/contextlib.rst`, `Doc/library/warnings.rst`, `Doc/library/signal.rst` | `Lib/test/test_contextlib.py`, `Lib/test/test_contextlib_async.py`, `Lib/test/test_warnings/`, `Lib/test/test_signal.py`, `Lib/test/test_io/test_signals.py` | `Modules/signalmodule.c`, `Python/_warnings.c`, `Lib/_py_warnings.py` |
+
+Path note: CPython paths above are relative to `/Users/yaseralnajjar/work/sifr/cpython`.
+
+## Current Sifr Baseline
+
+- `sifr.subprocess` has sync helpers and `CompletedProcess`, but no `Popen`, pipe lifecycle, timeout, signal, or async subprocess object model.
+- `sifr.asyncio` is a compatibility veneer over the canonical task model, but intentionally omits raw event loops, subprocesses, process pools, and transport/protocol APIs.
+- Core `asyncio` scheduler/task helpers are existing async-model infrastructure, not new scope here. This phase owns only `asyncio.Queue`, `asyncio.subprocess`, and queue/process-specific compatibility glue.
+- `sifr.sync` channels are the canonical queue-like async primitive, but `queue.Queue` accounting, `PriorityQueue`, `LifoQueue`, `SimpleQueue`, and multiprocessing queues are missing.
+- `sifr.contextlib`, `sifr.warnings`, `sifr.signal`, `sifr.queue`, `sifr.concurrent.futures`, and `sifr.multiprocessing` are not present as production stdlib surfaces.
+
+The Phase 32 async model remains binding:
+
+- Native async process and queue APIs must be real suspension points.
+- Sync queue/process APIs that can block must be classified as `@blocking_io`.
+- CPU-heavy work submitted to executors must use the existing `@cpu_heavy`/offload model.
+- Direct calls to blocking sync APIs from `async def` remain compiler errors unless routed through native async APIs or explicit offload.
+- The compiler must not expose Tokio, event-loop objects, raw callback transports/protocols, or runtime internals as the normal user model.
+
+## Parity Definition
+
+This phase targets current CPython-shaped interfaces under the canonical `sifr.*` namespace, not legacy compatibility layers or bare CPython import compatibility.
+
+For each module in scope:
+
+1. Support canonical Sifr stdlib imports for the CPython-shaped surface (`from sifr.queue import Queue`, `from sifr.subprocess import Popen`, etc.).
+2. Do not add bare CPython module-name imports as aliases for `sifr.*`. Bare forms such as `from queue import Queue` or `from subprocess import Popen` should receive the namespace-contract diagnostic once normal user/package resolution fails.
+3. Match CPython function/class names, constructor forms, constants, and common keyword arguments where compatible with Sifr's static type system.
+4. Adapt CPython exception behavior into Sifr-safe `Result[T, E]`, `Option[T]`, or compile-time diagnostics.
+5. Keep host-specific behavior explicitly marked `host-limited`.
+6. Keep CPython implementation-detail, deprecated, and historical compatibility behavior waived rather than reimplemented blindly.
+
+Every reviewed CPython test family must end in exactly one state: `adopted`, `adapted`, or `waived`. Every public surface must end in exactly one state: `done`, `intentional-diff`, `unsupported`, or `host-limited`. `open` is forbidden at phase exit.
+
+## Milestone Dependency Graph
+
+1. `milestone_concurrency_runtime_0` first. No implementation milestone starts until the inventory, CPython test matrix, import plan, shared error mapping, and workload/effect classification are checked in.
+2. `milestone_concurrency_runtime_1` before executor and multiprocessing queue work. Its asyncio control/synchronization closure audit is the first sub-step inside M1 and must close before `asyncio.Queue` or `asyncio.subprocess` claims CPython conformance.
+3. `milestone_concurrency_runtime_2` before process pools or multiprocessing pools. Process lifecycle, pipes, timeout, and signals are the substrate for process-backed concurrency, and its async subprocess conformance waits on M1's asyncio closure audit.
+4. `milestone_concurrency_runtime_3` may implement `Future`, `Executor`, and `ThreadPoolExecutor` after M1; `ProcessPoolExecutor` waits for M4 typed IPC.
+5. `milestone_concurrency_runtime_4` implements typed IPC, `ProcessPoolExecutor`, and the bounded multiprocessing subset after M2 and the M4 typed IPC design are ready.
+6. `milestone_concurrency_runtime_5` can run in parallel after M0 except where `signal` behavior depends on M2 subprocess lifecycle.
+7. `milestone_concurrency_runtime_6` closes docs, demos, validation, and waivers last.
+
+## Architecture Principles
+
+### Native Runtime First, Compatibility Second
+
+- Tokio remains the backing async runtime because the generated task runtime already depends on `tokio` and `sifr_stdlib::StdlibFeature::Tokio`.
+- M0 must expand the Tokio feature plan for `tokio::process`, `tokio::io`, `tokio::sync`, and signal support where adopted.
+- `sifr.process` / private intrinsics own child-process lifecycle, pipes, cancellation, and signal delivery.
+- `sifr.sync` / private intrinsics own queue, channel, and async backpressure primitives.
+- CPython-shaped canonical Sifr modules delegate to those primitives and must not duplicate target-runtime logic.
+
+### Typed Errors Instead Of Exceptions
+
+All fallible APIs must expose typed error results:
+
+- `SubprocessError`, `CalledProcessError`, `TimeoutExpired`
+- `QueueEmpty`, `QueueFull`, `QueueShutDown`
+- `CancelledError`, `ExecutorError`, `BrokenExecutor`, `TimeoutError`
+- `SignalError`
+- `ContextError`, `WarningError`
+
+Names may align with CPython where possible, but the operational contract is Sifr `Result`/`Option`, not exception-driven control flow. `check_*` convenience APIs such as `subprocess.check_output` must return typed failure evidence instead of throwing.
+
+### Panic-Free Runtime Contract
+
+Generated Rust for these APIs must not contain data-dependent `.unwrap()`, `.expect()`, or `panic!` on user-controlled process, pipe, queue, warning, signal, or executor data.
+
+### No Dynamic Serialization Fallback
+
+No arbitrary pickle-equivalent process-pool transport may be introduced. Process-backed APIs require typed IPC with explicit supported payload types. Unsupported payloads are compile-time errors where possible and typed runtime errors otherwise.
+
+## Non-Goals And Permanent Boundaries
+
+The following are not accepted as silent omissions. They must be either implemented or explicitly waived with tests:
+
+- raw event-loop policy mutation
+- callback transport/protocol APIs as the primary Sifr model
+- `contextvars` module parity, including single-task `ContextVar` reads/writes and implicit per-task context propagation; unsupported in this phase unless a separate contextvars phase lands first
+- public `threading` module parity; only the private thread-pool substrate needed by `ThreadPoolExecutor` is in scope
+- `threading.local`; unsupported in this phase with diagnostics because public thread-local storage belongs to future public `threading`/context isolation work
+- arbitrary object pickling for process pools
+- process pools without the stable typed IPC serialization contract designed and accepted inside `milestone_concurrency_runtime_4`; no separate external prerequisite is implied
+- `signal.signal` custom handler registration; unsupported in this phase
+- `contextmanager` and `asynccontextmanager`; formally waived in this phase because CPython-compatible generator `send`/`throw`/`close` and async-generator cleanup semantics are outside this phase's scope. The revisit rule is a future generator/async-generator semantics phase; until that exists, these decorators remain `unsupported` with diagnostics and CPython evidence rather than blocked implementation work.
+- `multiprocessing.Value`, `multiprocessing.Array`, and `multiprocessing.shared_memory`; unsupported until typed shared-memory ownership and unlink/drop rules are proven
+- fork/forkserver semantics without host-specific ownership evidence
+- mutation of interpreter-global warning/filter state from unstructured concurrent contexts
+
+## Milestones
+
+### milestone_concurrency_runtime_0: CPython Inventory, Error Mapping, And Effect Classification
+
+Scope:
+
+- Add a machine-readable parity inventory under `verification/stdlib/concurrency_runtime_parity_inventory.*`.
+- Scan every source/test/doc file listed in `Source Of Truth`.
+- Extract public functions, classes, constants, methods, common keyword forms, deprecation/legacy markers, and test-class/test-method names.
+- Add CPython-derived e2e fixtures:
+  - `cpython_asyncio_core_subset.sifr`
+  - `cpython_asyncio_sync_subset.sifr`
+  - `cpython_queue_subset.sifr`
+  - `cpython_asyncio_queue_subset.sifr`
+  - `cpython_subprocess_full_subset.sifr`
+  - `cpython_asyncio_subprocess_subset.sifr`
+  - `cpython_concurrent_futures_subset.sifr`
+  - `cpython_multiprocessing_subset.sifr`
+  - `cpython_contextlib_subset.sifr`
+  - `cpython_warnings_subset.sifr`
+  - `cpython_signal_subset.sifr`
+- Add import-resolution tests for canonical `sifr.*` module names and negative diagnostics for bare CPython stdlib import attempts.
+- Add shared error mapping for all concurrency/runtime target domains.
+- Add workload classifications for every blocking sync process, queue, executor, and signal API.
+- Add a named asyncio closure-audit checklist and pass/fail gate for the task/wait/timeout/synchronization primitives consumed by M1 and M2.
+- Assign each inventory entry one owner milestone and one terminal state.
+- Assign every deprecated, historical, or legacy-only entry the terminal state `unsupported` or `intentional-diff`. M0 may implement only current, non-deprecated target CPython surfaces that remain elegant under Sifr semantics.
+
+Definition of done:
+
+- The backlog is derived from CPython source/tests, not hand-written memory.
+- Every target module has a first-pass surface matrix and CPython test-family matrix.
+- M1-M6 implementation PRs have concrete backlog entries rather than prose-only scope.
+
+### milestone_concurrency_runtime_1: Asyncio Core, Queue, And Async Queue Parity
+
+Scope:
+
+- Close the `asyncio` control/synchronization subset consumed by this phase:
+  - `run`, `create_task`, `gather`, `wait`, `wait_for`, `sleep`, `timeout`
+  - `TaskGroup`
+  - `Event`, `Lock`, `Semaphore`, `Condition`
+  - raw event-loop policy and callback transport APIs remain out of scope
+  - `TaskGroup` maps to Sifr's fixed structured-concurrency executor and does not require exposing event-loop policies or callback transports
+  - `gather` borrows or clones task/future observation handles and must not consume caller-owned cancel handles
+  - `gather(return_exceptions=True)` returns per-element typed results, such as `List[Result[T, FutureError[E]]]`, not `List[T]`
+  - `gather(return_exceptions=False)` uses Sifr's structured failure policy and returns a typed aggregate/cancellation result rather than raising
+  - `TaskGroup` child failures are aggregated as `TaskGroupError[E]` or equivalent containing all observed `FutureError[E]` values; single-future `FutureError[E]` is not reused for multi-child failure without aggregation
+  - `contextvars.ContextVar` is unsupported in this phase, including single-task reads/writes and cross-task propagation; M1 must add fixtures proving all `contextvars` usage is diagnosed or explicitly waived, not silently ignored
+- The asyncio closure audit must finish before `asyncio.Queue` or `asyncio.subprocess` fixtures can be marked conformant. The audit passes only when M1 records all of these as binary pass/fail checklist items:
+  - each listed `asyncio` primitive has a terminal state (`done`, `adapted`, `unsupported`, or `host-limited`) in the inventory
+  - typed result/cancellation/timeout behavior is specified for `gather`, `wait`, `wait_for`, `timeout`, and `TaskGroup`
+  - handle ownership is specified for task/future observation, cancellation, and task-group child lifetimes
+  - synchronization primitives have deterministic wakeup/cancellation/drop behavior or explicit waivers
+  - raw event-loop policy, callback transport/protocol, and `contextvars` usages produce diagnostics or waivers rather than silent partial support
+  - CPython test families listed below are classified as `adopted`, `adapted`, or `waived` with at least one regression fixture per adopted/adapted behavior
+  - the execution ledger records `asyncio_closure_audit: pass`; any failed item blocks M1 conformance claims and M2 async-subprocess conformance
+- Add `queue`:
+  - `Queue`
+  - `PriorityQueue`
+  - `LifoQueue`
+  - `SimpleQueue`
+  - `Empty`
+  - `Full`
+  - `ShutDown`
+  - `put`, `get`, `put_nowait`, `get_nowait`, `task_done`, `join`, `shutdown`, `qsize`, `empty`, `full`
+- Add or extend `asyncio.Queue` compatibility on top of `sifr.sync`:
+  - `put`, `get`, `put_nowait`, `get_nowait`
+  - bounded capacity and backpressure
+  - `join`/`task_done` if accounting can be made deterministic
+- Mark sync queue operations that can block as `@blocking_io` when used from async contexts; prefer async queue/channel APIs.
+
+CPython tests to mine:
+
+- `Lib/test/test_queue.py`
+- `Lib/test/test_asyncio/test_tasks.py`
+- `Lib/test/test_asyncio/test_taskgroups.py`
+- `Lib/test/test_asyncio/test_waitfor.py`
+- `Lib/test/test_asyncio/test_timeouts.py`
+- `Lib/test/test_asyncio/test_locks.py`
+- `Lib/test/test_asyncio/test_runners.py`
+- `Lib/test/test_asyncio/test_queues.py`
+
+Rust/runtime candidates:
+
+- `crossbeam-channel`
+- `tokio::sync`
+
+Definition of done:
+
+- Thread queues and async queues have deterministic blocking/backpressure/cancellation behavior.
+- Asyncio core/synchronization primitives consumed by this phase are closed as `done`, `adapted`, or `unsupported` with CPython test evidence.
+- `gather(return_exceptions=...)` and `TaskGroup` have fixtures for handle ownership, per-element typed results, fail-fast/structured cancellation, and aggregated child failures.
+- Queue accounting preserves CPython-compatible `task_done`/`join` semantics or records exact waivers.
+- Async queue operations are real suspension points.
+
+### milestone_concurrency_runtime_2: Subprocess, Popen, Async Subprocess, And Signals
+
+Scope:
+
+- Expand `subprocess` from helper-only to CPython-shaped surface:
+  - `run`, `call`, `check_call`, `check_output`
+  - `CompletedProcess`, `CalledProcessError`, `TimeoutExpired`
+  - `Popen`
+  - `PIPE`, `STDOUT`, `DEVNULL`
+  - `Popen.poll`, `wait`, `communicate`, `send_signal`, `terminate`, `kill`, `close`
+  - stdin/stdout/stderr pipes as owned stream resources
+  - timeout handling
+  - binary pipe mode in this phase; text/encoding/error mode waits for text/i18n `milestone_text_i18n_1`
+  - `getoutput` and `getstatusoutput` are unsupported in this phase as legacy shell-invocation helpers; users should use typed `run(..., shell=...)` forms only where shell execution is explicitly allowed and effect-classified
+- Add `asyncio.subprocess` compatibility:
+  - `create_subprocess_exec`
+  - `create_subprocess_shell`
+  - async `Process.wait`
+  - async `Process.communicate`
+  - async pipe read/write/close
+- Add `signal` module basics required by subprocess and production shutdown:
+  - signal constants for supported host
+  - `Signals` enum-like surface where compatible
+  - `raise_signal`
+  - `strsignal`
+  - `getsignal` returns supported default/ignored state only; custom Python handler state remains unsupported with `signal.signal`
+  - `pause` is `unsupported` in this phase because safe custom handler registration and structured async signal wakeup are not adopted; static uses produce diagnostics, the waiver records CPython evidence, and the revisit rule is a future safe signal-handler or structured signal-stream phase
+  - `pthread_sigmask` only if host-limited support is deliberately added
+  - `signal.signal` custom handler registration is `unsupported` in this phase
+  - async signal notification may be added as a canonical `sifr.process`/`sifr.signal` stream if it integrates with structured cancellation and avoids arbitrary signal-handler closures
+- Integrate structured cancellation:
+  - cancelling async process wait requests child termination only when API says so
+  - `communicate` drains pipes deterministically
+  - timeout kills/terminates according to documented Sifr policy and returns typed evidence
+- Mark sync process APIs as `@blocking_io`.
+
+CPython tests to mine:
+
+- `Lib/test/test_subprocess.py`
+- `Lib/test/test_asyncio/test_subprocess.py`
+- `Lib/test/test_signal.py`
+- `Lib/test/test_io/test_signals.py`
+
+Rust/runtime candidates:
+
+- `std::process`
+- `tokio::process`
+- `nix` or platform-specific crates only for signal handling that cannot be covered by std/Tokio
+
+Definition of done:
+
+- Sync and async subprocess loopback tests pass on the supported host matrix.
+- Pipe ownership prevents double-close and use-after-close.
+- Timeout/cancellation semantics are documented and tested.
+- Signal support is clearly split into supported host behavior and waived platform behavior.
+- Custom handler registration is recorded as `unsupported` with CPython evidence and a revisit rule.
+- `getsignal`, `pause`, and `pthread_sigmask` each have terminal inventory states with CPython test evidence.
+
+### milestone_concurrency_runtime_3: Concurrent Futures And Thread Executors
+
+Scope:
+
+- Expand `concurrent.futures`:
+  - `Future`
+  - `Executor`
+  - `ThreadPoolExecutor`
+  - `Future.cancel`, cancellation observation, and cancelled terminal state
+  - `wait`
+  - `as_completed`
+  - `CancelledError`, `TimeoutError`, `BrokenExecutor`, executor-specific errors
+- Integrate thread execution with existing Sifr task/offload diagnostics:
+  - private thread-pool execution is owned by this milestone
+  - public `threading.Thread`, locks, conditions, and thread-local APIs are not implemented here
+  - CPU-heavy sync work must be routed through approved offload.
+  - Blocking sync functions submitted from async contexts require explicit offload semantics.
+  - cancellation semantics must not leave unobserved failed work without typed evidence.
+- ThreadPoolExecutor compatibility dispositions:
+  - `max_workers`, `submit`, `map`, and `shutdown(wait=..., cancel_futures=...)` are in scope.
+  - `thread_name_prefix` is accepted only as metadata and is an `intentional-diff` if no public thread naming is exposed.
+  - `initializer`/`initargs` are `unsupported` in this phase until Sifr has a formal user-visible sendability contract for cross-thread callable captures.
+  - public worker-thread inspection through `threading` objects is `unsupported`.
+- Worker error propagation contract:
+  - future result observation returns `Result[T, FutureError[E]]` or an equivalent typed sum with at least `Cancelled`, `TimedOut`, `Worker(E)`, and `WorkerRuntime` variants
+  - submitted callables returning plain `T` complete futures with `Ok(T)`
+  - submitted callables returning `Result[T, E]` complete futures with `Err(FutureError::Worker(E))` or equivalent
+  - worker callables must type-check as either `Callable[..., T]` or `Callable[..., Result[T, E]]`; any user-visible fallible path outside those return shapes is a compile-time error
+  - runtime failures from foreign/runtime boundaries are represented as typed `FutureError::WorkerRuntime`
+  - `Future.cancel` and cancelled futures are represented as `FutureError::Cancelled` or an equivalent typed cancelled terminal state
+  - `Future.cancel()` itself returns a typed cancel outcome with `Cancelled`, `AlreadyRunning`, and `AlreadyDone` variants, preserving CPython's false-return cases without hiding state in a boolean
+  - `Future.result(timeout=...)` timeout is represented as `FutureError::TimedOut` or an equivalent typed timeout terminal state
+  - `shutdown(wait=True, cancel_futures=...)` blocks until already-running futures complete and stores their typed results before returning; `shutdown(wait=False, cancel_futures=...)` rejects new submissions but keeps running task result channels alive so future handles can observe completion after shutdown returns
+  - `shutdown(cancel_futures=True)` routes only pending, not-yet-started futures through the same typed cancellation outcome path as `Future.cancel`, producing the `Cancelled` terminal state for each affected future; already-running futures continue to completion and their typed results remain observable through their `Future` handles until those handles are dropped
+  - `Executor.map` is adapted to return an ordered iterator of typed item results, `Iterator[Result[T, ExecutorError[E]]]` or equivalent, for homogeneous callable result type `T`; it does not raise during iteration
+  - `Executor.map(..., timeout=...)` computes one absolute monotonic deadline at `map()` call time and reports `ExecutorError::Timeout` on the first item that cannot be delivered within the remaining budget; the timeout never resets per item
+  - `wait` and `as_completed` accept homogeneous future collections only (`Iterable[Future[T, E]]` or equivalent); heterogeneous future collections require an explicit user-defined sum type and otherwise produce a compile-time diagnostic
+  - `as_completed` borrows or clones observation handles for futures; it must not consume the caller's future handles. Its iterator yields typed completed-future results such as `Result[Future[T, E], FutureError[E]]` or equivalent. Futures yielded before timeout are valid and owned by the caller, timeout is emitted as a terminal typed `Err(FutureError::TimedOut)`, the iterator terminates after that timeout error, and pending futures remain live/cancellable through the caller's original handles.
+  - `as_completed(..., timeout=...)` computes one absolute monotonic deadline at `as_completed()` call time and reports timeout as a typed terminal `Err(FutureError::TimedOut)` or equivalent when the total deadline expires before all futures complete; it must not silently stop with pending futures or reset the timeout per yielded future
+  - `wait` borrows or clones observation handles for futures; it must not consume the caller's future handles. Returned `done` and `not_done` sets are valid independent views over the same future objects, and `not_done` futures remain live/cancellable through the caller's original handles.
+  - `wait(..., return_when=FIRST_EXCEPTION)` maps "exception" to the first future whose observed worker result is typed `Err(_)`, including ordinary user `Result::Err` worker outcomes and executor/runtime worker failures; it still returns a full `(done, not_done)` partition containing all futures completed before and including the failing future, plus all remaining futures
+  - `not_done` futures returned by `wait(..., return_when=FIRST_EXCEPTION)` remain scheduled on the same executor unless the caller cancels them or shuts down the executor. Subsequent `shutdown(cancel_futures=True)` cancels only not-yet-started futures among them; already-running futures continue to typed completion.
+  - if `wait(..., return_when=FIRST_EXCEPTION)` observes no typed worker failure, it behaves like `ALL_COMPLETED` and returns `(all_done, empty_not_done)`
+  - unsupported `return_when` values produce diagnostics
+  - user-controlled worker failures must never cross the thread boundary as a panic or be swallowed silently
+
+CPython tests to mine:
+
+- `Lib/test/test_concurrent_futures/`
+
+Rust/runtime candidates:
+
+- `rayon` or existing Tokio blocking pool for threads
+- `tokio::task::spawn_blocking`
+
+Definition of done:
+
+- Future completion, cancellation, timeout, and callback behavior has CPython-derived fixtures.
+- Thread pool shutdown is deterministic and panic-free.
+- Executor APIs do not leak raw Tokio or Rust thread handles.
+- Any CPython `ThreadPoolExecutor` behavior requiring public `threading` module objects is explicitly adapted or waived.
+- `Future.result`/equivalent observation returns typed worker failure evidence and never panics on user-controlled worker errors.
+- Future cancellation has a distinct typed terminal state and CPython-derived cancellation fixtures.
+- `Future.result(timeout=...)`, `shutdown(cancel_futures=True)`, `Executor.map`, `wait`, and `as_completed` have CPython-derived adapted fixtures covering timeout, cancellation, ordered result iteration, and homogeneous future collection constraints.
+- `Future.cancel()` return outcome, `Executor.map(timeout=...)`, `as_completed(timeout=...)`, and `wait(return_when=FIRST_EXCEPTION)` have typed fixtures.
+
+### milestone_concurrency_runtime_4: Typed IPC, Process Pools, And Multiprocessing
+
+Scope:
+
+- Add typed IPC foundation before process pools:
+  - M4 owns the typed IPC design, implementation, and acceptance gate; no process-pool or multiprocessing pool item depends on an unnamed external phase
+  - supported payload types must be explicit
+  - no arbitrary pickle/object transport
+  - model class serialization must wait for the relevant model-serialization phase if needed
+  - unsupported payloads are compile-time errors where possible
+  - no process-backed executor API may ship before this contract has compile-time and runtime tests
+  - the design must specify payload ownership, serialization format, versioning, child-process bootstrap, result/error framing, cancellation/termination messages, and panic-free malformed-message handling before `ProcessPoolExecutor` work starts
+- Add `ProcessPoolExecutor` only after typed IPC supports:
+  - task submission
+  - ordered and unordered result streams
+  - worker lifecycle
+  - cancellation/termination
+  - initializer arguments
+  - typed error propagation
+- Add bounded `multiprocessing` subset:
+  - `Process`
+  - `Queue`, `SimpleQueue`, `JoinableQueue`
+  - `Pipe`
+  - `Pool` only after typed IPC supports the same payload and lifecycle contract as `ProcessPoolExecutor`; otherwise `Pool` is `unsupported`
+  - spawn start method first
+  - fork/forkserver are host-limited and require explicit ownership-safety evidence before adoption
+  - `Value`/`Array` are unsupported until typed shared-memory ownership is designed
+  - `shared_memory` is unsupported until explicit ownership/unlink/drop rules are proven
+  - no shared mutable references may cross a process boundary
+  - start-method APIs must record `done`, `intentional-diff`, `unsupported`, or `host-limited` per host
+
+CPython tests to mine:
+
+- `Lib/test/test_concurrent_futures/`
+- `Lib/test/_test_multiprocessing.py`
+- `Lib/test/test_multiprocessing_main_handling.py`
+- `Lib/test/test_multiprocessing_spawn/`
+- `Lib/test/test_multiprocessing_fork/`
+- `Lib/test/test_multiprocessing_forkserver/`
+
+Rust/runtime candidates:
+
+- typed local serialization such as `bincode` or `postcard` only after typed IPC design approval
+- platform process primitives from M2
+
+Definition of done:
+
+- Process pools do not ship until typed IPC is implemented and tested.
+- `multiprocessing.Pool` and `ProcessPoolExecutor` share the same typed IPC gate and cannot diverge in payload semantics.
+- Multiprocessing APIs are either implemented with typed IPC or explicitly waived; no pickle-equivalent dynamic fallback is allowed.
+- Shared-memory and fork-like behavior are blocked unless the execution ledger records the ownership proof and CPython test adaptations.
+
+### milestone_concurrency_runtime_5: Contextlib, Warnings, And Runtime Ergonomics
+
+Scope:
+
+- Add `contextlib`:
+  - `closing`, `aclosing`
+  - `nullcontext`
+  - `suppress`
+  - `redirect_stdout`, `redirect_stderr`
+  - `chdir`
+  - `ExitStack`, `AsyncExitStack`
+  - `AbstractContextManager`, `AbstractAsyncContextManager`
+  - `contextmanager`, `asynccontextmanager` are `unsupported` in this phase because CPython-compatible generator `send`/`throw`/`close` and async-generator cleanup semantics are outside this phase's scope
+  - class-based context-manager APIs are implemented independently, not as fallback implementations for the decorator APIs
+- Add `warnings`:
+  - `warn`
+  - `warn_explicit`
+  - `filterwarnings`
+  - `simplefilter`
+  - `resetwarnings`
+  - `catch_warnings`
+  - `showwarning`, `formatwarning`
+  - warning categories represented as typed classes
+- Make warning state concurrency-safe:
+  - process-global filters require an explicit `Mutex`/`RwLock`-backed runtime design or equivalent
+  - per-module warning registries require a typed module-state representation, not dynamic monkeypatching
+  - async tasks must not race warning filter mutation without explicit lock/state rules
+  - compile-time diagnostics remain separate from runtime warnings
+- Ensure context managers integrate with Sifr's sync and async context protocols.
+
+CPython tests to mine:
+
+- `Lib/test/test_contextlib.py`
+- `Lib/test/test_contextlib_async.py`
+- `Lib/test/test_warnings/`
+
+Definition of done:
+
+- Sync and async context manager helpers work with Sifr cleanup semantics.
+- `ExitStack` and `AsyncExitStack` preserve LIFO cleanup and typed secondary evidence rules.
+- Warnings are deterministic, thread-safe, and do not become hidden exceptions.
+- Generator-decorator helpers are recorded as `unsupported` with a revisit rule; no partial fake generator path is allowed.
+
+### milestone_concurrency_runtime_6: Integration, Documentation, And Production Gate
+
+Scope:
+
+- Update public docs for every new module and major intentional divergence:
+  - `queue`
+  - `subprocess`, `asyncio.subprocess`
+  - `concurrent.futures`, `multiprocessing`
+  - `contextlib`, `warnings`, `signal`
+- Update internal architecture docs for:
+  - process/queue/executor/runtime boundaries
+  - typed IPC and unsupported payload policy
+  - async counterpart and blocking/offload policy
+  - warning and signal global-state policy
+  - host-limited multiprocessing behavior
+- Add demos:
+  - async subprocess pipeline
+  - producer/consumer queues
+  - thread pool executor
+  - process pool where supported
+  - warning capture and context cleanup
+- Add generated Cargo dependency snapshots for all new feature combinations.
+- Add panic-scan and emitted-code quality checks for queue/process/runtime paths.
+- Update validation lane manifests with representative fixtures.
+- Close the inventory:
+  - every public surface has a terminal state
+  - every CPython test family has `adopted`, `adapted`, or `waived` evidence
+  - every waiver has a revisit rule and regression fixture
+  - every host-limited surface records the supported host matrix
+- Run an external review loop on the final inventory and close any blocking finding before phase completion.
+- External review owner is the stdlib phase owner plus the designated compiler/runtime reviewer recorded in the execution ledger. If review output is unavailable for five working days after the review artifact is posted, the phase owner may proceed only by recording the attempted review, open questions, and a conservative self-review in the ledger.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- file-size guardrail
+- `cargo test -p sifr_stdlib`
+- `cargo test -p sifr -- stdlib`
+- `scripts/run_e2e_pass.sh`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh`
+
+Definition of done:
+
+- Every module surface and CPython test family in the phase inventory is closed as `done`, `intentional-diff`, `unsupported`, or `host-limited`.
+- No implementation-owned source file exceeds the 900-line guardrail.
+- No user-triggerable runtime panic path exists in the added stdlib/runtime surfaces.
+- Async and sync APIs follow the Phase 32 workload and cancellation model.
+
+## Required Tracking Artifacts
+
+Create and keep current during implementation:
+
+- `issues/ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md`
+- `verification/stdlib/concurrency_runtime_parity_inventory.md`
+- `verification/stdlib/concurrency_runtime_parity_inventory.json`
+- `verification/stdlib/concurrency_runtime_parity_cpython_test_matrix.md`
+- one traceability document per milestone domain under `verification/stdlib/`
+
+The execution ledger must record:
+
+- planning/review artifacts
+- per-milestone PR links
+- local validation commands and results
+- CPython source/test files scanned
+- adopted/adapted/waived CPython test families
+- final unsupported/intentional-diff/host-limited waiver index
+
+## Quality Contract
+
+- Solve root causes rather than adding workaround wrappers.
+- No backward-compatibility shims, legacy aliases, deprecated behavior, or fallback paths may survive phase exit. Deliberate current-CPython adapters are allowed only when recorded in the inventory with Sifr-safe semantics and tests.
+- No direct Tokio/runtime types may leak into public Sifr APIs.
+- No arbitrary pickle-equivalent process-pool transport may be introduced.
+- No data-dependent emitted `.unwrap()`, `.expect()`, or `panic!` is allowed in user runtime paths.
+- Every added blocking sync function must be classified in the stdlib workload database.
+- Every added async function must have a real suspension summary.
+- Every added external crate dependency must be represented by a stable `StdlibFeature` in `sifr_stdlib`.
+- Every module added to embedded stdlib sources must have canonical `sifr.*` import-resolution tests, type-check tests, e2e pass tests, and negative diagnostics for unsupported bare CPython import forms.
+
+## Open Planning Questions To Resolve In `milestone_concurrency_runtime_0`
+
+1. What is the typed IPC serialization contract for `ProcessPoolExecutor` and `multiprocessing`?
+2. Which signal APIs are safe and deterministic across the supported host matrix?
+3. Which multiprocessing start methods are supported, host-limited, or unsupported?
+4. Which executor dependency strategy meets binary-size, safety, cancellation, and maintenance goals?
+5. How do warning filters and per-module warning registries interact with threads and async tasks?
+6. Which subprocess text-mode APIs remain blocked until text/i18n `milestone_text_i18n_1` closes?
+
+These questions must be answered in the phase execution ledger before implementing the affected milestone.

--- a/issues/ad-hoc-production-stdlib-platform-parity-execution.md
+++ b/issues/ad-hoc-production-stdlib-platform-parity-execution.md
@@ -1,0 +1,175 @@
+# Ad Hoc Phase Execution: Production Network And Web Stdlib Parity
+
+Phase contract: [ad-hoc-production-stdlib-platform-parity.md](./ad-hoc-production-stdlib-platform-parity.md)
+
+Status: draft
+
+## Scope Split
+
+The original broad planning scan was split into three implementation phases:
+
+- This ledger tracks network/web stdlib parity: `socket`, `select`, `selectors`, `ssl`, `urllib.*`, `http.*`, `socketserver`.
+- [ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md](./ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md) tracks queues, subprocess/process pools/multiprocessing, and runtime ergonomics.
+- [ad-hoc-production-text-i18n-stdlib-parity-execution.md](./ad-hoc-production-text-i18n-stdlib-parity-execution.md) tracks text and internationalization.
+
+## Milestone Checklist
+
+- [ ] `milestone_network_web_0`: CPython Inventory And Harness Lock
+- [ ] `milestone_network_web_1`: Socket, Select, Selectors, And Async Network Streams
+- [ ] `milestone_network_web_2`: TLS And SSL
+- [ ] `milestone_network_web_3`: URL Parsing, HTTP Client, HTTP Server, Cookies, And Robots
+- [ ] `milestone_network_web_4`: Integration, Documentation, And Production Gate
+
+## Planning Reviews
+
+- Initial Claude planning review covered the original combined phase.
+  - Full-file Claude attempts stalled before output and produced no retained review content.
+  - Embedded-summary review completed:
+    - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-1d.md`
+  - Result: `FAIL`; blockers folded into the original phase draft.
+- Second Claude planning review:
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-2.md`
+  - Result: `FAIL`; remaining conditional gates folded into the original phase draft.
+- Final Claude planning reviews:
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-3.md`
+  - Result: `FAIL`; one conditional `contextmanager` branch remained.
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-4.md`
+  - Result: `PASS`; no blocking gaps remained before the split.
+- Split-phase Claude review:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-1-constrained.md`
+  - Result: `FAIL`; cross-phase dependency and ownership gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-2-constrained.md`
+  - Result: `FAIL`; remaining ownership/disposition gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-3-constrained.md`
+  - Result: `FAIL`; remaining sequencing/error-surface gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-4-constrained.md`
+  - Result: `FAIL`; remaining async-context/file/default-encoding/thread-error gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-5-constrained.md`
+  - Result: `FAIL`; remaining contextvars/future-cancellation/open-policy/worker-typing gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-6-constrained.md`
+  - Result: `FAIL`; remaining executor map/timeout/cancellation/heterogeneous-future gaps and text-wrapper gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-7-constrained.md`
+  - Result: `FAIL`; remaining executor state-machine, `StringIO`, `threading.local`, and codec error-handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-8-constrained.md`
+  - Result: `FAIL`; remaining Future.cancel, wait partition, executor.map timeout, and text handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-9-constrained.md`
+  - Result: `FAIL`; remaining executor deadline/cancellation/wait fallback and codec handler classification gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-10-constrained.md`
+  - Result: `FAIL`; remaining handler enforcement, partial iteration, FIRST_EXCEPTION trigger, and shutdown pending/running gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-11-constrained.md`
+  - Result: `FAIL`; remaining future ownership/lifecycle and shutdown observability gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-12-constrained.md`
+  - Result: `FAIL`; remaining `wait()` ownership, cancelled result typing, and incremental codec finalization gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-13-constrained.md`
+  - Result: `FAIL`; remaining `gather()` ownership/result typing, `as_completed()` timeout signaling, codec recoverable-error, and `TaskGroup` aggregation gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-14-constrained.md`
+  - Result: `FAIL`; remaining network error hierarchy, TLS socket ownership, workload classification, handler model, concurrency gate, text decision, and review-gate gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-15-constrained.md`
+  - Result: `FAIL`; remaining TLS wrap failure-state, `signal.pause`, and text-i18n dependency milestone gaps were remediated.
+- Final split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-16-constrained.md`
+  - Result: `PASS`; no material implementation-blocking gaps remained.
+- Final implementation-readiness scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-17-final-readiness.md`
+  - Result: `PASS`; all three phases were implementation-ready, with one editorial ledger-title mismatch remediated in the concurrency/runtime ledger.
+- No-legacy readiness scans:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-18-no-legacy-readiness.md`
+  - Result: `FAIL`; text/i18n stale dynamic-handler and implicit-open wording were remediated.
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-19-no-legacy-readiness.md`
+  - Result: `PASS`; no remaining backward-compatibility, legacy-support, deprecated-behavior, shim, bridge-alias, or fallback decisions remained.
+- Namespace consistency scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-20-sifr-namespace-readiness.md`
+  - Result: `PASS`; all three phase docs consistently use canonical `sifr.*` stdlib imports and reject bare CPython stdlib aliases.
+
+## Planning Review Remediation Retained In This Phase
+
+- [x] Add `socketserver` source, docs, tests, and milestone scope.
+- [x] Add C-backed `_socket` reexport inventory requirements.
+- [x] Define async TLS stream boundary and reject public event-loop retry model.
+- [x] Define concrete async HTTP deliverables.
+- [x] Add milestone dependency graph.
+- [x] Add shared network/web error mapping requirement.
+- [x] Add M4 closeout acceptance criteria.
+- [x] Name Tokio as the backing async runtime for this phase and require concrete feature expansion in M0.
+- [x] Make HTTP/HTTPS dependency on M2 `AsyncTlsStream` explicit.
+- [x] Make `SSLContext.wrap_socket` sync-only for this phase.
+- [x] Mark `socketserver.ThreadingMixIn`, `socketserver.ForkingMixIn`, and `ThreadingHTTPServer` unsupported for this phase.
+- [x] Add explicit cross-phase dependency contract for text/i18n and concurrency/runtime consumers.
+- [x] Clarify that core `asyncio` scheduler/task helpers are prior async-model infrastructure and this phase owns only network stream compatibility additions.
+- [x] Clarify `urllib.parse` byte/ASCII/UTF-8 ownership and block non-UTF-8 codec lookup on the text/i18n phase.
+- [x] Mark non-ASCII/non-UTF-8 `urllib.parse` encoding behavior as `blocked-on-text-i18n` until `milestone_text_i18n_1`.
+- [x] Define pre-text-i18n user-visible behavior for non-UTF-8 `urllib.parse` encoding arguments: compile-time diagnostic for static values, typed `UnsupportedEncodingError`/`URLError` for dynamic values.
+- [x] Add concrete network/TLS/HTTP typed error hierarchy and cross-module nesting requirements.
+- [x] Add required workload classification table for socket/select/TLS/HTTP and async-context diagnostics.
+- [x] Specify `SSLContext.wrap_socket` consumes the plain socket and `SSLSocket.unwrap()` consumes TLS before returning a plain socket.
+- [x] Specify failed TLS wrapping returns a typed `TlsWrapError` carrying recovered-or-closed socket state and nested transport evidence.
+- [x] Define the static handler abstraction requirement for `socketserver` and `http.server` instead of dynamic Python inheritance.
+- [x] Add external-review owner and five-working-day fallback rule.
+- [x] Pin non-UTF-8 URL/HTTP text behavior to text/i18n `milestone_text_i18n_1` completion.
+- [x] Add no-backward-compatibility policy: current-CPython API shape under canonical `sifr.*` imports only, no bare CPython stdlib aliases, no legacy aliases, no deprecated behavior, and no compatibility shims; only inventory-recorded current adapters with Sifr-safe semantics are allowed.
+- [x] Align the phase with the stdlib namespace cleanup: `sifr.*` remains the permanent public stdlib namespace and bare CPython stdlib import attempts get namespace-contract diagnostics.
+
+## Implementation PRs
+
+- M0: pending.
+- M1: pending.
+- M2: pending.
+- M3: pending.
+- M4: pending.
+
+## Validation Evidence
+
+Record local validation for each milestone before opening its PR.
+
+Required baseline commands:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+python3 scripts/check_hir_maintainability_guardrails.py
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Required merge-gate command before milestone closure:
+
+```bash
+scripts/run_all_tests.sh
+```
+
+## CPython Scan Evidence
+
+Each milestone must record:
+
+- CPython source files scanned.
+- CPython docs files scanned.
+- CPython tests scanned.
+- Public APIs adopted, adapted, waived.
+- Unsupported/intentional-diff/host-limited surfaces.
+- Sifr e2e pass/fail fixtures added.
+
+## Waiver Index
+
+No waivers recorded yet.
+
+Every waiver must include:
+
+- surface
+- terminal state: `intentional-diff`, `unsupported`, or `host-limited`
+- rationale
+- revisit rule
+- CPython evidence
+- Sifr regression fixture

--- a/issues/ad-hoc-production-stdlib-platform-parity.md
+++ b/issues/ad-hoc-production-stdlib-platform-parity.md
@@ -1,0 +1,552 @@
+# Ad Hoc Phase: Production Network And Web Stdlib Parity
+
+Status: draft
+Phase placement: ad hoc expansion phase after the stdlib boundary refactor and before any stable GA claim that Sifr is production-ready for networked programs.
+Phase owner: stdlib/runtime implementation with compiler import, effect, and codegen support
+
+## Objective
+
+Close the production stdlib gaps that prevent Sifr from supporting common networked Python-shaped programs:
+
+- networking and readiness: `socket`, `select`, `selectors`
+- TLS: `ssl`
+- URL and HTTP: `urllib.*`, `http.*`, `socketserver`
+
+This phase is complete when each target surface has either:
+
+- current-CPython-shaped source parity with Sifr-safe semantics,
+- a native Sifr async/runtime implementation that backs that compatibility surface,
+- or an explicit, tested waiver with rationale, revisit rule, and CPython test-family evidence.
+
+This phase does not add backward-compatibility or legacy support. Parity means the current supported CPython stdlib API shape and behavior adapted under Sifr's canonical `sifr.*` namespace with Sifr's static, typed, ownership-safe model. Bare CPython stdlib imports, historical aliases, deprecated APIs, compatibility shims, and hidden bridge names are not implemented; they receive diagnostics or waivers.
+
+## Split-Out Phases
+
+The original broad planning scan also covered two important areas that are now tracked as separate ad hoc phases:
+
+- [ad-hoc-production-concurrency-runtime-stdlib-parity.md](./ad-hoc-production-concurrency-runtime-stdlib-parity.md): `queue`, `subprocess`, `asyncio.subprocess`, `concurrent.futures`, `multiprocessing`, `contextlib`, `warnings`, `signal`
+- [ad-hoc-production-text-i18n-stdlib-parity.md](./ad-hoc-production-text-i18n-stdlib-parity.md): `codecs`, `encodings`, `unicodedata`, `locale`, `gettext`
+
+This phase may depend on those phases for optional text decoding, subprocess demos, or executor-backed serving, but it must not implement their module surfaces here.
+
+This phase also depends on [ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md](./ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md). Its namespace contract is assumed complete before these stdlib parity milestones ship: Sifr stdlib remains publicly imported through `sifr.*`, and bare CPython stdlib names are not aliases.
+
+## Cross-Phase Dependency Contract
+
+The three split phases are not an implied ship order. Each phase may implement and test its self-contained binary/runtime subset independently, but cross-phase consumer features are blocked until their provider phase is complete:
+
+- Text/i18n is a hard prerequisite for non-UTF-8 HTTP body decoding, file/text handlers that require codec lookup, and any network demo that depends on `open(..., encoding=...)`.
+- The precise unblock point for those text-dependent network features is completion of text/i18n `milestone_text_i18n_1: Codecs Registry, Encodings, And Text I/O Integration`; M0/M3 network inventory entries must record those surfaces as `blocked-on-text-i18n-m1` until that milestone is closed.
+- Concurrency/runtime is a hard prerequisite for executor-backed server APIs. This phase does not implement public thread, executor, queue, process, warning, or signal modules.
+- Async scheduler/task primitives are prior runtime infrastructure owned by the existing async model. This phase owns only network-specific compatibility additions such as `asyncio.open_connection` and `asyncio.start_server`.
+- Binary socket, TLS, URL parsing, cookie parsing, and loopback HTTP tests can ship before the text/i18n phase as long as they do not duplicate the codec registry.
+
+## Source Of Truth
+
+The authoritative CPython source tree for this phase is:
+
+- `/Users/yaseralnajjar/work/sifr/cpython`
+
+The implementation must scan and classify these CPython files before each milestone implementation PR:
+
+| Domain | CPython library sources | CPython test sources | Native backing sources |
+| --- | --- | --- | --- |
+| sockets/selectors | `Lib/socket.py`, `Lib/selectors.py`, `Doc/library/socket.rst`, `Doc/library/selectors.rst`, `Doc/library/select.rst` | `Lib/test/test_socket.py`, `Lib/test/test_select.py`, `Lib/test/test_selectors.py`, `Lib/test/test_asyncio/test_streams.py`, `Lib/test/test_asyncio/test_server.py`, `Lib/test/test_asyncio/test_sock_lowlevel.py`, `Lib/test/test_asyncio/test_selector_events.py` | `Modules/socketmodule.c`, `Modules/selectmodule.c`, `Modules/clinic/socketmodule.c.h`, `Modules/clinic/selectmodule.c.h` |
+| TLS | `Lib/ssl.py`, `Doc/library/ssl.rst` | `Lib/test/test_ssl.py`, `Lib/test/test_asyncio/test_ssl.py`, `Lib/test/test_asyncio/test_sslproto.py` | `Modules/_ssl.c`, `Modules/_ssl/*`, `Modules/clinic/_ssl.c.h` |
+| HTTP and URLs | `Lib/http/*.py`, `Lib/urllib/*.py`, `Lib/socketserver.py`, `Doc/library/http*.rst`, `Doc/library/urllib*.rst`, `Doc/library/socketserver.rst` | `Lib/test/test_httplib.py`, `Lib/test/test_httpservers.py`, `Lib/test/test_http_cookies.py`, `Lib/test/test_http_cookiejar.py`, `Lib/test/test_socketserver.py`, `Lib/test/test_urllib.py`, `Lib/test/test_urllib2.py`, `Lib/test/test_urllib2_localnet.py`, `Lib/test/test_urllib_response.py`, `Lib/test/test_urllibnet.py`, `Lib/test/test_urllib2net.py` | stdlib Python sources plus Rust HTTP/TLS/runtime crates selected by this phase |
+
+Path note: CPython paths above are relative to `/Users/yaseralnajjar/work/sifr/cpython`.
+
+## Current Sifr Baseline
+
+Current Sifr stdlib support is intentionally curated under `lib/sifr/*.sifr`. Relevant existing surfaces:
+
+- `sifr.asyncio` is a compatibility veneer over the canonical task model, but intentionally omits raw event loops, public selectors, subprocesses, process pools, and transport/protocol APIs.
+- `sifr.io` has file handles and in-memory stream wrappers, but no socket streams.
+- `sifr.socket`, `sifr.ssl`, `sifr.select`, `sifr.selectors`, `sifr.urllib`, `sifr.socketserver`, and public `sifr.http` modules are not present as production stdlib surfaces.
+- `sifr.asyncio` already owns the core scheduler/task veneer (`run`, `create_task`, `gather`, `sleep`, timeout helpers). This phase consumes that runtime and adds only network stream compatibility entry points.
+
+The Phase 32 async model remains binding:
+
+- Native async I/O APIs must be real suspension points.
+- Sync network APIs that can block must be classified as `@blocking_io`.
+- Direct calls to blocking sync APIs from `async def` remain compiler errors unless routed through native async APIs or explicit offload.
+- The compiler must not expose Tokio, event-loop objects, or raw callback-first APIs as the normal user model.
+
+## Parity Definition
+
+This phase targets current CPython-shaped interfaces under the canonical `sifr.*` namespace, not legacy compatibility layers or bare CPython import compatibility.
+
+For each module in scope:
+
+1. Support canonical Sifr stdlib imports for the CPython-shaped surface (`from sifr.socket import socket`, `from sifr.urllib.parse import urlparse`, etc.).
+2. Do not add bare CPython module-name imports as aliases for `sifr.*`. Bare forms such as `from socket import socket` or `from urllib.parse import urlparse` should receive the namespace-contract diagnostic once normal user/package resolution fails.
+3. Match CPython function/class names, constructor forms, constants, and common keyword arguments where compatible with Sifr's static type system.
+4. Adapt CPython exception behavior into Sifr-safe `Result[T, E]`, `Option[T]`, or compile-time diagnostics.
+5. Keep host-specific behavior explicitly marked `host-limited`.
+6. Keep CPython implementation-detail, deprecated, and historical compatibility behavior waived rather than reimplemented blindly.
+
+Every reviewed CPython test family must end in exactly one state:
+
+- `adopted`: direct Sifr equivalent added.
+- `adapted`: behavior preserved with Sifr `Result`/`Option`, ownership, async, or host-limited adaptation.
+- `waived`: explicit unsupported/intentional-diff/host-limited rationale recorded.
+
+Every public surface must end in exactly one state:
+
+- `done`
+- `intentional-diff`
+- `unsupported`
+- `host-limited`
+
+`open` is allowed during implementation only and is forbidden at phase exit.
+
+## Milestone Dependency Graph
+
+Implementation PRs must follow this dependency order unless the execution ledger records an explicit split that preserves the same prerequisites:
+
+1. `milestone_network_web_0` first. No implementation milestone starts until the inventory, CPython test matrix, import plan, and shared error mapping are checked in.
+2. `milestone_network_web_1` before network-dependent HTTP/TLS/server work. Socket readiness and async streams are the substrate for TLS and HTTP.
+3. `milestone_network_web_2` before HTTPS client/server support in `milestone_network_web_3`. M3 may start URL parsing and plain HTTP work after M1, but HTTPS and async HTTPS wait for M2 `AsyncTlsStream`.
+4. `milestone_network_web_4` last, after every target surface and CPython test family in this phase is closed as `done`, `intentional-diff`, `unsupported`, or `host-limited`.
+
+Parallel work is allowed only for pure parser work that does not consume unfinished runtime substrate.
+
+## Architecture Principles
+
+### Native Runtime First, Compatibility Second
+
+Implement the canonical runtime primitive first, then layer CPython-shaped modules over it.
+
+- Tokio remains the backing async runtime for this phase because the generated task runtime already depends on `tokio` and `sifr_stdlib::StdlibFeature::Tokio`.
+- M0 must expand the Tokio dependency feature plan from the current task/sync/time set to the concrete features needed for `tokio::net` and `tokio::io`.
+- No `async-std`, custom event-loop runtime, or public Tokio type is introduced without a separate architecture issue.
+- `sifr.net` / private intrinsics own TCP/UDP/socket readiness.
+- `sifr.tls` / private intrinsics own TLS handshakes and certificate verification.
+- `sifr.http` / private intrinsics own request/response transport.
+- CPython-shaped canonical Sifr modules (`sifr.socket`, `sifr.ssl`, `sifr.urllib.request`, `sifr.http.client`, `sifr.http.server`, `sifr.socketserver`) delegate to those primitives.
+
+The exact internal module names may change during implementation, but the public stdlib namespace remains `sifr.*` and the boundary must exist: public modules must not duplicate target-runtime logic.
+
+### Async Counterpart Rule
+
+Any blocking production API added in this phase must have one of:
+
+- a native async counterpart,
+- a documented reason why async is not meaningful,
+- or an explicit `@blocking_io` classification plus approved offload-only guidance.
+
+Required native async counterparts:
+
+- TCP connect/listen/accept/read/write/close
+- TLS connect/accept/handshake/read/write/close
+- HTTP client request/response body streaming
+- HTTP server accept/request dispatch/shutdown
+
+M0 must add every network/web API to the stdlib workload database. The first table must include at least:
+
+| API family | Classification | Async-context behavior |
+| --- | --- | --- |
+| `socket.connect`, `accept`, `recv`, `recv_into`, `send`, `sendall`, `sendto`, `recvfrom`, DNS helpers, `create_connection`, `create_server` | sync `@blocking_io` | compile-time diagnostic suggesting native async network APIs or explicit offload |
+| `select.select`, selector `select`, blocking readiness waits | sync `@blocking_io` | compile-time diagnostic suggesting async readiness/stream APIs or explicit offload |
+| `ssl.SSLContext.wrap_socket`, sync TLS handshake/read/write/shutdown | sync `@blocking_io` | compile-time diagnostic suggesting async TLS APIs or explicit offload |
+| `urllib.request.urlopen`, `http.client` request/response body operations, `http.server`/`socketserver` serve loops | sync `@blocking_io` | compile-time diagnostic suggesting native async HTTP/server APIs or explicit offload |
+| `asyncio.open_connection`, `asyncio.start_server`, async TLS, and async HTTP APIs | async-native | legal suspension points |
+| pure URL parsing, percent-encoding, cookies, robotparser parsing | pure, or `@cpu_heavy` if M0 finds size-dependent paths | legal unless the exact path is marked `@cpu_heavy` |
+
+Implementation milestones cannot claim CPython conformance for a blocking family until its workload entries and async diagnostics are checked in.
+
+### No Raw Event Loop As Public Model
+
+CPython `asyncio` tests must be mined for behavior, but Sifr must not make raw event loops, event-loop policies, callback transports/protocols, or public selector internals the primary API. Compatibility functions should map to `task`, `sync`, stream, and network primitives.
+
+### Server Handler Model Without Python Inheritance
+
+`socketserver` and `http.server` handler classes rely on CPython subclass dispatch. Sifr must not emulate dynamic class inheritance. M0 must choose and document one static handler abstraction before M3 implementation starts:
+
+- preferred: generated trait-based handlers with statically typed `handle`, `setup`, and `finish` hooks for `BaseRequestHandler`/`BaseHTTPRequestHandler`-shaped source
+- allowed adaptation: enum or closure callback dispatch when CPython subclassing cannot be represented safely
+- unsupported forms: monkeypatching handler methods, dynamic attribute lookup, or inheritance patterns that cannot lower to a known trait/callback shape
+
+M3 fixtures must prove `HTTPServer(..., Handler)` and `socketserver.TCPServer(..., Handler)` route requests through the selected abstraction and must mark unsupported subclass forms with diagnostics.
+
+### Typed Errors Instead Of Exceptions
+
+All fallible APIs must expose typed error results:
+
+- `SocketError`, `AddressError`, `TimeoutError`, `ConnectionError`
+- `SSLError`, `CertificateError`
+- `HTTPError`, `URLError`, `CookieError`
+
+Names may align with CPython where possible, but the operational contract is Sifr `Result`/`Option`, not exception-driven control flow.
+
+`milestone_network_web_0` must add a shared error mapping document before M1 implementation:
+
+- map CPython `OSError`/`errno` families into stable Sifr variants used by sockets, TLS, selectors, and HTTP
+- define which current CPython exception class names remain importable from canonical `sifr.*` modules as typed error constructors for parity; historical aliases are not imported for backward compatibility
+- add cross-module regression tests proving equivalent failures use the same Sifr error family
+- define a concrete typed error hierarchy before M1 starts:
+  - `SocketError` is the base network transport error and carries address, timeout, readiness, descriptor, and platform/errno variants
+  - `TlsError`/`SSLError` wraps TLS handshake, verification, certificate, ALPN, and wrapped-stream failures and preserves the underlying `SocketError` when transport is the root cause
+  - `HttpError`/`URLError` wraps invalid URL, unsupported encoding, connection, redirect, bad status line, incomplete read, remote disconnect, proxy, cookie, and robotparser failures and preserves nested socket/TLS error evidence
+  - modern exception names such as `ssl.SSLError`, `urllib.error.URLError`, and `http.client.HTTPException` map to typed constructors, never exception-only control flow; legacy aliases such as `socket.error` are unsupported
+
+### Panic-Free Runtime Contract
+
+No user-triggerable runtime panics are allowed. Generated Rust for these APIs must not contain data-dependent `.unwrap()`, `.expect()`, or `panic!` on user-controlled network, TLS, URL, cookie, or HTTP data.
+
+## Non-Goals And Permanent Boundaries
+
+The following are not accepted as silent omissions. They must be either implemented or explicitly waived with tests:
+
+- platform-specific constants and address families not available on the host
+- CPython refcount/finalizer behavior
+- dynamic monkeypatching of module globals
+- raw event-loop policy mutation
+- callback transport/protocol APIs as the primary Sifr model
+- `socketserver.ThreadingMixIn` and `socketserver.ForkingMixIn`; both are unsupported in this phase
+- `http.server.ThreadingHTTPServer`; unsupported in this phase
+- process, queue, signal, warning, locale, codec, Unicode, or gettext APIs; those belong to the split-out phases
+
+## Milestones
+
+### milestone_network_web_0: CPython Inventory And Harness Lock
+
+Scope:
+
+- Add a machine-readable parity inventory under `verification/stdlib/network_web_parity_inventory.*`.
+- Scan every source/test/doc file listed in `Source Of Truth`.
+- Extract public functions, classes, constants, methods, common keyword forms, deprecation/legacy markers, and test-class/test-method names.
+- Create module-level CPython traceability docs for sockets/selectors, TLS, and HTTP/URL domains.
+- Add CPython-derived e2e fixtures:
+  - `cpython_socket_subset.sifr`
+  - `cpython_socketserver_subset.sifr`
+  - `cpython_ssl_subset.sifr`
+  - `cpython_selectors_subset.sifr`
+  - `cpython_urllib_parse_subset.sifr`
+  - `cpython_urllib_response_subset.sifr`
+  - `cpython_http_client_subset.sifr`
+  - `cpython_http_server_subset.sifr`
+- Add import-resolution tests for canonical `sifr.*` module names and negative diagnostics for bare CPython stdlib import attempts.
+- Add shared error mapping for all network/web target domains.
+- Add the concrete network/TLS/HTTP typed error hierarchy required by `Typed Errors Instead Of Exceptions`.
+- Add workload classifications and async-context diagnostics for socket, select/selectors, TLS, HTTP client/server, and URL/cookie/parser APIs.
+- Decide the `socketserver`/`http.server` handler abstraction used to adapt CPython subclass dispatch.
+- Assign each inventory entry one owner milestone and one terminal state. Duplicate ownership is forbidden unless the entry is explicitly shared infrastructure.
+- Assign every deprecated, historical, or legacy-only entry the terminal state `unsupported` or `intentional-diff`. M0 may implement only current, non-deprecated target CPython surfaces that remain elegant under Sifr semantics.
+
+Validation:
+
+- inventory generator/test proves no target module lacks a surface state
+- `cargo test -p sifr_stdlib`
+- `cargo test -p sifr -- stdlib`
+- `scripts/run_all_tests.sh --profile create-pr`
+
+Definition of done:
+
+- The implementation backlog is derived from CPython source/tests, not hand-written memory.
+- Every target module has a first-pass surface matrix and CPython test-family matrix.
+- Canonical `sifr.*` module imports are explicitly planned and regression-tested.
+- M1-M4 implementation PRs have concrete backlog entries rather than prose-only scope.
+
+### milestone_network_web_1: Socket, Select, Selectors, And Async Network Streams
+
+Scope:
+
+- Add `sifr.socket`, `sifr.select`, and `sifr.selectors` CPython-shaped modules. Do not add bare CPython stdlib import aliases.
+- Implement TCP IPv4/IPv6 client/server basics:
+  - `socket.socket`
+  - `socketpair`
+  - `fromfd`, `dup`, `close`
+  - `bind`, `listen`, `accept`
+  - `connect`, `connect_ex`
+  - `send`, `sendall`, `recv`, `recv_into` where compatible with Sifr bytes/buffer model
+  - `shutdown`, `close`
+  - `detach` only if ownership semantics are safe; otherwise explicit waiver
+  - `settimeout`, `gettimeout`, `setblocking`
+  - `getdefaulttimeout`, `setdefaulttimeout`
+  - `getsockname`, `getpeername`
+  - `family`, `type`
+  - `create_connection`, `create_server`
+  - `getaddrinfo`, `getnameinfo`, `gethostname`, `getfqdn`
+  - `gethostbyname`, `gethostbyaddr`, `getservbyname`, `getservbyport`, `getprotobyname`
+  - `inet_aton`, `inet_ntoa`, `inet_pton`, `inet_ntop`
+  - address-family, socket-type, protocol, message, shutdown, and option constants discovered from `Modules/socketmodule.c`
+- Classify low-level descriptor APIs:
+  - `detach`/`fromfd`/`dup` are adopted only if ownership transfer is statically safe.
+  - If a raw descriptor would allow double-close or aliasing, the API is `intentional-diff` with a CPython test adaptation.
+  - Host-only constants are `host-limited` with generated inventory evidence.
+- Implement UDP basics:
+  - `sendto`, `recvfrom`
+  - address tuple adaptation with typed address structs where needed
+- Implement selector readiness APIs as compatibility over runtime readiness:
+  - `EVENT_READ`, `EVENT_WRITE`
+  - `SelectorKey`
+  - `DefaultSelector`
+  - `SelectSelector`
+  - `BaseSelector.register`, `unregister`, `modify`, `select`, `close`, `get_key`, `get_map`
+- Add native async network streams:
+  - `asyncio.open_connection` compatibility over canonical Sifr streams
+  - `asyncio.start_server` compatibility over canonical Sifr streams
+  - async connect, accept loop, read/write, and close
+  - async iteration over incoming bytes/lines where appropriate
+- Mark sync socket APIs as `@blocking_io`.
+- Ensure async code gets diagnostics suggesting native async network APIs instead of direct sync calls.
+
+CPython tests to mine:
+
+- `Lib/test/test_socket.py`
+- `Lib/test/test_select.py`
+- `Lib/test/test_selectors.py`
+- `Lib/test/test_asyncio/test_streams.py`
+- `Lib/test/test_asyncio/test_server.py`
+- `Lib/test/test_asyncio/test_sock_lowlevel.py`
+- `Lib/test/test_asyncio/test_selector_events.py`
+
+Rust/runtime candidates:
+
+- `std::net` for sync compatibility
+- `tokio::net` for async network operations
+- `socket2` if low-level socket option coverage requires it
+
+Definition of done:
+
+- TCP/UDP loopback tests pass deterministically without external network dependency.
+- Timeout and nonblocking behavior is typed, deterministic, and panic-free.
+- Async network APIs are real `AsyncIo` suspension points.
+- Selector compatibility is implemented or explicitly waived per platform.
+
+### milestone_network_web_2: TLS And SSL
+
+Scope:
+
+- Add `ssl` CPython-shaped module and any native TLS helper module needed.
+- Implement:
+  - protocol/version constants and `TLSVersion`
+  - `Purpose`
+  - `SSLContext`
+  - `create_default_context`
+  - `get_default_verify_paths`
+  - `cert_time_to_seconds`
+  - `DER_cert_to_PEM_cert`
+  - `PEM_cert_to_DER_cert`
+  - `get_server_certificate`
+  - `SSLContext.load_verify_locations`
+  - `SSLContext.load_default_certs`
+  - `SSLContext.wrap_socket`
+  - `SSLContext.set_alpn_protocols` where the selected Rust TLS backend supports it
+  - `SSLSocket` read/write/recv/send/shutdown/unwrap/selected_alpn_protocol/cipher/version
+- Add async TLS:
+  - canonical `AsyncTlsStream`-style runtime primitive over the M1 async stream type
+  - `asyncio.open_connection(..., ssl=...)` compatibility over that primitive
+  - `asyncio.start_server(..., ssl=...)` compatibility over that primitive
+  - async client handshake
+  - async server handshake
+  - async read/write/close
+  - certificate verification failures as typed `SSLError`/`CertificateError`
+- Do not expose CPython's event-loop-driven `SSLWantReadError`/`SSLWantWriteError` retry model as the public Sifr async API. Mine those tests for readiness and retry behavior, then adapt them to real suspension points.
+- `SSLContext.wrap_socket` is sync-only in this phase. Async TLS uses the canonical async stream constructor/API added by M2, not an overloaded `wrap_socket`.
+- Mark sync TLS socket operations as `@blocking_io`.
+- Preserve safe ownership around wrapped sockets:
+  - `SSLContext.wrap_socket(sock, ...)` consumes/moves the plain socket handle and returns `Result[SSLSocket, SSLError]`
+  - after a successful wrap, the original plain socket variable is invalid and cannot be used, closed, detached, or aliased independently
+  - failed wrapping returns `Err(TlsWrapError { socket_state, error })` or equivalent; `socket_state` is either `Recovered(Socket)` when the underlying descriptor remains usable or `Closed` when the backend consumed/closed it during failure
+  - the original plain socket variable is invalid on both success and failure; on failure, the only way to recover a usable plain socket is through `TlsWrapError.socket_state`
+  - transport-root failures preserve nested `SocketError` inside the TLS error evidence
+  - `SSLSocket.unwrap()` consumes the TLS handle and returns the underlying plain socket only after a successful TLS shutdown; failure returns typed error evidence without leaving two mutable handles alive
+
+CPython tests to mine:
+
+- `Lib/test/test_ssl.py`
+- `Lib/test/test_asyncio/test_ssl.py`
+- `Lib/test/test_asyncio/test_sslproto.py`
+
+Rust/runtime candidates:
+
+- `rustls`
+- `tokio-rustls`
+- `webpki-roots` or platform-native roots, selected explicitly
+- `x509-parser` only if certificate inspection requires it
+
+Definition of done:
+
+- Local self-signed and CA-backed handshake fixtures are deterministic.
+- Host-network certificate tests are either disabled by default or recorded as non-blocking ecosystem signal.
+- TLS verification errors are typed and never panic.
+
+### milestone_network_web_3: URL Parsing, HTTP Client, HTTP Server, Cookies, And Robots
+
+Scope:
+
+- Add `urllib.parse`, `urllib.request`, `urllib.response`, `urllib.error`, `urllib.robotparser`.
+- Add `http`, `http.client`, `http.server`, `http.cookies`, `http.cookiejar`.
+- Add `socketserver` as the HTTP server substrate:
+  - `BaseServer`
+  - `TCPServer`
+  - `UDPServer` only if UDP service ownership can be tested deterministically
+  - `ThreadingMixIn` is `unsupported` in this phase; equivalent concurrent serving uses Sifr task/spawn APIs or explicit executor APIs after the concurrency/runtime phase
+  - `ForkingMixIn` is `unsupported` in this phase because fork semantics are owned by the concurrency/runtime phase and are host-limited even there
+  - `BaseRequestHandler`, `StreamRequestHandler`, `DatagramRequestHandler`
+- Implement URL parsing and quoting:
+  - `urlparse`, `urlsplit`, `urlunparse`, `urlunsplit`, `urljoin`, `urldefrag`
+  - `quote`, `quote_plus`, `quote_from_bytes`
+  - `unquote`, `unquote_plus`, `unquote_to_bytes`
+  - `urlencode`
+  - `parse_qs`, `parse_qsl`
+  - `ParseResult`, `SplitResult`, byte variants where compatible
+  - percent-encoding and URL quoting use byte/ASCII and UTF-8-compatible behavior in this phase only
+  - non-ASCII/non-UTF-8 forms such as `quote(value, encoding="latin-1")` are `blocked-on-text-i18n-m1` until text/i18n `milestone_text_i18n_1` ships the codec registry, core encodings, and typed codec errors; they must not be reimplemented locally
+  - before `milestone_text_i18n_1`, statically visible non-UTF-8 `encoding=` arguments produce a compile-time unsupported-codec diagnostic; dynamic non-UTF-8 encoding values return a typed `UnsupportedEncodingError`/`URLError` result, never silent UTF-8 coercion or panic
+- Implement HTTP client:
+  - `HTTPConnection`, `HTTPSConnection`
+  - `HTTPResponse`
+  - `request`, `getresponse`, `close`, `set_tunnel`
+  - headers and body reading
+  - typed errors for invalid URL, bad status line, incomplete read, remote disconnect, timeout
+- Implement higher-level URL request basics:
+  - `Request`
+  - `urlopen`
+  - `build_opener` minimal supported handler matrix
+  - redirects
+  - proxy environment support only if deterministic and documented
+  - file/data handlers only if Sifr path/bytes semantics are compatible
+- Implement HTTP server basics:
+  - `HTTPServer`
+  - `ThreadingHTTPServer` is `unsupported` in this phase
+  - `BaseHTTPRequestHandler`
+  - `SimpleHTTPRequestHandler`
+  - graceful shutdown
+- Implement cookies:
+  - `Morsel`
+  - `SimpleCookie`
+  - `Cookie`
+  - `CookieJar`
+  - `DefaultCookiePolicy`
+  - file-backed cookie jars only if safe file I/O support is sufficient
+- Implement `RobotFileParser` and pure parser helpers.
+- Add native async HTTP APIs with concrete entry points:
+  - `sifr.http.async_request` or final equivalent canonical API for one-shot requests
+  - async request builder with streaming request body support
+  - async response object with streaming body reads
+  - async server accept/dispatch/shutdown over M1 async streams and M2 async TLS for HTTPS
+  - `urllib.request.urlopen` remains sync `@blocking_io`; any async compatibility wrapper must have a distinct async name and real suspension behavior
+  - no raw event-loop, callback transport, or selector object is exposed as the user-facing HTTP API
+
+CPython tests to mine:
+
+- `Lib/test/test_httplib.py`
+- `Lib/test/test_httpservers.py`
+- `Lib/test/test_http_cookies.py`
+- `Lib/test/test_http_cookiejar.py`
+- `Lib/test/test_socketserver.py`
+- `Lib/test/test_urllib.py`
+- `Lib/test/test_urllib2.py`
+- `Lib/test/test_urllib2_localnet.py`
+- `Lib/test/test_urllib_response.py`
+- `Lib/test/test_urllibnet.py` and `Lib/test/test_urllib2net.py` as external-network, non-blocking signal unless converted to loopback
+
+Rust/runtime candidates:
+
+- `url`
+- `percent-encoding`
+- `http`
+- `hyper`
+- `hyper-util`
+- `reqwest` only if its API/dependency size is accepted by review
+- `tower`/`axum` only if server milestone needs them; avoid pulling a web framework into stdlib unless justified
+
+Definition of done:
+
+- URL parsing has CPython-derived edge-case fixtures.
+- URL parsing fixtures include an explicit split between byte/ASCII/UTF-8 behavior owned here and non-UTF-8 codec behavior blocked on the text/i18n phase.
+- HTTP client/server loopback tests require no external network.
+- Async HTTP operations are real suspension points.
+- Cookies and robotparser are pure or panic-free parser code with CPython-derived tests.
+
+### milestone_network_web_4: Integration, Documentation, And Production Gate
+
+Scope:
+
+- Update public docs for every new module and major intentional divergence:
+  - `socket`, `select`, `selectors`, `socketserver`
+  - `ssl`
+  - `urllib.parse`, `urllib.request`, `urllib.response`, `urllib.error`, `urllib.robotparser`
+  - `http`, `http.client`, `http.server`, `http.cookies`, `http.cookiejar`
+- Update internal architecture docs for:
+  - runtime networking/TLS/HTTP boundaries
+  - stdlib feature/dependency manifest
+  - async counterpart policy
+  - host-limited platform behavior
+- Add demos:
+  - TCP echo server/client
+  - TLS client/server loopback
+  - HTTP client/server loopback
+- Add generated Cargo dependency snapshots for all new feature combinations.
+- Add panic-scan and emitted-code quality checks for network/TLS/HTTP paths.
+- Update validation lane manifests with representative fixtures.
+- Close the inventory:
+  - every public surface has a terminal state
+  - every CPython test family has `adopted`, `adapted`, or `waived` evidence
+  - every waiver has a revisit rule and regression fixture
+  - every host-limited surface records the supported host matrix
+- Run an external review loop on the final inventory and close any blocking finding before phase completion.
+- External review owner is the stdlib phase owner plus the designated compiler/runtime reviewer recorded in the execution ledger. If review output is unavailable for five working days after the review artifact is posted, the phase owner may proceed only by recording the attempted review, open questions, and a conservative self-review in the ledger.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- file-size guardrail
+- `cargo test -p sifr_stdlib`
+- `cargo test -p sifr -- stdlib`
+- `scripts/run_e2e_pass.sh`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh`
+
+Definition of done:
+
+- Every module surface and CPython test family in the phase inventory is closed as `done`, `intentional-diff`, `unsupported`, or `host-limited`.
+- No implementation-owned source file exceeds the 900-line guardrail.
+- No user-triggerable runtime panic path exists in the added stdlib/runtime surfaces.
+- Async and sync APIs follow the Phase 32 workload and cancellation model.
+
+## Required Tracking Artifacts
+
+Create and keep current during implementation:
+
+- `issues/ad-hoc-production-stdlib-platform-parity-execution.md`
+- `verification/stdlib/network_web_parity_inventory.md`
+- `verification/stdlib/network_web_parity_inventory.json`
+- `verification/stdlib/network_web_parity_cpython_test_matrix.md`
+- one traceability document per milestone domain under `verification/stdlib/`
+
+The execution ledger must record:
+
+- planning/review artifacts
+- per-milestone PR links
+- local validation commands and results
+- CPython source/test files scanned
+- adopted/adapted/waived CPython test families
+- final unsupported/intentional-diff/host-limited waiver index
+
+## Quality Contract
+
+- Solve root causes rather than adding workaround wrappers.
+- No backward-compatibility shims, legacy aliases, deprecated behavior, or fallback paths may survive phase exit. Deliberate current-CPython adapters are allowed only when recorded in the inventory with Sifr-safe semantics and tests.
+- No direct Tokio/runtime types may leak into public Sifr APIs.
+- No data-dependent emitted `.unwrap()`, `.expect()`, or `panic!` is allowed in user runtime paths.
+- Every added blocking sync function must be classified in the stdlib workload database.
+- Every added async function must have a real suspension summary.
+- Every added external crate dependency must be represented by a stable `StdlibFeature` in `sifr_stdlib`.
+- Every module added to embedded stdlib sources must have canonical `sifr.*` import-resolution tests, type-check tests, e2e pass tests, and negative diagnostics for unsupported bare CPython import forms.
+
+## Open Planning Questions To Resolve In `milestone_network_web_0`
+
+1. Which `sifr.*` module paths exactly host the CPython-shaped API surfaces, and which private `_sifr.*`/runtime modules remain internal implementation details?
+2. Which Rust TLS root strategy is acceptable for deterministic local tests and production binaries?
+3. Which HTTP client/server dependency stack meets binary-size, safety, and maintenance goals?
+4. Which host-specific socket/select constants are shipped, waived, or host-limited?
+5. Which external-network CPython tests are converted to loopback fixtures versus retained as non-blocking ecosystem signal?
+
+These questions must be answered in the phase execution ledger before implementing the affected milestone.

--- a/issues/ad-hoc-production-text-i18n-stdlib-parity-execution.md
+++ b/issues/ad-hoc-production-text-i18n-stdlib-parity-execution.md
@@ -1,0 +1,187 @@
+# Ad Hoc Phase Execution: Production Text And Internationalization Stdlib Parity
+
+Phase contract: [ad-hoc-production-text-i18n-stdlib-parity.md](./ad-hoc-production-text-i18n-stdlib-parity.md)
+
+Status: draft
+
+## Scope Split
+
+This ledger tracks:
+
+- `codecs`, `encodings`
+- `unicodedata`
+- `locale`
+- `gettext`
+
+Network/web parity remains in [ad-hoc-production-stdlib-platform-parity-execution.md](./ad-hoc-production-stdlib-platform-parity-execution.md). Concurrency/runtime parity remains in [ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md](./ad-hoc-production-concurrency-runtime-stdlib-parity-execution.md).
+
+## Milestone Checklist
+
+- [ ] `milestone_text_i18n_0`: CPython Inventory, Error Mapping, And Registry Design
+- [ ] `milestone_text_i18n_1`: Codecs Registry, Encodings, And Text I/O Integration
+- [ ] `milestone_text_i18n_2`: Unicode Data And Normalization
+- [ ] `milestone_text_i18n_3`: Locale
+- [ ] `milestone_text_i18n_4`: Gettext
+- [ ] `milestone_text_i18n_5`: Integration, Documentation, And Production Gate
+
+## Planning Reviews
+
+- Inherited from the original combined stdlib parity planning review:
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-1d.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-2.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-3.md`
+  - `reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-4.md`
+- Final combined review result before split: `PASS`.
+- Split-phase Claude review:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-1-constrained.md`
+  - Result: `FAIL`; cross-phase dependency and ownership gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-2-constrained.md`
+  - Result: `FAIL`; remaining ownership/disposition gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-3-constrained.md`
+  - Result: `FAIL`; remaining sequencing/error-surface gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-4-constrained.md`
+  - Result: `FAIL`; remaining async-context/file/default-encoding/thread-error gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-5-constrained.md`
+  - Result: `FAIL`; remaining contextvars/future-cancellation/open-policy/worker-typing gaps were remediated across the split phase docs.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-6-constrained.md`
+  - Result: `FAIL`; remaining executor map/timeout/cancellation/heterogeneous-future gaps and text-wrapper gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-7-constrained.md`
+  - Result: `FAIL`; remaining executor state-machine, `StringIO`, `threading.local`, and codec error-handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-8-constrained.md`
+  - Result: `FAIL`; remaining Future.cancel, wait partition, executor.map timeout, and text handler gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-9-constrained.md`
+  - Result: `FAIL`; remaining executor deadline/cancellation/wait fallback and codec handler classification gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-10-constrained.md`
+  - Result: `FAIL`; remaining handler enforcement, partial iteration, FIRST_EXCEPTION trigger, and shutdown pending/running gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-11-constrained.md`
+  - Result: `FAIL`; remaining future ownership/lifecycle and shutdown observability gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-12-constrained.md`
+  - Result: `FAIL`; remaining `wait()` ownership, cancelled result typing, and incremental codec finalization gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-13-constrained.md`
+  - Result: `FAIL`; remaining `gather()` ownership/result typing, `as_completed()` timeout signaling, codec recoverable-error, and `TaskGroup` aggregation gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-14-constrained.md`
+  - Result: `FAIL`; remaining network error hierarchy, TLS socket ownership, workload classification, handler model, concurrency gate, text decision, and review-gate gaps were remediated.
+- Split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-15-constrained.md`
+  - Result: `FAIL`; remaining TLS wrap failure-state, `signal.pause`, and text-i18n dependency milestone gaps were remediated.
+- Final split-phase Claude follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-16-constrained.md`
+  - Result: `PASS`; no material implementation-blocking gaps remained.
+- Final implementation-readiness scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-17-final-readiness.md`
+  - Result: `PASS`; all three phases were implementation-ready, with one editorial ledger-title mismatch remediated in the concurrency/runtime ledger.
+- No-legacy readiness scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-18-no-legacy-readiness.md`
+  - Result: `FAIL`; stale dynamic handler lookup wording and misleading M3 implicit-open wording were remediated.
+- No-legacy follow-up:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-19-no-legacy-readiness.md`
+  - Result: `PASS`; no remaining backward-compatibility, legacy-support, deprecated-behavior, shim, bridge-alias, or fallback decisions remained.
+- Namespace consistency scan:
+  - `reviews/ad-hoc-production-split-stdlib-phases-review-pass-20-sifr-namespace-readiness.md`
+  - Result: `PASS`; all three phase docs consistently use canonical `sifr.*` stdlib imports and reject bare CPython stdlib aliases.
+- Required follow-up: run a dedicated external review after M0 inventory and before M1 implementation, because this phase is now independently scoped.
+
+## Planning Review Remediation Retained In This Phase
+
+- [x] Add text/i18n CPython source, docs, tests, and native backing scope.
+- [x] Add shared text/i18n error mapping requirement.
+- [x] Add codec registry mutation policy as an M0 decision.
+- [x] Add Unicode data version and generated-table strategy as M0 decisions.
+- [x] Add locale process-global synchronization as an M0 decision.
+- [x] Add gettext global-installation policy as an M0 decision.
+- [x] Require `str.encode(...)`, `bytes.decode(...)`, and `open(..., encoding=...)` to use the same codec registry.
+- [x] Require global-state mutation to be synchronized, waived, or host-limited with tests.
+- [x] Add explicit provider contract for network/web and concurrency/runtime text consumers.
+- [x] Clarify that binary-mode file I/O is prior infrastructure and this phase owns only text-mode `open(..., encoding=..., errors=...)` integration.
+- [x] Clarify locale state is process-scoped and threaded/process-pool code must serialize locale-sensitive operations through this phase's locale lock or record host-limited/intentional-diff behavior.
+- [x] Name binary file I/O as prior runtime/file-object parity and current `sifr.io` infrastructure, with M0 verification before text-mode `open(..., encoding=..., errors=...)`.
+- [x] Make binary file I/O verification a hard prerequisite: failures block `milestone_text_i18n_1` and are fixed in the existing `sifr.io`/runtime file-object surface rather than worked around in text-mode code.
+- [x] Define `open(path)`/`open(path, mode="r")` without explicit `encoding=` as permanently `unsupported`/`intentional-diff` from CPython's locale-derived default; M3 documents this as the final intentional difference and does not unblock these forms. Static omissions get compile-time diagnostics; dynamic cases get typed unsupported-default-encoding errors.
+- [x] Make explicit text encodings permanently required for text-mode `open(...)`; locale preferred encoding APIs do not make implicit text opens legal.
+- [x] Require literal/static `open(...)` modes so the compiler can choose binary versus text handle types; dynamic/nonliteral mode strings get a compile-time diagnostic unless routed through a future typed helper API.
+- [x] Extend the explicit-encoding policy to text stream wrappers such as `io.TextIOWrapper`, or record `io.TextIOWrapper` as unsupported with CPython evidence.
+- [x] Carve out `io.StringIO` as encoding-free native-string I/O; it must not inherit the codec-backed wrapper encoding requirement.
+- [x] Define typed/statically known codec `errors=` handling for `str.encode`, `bytes.decode`, `open`, and text wrappers, with dynamic error-handler names unsupported because synchronized runtime lookup is not adopted in this phase.
+- [x] Require `io.StringIO(newline=...)` to either implement CPython-compatible newline semantics or reject unsupported newline parameters with diagnostics.
+- [x] Require encode/decode context validation for codec error handlers, including rejecting encode-only handlers such as `xmlcharrefreplace` on decode call sites.
+- [x] Add explicit codec error-handler applicability classes: encode-only, bidirectional, and codec-limited bidirectional, preserving `backslashreplace` as valid for both encode and decode.
+- [x] Define encode/decode error-handler enforcement through separate typed handler parameters and compile-time diagnostics for invalid static literals; synchronized dynamic handler lookup is not adopted in this phase.
+- [x] Document the static-versus-dynamic codec handler diagnostic timing difference as intentional.
+- [x] Define incremental encoder/decoder finalization as transitioning to exhausted state, with typed exhausted errors on subsequent encode/decode calls.
+- [x] Define incremental strict errors as typed failures with no partial success value, and recoverable non-strict errors as typed success outcomes carrying both produced output and recovery diagnostics.
+- [x] Resolve the registry mutation fork to a static registry in this phase, with `codecs.register`/`codecs.unregister` unsupported or intentional-diff.
+- [x] Resolve locale mutation to a process-global lock for adopted APIs, with locale names/host behavior recorded as host-limited where needed.
+- [x] Resolve `gettext.install` global mutation to unsupported/waived in this phase, with explicit translation objects as the supported path.
+- [x] Define incremental encoder/decoder ownership as unique mutable linear state, not hidden shared mutation.
+- [x] Add pre-M0 binary file I/O smoke criteria and `sifr.io` owner for prerequisite fixes.
+- [x] Add external-review owner and five-working-day fallback rule.
+- [x] Define `milestone_text_i18n_1` as the reciprocal unblock point for network/web non-UTF-8 URL/HTTP text behavior and concurrency/runtime subprocess/warning text behavior, with locale-sensitive formatting still additionally blocked on M3.
+- [x] Add no-backward-compatibility policy: current-CPython API shape under canonical `sifr.*` imports only, no bare CPython stdlib aliases, no legacy aliases, no deprecated behavior, no implicit locale-default text behavior, and no compatibility shims; only inventory-recorded current adapters with Sifr-safe semantics are allowed.
+- [x] Align the phase with the stdlib namespace cleanup: `sifr.*` remains the permanent public stdlib namespace and bare CPython stdlib import attempts get namespace-contract diagnostics.
+- [x] Remove stale dynamic error-handler lookup wording; dynamic handler names remain unsupported in this phase.
+- [x] Clarify no-encoding text `open(...)` remains permanently unsupported after M3; M3 documents the intentional difference rather than unblocking locale-derived defaults.
+
+## Implementation PRs
+
+- M0: pending.
+- M1: pending.
+- M2: pending.
+- M3: pending.
+- M4: pending.
+- M5: pending.
+
+## Validation Evidence
+
+Record local validation for each milestone before opening its PR.
+
+Required baseline commands:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+python3 scripts/check_hir_maintainability_guardrails.py
+scripts/run_all_tests.sh --profile create-pr
+```
+
+Required merge-gate command before milestone closure:
+
+```bash
+scripts/run_all_tests.sh
+```
+
+## CPython Scan Evidence
+
+Each milestone must record:
+
+- CPython source files scanned.
+- CPython docs files scanned.
+- CPython tests scanned.
+- Public APIs adopted, adapted, waived.
+- Unsupported/intentional-diff/host-limited surfaces.
+- Sifr e2e pass/fail fixtures added.
+
+## Waiver Index
+
+No waivers recorded yet.
+
+Every waiver must include:
+
+- surface
+- terminal state: `intentional-diff`, `unsupported`, or `host-limited`
+- rationale
+- revisit rule
+- CPython evidence
+- Sifr regression fixture

--- a/issues/ad-hoc-production-text-i18n-stdlib-parity.md
+++ b/issues/ad-hoc-production-text-i18n-stdlib-parity.md
@@ -1,0 +1,443 @@
+# Ad Hoc Phase: Production Text And Internationalization Stdlib Parity
+
+Status: draft
+Phase placement: ad hoc expansion phase after the stdlib boundary refactor and before any stable GA claim that Sifr is production-ready for internationalized programs or non-UTF-8 text I/O.
+Phase owner: stdlib/runtime implementation with compiler import, file/text I/O, effect, and codegen support
+
+## Objective
+
+Close the production stdlib gaps for text encoding, Unicode data, locale, and translation support:
+
+- codec registry and encodings: `codecs`, `encodings`
+- Unicode properties and normalization: `unicodedata`
+- locale-aware text/numeric behavior: `locale`
+- message catalogs and translation: `gettext`
+
+This phase is complete when each target surface has either:
+
+- current-CPython-shaped source parity with Sifr-safe semantics,
+- a native Sifr text/i18n runtime implementation that backs that compatibility surface,
+- or an explicit, tested waiver with rationale, revisit rule, and CPython test-family evidence.
+
+This phase does not add backward-compatibility or legacy support. Parity means the current supported CPython stdlib API shape and behavior adapted under Sifr's canonical `sifr.*` namespace with Sifr's static, typed, ownership-safe model. Bare CPython stdlib imports, historical aliases, deprecated APIs, implicit locale-default text behavior, compatibility shims, and hidden bridge names are not implemented; they receive diagnostics or waivers.
+
+## Related Phases
+
+- Network/web stdlib parity remains in [ad-hoc-production-stdlib-platform-parity.md](./ad-hoc-production-stdlib-platform-parity.md).
+- Concurrency/runtime stdlib parity is tracked in [ad-hoc-production-concurrency-runtime-stdlib-parity.md](./ad-hoc-production-concurrency-runtime-stdlib-parity.md).
+- This phase provides the codec/text substrate needed by subprocess text mode, HTTP text decoding, file `open(..., encoding=...)`, warning formatting, locale-aware formatting, and gettext demos.
+- This phase assumes [ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md](./ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md) is complete: Sifr stdlib remains publicly imported through `sifr.*`, and bare CPython stdlib names are not aliases.
+
+## Cross-Phase Dependency Contract
+
+The three split phases are not an implied ship order. This phase is the provider for text-dependent features in the other two phases:
+
+- Network/web may ship binary socket/TLS/HTTP and byte/ASCII/UTF-8 URL behavior before this phase, but non-UTF-8 HTTP body decoding, file/text handlers requiring codec lookup, and text-heavy demos are unblocked only after `milestone_text_i18n_1: Codecs Registry, Encodings, And Text I/O Integration` is complete.
+- Concurrency/runtime may ship binary subprocess pipes before this phase, but `text=True`, `encoding=...`, `errors=...`, warning output encoding, and locale-sensitive warning formatting are unblocked only after `milestone_text_i18n_1` is complete; any locale-specific formatting still also waits for `milestone_text_i18n_3`.
+- Binary-mode file I/O is prior stdlib/runtime infrastructure owned by the earlier runtime/file-object parity work (`issues/archive/ad-hoc-runtime-and-file-object-parity-expansion.md`) and the current `sifr.io` surface. M0 must verify that binary `open()`/file handles are usable before text-mode integration starts.
+- Before M0 starts, run a binary file I/O smoke check covering binary `open`, read, write, seek/tell where supported, close/drop, error-on-use-after-close, and byte-preserving round trips. If it fails, M0 may record inventory only; `milestone_text_i18n_1` is blocked until the stdlib/runtime file-object owner fixes `sifr.io` in a prerequisite PR recorded in this phase's execution ledger. Text-mode code must not work around or duplicate broken binary I/O behavior.
+- This phase owns only text-mode integration through `open(..., encoding=..., errors=...)`.
+- Text-mode `open(path)`, `open(path, mode="r")`, and any other text mode without an explicit `encoding=` are unsupported in this phase and remain unsupported after M3. Sifr requires explicit text encodings to preserve static behavior; M3 documents this as an intentional difference from CPython's locale-derived default.
+- Text stream wrappers such as `io.TextIOWrapper(binary_stream, ...)` follow the same policy: explicit `encoding=` is required for text wrapping, and omitted/default locale-derived encoding is unsupported with diagnostics. If `io.TextIOWrapper` itself is not implemented in this phase, that surface is recorded as `unsupported` with CPython evidence.
+- In-memory text streams such as `io.StringIO` are encoding-free because they operate on native strings. If touched by this phase, `StringIO` must not require an `encoding=` argument and its `newline=` parameter is either implemented with CPython-compatible universal-newline behavior or rejected with an unsupported-parameter diagnostic. Otherwise it remains existing `sifr.io` prior infrastructure or is recorded as unsupported separately from codec-backed wrappers.
+- `open(...)` mode strings must be statically known for the compiler to choose binary versus text handle types. Nonliteral/dynamic mode strings are unsupported unless routed through a future typed helper API; this avoids false-positive encoding diagnostics for dynamic binary modes and avoids a handle type that depends on runtime string contents.
+- Statically visible text-mode opens without `encoding=` produce a compile-time diagnostic requiring `encoding=...`. Dynamic/nonliteral mode opens produce a compile-time diagnostic requiring a literal mode or typed helper. Sifr must not silently substitute UTF-8 for CPython's locale-derived default.
+- Consumers must call the codec registry owned by this phase; they must not add local encoding fallbacks.
+
+## Source Of Truth
+
+The authoritative CPython source tree for this phase is:
+
+- `/Users/yaseralnajjar/work/sifr/cpython`
+
+The implementation must scan and classify these CPython files before each milestone implementation PR:
+
+| Domain | CPython library sources | CPython test sources | Native backing sources |
+| --- | --- | --- | --- |
+| codecs/encodings | `Lib/codecs.py`, `Lib/encodings/*.py`, `Doc/library/codecs.rst` | `Lib/test/test_codecs.py`, `Lib/test/test_capi/test_codecs.py` | `Modules/_codecsmodule.c`, `Modules/cjkcodecs/*` |
+| Unicode data | `Doc/library/unicodedata.rst` | `Lib/test/test_unicodedata.py` | `Modules/unicodedata.c` |
+| locale/gettext | `Lib/locale.py`, `Lib/gettext.py`, `Doc/library/locale.rst`, `Doc/library/gettext.rst` | `Lib/test/test_locale.py`, `Lib/test/test_gettext.py` | `Modules/_localemodule.c` |
+
+Path note: CPython paths above are relative to `/Users/yaseralnajjar/work/sifr/cpython`.
+
+## Current Sifr Baseline
+
+- `sifr.io` has file handles and in-memory stream wrappers, but no codec-driven text stream layer beyond current UTF-8-oriented boundaries.
+- Binary-mode file I/O is existing `sifr.io` infrastructure and remains outside this phase except where text-mode wrappers compose over it.
+- `str.encode(...)`, `bytes.decode(...)`, and `open(..., encoding=...)` do not have production CPython-style codec registry parity.
+- `sifr.codecs`, `sifr.encodings`, `sifr.unicodedata`, `sifr.locale`, and `sifr.gettext` are not present as production stdlib surfaces.
+
+The Phase 32 async/workload model remains binding:
+
+- CPU-heavy table generation, normalization, or large codec work must be classified as `@cpu_heavy` where appropriate.
+- Blocking file reads for `.mo` catalogs or locale resources must be classified as `@blocking_io`.
+- Direct calls to blocking or CPU-heavy sync APIs from `async def` remain compiler errors unless routed through native async APIs or explicit offload.
+
+## Parity Definition
+
+This phase targets current CPython-shaped interfaces under the canonical `sifr.*` namespace, not legacy compatibility layers or bare CPython import compatibility.
+
+For each module in scope:
+
+1. Support canonical Sifr stdlib imports for the CPython-shaped surface (`from sifr import codecs`, `from sifr import unicodedata`, `from sifr import locale`, etc.).
+2. Do not add bare CPython module-name imports as aliases for `sifr.*`. Bare forms such as `import codecs` or `import locale` should receive the namespace-contract diagnostic once normal user/package resolution fails.
+3. Match CPython function/class names, constructor forms, constants, and common keyword arguments where compatible with Sifr's static type system.
+4. Adapt CPython exception behavior into Sifr-safe `Result[T, E]`, `Option[T]`, or compile-time diagnostics.
+5. Keep host-specific behavior explicitly marked `host-limited`.
+6. Keep CPython implementation-detail, deprecated, and historical compatibility behavior waived rather than reimplemented blindly.
+
+Every reviewed CPython test family must end in exactly one state: `adopted`, `adapted`, or `waived`. Every public surface must end in exactly one state: `done`, `intentional-diff`, `unsupported`, or `host-limited`. `open` is forbidden at phase exit.
+
+## Milestone Dependency Graph
+
+1. `milestone_text_i18n_0` first. No implementation milestone starts until the inventory, CPython test matrix, import plan, shared error mapping, Unicode version decision, and codec registry mutation policy are checked in.
+2. `milestone_text_i18n_1` before all consumers. Codec registry basics and core encodings are the substrate for file I/O, subprocess text mode, HTTP text decoding, and gettext catalog parsing.
+3. `milestone_text_i18n_2` can run after M0 but must lock the Unicode data version before normalization/property APIs ship.
+4. `milestone_text_i18n_3` waits for M1 where locale APIs depend on encodings.
+5. `milestone_text_i18n_4` waits for M1 for `.mo` file decoding and declared catalog encodings.
+6. `milestone_text_i18n_5` closes docs, demos, validation, and waivers last.
+
+## Architecture Principles
+
+### Native Registry First, Compatibility Second
+
+Implement the canonical codec/text primitive first, then layer CPython-shaped modules over it.
+
+- A private runtime registry owns codec lookup, encoder/decoder construction, and error handler lookup.
+- CPython-shaped canonical Sifr modules (`sifr.codecs`, `sifr.encodings.*`) delegate to that registry.
+- `str.encode(...)`, `bytes.decode(...)`, and `open(..., encoding=...)` must use the same registry to avoid dual semantics.
+- Registry mutation is not adopted in this phase. The phase ships a static built-in registry, records `codecs.register`/`codecs.unregister` as `unsupported`/`intentional-diff` with CPython evidence, and may revisit synchronized mutation only in a future registry-mutation phase. Dynamic codec lookup by name is still supported against the static registry.
+
+### Incremental Codec Ownership
+
+`IncrementalEncoder` and `IncrementalDecoder` are stateful linear values:
+
+- encode/decode calls require a unique mutable handle (`&mut`-equivalent in the lowered Rust model)
+- the compiler rejects concurrent aliasing of the same incremental codec object
+- incremental codec objects are not `Send`/`Sync` and are not shareable across tasks/threads unless a future explicit locked wrapper API is added
+- `final=True` transitions the object to an exhausted state; later calls through the same handle return typed exhausted errors
+- CPython-shaped wrapper objects lower to this same unique-mutable state model rather than `RefCell`/hidden global state
+
+### Text Data Versioning
+
+- M0 must record the Unicode data version and the CPython checkout version used for parity fixtures.
+- Generated Unicode tables must be reproducible, reviewed, and excluded from the hand-maintained 900-line guardrail where appropriate.
+- Runtime APIs must expose `unicodedata.unidata_version` consistently with the table set used by the build.
+
+### Typed Errors Instead Of Exceptions
+
+All fallible APIs must expose typed error results:
+
+- `CodecError`, `UnicodeEncodeError`, `UnicodeDecodeError`, `UnicodeTranslateError`
+- `UnicodeDataError`
+- `LocaleError`
+- `GettextError`
+
+Names may align with CPython where possible, but the operational contract is Sifr `Result`/`Option`, not exception-driven control flow.
+
+### Panic-Free Runtime Contract
+
+Generated Rust for these APIs must not contain data-dependent `.unwrap()`, `.expect()`, or `panic!` on user-controlled text, byte sequences, locale names, format strings, or `.mo` catalog data.
+
+### Global-State Discipline
+
+- Codec registry mutation, locale mutation, and gettext global installation never create unsynchronized process-global state.
+- Locale-mutating APIs adopted in this phase use a process-global lock around `setlocale`, `localeconv`, `strcoll`, `strxfrm`, and formatting operations that consult mutable locale state. Locale names and platform-specific behavior remain `host-limited` where the supported host matrix cannot make them deterministic.
+- Locale state is process-scoped. Threaded and process-pool code from the concurrency/runtime phase must either serialize locale-sensitive operations through this phase's locale lock or record host-limited/intentional-diff behavior.
+- `gettext.install`-style global mutation is waived/unsupported in this phase. Explicit `translation(...)` objects, fallback chains, and direct `gettext`/`ngettext` calls are the supported path; global builtins/module mutation gets diagnostics plus CPython evidence and a revisit rule.
+
+## Non-Goals And Permanent Boundaries
+
+The following are not accepted as silent omissions. They must be either implemented or explicitly waived with tests:
+
+- codec registry mutation through `codecs.register`/`codecs.unregister`; unsupported in this phase
+- unsynchronized process-global locale mutation
+- dynamic monkeypatching of module globals
+- C API compatibility for external CPython extensions
+- CJK encodings before dependency size, generated table size, and test cost are reviewed
+- host-specific locale names that cannot be made deterministic on the supported host matrix
+
+## Milestones
+
+### milestone_text_i18n_0: CPython Inventory, Error Mapping, And Registry Design
+
+Scope:
+
+- Add a machine-readable parity inventory under `verification/stdlib/text_i18n_parity_inventory.*`.
+- Scan every source/test/doc file listed in `Source Of Truth`.
+- Extract public functions, classes, constants, methods, common keyword forms, current codec aliases, encoding module names, deprecation/legacy markers, and test-class/test-method names. Legacy-only codec aliases are waived.
+- Add CPython-derived e2e fixtures:
+  - `cpython_codecs_subset.sifr`
+  - `cpython_encodings_subset.sifr`
+  - `cpython_unicodedata_subset.sifr`
+  - `cpython_locale_subset.sifr`
+  - `cpython_gettext_subset.sifr`
+- Add import-resolution tests for canonical `sifr.*` module names and negative diagnostics for bare CPython stdlib import attempts.
+- Add shared error mapping for all text/i18n target domains.
+- Decide:
+  - Unicode data version
+  - generated table strategy
+  - static registry alias table and unsupported diagnostics for registry mutation
+  - locale global-state lock implementation and host-limited locale matrix
+  - diagnostic wording for explicit-encoding-required text `open(...)` and literal-mode-required `open(...)`
+  - gettext global installation unsupported diagnostics and waiver evidence
+- Assign each inventory entry one owner milestone and one terminal state.
+- Assign every deprecated, historical, or legacy-only entry the terminal state `unsupported` or `intentional-diff`. M0 may implement only current, non-deprecated target CPython surfaces that remain elegant under Sifr semantics.
+
+Definition of done:
+
+- The backlog is derived from CPython source/tests, not hand-written memory.
+- Every target module has a first-pass surface matrix and CPython test-family matrix.
+- M1-M5 implementation PRs have concrete backlog entries rather than prose-only scope.
+
+### milestone_text_i18n_1: Codecs Registry, Encodings, And Text I/O Integration
+
+Scope:
+
+- Provide the exact cross-phase unblock point for:
+  - network/web `blocked-on-text-i18n-m1` surfaces: non-UTF-8 URL quoting/parsing forms, HTTP body text decoding, and network demos that require `open(..., encoding=...)`
+  - concurrency/runtime `blocked-on-text-i18n-m1` surfaces: subprocess `text=True`, `encoding=...`, `errors=...`, warning output encoding, and demos that require text-mode `open`
+  - locale-sensitive warning formatting remains additionally blocked on `milestone_text_i18n_3`
+
+- Add `codecs` registry:
+  - `lookup`
+  - `register`, `unregister` are unsupported/intentional-diff in this phase because the registry is static
+  - `encode`, `decode`
+  - `getencoder`, `getdecoder`
+  - `getincrementalencoder`, `getincrementaldecoder`
+  - `iterencode`, `iterdecode`
+  - `CodecInfo`
+  - `IncrementalEncoder`, `IncrementalDecoder`
+  - incremental codec finalization uses explicit exhausted state: `encode(..., final=True)` and `decode(..., final=True)` flush pending state and mark the encoder/decoder exhausted; subsequent encode/decode calls return typed `CodecError::EncoderExhausted`/`CodecError::DecoderExhausted` or equivalent rather than silently succeeding or panicking
+  - implementations may add consuming/type-state overloads for statically known `final=True`, but the runtime contract must still handle dynamic `final` values with typed exhaustion errors
+  - error handlers: `strict`, `ignore`, `replace`, `backslashreplace`, `namereplace`, `xmlcharrefreplace`, `surrogateescape`, `surrogatepass` where compatible with Sifr string invariants
+  - `errors=` parameters for `str.encode`, `bytes.decode`, `open`, and text wrappers use a typed error-handler enum or statically known string literals mapped to that enum
+  - M1 must define an explicit error-handler applicability table with at least:
+    - encode-only: `xmlcharrefreplace`, `namereplace`
+    - bidirectional: `strict`, `ignore`, `replace`, `backslashreplace`
+    - codec-limited bidirectional: `surrogateescape`, `surrogatepass` only where compatible with the selected Unicode/codec invariants
+  - encode and decode APIs use separate typed handler parameters, such as `EncodeErrorHandler` and `DecodeErrorHandler`, so encode-only handlers are rejected from decode call sites by signature when statically known
+  - statically known string literals are lowered to those typed handler values; invalid literal/context combinations produce compile-time diagnostics
+  - dynamic handler names are unsupported in this phase because synchronized runtime error-handler lookup is not adopted; invalid context combinations for static literals produce compile-time diagnostics
+  - codec-limited handlers are rejected outside their valid codec/context; bidirectional handlers such as `backslashreplace` must remain valid for both encode and decode
+  - dynamic `errors=` strings are unsupported in this phase because synchronized runtime error-handler lookup is not adopted; no silent fallback to `strict`
+  - strict incremental encode/decode failures return `Err(CodecError::...)` with no successful partial-output value
+  - recoverable non-strict handlers (`ignore`, `replace`, `backslashreplace`, and codec-limited handlers where valid) return typed success outcomes that preserve both produced output and recovery evidence, such as `DecodeOutcome { text, recoveries }` or `EncodeOutcome { bytes, recoveries }`
+  - CPython-shaped convenience wrappers may expose only the produced text/bytes where CPython does, but the internal runtime contract must retain recovery diagnostics for validation, tracing, and typed adapter layers; recovery must not be silently discarded in lower-level runtime APIs
+- Add encoding families in waves:
+  - UTF core: `utf-8`, `utf-8-sig`, `utf-16`, `utf-16-le`, `utf-16-be`, `utf-32`, `utf-32-le`, `utf-32-be`
+  - Latin/ASCII: `ascii`, `latin-1`, ISO-8859 family
+  - URL/web adjacent: `idna`, `punycode`
+  - common Windows/code pages: `cp1250`-`cp1258`, selected `cp437`/`cp850`
+  - CJK encodings only after dependency and test size are reviewed
+- Integrate:
+  - `str.encode(...)`
+  - `bytes.decode(...)`
+  - `open(..., encoding=..., errors=...)`
+  - `io.TextIOWrapper(..., encoding=..., errors=...)` if text stream wrappers are adopted; otherwise record `io.TextIOWrapper` as unsupported
+  - no-encoding text `open(...)` is not implemented; it emits the explicit-encoding-required diagnostics defined by M0
+  - subprocess text mode and HTTP decoding only after their owning phases consume the registry
+
+CPython tests to mine:
+
+- `Lib/test/test_codecs.py`
+- `Lib/test/test_capi/test_codecs.py`
+
+Rust/runtime candidates:
+
+- `encoding_rs`
+- generated tables for encodings not covered by selected crates
+
+Definition of done:
+
+- Core codec lookup, aliases, BOM handling, incremental encoding/decoding, and error handlers pass CPython-derived fixtures.
+- Incremental encoder/decoder finalization and post-finalization exhaustion have fixtures for both statically known and dynamic `final` values.
+- Incremental codec fixtures cover mid-stream strict errors with no partial success and recoverable non-strict errors that return partial output plus recovery diagnostics.
+- `str.encode(encoding, errors)` and `bytes.decode(encoding, errors)` have fixtures for supported error-handler literals, unsupported dynamic handler names, and typed error-handler values.
+- Encode/decode context restrictions for error handlers have fixtures, including rejecting encode-only handlers on decode call sites.
+- Text I/O uses the same codec registry as explicit encode/decode APIs.
+- Registry mutation is synchronized or explicitly waived with tests.
+- Static-registry behavior has fixtures for lookup, alias resolution, unsupported `register`/`unregister`, and no silent fallback on missing codecs.
+
+### milestone_text_i18n_2: Unicode Data And Normalization
+
+Scope:
+
+- Add `unicodedata`:
+  - `name`
+  - `lookup`
+  - `category`
+  - `bidirectional`
+  - `combining`
+  - `east_asian_width`
+  - `mirrored`
+  - `decomposition`
+  - `normalize`
+  - `is_normalized`
+  - `decimal`, `digit`, `numeric`
+  - `unidata_version`
+- Generate or vendor Unicode data tables according to the M0 version decision.
+- Ensure normalization and property queries share the same table version.
+
+CPython tests to mine:
+
+- `Lib/test/test_unicodedata.py`
+
+Rust/runtime candidates:
+
+- `unicode-normalization`
+- `unicode-general-category`
+- generated Unicode tables if crate coverage is insufficient
+
+Definition of done:
+
+- Unicode normalization and property queries pass CPython-derived fixtures.
+- `unidata_version` matches the shipped table data.
+- Missing-name and missing-property paths return typed errors/options, never panics.
+
+### milestone_text_i18n_3: Locale
+
+Scope:
+
+- Add `locale`:
+  - `getlocale`
+  - `getdefaultlocale` is waived/unsupported as deprecated; no deprecated locale-default behavior is implemented for backward compatibility
+  - `getpreferredencoding`
+  - `getencoding`
+  - `setlocale`, `localeconv`, `strcoll`, `strxfrm`
+  - `format_string`, `currency`, `atof`, `atoi`, `normalize`
+  - process-global mutation rules and thread-safety contract
+  - read-only locale queries (`getpreferredencoding`, `getencoding`, `localeconv` snapshots where possible) are prioritized before mutating APIs
+  - `setlocale`/`strcoll`/`strxfrm`/formatting APIs must be guarded by a process-global lock or marked `host-limited`/`intentional-diff` if deterministic concurrent use cannot be guaranteed
+  - locale preferred encoding APIs do not make text `open(...)` without `encoding=` legal; explicit encoding remains required
+
+CPython tests to mine:
+
+- `Lib/test/test_locale.py`
+
+Rust/runtime candidates:
+
+- platform locale APIs behind synchronized wrappers
+- `unic-langid` only if locale parsing needs it
+
+Definition of done:
+
+- Locale process-global behavior is synchronized and host-limited where necessary.
+- Supported locale names and host assumptions are documented and tested.
+- Locale errors are typed and never panic.
+
+### milestone_text_i18n_4: Gettext
+
+Scope:
+
+- Add `gettext`:
+  - `NullTranslations`
+  - `GNUTranslations`
+  - `translation`
+  - `find`
+  - `gettext`, `ngettext`, `pgettext`, `npgettext`
+  - `.mo` file parsing with typed errors
+  - global installation only if synchronized and explicit; otherwise waived
+- Integrate `.mo` decoding with the M1 codec registry.
+
+CPython tests to mine:
+
+- `Lib/test/test_gettext.py`
+
+Definition of done:
+
+- Gettext `.mo` parsing is deterministic and panic-free.
+- Plural forms, contexts, fallback chains, and missing catalog paths have CPython-derived fixtures.
+- Global installation is synchronized or explicitly waived.
+
+### milestone_text_i18n_5: Integration, Documentation, And Production Gate
+
+Scope:
+
+- Update public docs for every new module and major intentional divergence:
+  - `codecs`, `encodings`
+  - `unicodedata`
+  - `locale`
+  - `gettext`
+- Update internal architecture docs for:
+  - codec registry and text I/O boundaries
+  - generated Unicode table strategy
+  - locale/global-state synchronization
+  - gettext catalog parsing
+  - host-limited behavior
+- Add demos:
+  - non-UTF-8 encode/decode
+  - `open(..., encoding=...)`
+  - Unicode normalization/property lookup
+  - locale formatting where supported
+  - gettext `.mo` translation
+- Add generated Cargo dependency snapshots for all new feature combinations.
+- Add panic-scan and emitted-code quality checks for codec, Unicode, locale, and gettext paths.
+- Update validation lane manifests with representative fixtures.
+- Close the inventory:
+  - every public surface has a terminal state
+  - every CPython test family has `adopted`, `adapted`, or `waived` evidence
+  - every waiver has a revisit rule and regression fixture
+  - every host-limited surface records the supported host matrix
+- Run an external review loop on the final inventory and close any blocking finding before phase completion.
+- External review owner is the stdlib phase owner plus the designated compiler/runtime reviewer recorded in the execution ledger. If review output is unavailable for five working days after the review artifact is posted, the phase owner may proceed only by recording the attempted review, open questions, and a conservative self-review in the ledger.
+
+Validation:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- file-size guardrail
+- `cargo test -p sifr_stdlib`
+- `cargo test -p sifr -- stdlib`
+- `scripts/run_e2e_pass.sh`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh`
+
+Definition of done:
+
+- Every module surface and CPython test family in the phase inventory is closed as `done`, `intentional-diff`, `unsupported`, or `host-limited`.
+- No implementation-owned source file exceeds the 900-line guardrail.
+- No user-triggerable runtime panic path exists in the added stdlib/runtime surfaces.
+- Global-state mutation is synchronized, waived, or host-limited with tests.
+
+## Required Tracking Artifacts
+
+Create and keep current during implementation:
+
+- `issues/ad-hoc-production-text-i18n-stdlib-parity-execution.md`
+- `verification/stdlib/text_i18n_parity_inventory.md`
+- `verification/stdlib/text_i18n_parity_inventory.json`
+- `verification/stdlib/text_i18n_parity_cpython_test_matrix.md`
+- one traceability document per milestone domain under `verification/stdlib/`
+
+The execution ledger must record:
+
+- planning/review artifacts
+- per-milestone PR links
+- local validation commands and results
+- CPython source/test files scanned
+- adopted/adapted/waived CPython test families
+- final unsupported/intentional-diff/host-limited waiver index
+
+## Quality Contract
+
+- Solve root causes rather than adding workaround wrappers.
+- No backward-compatibility shims, legacy aliases, deprecated behavior, implicit locale-default behavior, or fallback paths may survive phase exit. Deliberate current-CPython adapters are allowed only when recorded in the inventory with Sifr-safe semantics and tests.
+- No unsynchronized process-global state may be introduced.
+- No data-dependent emitted `.unwrap()`, `.expect()`, or `panic!` is allowed in user runtime paths.
+- Every added CPU-heavy or blocking sync function must be classified in the stdlib workload database.
+- Every added external crate dependency must be represented by a stable `StdlibFeature` in `sifr_stdlib`.
+- Every module added to embedded stdlib sources must have canonical `sifr.*` import-resolution tests, type-check tests, e2e pass tests, and negative diagnostics for unsupported bare CPython import forms.
+
+## M0 Implementation Decisions To Record
+
+1. Which encoding families are required for phase exit versus explicitly deferred?
+2. Which Unicode data version is shipped, and how are generated tables produced reproducibly?
+3. Which static codec aliases are shipped, and what diagnostics are used for unsupported registry mutation?
+4. Which lock implementation guards locale process-global mutation, and how does it interact with threads and async tasks?
+5. Which host locale names are supported in local validation?
+6. What exact diagnostics and waiver evidence are recorded for unsupported `gettext.install` global mutation?
+7. Which crates or generated tables meet binary-size, safety, and maintenance goals for codecs and Unicode data?
+
+These questions must be answered in the phase execution ledger before implementing the affected milestone.

--- a/issues/ad-hoc-stdlib-namespace-contract-and-compat-cleanup-execution.md
+++ b/issues/ad-hoc-stdlib-namespace-contract-and-compat-cleanup-execution.md
@@ -1,0 +1,44 @@
+# Ad Hoc Phase Execution Checklist: Stdlib Namespace Contract And Compatibility Cleanup
+
+Phase contract: [ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md](./ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md)
+
+Status: planning
+
+## Checklist
+
+- [ ] `milestone_stdlib_namespace_1`: Policy And Diagnostics
+- [ ] `milestone_stdlib_namespace_2`: Atomic Compatibility Removal
+- [ ] `milestone_stdlib_namespace_3`: Corpus Adoption And Closeout
+
+## Review Artifacts
+
+Record planning and implementation reviews here.
+
+- Planning review pass 1: `reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-1.md` -> `CHANGES_REQUESTED`; requested explicit `Stmt::Import` coverage, corrected current bare-import no-op framing, pinned `SIFR-IMPORT-0008` / `IMPORT_BARE_STDLIB`, clarified stdlib-tail resolution order, split M2 synthetic-import cleanup from M3 defaultdict cleanup, added synthetic import consumer removal, tightened guardrails, and renamed typed defaultdict internals away from `__compat_defaultdict_*`.
+- Planning review pass 2: `reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-2.md` -> `CHANGES_REQUESTED`; narrowed guardrails to the removed `math|heapq|collections` synthetic aliases so retained async/task aliases stay out of scope, added explicit cleanup for Rust tests that hard-code removed aliases, kept the generic async/task codegen guard intentionally retained, required grep-driven fixture classification, and originally requested a transitional defaultdict helper. The transitional-helper decision is superseded by the no-legacy-support clarification below.
+- Planning review pass 3: `reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-3.md` -> `READY`; reviewer verified the plan was implementation-ready before the later no-legacy-support clarification removed the transitional defaultdict bridge.
+- Gap audit pass 1: `reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-1.md` -> `CHANGES_REQUESTED`; found missing cross-layer diagnostic ownership and transport decisions. Addressed by requiring structured args in `HirDiagnostic`/lowering transport, assigning project/package `ImportFrom` diagnostics to discovery after real resolution fails, assigning all `Stmt::Import` bare-stdlib diagnostics to lowering, adding shared `sifr_stdlib` tail helpers, defining duplicate-prevention rules, expanding M1 project/package/single-file tests, and naming explicit defaultdict binding state.
+- Gap audit pass 2: `reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-2.md` -> `READY`; reviewer confirmed all cross-layer decisions are locked, including structured lowering diagnostic transport, discovery/lowering ownership split, duplicate prevention, exact-tail/root-fallback matching, M1 test scope, explicit defaultdict binding state, and guardrail coverage.
+- Final readiness pass 1: `reviews/ad-hoc-stdlib-namespace-contract-final-readiness-pass-1.md` -> `READY`; reviewer confirmed the phase is implementation-ready after the final scan added exact diagnostic arg shape, compile-order/dependency-collector carveouts, and explicit cleanup for `class_field_inference.rs` bare `deque`/`Counter`/`defaultdict` compatibility paths.
+- No-legacy clarification: superseded the previous M2/M3 transitional split. Current phase requires atomic compatibility removal: `math.*`, `heapq.*`, `collections.*`, bare `deque(...)`, bare `Counter(...)`, bare `defaultdict(...)`, `collections.defaultdict(...)`, class-field inference compatibility, synthetic imports, and `__compat_defaultdict_*` naming are removed or converted directly to explicit `sifr.*` binding in `milestone_stdlib_namespace_2`.
+- No-legacy review pass 1: `reviews/ad-hoc-stdlib-namespace-contract-no-legacy-review-pass-1.md` -> `READY`; reviewer confirmed the revised phase has no backward-compatibility or legacy-support loopholes for CPython-style bare stdlib calls.
+- Corpus discovery update: added final LeetCode/demo adoption requirements after scanning `audits/leetcode/src` and `demos`. Current discovery found 416 checked-in LeetCode `.sifr` fixtures and 389 demo `.sifr` files; M3 must update/validate all affected LeetCode fixtures and demos, and add or update corpus validation commands so all checked-in LeetCode fixtures and all runnable demos work.
+- Corpus review pass 1: `reviews/ad-hoc-stdlib-namespace-contract-corpus-review-pass-1.md` -> `READY`; reviewer confirmed the final corpus milestone is implementation-ready and covers all checked-in LeetCode fixtures, all runnable demos, and repeated discovery after implementation.
+- Final implementation-readiness pass 1: `reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-1.md` -> `READY` with one non-blocking observation that `demos/collections_and_argparse/main.sifr` left a small `defaultdict(0)` judgment call.
+- Final implementation-readiness pass 2: `reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-2.md` -> `READY`; reviewer confirmed the phase is implementation-ready with no hidden decisions after the phase explicitly chose the typed `defaultdict(int/list/set)` public contract and rejected preserving the older integer-default `defaultdict(0)` class-style API.
+
+## Validation Ledger
+
+Record local validation for each milestone before opening the corresponding PR.
+
+- M1: pending.
+- M2: pending.
+- M3: pending.
+
+## Merged PRs
+
+Record merged PR links here as each milestone lands.
+
+- M1: pending.
+- M2: pending.
+- M3: pending.

--- a/issues/ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md
+++ b/issues/ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md
@@ -1,0 +1,324 @@
+# Ad Hoc Phase: Stdlib Namespace Contract And Compatibility Cleanup
+
+Status: planning
+
+## Objective
+
+Make the stdlib import contract explicit, diagnostic-backed, and internally consistent.
+
+Sifr stdlib modules are permanently public as `sifr.*`. CPython-style bare stdlib names such as `math`, `json`, `os`, `heapq`, and `collections` are not aliases for Sifr stdlib. This phase closes the current inconsistency where some Python-shaped call expressions compile through hidden lowering compatibility, while bare stdlib imports either silently no-op and fail later at the use site or hit generic unsupported-import diagnostics instead of the namespace-contract diagnostic.
+
+This phase is complete when:
+
+- architecture and user docs state the namespace contract;
+- bare stdlib import attempts produce targeted suggestions to use `sifr.*`;
+- lowering no longer synthesizes hidden `sifr.*` imports for `math.*`, `heapq.*`, `collections.*`, `deque(...)`, or `Counter(...)`;
+- `defaultdict(int/list/set)` remains supported only through an explicit `from sifr.collections import defaultdict` binding;
+- tests and demos use explicit `sifr.*` imports for stdlib symbols.
+
+This phase does not provide backward compatibility, legacy support, staged deprecation, compatibility warnings, or temporary bridges for Python-shaped stdlib calls. Milestones may be split for review and validation, but once a compatibility surface is touched it must be removed or converted directly to the explicit `sifr.*` contract in that same milestone. There is no intermediate production state where legacy bare stdlib call forms are intentionally preserved.
+
+Execution status, validation evidence, review artifacts, and merged PR links are tracked in [ad-hoc-stdlib-namespace-contract-and-compat-cleanup-execution.md](./ad-hoc-stdlib-namespace-contract-and-compat-cleanup-execution.md).
+
+## Context
+
+The current stdlib architecture has three tiers:
+
+```text
+_sifr.*       compiler intrinsics, internal only
+sifr.*        embedded Sifr stdlib wrappers
+top-level     user modules and third-party package import roots
+```
+
+The first two tiers are embedded and must not resolve to filesystem or package-manager modules. Top-level names are reserved for user code, packages, and any future interop story. The existing resolver already treats `sifr.*` and `_sifr.*` as special import roots, but lowering still contains a hidden call-expression compatibility path in `crates/sifr_lowering/src/lower/compat_imports.rs`.
+
+That path accepts forms such as:
+
+```python
+math.fmod(x, y)
+heapq.heapify(items)
+collections.defaultdict(list)
+deque(items)
+Counter(items)
+```
+
+by synthesizing hidden aliases like `__compat_sifr_math_fmod` and pushing synthetic `HirImport` entries for `sifr.math`, `sifr.heapq`, or `sifr.collections`. This creates a mixed contract: `math.fmod(...)` may compile, while `from math import fmod` does not resolve as a Sifr stdlib import.
+
+Current bare stdlib import diagnostics are inconsistent:
+
+| Mode | `from math import sqrt` today | `import math` today |
+|---|---|---|
+| Single-file lowering | `SIFR-IMPORT-0002` unknown import target from lowering. | `SIFR-IMPORT-0003` unsupported import form from lowering. |
+| Project discovery | `SIFR-IMPORT-0002` unknown import target with workspace tried paths before lowering. | Discovery ignores `Stmt::Import`; lowering later emits `SIFR-IMPORT-0003`. |
+| Package discovery | `SIFR-IMPORT-0002` unknown import target during package import resolution. | Package discovery ignores `Stmt::Import`; lowering later emits `SIFR-IMPORT-0003` if the module is compiled. |
+
+## Locked Decisions
+
+1. Sifr stdlib is reached through `sifr.*`; this is a permanent public contract.
+2. Bare CPython stdlib names are not aliases for `sifr.*` in any edition, manifest option, warning mode, migration mode, or deprecation track.
+3. Sifr is Python-syntax and CPython-behavior-informed, not Python-source-compatible.
+4. No `sifr migrate`, codemod, or Python-source conversion tool is part of this phase.
+5. `typing` and `enum` remain closed frontend/type-system support imports. They do not generalize to runtime stdlib.
+6. `_sifr.*` remains internal and blocked in user code.
+7. Existing compatibility behavior is removed atomically at each touched surface. Do not keep `collections.defaultdict(...)`, bare `defaultdict(...)`, bare `deque(...)`, bare `Counter(...)`, `math.*`, `heapq.*`, or `collections.*` working as a transitional production bridge once the call-compatibility milestone lands.
+8. The current `__compat_defaultdict_int`, `__compat_defaultdict_list`, and `__compat_defaultdict_set` names are internal typed defaultdict representations, not stdlib namespace aliases. This phase renames them to `__sifr_defaultdict_int`, `__sifr_defaultdict_list`, and `__sifr_defaultdict_set` in the same milestone that removes bare `defaultdict` compatibility, so no legacy `__compat_defaultdict_*` naming remains after the explicit-binding change.
+9. Async/task compatibility bookkeeping for explicitly imported `sifr.asyncio`, `sifr.task`, `sifr.sync`, or `sifr.concurrent` surfaces is out of scope unless it depends directly on the removed synthetic stdlib import path. Existing `__compat_sifr_sync_*`, `__compat_sifr_concurrent_*`, and generic async/task defensive codegen checks are intentionally retained for now.
+
+## Non-Goals
+
+- Do not add support for bare `import math` or `from math import sqrt`.
+- Do not add transitional support, compatibility warnings, deprecation periods, or legacy fallback behavior for bare stdlib calls.
+- Do not add a `--python-compat` mode.
+- Do not add a `sifr.toml` setting for Python-compatible imports.
+- Do not make `sifr.*` optional, deprecated, or secondary.
+- Do not remove the specialized typed `defaultdict` lowering itself.
+- Do not broaden this phase into package-manager aliasing, Python interop, or general import-form expansion.
+
+## Namespace Policy
+
+Add the following invariant to `internal_docs/architecture.md` and summarize it in user docs:
+
+| Import root | Owner | Resolution |
+|---|---|---|
+| `_sifr.*` | Compiler intrinsics | Embedded only; never filesystem or package-manager resolution. |
+| `sifr.*` | Sifr standard library | Embedded `sifr_stdlib::STDLIB_SOURCES`; never filesystem or package-manager resolution. |
+| top-level | User code and third-party packages | Workspace/package resolution. |
+
+Bare module names that happen to match Sifr stdlib module tails are rejected as bare stdlib import attempts only after normal top-level user/package resolution fails. User or package modules named `math`, `json`, or similar therefore keep priority once they are real import targets.
+
+The bare-stdlib module-tail set is derived from `sifr_stdlib::STDLIB_SOURCES` by stripping the leading `sifr.` from each embedded stdlib module name. `_sifr.*` intrinsic names are not part of this set. Add shared `sifr_stdlib` helpers, e.g. `is_bare_stdlib_tail(module: &str) -> Option<BareStdlibMatch>`, so driver discovery, package discovery, and lowering use the same source of truth.
+
+Matching is exact full-tail first, then leading-root fallback:
+
+1. If `module` is exactly in the tail set, match that full tail and suggest `sifr.<module>`.
+2. Otherwise, if the first dotted component is in the tail set, match the full written module as `bare_module`, use the root as `matched_tail`, and suggest `sifr.<root>` with help that no embedded `sifr.<module>` module exists.
+3. Otherwise, the import is not a bare stdlib import.
+
+Examples:
+
+- `from math import sqrt` -> `bare_module = "math"`, `suggested_module = "sifr.math"`.
+- `from collections.abc import Iterable` when `sifr.collections.abc` is not embedded -> `bare_module = "collections.abc"`, `suggested_module = "sifr.collections"`, with help that `sifr.collections.abc` is unavailable.
+- `import collections.abc` follows the same match data, but still reports that Sifr does not support module-object imports.
+
+`typing` and `enum` are closed frontend/type-system support imports. They emit no Rust, have no embedded stdlib source, and are not runtime stdlib aliases.
+
+## Diagnostics Contract
+
+Bare stdlib import attempts should not fall through to generic unknown-name, unknown-import, or unsupported-import messages when the requested root is a known Sifr stdlib module tail and top-level user/package resolution did not find a real module.
+
+Examples:
+
+```python
+import math
+import math as m
+from math import sqrt
+from collections import deque
+from json import dumps
+```
+
+Expected diagnostic shape:
+
+```text
+bare stdlib import 'math'; Sifr stdlib lives under 'sifr.*'
+help: use 'from sifr.math import sqrt'
+```
+
+The diagnostic must:
+
+- use diagnostic code `SIFR-IMPORT-0008` with registry constant `IMPORT_BARE_STDLIB`;
+- cover both `Stmt::Import` and `Stmt::ImportFrom`;
+- for `import math` / `import math as m`, suggest `from sifr.math import <name>` because Sifr does not currently support module-object imports;
+- for `import sifr.math` / `import sifr.math as m`, keep the existing unsupported-import-form behavior unless a later import-form phase adds module-object imports;
+- for `from math import sqrt`, suggest `from sifr.math import sqrt`;
+- for `import collections.abc`, report `bare_module = "collections.abc"` and suggest `sifr.collections.abc` only if that embedded stdlib module exists; otherwise suggest `sifr.collections` and state that no `sifr.collections.abc` module exists;
+- preserve existing unresolved-user-module diagnostics for names that do not match stdlib module tails;
+- avoid masking real workspace/package modules named `math`, `json`, or similar by attempting top-level resolution before the bare-stdlib diagnostic;
+- include machine-readable diagnostic data: `bare_module`, `suggested_module`, and `imported_names` for `from ... import ...` forms;
+- have docs under `docs/errors/` and an entry in `internal_docs/diagnostic_codes.md`.
+
+### Diagnostic Transport
+
+M1 extends lowering diagnostic transport so `SIFR-IMPORT-0008` carries the same structured args in single-file lowering as it does in driver discovery:
+
+- Add `args: BTreeMap<String, DiagnosticArg>` to `sifr_ir::HirDiagnostic`.
+- Add a lowering helper such as `LowerCtx::error_with_code_args_at`.
+- Thread lowering args through frontend rendering in `crates/sifr_frontend/src/query_diagnostics.rs`.
+- Existing lowering diagnostics may keep empty args; this phase does not require backfilling structured args for unrelated diagnostics.
+- Because `DiagnosticArg` currently has scalar variants only, encode `imported_names` as a stable comma-separated string in declaration order, with aliases rendered as `name as alias`. For `Stmt::Import` diagnostics, use an empty string for `imported_names`.
+- `bare_module` is always the exact module text written by the user. `suggested_module` is the embedded `sifr.*` module the diagnostic recommends. Discovery-owned diagnostics may keep existing resolution-scope args such as `resolution_scope` and `tried_paths` in addition to these required args.
+
+### Layer Ownership
+
+`SIFR-IMPORT-0008` ownership is split by import form and compilation layer:
+
+- Project `Stmt::ImportFrom`: `crates/sifr_driver/src/project/discovery.rs` probes workspace candidates first. If resolution is `Unresolved` and the written module matches a bare stdlib tail, discovery reclassifies the failure to a bare-stdlib diagnostic and emits `SIFR-IMPORT-0008` with `bare_module`, `suggested_module`, `imported_names`, and resolution-scope args. Lowering does not run for that unresolved module, so no duplicate diagnostic is emitted.
+- Package `Stmt::ImportFrom`: `crates/sifr_driver/src/project/package_discovery.rs` applies the same probe-then-reclassify rule after package/source-map resolution fails.
+- Single-file `Stmt::ImportFrom`: lowering owns `SIFR-IMPORT-0008` in the import resolution path because there is no project discovery pass.
+- `Stmt::Import` in all modes: lowering owns `SIFR-IMPORT-0008` in `crates/sifr_lowering/src/lower/mod_impl.rs`, replacing the generic unsupported-form diagnostic only when the imported module matches a bare stdlib tail. Project/package discovery intentionally continues to ignore `Stmt::Import` for dependency edges because Sifr has no module-object import support in this phase.
+
+Duplicate prevention rule: only the layer that first observes an unresolved bare stdlib import emits `SIFR-IMPORT-0008`. Discovery-owned `ImportFrom` diagnostics stop project/package processing before lowering. Lowering-owned `Import` diagnostics are not emitted by discovery.
+
+No user-facing bare-stdlib diagnostics are emitted by dependency collectors. `crates/sifr_driver/src/project/compile_order.rs` remains dependency-order-only, keeps collecting only supported `Stmt::ImportFrom` local-module edges, and does not emit `SIFR-IMPORT-0008`. No changes are required in `crates/sifr_frontend/src/query_diagnostics.rs` dependency collection or `crates/sifr_frontend/src/module_signatures.rs` import signatures for `Stmt::Import`; these collectors do not emit user-facing import diagnostics and bare stdlib imports do not create local dependency edges or supported module-object signature entries.
+
+## Defaultdict Contract
+
+`defaultdict(int/list/set)` remains a compiler-recognized typed surface because current codegen relies on specialized alias types for efficient defaulting and mutation. Only `int`, `list`, and `set` factories are recognized; other factory expressions continue to produce the existing unsupported-factory diagnostic. Expanding the factory set is out of scope.
+
+This phase chooses the typed factory-based `defaultdict` surface as the public `sifr.collections.defaultdict` contract. The older integer-default class-style API currently present in `lib/sifr/collections.sifr`, e.g. `defaultdict(0)` with `.ensure(...)` / `.set(...)`, is not preserved as compatibility behavior. Any tests, demos, or LeetCode fixtures using that older API must be rewritten to the typed `defaultdict(int/list/set)` surface or to an ordinary `dict` helper, depending on the use case.
+
+The public spelling becomes explicit:
+
+```python
+from sifr.collections import defaultdict
+
+def main():
+    groups = defaultdict(list)
+```
+
+Aliases must work:
+
+```python
+from sifr.collections import defaultdict as dd
+
+def main():
+    groups = dd(set)
+```
+
+Bare forms must fail:
+
+```python
+defaultdict(list)
+collections.defaultdict(list)
+```
+
+`from sifr.collections import defaultdict as defaultdict` is treated the same as a plain import.
+
+Implementation should record explicit imported special constructors in lowering state rather than treating `defaultdict` as an unconditional builtin name. The compatibility-removal milestone owns all `defaultdict` compatibility removal atomically: the `collections.defaultdict(...)` attribute-call short-circuit, the bare `defaultdict(...)` short-circuit in `compat_imports.rs`, the unconditional builtin recognition in `call_builtins.rs`, the older integer-default `lib/sifr/collections.sifr` class API conflict, and the `__compat_defaultdict_*` internal alias rename.
+
+Class-field inference must follow the same contract. `crates/sifr_lowering/src/lower/class_field_inference.rs` currently infers bare compatibility constructors for `deque`, `Counter`, and bare `defaultdict`. The compatibility-removal milestone removes the bare `deque`/`Counter` inference helper and changes field inference for `defaultdict(...)` to consult the same explicit `sifr.collections.defaultdict` import-binding state used by call lowering. Bare `defaultdict(...)` in class-field initializer inference must not continue to infer a typed mapping after the call itself is rejected.
+
+## Example Corpus Discovery
+
+Full discovery found two first-party example corpora that must be adapted and validated before phase closeout:
+
+- LeetCode audit corpus: `audits/leetcode/src` contains 416 checked-in `.sifr` fixtures.
+- Demo corpus: `demos` contains 389 `.sifr` files, including 310 `main.sifr` entrypoints.
+
+LeetCode namespace-impact discovery:
+
+- Must update source: `audits/leetcode/src/0036_valid_sudoku.sifr` uses `collections.defaultdict(set)`.
+- Must update source: `audits/leetcode/src/0350_intersection_of_two_arrays_ii.sifr` uses bare `Counter(...)` and bare `defaultdict(...)`.
+- Must update source: `audits/leetcode/src/0383_ransom_note.sifr` uses bare `Counter(...)`.
+- Must update source: `audits/leetcode/src/0474_ones_and_zeroes.sifr` uses bare `defaultdict(...)`.
+- Must update source: `audits/leetcode/src/0621_task_scheduler.sifr` uses bare `Counter(...)`.
+- Must update source: `audits/leetcode/src/0767_reorganize_string.sifr` uses bare `Counter(...)`.
+- Must update source: `audits/leetcode/src/1189_maximum_number_of_balloons.sifr` uses bare `Counter(...)`.
+- Must update source: `audits/leetcode/src/1383_maximum_performance_of_a_team.sifr` uses `heapq.heappop(...)` and `heapq.heappush(...)`.
+- Must update source: `audits/leetcode/src/1481_least_number_of_unique_integers_after_k_removals.sifr` uses bare `Counter(...)`.
+- Already explicit but must remain green: `audits/leetcode/src/0752_open_the_lock.sifr` imports `deque` from `sifr.collections`.
+- Existing explicit `sifr.heapq` fixtures must remain green: `0355_design_twitter`, `0502_ipo`, `0703_kth_largest_element_in_a_stream`, `0743_network_delay_time`, `0778_swim_in_rising_water`, `0973_k_closest_points_to_origin`, `1046_last_stone_weight`, `1631_path_with_minimum_effort`, `1834_single_threaded_cpu`, and `1985_find_the_kth_largest_integer_in_the_array`.
+- `audits/leetcode/src/1963_minimum_number_of_swaps_to_make_the_string_balanced.sifr` only mentions `math.ceil` in a comment; update the comment if it reads as an endorsed bare stdlib spelling.
+
+Demo namespace-impact discovery:
+
+- Must update source: `demos/defaultdict/main.sifr` uses `collections.defaultdict(...)` and bare `defaultdict(...)`.
+- Must update source: `demos/collections_and_argparse/main.sifr` explicitly imports `defaultdict` but uses the older integer-default `defaultdict(0)` API. Rewrite it to the typed `defaultdict(int)` surface or an ordinary `dict` helper; do not preserve `defaultdict(0)` for this demo.
+- Already explicit but must remain green: `demos/generic_stdlib/main.sifr`, `demos/collections/main.sifr`, `demos/ordered_collections/main.sifr`, `demos/stdlib_classes/main.sifr`, and `demos/advanced_class_libraries/main.sifr`.
+- Text/comment cleanup only unless validation fails: `demos/core_libraries/main.sifr` prints labels containing `math.*` while calling explicitly imported `sifr.math` functions; comments in `demos/stdlib_classes/main.sifr` and `demos/advanced_class_libraries/main.sifr` mention `collections.*` as module names.
+- False positive: `demos/subscript_assignment/main.sifr` defines a local `Counter` class and does not rely on stdlib compatibility.
+
+The final corpus milestone must repeat this discovery after implementation, because new checked-in examples may appear while earlier milestones are landing.
+
+## Milestones
+
+### milestone_stdlib_namespace_1: Policy And Diagnostics
+
+- Add the namespace ownership invariant to `internal_docs/architecture.md`.
+- Add `docs/stdlib_imports.md`, linked from the docs index if an index is present, explaining why stdlib imports use `sifr.*`.
+- Add shared `sifr_stdlib` bare-stdlib tail helpers derived from `STDLIB_SOURCES`.
+- Add `SIFR-IMPORT-0008` / `IMPORT_BARE_STDLIB` for bare stdlib import attempts.
+- Extend lowering diagnostic transport so `HirDiagnostic` can carry structured args and frontend rendering preserves them.
+- Add project discovery and package discovery reclassification from unresolved import to bare-stdlib import after real top-level resolution fails.
+- Add positive and negative diagnostic tests covering at least `import math`, `import math as m`, `from math import sqrt`, `from collections import deque`, `from collections.abc import Iterable`, and a non-stdlib missing import.
+- Add project-mode coverage where `from math import sqrt` without `math.sifr` produces `SIFR-IMPORT-0008`, and a paired case with real `math.sifr` proves user modules win.
+- Add package-mode coverage for unresolved bare stdlib `ImportFrom`.
+- Add single-file lowering coverage for both `Stmt::Import` and `Stmt::ImportFrom`.
+- Add CLI verification fixture coverage for human/json/compact output and register required args in `crates/sifr_driver/src/bin/diagnostic_contract_harness.rs`.
+
+Validation:
+
+- the bare-stdlib diagnostic tests added in this milestone;
+- focused `sifr_stdlib` helper tests for exact-tail and root-fallback matching;
+- verification fixture update for human/json/compact output.
+
+### milestone_stdlib_namespace_2: Atomic Compatibility Removal
+
+- Remove the lowering path that maps `math.*`, `heapq.*`, non-`defaultdict` `collections.*`, bare `deque(...)`, and bare `Counter(...)` to hidden `sifr.*` imports.
+- Remove `collections.defaultdict(...)` and bare `defaultdict(...)` compatibility in the same milestone. Do not keep a transitional helper, compatibility bridge, deprecation path, warning mode, or legacy fallback.
+- Add lowering state `explicit_defaultdict_bindings: HashSet<String>` or equivalent, recording local names imported from `sifr.collections.defaultdict`, including aliases.
+- Populate the state during import resolution for `from sifr.collections import defaultdict`, `from sifr.collections import defaultdict as dd`, and `from sifr.collections import defaultdict as defaultdict`.
+- In call lowering, before unconditional builtin dispatch, route only names present in `explicit_defaultdict_bindings` to `lower_defaultdict_constructor_call`.
+- Remove the `collections.defaultdict(...)` and bare `defaultdict(...)` short-circuits from `compat_imports.rs`.
+- Remove unconditional builtin lowering for bare `defaultdict` from `call_builtins.rs`.
+- Resolve the `lib/sifr/collections.sifr` `defaultdict` name conflict in favor of the typed `defaultdict(int/list/set)` public contract. Remove or rename the older integer-default class-style API so `from sifr.collections import defaultdict` has one public meaning.
+- Remove `synthetic_imports` and `synthetic_import_aliases` from lowering if no remaining producer uses them.
+- Remove the consuming site in `crates/sifr_lowering/src/lower/mod_impl.rs` that extends final `imports` with `ctx.synthetic_imports`, and verify no readers or writers remain.
+- Remove bare `deque` and `Counter` compatibility inference from `crates/sifr_lowering/src/lower/class_field_inference.rs`; class-field inference must use real local/class/import bindings after this milestone.
+- Update `class_field_inference.rs` so `defaultdict(...)` field inference only applies when the called local name is in `explicit_defaultdict_bindings`; bare unimported `defaultdict(...)` must not infer a typed mapping.
+- Remove codegen canonicalization for `__compat_sifr_math_*`, `__compat_sifr_heapq_*`, and `__compat_sifr_collections_*`.
+- Remove or rewrite Rust unit tests in `sifr_codegen` that construct or assert on `__compat_sifr_math_*`, `__compat_sifr_heapq_*`, or `__compat_sifr_collections_*`; those tests lose meaning once the synthetic import path is deleted.
+- Leave the generic `is_compat_stdlib_alias` codegen guard in place for retained async/task aliases unless the implementation proves no retained path can reach it.
+- Rename typed aliases from `__compat_defaultdict_int/list/set` to `__sifr_defaultdict_int/list/set` across lowering, type rendering, and codegen.
+- Add negative coverage for bare `defaultdict(list)`, `collections.defaultdict(list)`, and explicit-import `defaultdict(0)`.
+- Update e2e `.sifr` fixtures that rely on `math.*`, `heapq.*`, `collections.*`, bare `deque(...)`, bare `Counter(...)`, bare `defaultdict(...)`, or `collections.defaultdict(...)` to import stdlib symbols explicitly.
+- The implementation should grep `math\.`, `heapq\.`, `collections\.`, `deque(`, `Counter(`, and `defaultdict(` under `crates/sifr/tests/e2e/pass/` and `crates/sifr/tests/e2e/fail/`, then update or intentionally classify every hit. Demo and LeetCode adoption is owned by M3.
+- Confirm mixed imports such as `from sifr.collections import defaultdict, deque` keep both surfaces working after M2; `deque(...)` must work through the explicit imported class/function path, not through synthetic compatibility.
+
+Validation:
+
+- focused lowering/codegen tests touched by this milestone;
+- focused lowering tests for direct `defaultdict` import, alias import, bare rejection, and `collections.defaultdict` rejection;
+- codegen tests for `defaultdict(int/list/set)` with explicit imports;
+- e2e pass/fail fixtures for explicit and rejected forms;
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/module_attribute_calls.sifr`;
+- affected e2e pass/fail fixtures.
+
+### milestone_stdlib_namespace_3: Corpus Adoption And Closeout
+
+- Add a guardrail test or script check that no production lowering code synthesizes `__compat_sifr_*` stdlib imports.
+- Sweep docs, tests, demos, and comments for stale claims that Python-shaped stdlib calls work without imports.
+- Repeat namespace-impact discovery across `audits/leetcode/src`, `demos`, `crates/sifr/tests/e2e/pass`, and `crates/sifr/tests/e2e/fail` after M2 lands.
+- Update every affected LeetCode `.sifr` fixture to use explicit `sifr.*` imports or project-local helpers only. All checked-in LeetCode `.sifr` fixtures must compile and run under the post-cleanup namespace contract.
+- Add or update a validation command for the checked-in LeetCode corpus. Do not rely on `audits/leetcode/run_audit.py` unless it is changed to validate the checked-in corpus without regenerating fixtures from hard-coded external paths.
+- Update every affected demo to use explicit `sifr.*` imports, and update stale demo labels/comments that imply bare Python stdlib module calls are supported.
+- Add or update a validation command for all runnable demos. Negative-case demos may be excluded only by an explicit, documented exclusion list; all non-negative demo `main.sifr` entrypoints must work.
+- Update execution checklist with validation evidence, PR links, and review artifacts.
+- Run create-PR validation before implementation PRs and merge-gate validation before phase closeout.
+
+Validation:
+
+- repeated discovery commands show no unclassified `math.*`, `heapq.*`, `collections.*`, bare `deque(...)`, bare `Counter(...)`, bare `defaultdict(...)`, or `collections.defaultdict(...)` uses in `audits/leetcode/src`, `demos`, or e2e fixtures;
+- all checked-in LeetCode `.sifr` fixtures in `audits/leetcode/src` compile and run through the final corpus validation command;
+- all runnable demos compile and run through the final demo validation command;
+- `rg "__compat_sifr_(math|heapq|collections)_" crates/sifr_lowering/src crates/sifr_codegen/src crates/sifr_type_system/src -g '*.rs'` returns no production hits;
+- `rg "__compat_defaultdict_|resolve_python_compat_call_alias|resolve_bare_python_compat_call_alias|synthetic_imports|synthetic_import_aliases" crates/sifr_lowering/src crates/sifr_codegen/src crates/sifr_type_system/src -g '*.rs'` returns no production hits;
+- `cargo fmt --check`;
+- `cargo clippy --workspace -- -D warnings`;
+- `python3 scripts/check_file_size_guardrails.py`;
+- `scripts/run_all_tests.sh --profile create-pr`;
+- `scripts/run_all_tests.sh` before phase closeout.
+
+## Exit Gates
+
+This phase may close only when:
+
+1. `sifr.*` namespace policy is documented in architecture and user docs.
+2. Bare stdlib imports receive targeted diagnostics with suggestions.
+3. No production lowering path synthesizes hidden `sifr.*` imports from Python-shaped bare module calls.
+4. `defaultdict` support requires an explicit `sifr.collections` import or alias, with no transitional support for bare `defaultdict(...)` or `collections.defaultdict(...)`.
+5. Checked-in LeetCode fixtures, demos, and e2e fixtures use explicit stdlib imports.
+6. All checked-in LeetCode `.sifr` fixtures compile and run.
+7. All runnable demos compile and run.
+8. Typed defaultdict internals use `__sifr_defaultdict_*`, with no remaining `__compat_defaultdict_*` names.
+9. Local validation evidence is recorded in the execution checklist.
+10. Claude planning and final-readiness reviews have returned `READY` after all blocking findings are addressed.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-1-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-1-constrained.md
@@ -1,0 +1,69 @@
+**FAIL**
+
+---
+
+## Critical
+
+**1. Phase ordering contradiction — text phase must precede both others**
+
+Phase 1 (network) and Phase 2 (concurrency/subprocess) both declare text-decoding dependencies on Phase 3 (text/i18n). If phases imply a build/ship sequence, Phase 3 must execute first, making the numbering misleading. If they're parallel, the inter-phase dependency boundary is unresolved: Phase 1 cannot ship a working `socket.recv().decode()` or HTTP response body decoding before Phase 3's codec registry exists. Fix: either reorder (text → network → concurrency) or explicitly declare text as a hard prerequisite and block Phase 1/2 integration tests on Phase 3 delivery.
+
+---
+
+## High
+
+**2. asyncio core is unassigned**
+
+`asyncio.run`, `asyncio.gather`, `asyncio.create_task`, `asyncio.sleep`, `asyncio.Event`, `asyncio.Lock`, and the task scheduler are not in any phase's ownership list. Phase 1 implicitly requires them (async network streams need a running executor), and Phase 2 uses `asyncio.Queue`. Without an explicit owner, implementation work falls into a gap between phases and integration contracts are undefined. Assign asyncio's core scheduler to Phase 1 (since it's the first async consumer) and have Phase 2 extend it for `asyncio.Queue` and `asyncio.subprocess`.
+
+**3. `ThreadPoolExecutor` depends on unowned threading primitives**
+
+Phase 2 owns `concurrent.futures`, which includes `ThreadPoolExecutor`. Threading is not in any of the three phases. Either `ThreadPoolExecutor` must be explicitly declared unsupported (alongside `signal.signal` and `contextmanager`), or threading primitives must be assigned — likely to Phase 2 alongside the other concurrency primitives. The current plan leaves this ambiguous, which will cause scope creep or a silent gap at implementation time.
+
+---
+
+## Medium
+
+**4. `contextlib` supported subset is unspecified**
+
+Phase 2 owns `contextlib` but declares `contextmanager` decorators unsupported. This leaves open: `asynccontextmanager`, `suppress`, `ExitStack`, `AsyncExitStack`, `closing`, `redirect_stdout/stderr`. Each has different implementation complexity. Without an explicit supported subset, implementers have no contract and reviewers have no acceptance criterion.
+
+**5. `signal` module supported subset is unspecified**
+
+`signal.signal` is unsupported, but the signal module contains signal constants (`SIGTERM`, `SIGINT`, etc.), `signal.getsignal`, `signal.raise_signal`, and `signal.pause`. Without specifying which of these are in scope, the ownership claim on the module provides no actionable implementation target.
+
+**6. `socketserver` supported subset is unspecified**
+
+Threading/Forking mixins are unsupported, but the plan doesn't say which classes are supported. `BaseServer`, `TCPServer`, `UDPServer` have no threading dependency and are implementable. `StreamRequestHandler` and `DatagramRequestHandler` are likely in scope. Without this list, the phase boundary with "socketserver" as a single token is ambiguous.
+
+**7. `urllib.parse` encoding dependency crosses phase boundary**
+
+`urllib` is Phase 1, but `urllib.parse` does percent-encoding/decoding on byte sequences and touches charset normalization (RFC 3986 §2.1). This is text-handling work that may require Phase 3's codec infrastructure. If `urllib.parse` is entirely in Phase 1 with no dependency on Phase 3, that constraint should be stated explicitly. If it does depend on Phase 3, it's another ordering issue under finding #1.
+
+---
+
+## Low
+
+**8. `open(encoding=)` ownership creates a split-module problem**
+
+Phase 3 owns `open(encoding=...)` as part of the codec registry. Binary-mode `open()` is not assigned to any of these three phases, implying it exists already (from a prior phase). The plan should confirm this and define the exact boundary: text-mode `open()` is Phase 3, binary-mode `open()` is prior art. Without this statement, Phase 3 implementers may duplicate or conflict with existing file-I/O work.
+
+**9. Locale state in concurrent execution is unaddressed**
+
+Phase 3 owns locale/gettext global state; Phase 2 owns process pools and typed IPC. `locale.setlocale` is process-global and unsafe across threads. The plan should either declare locale state as process-scoped only (valid in Sifr's model since threads are unowned), or require that locale-sensitive operations serialize against a process-wide lock. No coordination mechanism is specified between the two phases.
+
+---
+
+## Summary table
+
+| # | Severity | Finding |
+|---|----------|---------|
+| 1 | Critical | Phase ordering inverted — text must precede network and concurrency |
+| 2 | High | asyncio core scheduler has no owner |
+| 3 | High | `ThreadPoolExecutor` threading dependency unresolved |
+| 4 | Medium | `contextlib` supported subset undefined |
+| 5 | Medium | `signal` supported subset undefined |
+| 6 | Medium | `socketserver` supported subset undefined |
+| 7 | Medium | `urllib.parse` encoding dependency crosses phase boundary |
+| 8 | Low | `open()` binary vs text mode ownership gap |
+| 9 | Low | Locale/concurrency interaction unaddressed |

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-10-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-10-constrained.md
@@ -1,0 +1,31 @@
+**PASS 10 — FAIL**
+
+Four remaining gaps found.
+
+---
+
+**Gap 1: Error handler rejection mechanism is unspecified (text/i18n)**
+
+The table says encode-only handlers are "rejected on decode," but doesn't specify *how*. For a statically-typed language this is load-bearing: is this a compile-time type error (the encode-handler type is rejected by the decode API signature), or a runtime `Result::Err`? If runtime, which typed error variant? Without specifying the enforcement layer, implementers may produce compile-time rejection in one codec path and runtime rejection in another, creating inconsistency. Specify: encode-only handlers should be a distinct type that the decode API does not accept by signature, eliminating the need for a runtime check.
+
+---
+
+**Gap 2: as_completed timeout — partial iteration state undefined**
+
+The spec defines `ExecutorError::Timeout` when the deadline expires before all futures complete, but does not describe what the caller has already received. In Python, `as_completed` with timeout yields completed futures up to the moment `TimeoutError` is raised — the caller observes a partial sequence, then gets the error. Sifr's iterator-based equivalent must specify: (a) are already-yielded items valid and owned by the caller, (b) does the iterator produce `Result::Err(ExecutorError::Timeout)` as a terminal item or terminate early, and (c) are pending futures left in a defined state. Without this, callers cannot write correct partial-result recovery logic.
+
+---
+
+**Gap 3: FIRST_EXCEPTION trigger condition ambiguous in typed model**
+
+The remediation says FIRST_EXCEPTION falls back to ALL_COMPLETED if "no typed worker failure occurs." But "typed worker failure" is not defined. In Python, FIRST_EXCEPTION triggers on any worker exception. In Sifr, workers return `Result` types — does returning `Err(...)` count as a worker failure triggering FIRST_EXCEPTION, or only executor-level faults (panics, cancellations, timeouts)? If `Err` return values do *not* trigger early return, FIRST_EXCEPTION is nearly inert in normal Sifr typed-error workflows — the semantics collapse to ALL_COMPLETED in most real programs. This must be specified explicitly: either `Err` results are worker failures for FIRST_EXCEPTION purposes, or they are not (with rationale).
+
+---
+
+**Gap 4: shutdown(cancel_futures=True) — running vs. pending distinction absent**
+
+Python specifies that `shutdown(cancel_futures=True)` cancels only *pending* (not-yet-started) futures; futures already executing continue to completion. The remediation routes pending futures through the cancellation path but says nothing about in-flight tasks. Omitting this distinction leaves implementers free to either interrupt running tasks or not. For a language with "if it compiles, it works" semantics, the contract for running-task behavior under shutdown must be explicit: running tasks complete normally and their results are available; only unstarted futures transition to `Cancelled`.
+
+---
+
+**FAIL** — four actionable gaps remain: (1) encode-only rejection enforcement layer, (2) partial iteration state at as_completed timeout, (3) FIRST_EXCEPTION trigger definition in typed model, (4) running-vs-pending distinction in shutdown cancellation.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-11-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-11-constrained.md
@@ -1,0 +1,52 @@
+**REVIEW PASS 11 — FAIL**
+
+Three significant gaps remain.
+
+---
+
+**Gap 1: as_completed handle ownership is under-specified**
+
+The remediation states pending futures remain live/cancellable through "original handles." This assumes callers retain separate handle references after passing futures into as_completed. The spec does not address what happens when futures are moved (consumed) into the iterator — a common pattern where the caller holds no independent handle. If ownership transfers to the iterator on construction, the "original handle" no longer exists and the cancellation guarantee is unreachable by the caller.
+
+*Required resolution:* Specify the ownership model explicitly. Either (a) as_completed borrows futures, not moves them, so original handles remain valid; or (b) as_completed returns cancellation tokens alongside each yielded result, allowing post-timeout cancellation of pending items. The current text implies (a) but does not enforce it.
+
+---
+
+**Gap 2: FIRST_EXCEPTION not_done futures have no defined lifecycle**
+
+The remediation specifies the return shape (done, not_done partition) and trigger conditions, but is silent on what happens to futures in not_done after the call returns. Two conflicting behaviors are possible:
+
+- Not_done futures continue executing in the background (implicit background executor state, potential resource leak if caller ignores them).
+- Not_done futures are suspended/cancelled when FIRST_EXCEPTION returns (but then they are effectively already done, making the partition label misleading).
+
+This matters especially for the interaction with shutdown(cancel_futures=True): if not_done futures are still executing after FIRST_EXCEPTION, calling shutdown(cancel_futures=True) should cancel only the not-yet-started subset of not_done — but the remediation for shutdown does not account for futures already partitioned into not_done by FIRST_EXCEPTION.
+
+*Required resolution:* State whether not_done futures remain scheduled on the same executor and, if so, whether subsequent shutdown calls act on them. Define who is responsible for driving or cancelling them.
+
+---
+
+**Gap 3: shutdown(cancel_futures=True) result observability is contradicted by executor teardown**
+
+The remediation states that already-running futures "continue to completion and results remain observable." Observable by whom, and through what mechanism? If shutdown is blocking (waits for running futures to finish before returning), observability is implicit — results are stored in Future state before shutdown returns. But if shutdown is non-blocking or has a timeout, the executor may tear down its internal dispatch machinery before running futures complete, making results unobservable even though the futures nominally finish.
+
+The spec does not define whether shutdown blocks until running futures complete. Without this, "results remain observable" is either a tautology (if blocking) or unimplementable (if non-blocking with teardown).
+
+*Required resolution:* Specify shutdown's blocking semantics. If blocking: results are observable through normal Future polling/await after shutdown returns. If non-blocking: define the window during which results remain accessible and what happens if the caller polls after that window.
+
+---
+
+**Minor note (not a FAIL criterion, but worth tracking):**
+
+The error handler dual-path — compile-time error for invalid static literals, runtime CodecError::InvalidErrorHandlerForOperation for invalid dynamic names — is architecturally coherent but creates a user-facing asymmetry. Code that is structurally identical except for how the handler name is spelled (static vs. dynamic) gets different error timing. This should be explicitly documented as intentional, not left as an emergent property of the implementation strategy, otherwise future reviewers may attempt to "fix" it.
+
+---
+
+**Summary**
+
+| # | Gap | Severity |
+|---|-----|----------|
+| 1 | as_completed handle ownership undefined — cancellation guarantee may be unreachable | Significant |
+| 2 | FIRST_EXCEPTION not_done futures have no lifecycle after return; interacts poorly with shutdown | Significant |
+| 3 | shutdown(cancel_futures=True) observability contradicted without blocking semantics defined | Significant |
+
+**FAIL** — resolve gaps 1–3 before Pass 12.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-12-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-12-constrained.md
@@ -1,0 +1,53 @@
+## Pass 12 Review
+
+**Scope:** Verify Pass 11 remediations are complete and search for remaining gaps across concurrency, text/i18n, platform, and network phases.
+
+---
+
+### FINDING 1 — `wait()` not_done ownership: parallel gap to Pass 11 as_completed fix (CONCURRENCY)
+
+Pass 11 corrected `as_completed` to borrow rather than consume caller Future handles. `wait(fs, timeout, return_when)` has the same structural requirement but was not explicitly addressed in the remediation.
+
+`wait()` returns `(done, not_done)`. The caller must be able to use `not_done` as live, cancellable handles — passing them to a subsequent `wait()`, calling `.cancel()`, or submitting to another executor. If the spec allows `wait()` to consume futures from `fs` to build `done`, then `not_done` cannot be returned as live handles over the same underlying futures; they would be dangling.
+
+The fix applied to `as_completed` must be stated equivalently for `wait()`: `wait()` borrows `fs` (or yields shared references into it), so both return sets are valid, independent views over the same future objects. Without this, the Pass 11 fix is incomplete for the full `concurrent.futures` surface.
+
+**Action:** Add a parallel ownership clause to `wait()` in the concurrency spec, mirroring the `as_completed` borrow/clone wording.
+
+---
+
+### FINDING 2 — `CancelledError` has no dedicated typed variant (CONCURRENCY)
+
+Pass 11 clarified `shutdown(cancel_futures=True)` only cancels not-yet-started futures and that already-running futures complete normally. It did not specify the typed result when the caller later calls `.result()` or `.exception()` on a future that *was* cancelled (not-yet-started, caught by shutdown).
+
+Python distinguishes three terminal states for a future: raised an exception, was cancelled, timed out on `.result(timeout=...)`. In Sifr's Result model these need distinct variants. If "cancelled" and "raised" collapse into a generic `Err`, code that must distinguish them — e.g., retry logic that should retry on cancellation but not on a domain exception — cannot do so at the type level without downcasting.
+
+This is a direct hole left by the shutdown observability remediation: it describes observable completion for running futures but leaves the typed terminal state for cancelled futures unspecified.
+
+**Action:** Define a `FutureError` sum type with at least `Cancelled`, `TimedOut`, and `Panicked(E)` variants. Specify that `.result()` on a cancelled future returns `Err(FutureError::Cancelled)`.
+
+---
+
+### FINDING 3 — Stateful codec finalization is consuming but spec treats it as borrowed (TEXT/I18N)
+
+Pass 11 addressed static vs dynamic codec handler diagnostics. It did not address `IncrementalEncoder`/`IncrementalDecoder` finalization semantics.
+
+A stateful incremental decoder accumulates partial multi-byte sequences between calls. Calling `decode(chunk, final=True)` flushes accumulated state and logically exhausts the decoder. This is a consuming operation in Rust ownership terms. If the spec models `final=True` as a `&mut self` call (borrowed), a caller can invoke `decode` again on an exhausted decoder and receive either incorrect output (double-flush of empty state) or a silent no-op, both of which violate the "if it compiles, it works" guarantee.
+
+Two conformant options exist: (a) make `decode(..., final=True)` take `self` by value, preventing post-finalization calls at compile time; or (b) track exhaustion in the type state and return `Err(CodecError::DecoderExhausted)` on subsequent calls. Neither is specified.
+
+**Action:** Choose and document one of the two options above for `IncrementalDecoder::decode` with `final=True`. Apply the same decision to `IncrementalEncoder::encode` with `final=True`.
+
+---
+
+### Summary
+
+Three actionable gaps remain:
+
+| # | Area | Severity | Root cause |
+|---|------|----------|------------|
+| 1 | `wait()` ownership | High — contradicts Pass 11 fix spirit | Pass 11 remediation scoped to `as_completed` only |
+| 2 | `CancelledError` variant | High — type system hole | Shutdown observability fix left terminal state untyped |
+| 3 | Incremental codec finalization | Medium — correctness risk | Codec remediation addressed diagnostics, not state lifecycle |
+
+**FAIL** — three significant gaps remain.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-13-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-13-constrained.md
@@ -1,0 +1,46 @@
+**FAIL**
+
+Four significant gaps remain after pass 12 remediation.
+
+---
+
+**Gap 1: `gather()` ownership and `return_exceptions` typing**
+
+The wait ownership fix (pass 12) established that observation handles must be borrowed, not consumed. `gather()` has the same unresolved ownership question — does it borrow or consume its future arguments? The answer must be consistent with wait: borrow, so callers retain cancel handles.
+
+More critically, `gather(return_exceptions=True)` cannot be typed as `List[T]` in a sound system. Each element may be a success or a per-task error. The return type must be `List[Result[T, FutureError[E]]]` to express per-element failure. Without this, callers distinguish results from errors through runtime checks, defeating Sifr's type guarantees. The current spec is silent on gather's element-level result type.
+
+---
+
+**Gap 2: `as_completed()` ownership and timeout signal**
+
+`as_completed(fs, timeout=None)` yields futures in completion order. Ownership is unspecified: if it consumes the input futures, callers lose cancel handles — violating the pattern established for wait. It must borrow.
+
+The timeout interaction is also unresolved. When the overall timeout fires mid-iteration, Python raises `TimeoutError`. Sifr must integrate this with `FutureError::TimedOut` from pass 12, but the spec does not define what the iterator yields or signals at timeout boundary — whether it terminates the iterator, returns a typed sentinel, or surfaces `TimedOut` inline.
+
+---
+
+**Gap 3: Codec mid-stream recoverable error with partial output**
+
+Pass 12 addressed finalization/exhaustion. The unaddressed case: `IncrementalDecoder.decode(data, final=False)` with `errors='replace'` or `errors='ignore'` encountering a malformed sequence mid-buffer. Python continues decoding after the replacement/skip and returns the partial valid output alongside continuation state.
+
+`Result<String, DecodeError>` cannot express this: an `Err` path loses the partial output; an `Ok` path loses the error signal. The spec needs a wrapper type — something like `(String, Option<DecodeWarning>)` — to express partial success with a recoverable diagnostic. This is distinct from the hard-stop `Err` path for `errors='strict'`. Without it, implementations will silently either discard partial output or swallow the error signal.
+
+---
+
+**Gap 4: `TaskGroup` aggregated error type**
+
+Python 3.11 `asyncio.TaskGroup` collects errors from all child tasks and raises `ExceptionGroup` on context manager exit. If Sifr targets modern Python parity and includes `TaskGroup`, the exit error type cannot reuse single-future `FutureError<E>` — multiple concurrent child failures must be aggregated, e.g. `TaskGroupError<E>(Vec<FutureError<E>>)`.
+
+The current spec is silent on this. If `TaskGroup` is deferred to a later phase, the spec must say so explicitly and note that `FutureError<E>` is insufficient for the aggregated case, to prevent implementors from silently misapplying the single-task error type.
+
+---
+
+**Summary**
+
+| # | Area | Nature |
+|---|------|--------|
+| 1 | `gather()` | Ownership unspecified; `return_exceptions` element type missing |
+| 2 | `as_completed()` | Ownership unspecified; timeout/`FutureError` integration missing |
+| 3 | Codec mid-stream | Partial output + recoverable error not expressible in `Result` |
+| 4 | `TaskGroup` | Aggregated error type absent or undeferral noted |

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-14-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-14-constrained.md
@@ -1,0 +1,53 @@
+FAIL
+
+---
+
+**Phase 1 — Network/web**
+
+**B1: No socket error type hierarchy.**
+All network APIs return `Result<T, E>` but no shared error type is defined (no `SocketError`, `TlsError`, `HttpError` etc.). Implementers cannot write typed returns or cross-phase error composition. Required: add a shared typed error map for socket/TLS/HTTP to the phase spec before M1.
+
+**B2: SSL socket ownership transfer unspecified.**
+`SSLContext.wrap_socket(sock)` moves or borrows the underlying socket — this is a core ownership question. Sifr enforces ownership strictly; without the rule, two valid-looking implementations will produce incompatible APIs. Required: specify move vs. borrow semantics for `wrap_socket` in the phase spec.
+
+**B3: Blocking API classification absent for socket/select.**
+`socket.recv`, `socket.connect`, `select.select`, and related calls are blocking. Sifr's constraint is explicit: blocking calls in async contexts require offloading or a diagnostic. No per-API classification table is provided. Without it, async/sync boundary enforcement is undefined. Required: add a workload classification table (sync-only / offload-required / async-native / diagnostic-in-async) covering at minimum the socket and select families.
+
+**B4: No compilation strategy for socketserver/http.server handler inheritance.**
+Both modules are in scope and both rely on Python class-based handler dispatch (`BaseRequestHandler`, `BaseHTTPRequestHandler` subclasses). Sifr compiles to Rust, which has no class inheritance. No trait/enum/callback substitution strategy is specified. Without one, the feature boundary is undefined. Required: specify the handler abstraction (trait object, enum dispatch, or closure callback) before M1.
+
+---
+
+**Phase 2 — Concurrency/runtime**
+
+**B5: asyncio audit pass criteria undefined.**
+`asyncio.Queue` and `subprocess` conformance are explicitly gated on "asyncio task/wait/timeout/sync closure audit," but what the audit checks and what constitutes a passing result are not defined. Gated work cannot be scheduled. Required: add audit checklist items and a binary pass/fail criterion to the phase spec.
+
+**B6: Generator semantics prerequisite is untracked.**
+`contextmanager` and `asynccontextmanager` are blocked on a "generator semantics phase" that is not one of the three named phases, has no plan document reference, and has no scheduled timeline. These features are in permanent blocked state with no unblock path. Required: either reference the plan for generator semantics with a milestone link, or formally waive and mark these as out-of-scope.
+
+**B7: Typed IPC serialization prerequisite is untracked.**
+`multiprocessing` and `ProcessPoolExecutor` are blocked on "typed IPC serialization," which is not specified in any of the three phases and has no external plan reference. Same problem as B6. Required: reference or create a plan for typed IPC serialization, or waive.
+
+**B8: `signal.pause()` blocking classification missing.**
+The plan lists `pause()` in the safe signal subset, but `pause()` blocks indefinitely until a signal arrives. In an async context this violates the blocking constraint. Required: explicitly classify `pause()` as sync-only with a diagnostic-in-async error, or specify offload mechanism.
+
+---
+
+**Phase 3 — Text/i18n**
+
+**B9: Three binary design choices are unresolved, leaving the public API undefined.**
+The plan presents two options each for codec registry mutation strategy ("synchronized or static-plus-waiver"), locale mutation strategy ("locked or host-limited"), and gettext global install ("synchronized or waived"). An implementer cannot define a public API surface with unresolved forks. Required: resolve each choice and record the decision with rationale before M1 starts.
+
+**B10: `IncrementalEncoder`/`IncrementalDecoder` ownership model unspecified.**
+These objects hold mutable encoder/decoder state between calls. Whether the caller moves them, passes `&mut`, or wraps them in `RefCell`/`Arc<Mutex<...>>` is a foundational ownership question that affects every caller API. Required: specify the ownership/lifetime model for incremental codec objects.
+
+**B11: Binary file I/O prerequisite has no go/no-go criterion.**
+The plan acknowledges text_i18n_1 is blocked if `sifr.io` binary I/O is broken, but provides no mechanism to verify readiness before M0 begins. If M0 starts and discovers the blocker mid-flight, the milestone has no defined rollback or triage path. Required: add an explicit pre-M0 smoke test criterion for binary file I/O, with a named owner for the fix if it fails.
+
+---
+
+**Cross-phase**
+
+**B12: "External review after M0 before M1" has no identified reviewer or escalation path.**
+All three phases require external review between M0 and M1. No reviewer is named and no escalation path exists if review stalls. This turns a synchronization point into an unbounded block. Required: name a reviewer (or role) and a maximum wait window before M1 is unblocked unilaterally.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-15-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-15-constrained.md
@@ -1,0 +1,27 @@
+**FAIL**
+
+Three implementation-blocking gaps remain.
+
+---
+
+**Blocker 1 — Phase 1 / M2: TLS wrap failure state is an open decision**
+
+The plan explicitly flags "Failed wrap state must be chosen before M2" but records no decision. The failure-path ownership model (what type is returned, whether the original socket is consumed or not, what error variant carries the state) is undefined. M2 implementation cannot begin without it.
+
+*Required doc change:* Add the chosen failure-state ownership rule to the Phase 1 plan before the M2 gate, with the typed error variant and socket consumption semantics specified.
+
+---
+
+**Blocker 2 — Phase 2: signal.pause adoption is unresolved**
+
+The plan says "signal.pause is sync-only blocking with async diagnostic **if adopted**." The conditional "if adopted" leaves scope open. Implementers cannot know whether to build this API or write a waiver. Neither an adoption decision nor a CPython-evidenced waiver is recorded.
+
+*Required doc change:* Replace the conditional with either (a) an explicit adoption entry with sync-only behavior spec and async-context diagnostic defined, or (b) a waiver entry with CPython evidence and revisit rule, consistent with the pattern used for contextmanager/asynccontextmanager.
+
+---
+
+**Blocker 3 — Cross-phase: text_i18n_1 dependency milestone is unspecified**
+
+Both Phase 1 ("Non-UTF-8 URL/HTTP text behavior waits on text_i18n_1") and Phase 2 ("subprocess text waits on text_i18n_1") have hard forward dependencies on Phase 3, but neither names *which milestone* of text_i18n_1 is required. Without the milestone pin, the dependent phases cannot sequence their own milestones relative to Phase 3 — specifically, the Phase 1 URL/HTTP feature gates and Phase 2 subprocess text gates have no schedulable unblock point.
+
+*Required doc change:* In both Phase 1 and Phase 2 plans, replace "waits on text_i18n_1" with "waits on text_i18n_1 M[N]" naming the exact milestone, and add the reciprocal dependency note in the Phase 3 plan at that milestone boundary.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-16-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-16-constrained.md
@@ -1,0 +1,37 @@
+After a thorough line-by-line review of all three phase plans against the full list of resolved blockers and Sifr constraints, my finding is:
+
+**PASS**
+
+No material implementation-blocking gap remains. Here is my evidence:
+
+**Network/Web phase**
+- TLS wrap ownership (success/failure/recovery/unwrap): fully specified in M2 scope, lines 346–352.
+- Workload classification table for all socket/select/TLS/HTTP/URL/cookie/parser families: present in Architecture Principles.
+- Static handler abstraction (trait-based / enum-closure / unsupported): three concrete options named; M0 selects one before M3 starts.
+- Typed error hierarchy (SocketError → TlsError → HttpError): specified in M0 scope.
+- Non-UTF-8 URL/HTTP surfaces: correctly labeled `blocked-on-text-i18n-m1` with diagnostic fallback specified for both static and dynamic cases.
+- Open planning questions (TLS root strategy, HTTP dependency stack, canonical import names, host constants, external-network test disposition): properly deferred to M0, not pre-M0 blockers.
+
+**Concurrency/Runtime phase**
+- asyncio closure-audit checklist with binary pass/fail gate: fully enumerated in M1 scope.
+- `contextvars`/`threading.local`: unsupported with diagnostics, not silent.
+- `contextmanager`/`asynccontextmanager`: formally waived with generator-semantics revisit rule.
+- `signal.pause`: unsupported with diagnostics and CPython evidence, revisit rule stated.
+- M4 typed IPC: self-contained within M4 — no unnamed external prerequisite phase.
+- Future/executor/cancel/timeout/shutdown/map/wait/as_completed ownership and typed-result semantics: fully specified in M3 scope.
+- `Future.cancel()` return variants, `shutdown(cancel_futures=True)` behavior, `Executor.map(timeout=...)` monotonic deadline, `wait(return_when=FIRST_EXCEPTION)` mapping: all present.
+- Subprocess text-mode surfaces: labeled `blocked-on-text-i18n-m1`; binary-pipe M2 is unblocked.
+
+**Text/i18n phase**
+- Binary I/O pre-M0 smoke gate: defined with fallback path (`sifr.io` owner fixes, prerequisite PR recorded).
+- Static codec registry with unsupported `register`/`unregister`: specified.
+- Incremental codec ownership/finalization/exhausted-state/recoverable-output: fully specified in M1 scope.
+- Typed error-handler enum separation (EncodeErrorHandler / DecodeErrorHandler) and applicability table: M1 deliverable, content fully specified.
+- Locale mutation lock model: specified (process-global Mutex/RwLock); open question #4 defers the specific lock implementation to M0.
+- `gettext.install` global mutation: unsupported/waived with diagnostics and revisit rule.
+- `open(...)` explicit-encoding-required and literal-mode-required diagnostics: specified.
+- M0 decision questions (Unicode version, generated table strategy, locale matrix, CJK gating): properly deferred as M0 deliverables, not pre-M0 blockers.
+
+**Cross-cutting**
+- All three phases: CPython source/test/doc inventory in M0, terminal-state enforcement (`done`/`intentional-diff`/`unsupported`/`host-limited`) at phase exit, adopted/adapted/waived CPython test-family requirement, import tests, workload classifications, waivers with evidence and revisit rules, docs/demos/validation at the gate milestone.
+- External review loop with named owner and five-working-day fallback: present in all three gate milestones.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-17-final-readiness.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-17-final-readiness.md
@@ -1,0 +1,58 @@
+**PASS**
+
+All three phases are implementation-ready. No material planning blocker remains. The analysis below covers every gap found, classified strictly.
+
+---
+
+## Verdict by phase
+
+### Network/web (platform parity)
+
+All gates are met:
+
+- M0 deliverables are fully enumerated: inventory, CPython test matrix, typed error hierarchy (`SocketError`→`TlsError`→`HttpError` with cross-module nesting), workload table with async diagnostic rows, handler abstraction decision (trait vs. enum/closure), import-resolution tests, and open-question closure.
+- M2 TLS ownership contract is airtight: `wrap_socket` consumes the plain socket; failure path returns `TlsWrapError { socket_state: Recovered(Socket) | Closed, error }` with nested `SocketError` evidence; `unwrap()` consumes TLS. No ambiguity.
+- `ThreadingMixIn`, `ForkingMixIn`, `ThreadingHTTPServer` are explicitly unsupported, not silent omissions.
+- Non-UTF-8 URL/HTTP text is `blocked-on-text-i18n-m1`; static encoding literals get a compile-time diagnostic, dynamic values return `UnsupportedEncodingError`/`URLError`. Both paths are specified.
+- External review owner and five-working-day fallback rule are in place.
+
+All open planning questions (TLS root strategy, HTTP dependency stack, host constants, external-network test disposition, canonical import naming) are correctly classified as M0 decisions, not pre-implementation blockers.
+
+---
+
+### Concurrency/runtime
+
+All gates are met:
+
+- M0 deliverables match the template: inventory, typed error map, workload classification, and the named asyncio audit gate.
+- M1 asyncio audit pass/fail checklist is complete and binary: terminal states, typed cancel/timeout/result behavior, ownership of observation handles, primitive wake/drop/cancel determinism, diagnostics for raw event-loop/contextvars, CPython test classification, and ledger `asyncio_closure_audit: pass` flag. Failed items explicitly block M1/M2 conformance.
+- M3 executor semantics are fully specified to a degree beyond any prior review: `FutureError[Cancelled | TimedOut | Worker(E) | WorkerRuntime]`, `Future.cancel()` returning `Cancelled | AlreadyRunning | AlreadyDone`, one absolute deadline for `map(..., timeout=...)` and `as_completed(..., timeout=...)`, `wait(FIRST_EXCEPTION)` full `(done, not_done)` partition with `ALL_COMPLETED` fallback, `shutdown(wait=False)` keeping result channels alive, `shutdown(cancel_futures=True)` cancelling only pending-not-started futures, homogeneous-only `wait`/`as_completed` collections.
+- `signal.pause`, `contextmanager`, `asynccontextmanager`, `contextvars`, `threading.local` are all formally waived with revisit rules, not open questions.
+- M4 typed IPC owns `ProcessPoolExecutor` and `multiprocessing.Pool` with no unnamed external prerequisite.
+
+One editorial item (not a blocker): the execution ledger milestone checklist at line 22 names M1 "Queue And Async Queue Parity" while the plan names it "Asyncio Core, Queue, And Async Queue Parity." The asyncio audit scope is fully defined in the plan; the ledger name should be updated to match to avoid implementer confusion. This is a one-line doc fix, not a planning gap.
+
+---
+
+### Text/i18n
+
+All gates are met:
+
+- Pre-M0 binary I/O smoke gate is specified with clear failure routing: failures block `milestone_text_i18n_1` and are fixed by the `sifr.io` owner, not worked around in text-mode code.
+- Static codec registry with `register`/`unregister` as `unsupported`/`intentional-diff` is a resolved decision, not an open question.
+- Error-handler applicability table with three classes (encode-only, bidirectional, codec-limited bidirectional) is specified, including that `backslashreplace` is valid for both encode and decode.
+- Separate typed handler parameters (`EncodeErrorHandler`, `DecodeErrorHandler`) enforce context restrictions at call sites; dynamic handler names are unsupported with no silent fallback.
+- Incremental codec ownership is specified as unique mutable linear state, not `Send`/`Sync`; `final=True` exhausts the object; strict errors return `Err` with no partial output; recoverable handlers return `{ text/bytes, recoveries }` — recovery evidence is not discarded in lower-level runtime APIs.
+- `open()` requiring explicit encoding and literal mode is permanently required; locale preferred-encoding APIs do not make implicit text opens legal.
+- `io.StringIO` is correctly carved out as encoding-free; `io.TextIOWrapper` is conditional (`unsupported` if not adopted).
+- `gettext.install` is waived; explicit translation objects are the supported path.
+- M3 locale mutating APIs use a process-global lock; host-limited locale names are acknowledged.
+- M1 is correctly named as the reciprocal unblock point for network non-UTF-8 URL/HTTP text and concurrency subprocess/warning text, with M3 as the additional gate for locale-sensitive formatting.
+
+All seven M0 implementation decisions (encoding families, Unicode version, static alias table, locale lock, host locale names, gettext diagnostics, crate selection) are correctly classified as M0 deliverables.
+
+---
+
+## Summary
+
+No material planning blocker across any of the three phases. The one item requiring a doc edit — the concurrency/runtime execution ledger M1 milestone name — is editorial and does not affect implementation readiness. All three phases may proceed to M0.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-18-no-legacy-readiness.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-18-no-legacy-readiness.md
@@ -1,0 +1,25 @@
+FAIL. Two doc edits required:
+
+---
+
+**Edit 1** — `issues/ad-hoc-production-text-i18n-stdlib-parity.md`, `milestone_text_i18n_1` scope, codec error-handler bullet list.
+
+Remove this line:
+
+> the different timing between compile-time diagnostics for static handler literals and typed runtime errors for adopted dynamic lookup is intentional and must be documented
+
+The phrase "typed runtime errors for **adopted** dynamic lookup" implies a runtime dynamic-handler-lookup path exists in this phase. The two flanking bullets already state clearly that dynamic handler names are unsupported and there is no silent fallback to strict. This line creates a false implication that a partial runtime fallback path should be implemented. Removing it leaves the policy unambiguous.
+
+---
+
+**Edit 2** — `issues/ad-hoc-production-text-i18n-stdlib-parity-execution.md`, planning review remediation list, line 103.
+
+Current:
+
+> [x] Define `open(path)`/`open(path, mode="r")` without explicit `encoding=` as **blocked until the M3 locale/default-encoding contract**, with compile-time diagnostics for static omissions and typed unsupported-default-encoding errors for dynamic cases.
+
+Change to:
+
+> [x] Define `open(path)`/`open(path, mode="r")` without explicit `encoding=` as permanently `unsupported`/`intentional-diff` from CPython's locale-derived default; M3 documents this as the final intentional difference, it does not unblock these forms; compile-time diagnostics for static omissions and typed unsupported-default-encoding errors for dynamic cases.
+
+"Blocked until M3" implies these APIs could be unblocked when M3's locale contract lands. The plan document (same file) states they "remain unsupported after M3" and that M3's job is to **document** the intentional difference, not to implement locale-derived defaults. The execution ledger must match the plan to prevent an implementer from interpreting M3 completion as a signal to add locale-default text-open behavior, which is exactly the deprecated CPython path that must not be implemented.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-19-no-legacy-readiness.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-19-no-legacy-readiness.md
@@ -1,0 +1,12 @@
+Having read all six issue files plus the namespace contract and cleanup files in full, I checked every decision for: backward compatibility, legacy support, deprecated behavior, compatibility shims, old `sifr.*` bridge aliases, fake fallbacks, historical CPython aliases, dynamic handler lookup, and implicit locale-default text open behavior.
+
+**PASS**
+
+All documents are clean across every axis:
+
+- **Network/web**: socket.error legacy alias explicitly unsupported; ThreadingMixIn/ForkingMixIn/ThreadingHTTPServer explicitly unsupported; static handler model required; no dynamic class inheritance emulated; no sifr.* bridge aliases.
+- **Concurrency/runtime**: getoutput/getstatusoutput explicitly unsupported as legacy shell helpers; contextmanager/asynccontextmanager formally waived with explicit revisit rule (not a compatibility bridge); no pickle-style process-pool fallback; no sifr.* bridge aliases.
+- **Text/i18n**: getdefaultlocale explicitly unsupported as deprecated; static codec registry with no dynamic handler lookup; open(path)/open(path, mode="r") without explicit encoding permanently unsupported as intentional-diff; no implicit locale-derived defaults; legacy-only codec aliases waived; gettext.install global mutation waived; no sifr.* bridge aliases.
+- **Namespace contract/cleanup**: atomic compatibility removal required (no transitional bridges, no staged deprecation, no warning mode, no migration mode); `__compat_sifr_sync_*`/`__compat_sifr_concurrent_*` retained internally are scoped only to explicitly-imported canonical `sifr.*` modules, not CPython bare-name compatibility surfaces, and are not user-facing aliases.
+
+No remaining decision implies any of the prohibited categories.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-2-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-2-constrained.md
@@ -1,0 +1,33 @@
+**FAIL** — four remaining gaps.
+
+---
+
+**1. asyncio core synchronization primitives are unowned**
+
+Remediation designates "core asyncio scheduler/task helpers" as prior infrastructure but assigns ownership to no phase and no doc. `asyncio.gather`, `asyncio.wait`, `asyncio.sleep`, `asyncio.timeout`, `asyncio.TaskGroup`, `asyncio.Event`, `asyncio.Lock`, `asyncio.Semaphore`, and `asyncio.Condition` are neither network entries nor Queue — they fall into the gap between concurrency/runtime (Queue only) and network/web (open_connection/start_server only). No phase has a completion criterion that covers them. If any downstream phase (network/web's executor-backed serving, concurrency/runtime's async Queue) is allowed to depend on them as prior infrastructure, there must be a named milestone or doc section that owns their scope, even if that scope is "host-runtime, no parity target." Without it, the prior-infrastructure claim is unverifiable and blocks no gate.
+
+**Action:** Assign asyncio synchronization/control-flow primitives explicitly — either to concurrency/runtime's scope, to a named prior milestone, or declare them host-runtime with intentional-diff status in each consuming doc.
+
+---
+
+**2. Binary file I/O as prior infrastructure is equally unowned**
+
+Text/i18n correctly scopes itself to text-mode `open(encoding/errors)` and calls binary file I/O "prior infrastructure." But no phase doc owns binary open. This is the same structural defect as the asyncio core gap: text/i18n's own entry point has an unresolved hard dependency with no owning milestone. A consumer reading the text/i18n doc cannot determine which milestone to block on before text-mode open is deliverable.
+
+**Action:** Name the milestone or crate that owns binary file I/O, even briefly, so text/i18n's dependency chain is complete.
+
+---
+
+**3. ThreadPoolExecutor "adapted/waived" is an unresolved decision, not a boundary**
+
+Concurrency/runtime says ThreadPoolExecutor behaviors requiring threading objects are "adapted/waived" but does not enumerate which behaviors are adapted (and how), which are waived, and who decides. Network/web depends on concurrency/runtime for executor-backed serving. If network/web uses `loop.run_in_executor` with the default ThreadPoolExecutor, the adaptation/waiver decision directly affects what network/web can claim about its observable behavior. An unenumerated waiver at a phase boundary is equivalent to having no boundary.
+
+**Action:** List at minimum the top two or three ThreadPoolExecutor behaviors that are adapted or waived (e.g., `initializer`/`initargs`, `cancel_futures` on shutdown, worker-thread naming), and state whether they become intentional-diffs or are simply deferred.
+
+---
+
+**4. urllib.parse non-ASCII URL behavior has no stated disposition**
+
+Network/web constrains urllib.parse to byte/ASCII/UTF-8 and says it must not duplicate the codec registry. Python's `urllib.parse.quote`/`unquote` with non-UTF-8 encodings consumes the codec registry via `str.encode(encoding)`. The remediation correctly excludes codec duplication but does not state whether non-ASCII, non-UTF-8 URL encoding is (a) intentional-diff, (b) blocked on text/i18n, or (c) out of scope entirely. Without a disposition, any future work touching `quote(string, encoding='latin-1')` will relitigate the boundary.
+
+**Action:** Add a one-line disposition for non-ASCII/non-UTF-8 URL encoding — either "intentional-diff: unsupported" or "blocked on text/i18n codec registry milestone."

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-20-sifr-namespace-readiness.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-20-sifr-namespace-readiness.md
@@ -1,0 +1,11 @@
+The grep results fully cover all the key files. One item needs context verification — `12_stdlib_remediation.md:38` uses "backward compatibility" and `12_stdlib_remediation.md:49` uses "alias" — both are clearly scoped to Sifr's own internal API (accepting `str` or `FileHandle`; `datetime.today()` delegating to `datetime.now()`), not CPython namespace aliases. The namespace cleanup doc's carve-out on line 65 for `__compat_sifr_sync_*`/`__compat_sifr_concurrent_*` names is intentionally scoped to internal codegen bookkeeping, not user-facing namespace aliases.
+
+**PASS**
+
+All stdlib parity phase plans are consistent with the enforced decision:
+
+- All three parity phase docs (platform, concurrency, text/i18n) explicitly prohibit bare CPython module-name imports, transitional bridges, legacy aliases, deprecated behavior, and compatibility shims.
+- All three execution ledgers record a namespace review result of PASS.
+- The namespace-contract cleanup doc (`ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md`) correctly identifies remaining compat infrastructure as a cleanup target, not a permitted state.
+- No phase doc endorses bare-name aliases or optional `sifr.*` usage.
+- No phase doc contains import examples using bare CPython module names as valid user-facing forms.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-3-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-3-constrained.md
@@ -1,0 +1,40 @@
+**FAIL** — four remaining significant gaps.
+
+---
+
+**Gap 1: asyncio audit → queue/subprocess sequencing is unresolved**
+
+The remediation says concurrency/runtime owns the CPython asyncio closure audit "for the asyncio subset consumed by queue/subprocess." But it does not specify a delivery relationship: does network/web's queue and subprocess parity work block on completion of that audit, or proceed in parallel and absorb findings ad hoc? If they proceed in parallel and the audit surfaces an asyncio behavioral gap, network/web may ship queue/subprocess parity against a non-conformant asyncio base. The phases need an explicit sequencing rule: asyncio audit must close before queue/subprocess parity claims conformance.
+
+---
+
+**Gap 2: Binary file I/O dual-ownership creates a fix-responsibility vacuum**
+
+The remediation assigns ownership of binary `open`/file handles jointly to prior runtime work and `sifr.io`, while requiring text_i18n_0 to *verify* binary open before text-mode integration. This splits discovery (text_i18n_0) from ownership (sifr.io). If text_i18n_0 verification finds a binary open conformance failure, there is no stated path: is text_i18n_0 blocked until sifr.io fixes it? Who triages it? Who decides whether it is a blocker? Without a clear fix-responsibility and blocking rule, the verification gate is advisory rather than a hard prerequisite, which defeats its purpose.
+
+---
+
+**Gap 3: "Sifr-sendable callable" is undefined**
+
+The ThreadPoolExecutor remediation gates `initializer`/`initargs` support on "Sifr-sendable callables." No definition of "Sifr-sendable" appears in the phase documents. In Rust terms this likely maps to `Send`-bounded, but Sifr's surface type system may not yet expose that concept explicitly to users. Without a concrete definition — a type annotation, a compiler error message, or a reference to where the concept is specified — implementors have no deterministic gate. A callable that is borderline (captures a value whose sendability is inferred) has no disposition. The remediation should either define the term or defer initializer/initargs entirely rather than leave it conditional on an undefined predicate.
+
+---
+
+**Gap 4: urllib.parse blocked-on-text-i18n has no defined user-visible error surface**
+
+The remediation says non-ASCII/non-UTF-8 `quote`/`unquote` calls (e.g., `encoding="latin-1"`) are blocked until text_i18n_1 ships and specifies no local codec fallback. But it does not say what the user sees before text_i18n_1 ships: compile-time error, runtime `UnsupportedError`, silent UTF-8 coercion, or a panic. This matters because network/web may ship before text_i18n_1, and users will hit this boundary. Without a defined error surface the phase is incomplete on its own terms — shipping a feature with an undefined failure mode is a conformance gap regardless of the deferred dependency.
+
+---
+
+**Observation (not a gap): TaskGroup vs. event-loop-policy exclusion warrants a note**
+
+`asyncio.TaskGroup` (3.11+) relies on structured task scoping that is implemented in CPython against internal event-loop machinery. Excluding event-loop policy/transports while including TaskGroup is probably safe if Sifr's async runtime wraps a single well-known executor, but the audit scope should say so explicitly — otherwise a future reviewer may re-litigate whether TaskGroup is achievable without event-loop hooks. A one-line rationale ("TaskGroup is implementable against Sifr's fixed async executor without event-loop policy exposure") would close this before it becomes a recurring question.
+
+---
+
+**Summary of required remediations:**
+
+1. Add an explicit sequencing rule: asyncio closure audit must reach a stated completion milestone before queue/subprocess parity claims CPython conformance.
+2. Add a fix-responsibility rule for binary open failures found during text_i18n_0 verification, including a blocking/non-blocking disposition.
+3. Define "Sifr-sendable callable" with a concrete criterion, or demote initializer/initargs to "unsupported" until the definition exists.
+4. Define the user-visible error surface for `encoding=non-utf8` urllib.parse calls before text_i18n_1 ships.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-4-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-4-constrained.md
@@ -1,0 +1,35 @@
+**PASS 4 — FAIL**
+
+Four significant gaps remain.
+
+---
+
+**1. contextvars propagation not in M1 audit scope**
+
+CPython asyncio tasks copy the current `ContextVar` context at spawn time; workers read/write isolated copies. The M1 audit is scoped to "control/sync" — which will catch `asyncio.Event`, `asyncio.Lock`, and scheduling order, but will not surface ContextVar propagation divergence unless a fixture explicitly exercises it. If Sifr's structured-concurrency executor doesn't replicate per-task context copies, programs using `contextvars.ContextVar` will silently observe stale values rather than fail to compile or produce a typed error. This violates the "if it compiles, it works" guarantee. **Action:** extend the M1 audit scope to include a ContextVar propagation fixture, or explicitly declare ContextVar out-of-scope with a follow-on tracking item before M1 is marked closed.
+
+---
+
+**2. Cross-phase unblock condition is under-specified**
+
+Item 2 says text/i18n M1 is unblocked by "sifr.io/runtime file-object surface prerequisite PR/items." Concurrency/runtime also modifies async file handles (asyncio-based open/read paths land in M2). These are two separate phase timelines touching the same sifr.io/runtime surface. The current framing leaves text/i18n M1's unblock condition pointing at a moving target — if the runtime file-object PR ships as part of concurrency/runtime M2, text/i18n M1 cannot close until after concurrency/runtime M2, but no phase document declares this sequencing. **Action:** the prerequisite must name a concrete deliverable anchor (a specific PR, a tagged interface version, or an explicit "ships no later than concurrency/runtime M1") so the cross-phase gate is deterministic, not implicit.
+
+---
+
+**3. ThreadPoolExecutor exception propagation contract missing**
+
+Item 3 declares `initializer`/`initargs` unsupported. That is a construction-time gap. The runtime gap is separate: `Future.result()` in CPython re-raises whatever exception the worker thread raised. In Sifr, worker code runs under Result/Option semantics, but an arbitrary Python-surface exception crossing a thread boundary back to the caller requires a defined wrapping: which `E` type does it become, and does it arrive as `Err(…)` or trigger a panic? Without this contract, the only safe implementation is to panic on unhandled worker errors — which violates the no-user-triggerable-panic guarantee — or to swallow them silently. Neither is acceptable, and neither is currently addressed by the sendability gap remediation. **Action:** define the thread-worker-exception-to-Result wrapping contract as a prerequisite item in this phase, even if the answer is "worker functions must return `Result`; non-Result panics are a programmer invariant violation caught at compile time."
+
+---
+
+**4. `open()` with `encoding=None` falls outside both fixed items' scope**
+
+Item 2 covers binary open/file-handle conformance. Item 4 covers non-UTF-8 codec args in urllib.parse. Neither covers `open(filepath)` or `open(filepath, mode='r')` — no explicit encoding argument — which in CPython resolves to `locale.getpreferredencoding(False)`, not UTF-8. If Sifr silently substitutes UTF-8 for the absent encoding, programs that rely on locale encoding (common in system-level or legacy interop code) will compile and run but produce wrong output on non-UTF-8 systems. This is a behavioral divergence with no compile-time or runtime signal. The M0 binary I/O audit as currently scoped will not catch it because `mode='r'` is text mode, not binary. **Action:** M0's audit scope must explicitly include a `open(file)` no-encoding fixture. If Sifr mandates explicit encoding arguments, that should produce a compile-time diagnostic ("encoding argument required"), consistent with the static diagnostic pattern established for urllib.parse in item 4.
+
+---
+
+**Summary**
+
+All four are actionable before the affected milestones can close: (1) extend M1 audit scope or create a ContextVar tracking item; (2) name a concrete cross-phase anchor for the sifr.io/runtime prerequisite; (3) define the thread-worker exception-to-Result contract; (4) add a default-encoding-None fixture to M0 and specify the diagnostic behavior.
+
+**FAIL**

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-5-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-5-constrained.md
@@ -1,0 +1,44 @@
+**PASS 5 — Remaining Gaps Review**
+
+---
+
+**Gap 1: ContextVar single-task usage scope is unresolved**
+
+Remediation 1 marks cross-task ContextVar *propagation* out of scope. It does not answer whether `contextvars.ContextVar` as a type is supported within a single task (reads and writes that never cross an executor or asyncio boundary). If ContextVar is entirely unsupported, any usage needs a diagnostic. If only propagation is out of scope, single-task reads/writes need a spec — behavior, type, and lifetime. The current remediation addresses only the propagation diagnostic fixture and leaves this prior question open. Implementers will guess.
+
+---
+
+**Gap 2: ThreadPoolExecutor future cancellation is untyped**
+
+Remediation 3 defines two terminal states: `Ok(T)` for success and `Err(ExecutorError::Worker(E))` for worker failure. Python futures have a third distinct terminal state: cancelled. `Future.cancel()` is part of the standard API. The remediation makes no mention of cancellation — no `ExecutorError::Cancelled` variant, no "out of scope" marking, no diagnostic. If cancellation is silently omitted, callers matching on ExecutorError are working with an incomplete set of variants, which undermines the "never panics or swallows" guarantee. This needs either a named variant or an explicit out-of-scope marker with a compile-time diagnostic for `.cancel()` calls.
+
+---
+
+**Gap 3: M3 encoding policy outcome is ambiguous and creates a contradiction risk**
+
+Remediation 4 defers the question of `open(path)` without encoding to M3 locale/default-encoding policy. But the remediation does not commit to what M3 actually delivers. Two outcomes are possible after M3 lands:
+
+- Option A: `open()` without encoding becomes legal and uses the locale default.
+- Option B: explicit encoding remains always required, M3 only defines what error message is emitted.
+
+Option A conflicts with Sifr's static typing model — locale-dependent encoding means the type of a file handle's character codec is not knowable at compile time. Option B makes M3's relevance to this remediation unclear. The phase plan needs to state which option M3 commits to, or the current text will be interpreted differently by the text/i18n and runtime teams.
+
+---
+
+**Gap 4: Dynamically-specified binary mode collides with encoding enforcement**
+
+Remediations 2 and 4 interact poorly. Remediation 2 anchors binary file I/O (`mode="rb"`, `mode="wb"`) to sifr.io/runtime — binary handles don't need encoding. Remediation 4 says `open(path, mode=dynamic_var)` without encoding returns a typed unsupported-default-encoding error when the mode is not statically knowable.
+
+At runtime, `dynamic_var` might be `"rb"`. In that case the encoding error is a false positive — binary mode does not require an encoding argument. The current text has no exclusion for dynamically-specified binary modes from the encoding-required diagnostic path. The boundary condition must be stated: either dynamic binary mode is inferred and excluded from the encoding check, or `open()` with a non-literal mode string requires encoding unconditionally (which would make binary-mode calls with a dynamic mode string permanently illegal, a significant usability restriction that should be explicit).
+
+---
+
+**Gap 5: "Where possible" in worker compile-time error coverage is unactionable**
+
+Remediation 3 says non-Result user failure paths in worker functions are "compile-time errors where possible." The qualifier "where possible" is undefined. Implementers need to know: possible under what conditions? What determines whether a worker's failure path is statically analyzable? Without a bounded definition — at minimum a list of cases where static detection is guaranteed and cases where it is not — this becomes an open-ended implementation decision rather than a spec commitment. The typed ExecutorError fallback has no clear triggering conditions, so the "where possible / typed ExecutorError otherwise" split will be resolved inconsistently across compiler passes.
+
+---
+
+**FAIL**
+
+Five actionable gaps remain. The highest-risk items are Gap 3 (M3 policy ambiguity creates a downstream contradiction) and Gap 4 (false-positive encoding diagnostics on dynamic binary-mode opens). Gaps 1 and 2 are scope definition omissions that will produce inconsistent behavior. Gap 5 is an implementation guidance deficit that will surface as spec disputes during code review.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-6-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-6-constrained.md
@@ -1,0 +1,32 @@
+**FAIL**
+
+---
+
+**1. `executor.map()` excluded from worker typing contract**
+
+Pass 5 fix 5 addresses `submit()` worker callables (Callable[..., T] or Callable[..., Result[T,E]]) and `Future.result` typed evidence. `executor.map(fn, *iterables)` is a distinct API with different failure semantics: it raises on first exception, yields results in order, and has no Future intermediary. If map() is in scope for this phase, it needs its own callable type contract and error surface (does it return `Iterator[T]` or `Iterator[Result[T,E]]`? Does it propagate `ExecutorError::WorkerRuntime`?). If out of scope, it needs a compile-time diagnostic. Neither is currently specified. The omission creates an inconsistency: users who switch from submit/Future to map() lose the safety guarantees mid-phase.
+
+**2. `Future.result(timeout=N)` is an unresolved typed terminal state**
+
+Pass 5 added `ExecutorError::Cancelled` as a typed distinct state. `Future.result(timeout=N)` raises `TimeoutError` in CPython — a third terminal state alongside `Cancelled` and `WorkerRuntime`. The current fix doesn't classify timeout, leaving it ambiguous: does it become `ExecutorError::Timeout`, a separate `TimeoutError` type, or an undocumented panic path? The typed evidence guarantee for `Future.result` is incomplete without specifying timeout as a first-class terminal state with a CPython fixture.
+
+**3. `io.TextIOWrapper` encoding policy not covered by open() fix**
+
+Pass 5 fix 3 mandates explicit encoding for text-mode `open()`. However, `io.TextIOWrapper(binary_stream)` is a standard alternative for wrapping binary sockets, pipes, and other streams with a text codec. It accepts the same `encoding=` parameter and defaults to `locale.getpreferredencoding()` in CPython. The open() encoding fix doesn't extend to `TextIOWrapper`, creating a bypass: a user who calls `TextIOWrapper(sys.stdin.buffer)` without encoding gets no diagnostic despite the same implicit-locale hazard. The policy needs explicit extension or `TextIOWrapper` must be marked unsupported in text/i18n.
+
+**4. `shutdown(cancel_futures=True)` interaction with `ExecutorError::Cancelled` is unspecified**
+
+Pass 5 fix 2 adds `ExecutorError::Cancelled` as a typed terminal state triggered by `Future.cancel()`. Python 3.9+ `executor.shutdown(cancel_futures=True)` bulk-cancels pending futures at shutdown. The typed contract for this path is absent: do futures cancelled via shutdown carry `ExecutorError::Cancelled`? Are they observably distinct from `Future.cancel()`-triggered cancellations? If shutdown is in scope (it's a core lifecycle API), the interaction must be specified. If cancel_futures is unsupported, a compile-time diagnostic is required when the keyword argument is passed.
+
+**5. `as_completed()` / `wait()` heterogeneous Future type erasure is unresolved**
+
+The typed Future[T] returned by submit() creates a soundness question for `as_completed(futures)` and `wait(futures)`: these functions accept `Iterable[Future]` over futures with potentially different T types. CPython uses structural subtyping and runtime erasure. In Sifr's static type system, iterating a mixed `[Future[int], Future[str]]` collection needs either a type-erased `Future[Any]` (unsafe), a sum type, or a restriction to homogeneous collections. This is not a minor edge case — concurrent.futures patterns almost always mix future types in wait/as_completed calls. The phase must declare one of: (a) all futures in a set must share T, (b) a type-erased handle exists, or (c) as_completed/wait are out of scope with diagnostics. Silence here makes typed Futures less useful than CPython's untyped ones for real patterns.
+
+---
+
+**Summary of actionable items:**
+- Specify executor.map() type contract or mark unsupported with diagnostic
+- Add `ExecutorError::Timeout` (or equivalent) as typed terminal state for `Future.result(timeout=N)`
+- Extend explicit-encoding mandate to `io.TextIOWrapper` or mark it unsupported
+- Specify `shutdown(cancel_futures=True)` interaction with `ExecutorError::Cancelled`
+- Resolve heterogeneous Future collection type strategy for `as_completed()`/`wait()`

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-7-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-7-constrained.md
@@ -1,0 +1,47 @@
+**PASS 7 — REVIEW**
+
+---
+
+**GAP 1: `executor.map(timeout)` not addressed alongside `Future.result(timeout)`**
+
+Pass 6 fixed `Future.result(timeout)` to yield a typed `ExecutorError::Timeout`. But `executor.map` also accepts a `timeout` parameter (`executor.map(fn, *iterables, timeout=None)`). The timeout on `map` raises `TimeoutError` in CPython when iterating past the deadline. If the phases fixed the return type of `map` but did not address its timeout parameter's typed terminal state, there is a hole: the typed item-result iterator needs to express timeout per-item or as an iterator-level exhaustion state consistent with `ExecutorError::Timeout`.
+
+---
+
+**GAP 2: `Future.cancel()` on already-running futures — return value semantics untyped**
+
+Python's `Future.cancel()` returns `False` if the future is already executing (cannot be cancelled) and `True` if it was pending and successfully cancelled. Pass 6 addressed `shutdown(cancel_futures=True)` giving pending futures a cancelled terminal state, but the interactive `Future.cancel()` call involves a two-outcome typed return. If the design does not distinguish `CancelResult::AlreadyRunning(False)` from `CancelResult::Cancelled(True)`, callers have no typed signal to branch on, and the state machine is incomplete.
+
+---
+
+**GAP 3: `as_completed(timeout)` typed exhaustion**
+
+Pass 6 fixed `wait`/`as_completed` to require homogeneous collections, but `as_completed(fs, timeout=None)` raises `TimeoutError` in CPython when the timeout expires before all futures complete. In Sifr's non-raising model this needs a typed exhaustion signal — either the iterator yields `Result<T, ExecutorError>` where `ExecutorError::Timeout` signals end-of-iteration, or the iterator terminates and the caller checks remaining futures. If this is unspecified, iteration over `as_completed` with a timeout has no typed contract.
+
+---
+
+**GAP 4: `wait(return_when=FIRST_EXCEPTION)` semantics in a non-raising world**
+
+`concurrent.futures.wait` accepts `return_when` values: `ALL_COMPLETED`, `FIRST_COMPLETED`, `FIRST_EXCEPTION`. The `FIRST_EXCEPTION` variant in CPython terminates when any future raises. In Sifr, worker failures are typed (previously fixed), so a future carrying a typed error value is not an "exception" but a `Result::Err`. The design needs to specify whether `FIRST_EXCEPTION` maps to "first future whose result is `Err(_)`" or is unsupported. If unaddressed, `return_when` is either silently ignored or semantically mismatched.
+
+---
+
+**GAP 5: `io.StringIO` not separated from `TextIOWrapper` encoding requirement**
+
+Pass 6 applied an explicit encoding requirement to `io.TextIOWrapper`. But `io.StringIO` is an in-memory text stream that takes no `encoding` argument — it operates on native unicode strings already. If the encoding requirement was applied broadly to the text-IO surface without carving out `StringIO`, this is a contradiction: requiring encoding on `StringIO` is wrong, but omitting the carve-out leaves the spec ambiguous. The phases need an explicit statement that `StringIO` is encoding-free (or unsupported with separate rationale).
+
+---
+
+**GAP 6: `threading.local()` — distinct from `contextvars`, no explicit ruling**
+
+`contextvars` was marked entirely unsupported. However, `threading.local()` is a separate mechanism (class-based, not context-variable-based) for thread-local storage. These are often used interchangeably in Python code. If `threading.local()` has no explicit position in the concurrency phase — supported with typed contract, or unsupported with diagnostic — there is a missing ruling. Leaving it implicit while explicitly ruling out `contextvars` creates an asymmetry that will surface in user-facing error messages.
+
+---
+
+**GAP 7: `bytes.decode(errors=)` / `str.encode(errors=)` error-handler typing**
+
+The text/i18n phase addressed explicit encoding for `open()` and `TextIOWrapper`. But `str.encode(encoding, errors)` and `bytes.decode(encoding, errors)` take an `errors` parameter with runtime-dispatch values (`'strict'`, `'ignore'`, `'replace'`, `'surrogateescape'`, etc.). Static compilation cannot express these as a runtime string. The phases need either: a typed `EncodeErrors` enum restricting to statically-known variants, or a diagnostic blocking non-`'strict'` error handlers with CPython evidence. No ruling here leaves the i18n phase incomplete for the encode/decode surface.
+
+---
+
+**FAIL** — 7 actionable gaps remain across the executor, future state machine, io, and text surfaces.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-8-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-8-constrained.md
@@ -1,0 +1,41 @@
+## Pass 8 Review
+
+---
+
+**Finding 1 — Future.cancel: typed outcome covers only two of CPython's three false-return cases (FAIL)**
+
+CPython returns `False` for three distinct states: future is already running, already finished (success/error), and already cancelled. The Pass 7 remediation maps to `Cancelled` vs `AlreadyRunning`, which silently conflates "already done" and "already cancelled" under `AlreadyRunning`. This is semantically wrong. A caller distinguishing retry-after-cancel from "result already available" gets incorrect information. The typed enum needs a third variant — `AlreadyDone` or equivalent covering both completed and pre-cancelled futures — to faithfully represent the `False` surface without misleading names.
+
+---
+
+**Finding 2 — wait(FIRST_EXCEPTION): return shape, not just first-failure mapping (FAIL)**
+
+CPython's `wait()` always returns `(done, not_done)` — a full partition of futures at the moment the condition triggered. For `FIRST_EXCEPTION`, "done" includes every future that completed *before and including* the first exception-raising one, not only the failing future. The remediation describes mapping "exception to first future with typed worker failure Err(_)" — this addresses what to do with the failing future but says nothing about the full `done` set or the `not_done` remainder. If the implementation returns only the single failing future's result, callers that process the full done-set (standard CPython idiom) will silently lose results. The return type must be `(Vec<completed>, Vec<pending>)` or equivalent, with the failing future present inside `completed` alongside any prior successes.
+
+---
+
+**Finding 3 — executor.map timeout: absolute deadline vs rolling per-item deadline is unspecified (FAIL)**
+
+CPython starts a monotonic clock at the `map()` call site; each iteration of the returned iterator checks time remaining against that single absolute deadline. The remediation says "timeout reports ExecutorError::Timeout on next item result that cannot be delivered before deadline" — "deadline" implies absolute, but the phrase "next item result" leaves open whether the implementation resets the clock between items. A per-item reset would allow arbitrarily long total execution (N items × timeout seconds), violating CPython semantics. The implementation spec must state explicitly: one absolute deadline computed once at `map()` call time, decremented across all item waits, with `ExecutorError::Timeout` on first item that exceeds the remaining budget.
+
+---
+
+**Finding 4 — str.encode/bytes.decode: encode-only error handlers lack decode-context diagnostic (FAIL)**
+
+`xmlcharrefreplace` is encode-only. Passing it as the `errors` argument to `bytes.decode()` raises `LookupError` in CPython. The remediation lists it among supported handlers without distinguishing decode vs encode applicability. "Where compatible" is not strong enough — if applied statically (typed enum or statically known literal), the compiler has enough information at the call site to reject `xmlcharrefreplace` on a decode call. Without this diagnostic, the handler silently succeeds or silently falls back, both wrong. The encode-only restriction for `xmlcharrefreplace` (and the decode-only restriction for `surrogateescape` in its primary form) must be encoded in the type system or checked statically at the call site with a clear error.
+
+---
+
+**Finding 5 — io.StringIO: newline parameter behavior unaddressed (minor, but flag)**
+
+The Pass 7 remediation covers only the encoding-free guarantee. CPython's `StringIO` accepts a `newline` parameter controlling universal newlines translation (default `None` normalises `\r\n` and `\r` to `\n` on read; `newline=''` disables). If `newline` is accepted but silently ignored, callers processing mixed-newline input get wrong data. This is narrower than the encoding issue but should be explicitly listed as either supported with correct semantics or diagnosed as unsupported-parameter.
+
+---
+
+**Verdict: FAIL**
+
+Four actionable findings remain:
+1. `Future.cancel` typed outcome missing `AlreadyDone` variant.
+2. `wait(FIRST_EXCEPTION)` return shape must include full `(done, not_done)` partition.
+3. `executor.map` timeout must be specified as a single absolute deadline, not per-item.
+4. `xmlcharrefreplace` (encode-only) must be statically rejected on decode call sites.

--- a/reviews/ad-hoc-production-split-stdlib-phases-review-pass-9-constrained.md
+++ b/reviews/ad-hoc-production-split-stdlib-phases-review-pass-9-constrained.md
@@ -1,0 +1,25 @@
+**FAIL** — four significant gaps remain.
+
+---
+
+**1. `backslashreplace` misclassified as encode-only**
+
+Pass 8 statically rejects encode-only handlers on decode call sites, using `xmlcharrefreplace` as the canonical example. However, `backslashreplace` is bidirectional since Python 3.1: it is valid on both encode and decode. If the implementation classifies it in the encode-only rejection set, any `bytes.decode(errors='backslashreplace')` call site would be incorrectly diagnosed as a compile error. Similarly, `surrogatepass` is valid for encode and decode of UTF-8/UTF-16/UTF-32 and must not appear in the encode-only bucket. The classification table needs an explicit tripartite split: encode-only, decode-only, and bidirectional, rather than a binary encode-only vs everything-else scheme.
+
+---
+
+**2. `as_completed()` timeout model inconsistent with fixed `executor.map`**
+
+Pass 8 established that `executor.map` computes one absolute monotonic deadline at call time. `concurrent.futures.as_completed()` is a separate code path with its own `timeout` parameter. If `as_completed()` was not updated in the same pass, it likely still measures `timeout` as a per-call-to-`next()` budget rather than an absolute deadline. A caller doing `for f in as_completed(fs, timeout=5)` expects 5 seconds total, not 5 seconds per yield. The fix must apply the same single-deadline model: deadline computed at `as_completed()` call time, remaining budget decremented on each yield.
+
+---
+
+**3. `wait(FIRST_EXCEPTION)` no-exception fallback unspecified**
+
+The pass 8 description covers the exception path (first typed worker failure, full (done, not_done) partition) but omits the no-exception case. In CPython, `wait(FIRST_EXCEPTION)` behaves identically to `ALL_COMPLETED` when no future raises. If this fallback is absent, a call where all futures succeed will either return prematurely (before all complete) or block indefinitely. The specification must explicitly state: if no future raises, block until all futures complete and return `(all, empty_set)`.
+
+---
+
+**4. `shutdown(cancel_futures=True)` typed outcome mismatch**
+
+Pass 8 gave `Future.cancel()` typed outcomes: `Cancelled`, `AlreadyRunning`, `AlreadyDone`. `executor.shutdown(cancel_futures=True)`, introduced in Python 3.9, triggers cancellation of pending futures internally without going through the public `cancel()` API. If shutdown-triggered cancellation does not produce the `Cancelled` variant in each affected future's outcome, match arms written against the typed outcome enum will silently fail to handle shutdown-cancelled futures. The implementation must route shutdown cancellation through the same typed outcome path, or explicitly document that shutdown produces a separate `ShutdownCancelled` variant that callers must also handle.

--- a/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-1d.md
+++ b/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-1d.md
@@ -1,0 +1,60 @@
+## Review Findings
+
+### Critical gaps (block implementation)
+
+**1. `socketserver` missing from scope**
+M3 targets `HTTPServer`/`BaseHTTPRequestHandler`/`SimpleHTTPRequestHandler`, all of which are built on `socketserver`. CPython evidence confirms `socketserver` exists as a separate module with its own test file. It must be listed as an M3 prerequisite or a separate sub-item, not left as an implicit dependency.
+
+**2. Socket C module reexports unaccounted for**
+M1 lists `socket.socket`, TCP/UDP basics, and four name-resolution functions. The CPython evidence lists 15+ additional APIs reexported from the C module (`inet_aton/inet_ntoa/inet_pton/inet_ntop`, `gethostbyname/gethostbyaddr`, `getservbyname/getservbyport`, `getprotobyname`, `socketpair`, `fromfd`, `dup`, `close`, `defaulttimeout`, plus constants). Each needs an adopt/adapt/waive decision before M1 implementation starts. Without this, M1 scope is undefined.
+
+**3. Async SSL design absent**
+M2 says "async TLS handshake/read/write" but CPython's non-blocking SSL is driven by `WANT_READ`/`WANT_WRITE` retry loops tied to the event loop. Sifr bars raw event-loop public API and requires real async suspension. There is no design for how `SSLSocket` integrates with the async runtime — is there a distinct `AsyncSSLStream` type? Is `wrap_socket` sync-only? Without this, M2 cannot be implemented.
+
+**4. M3 "async HTTP APIs" is a placeholder, not a spec**
+No deliverable is defined. Does this mean an async version of `HTTPConnection`? An `asyncio`-backed `urlopen`? A thin wrapper over async streams from M1? This needs concrete API names or an explicit waive.
+
+**5. M6 generator dependency is unresolved**
+`contextmanager`/`asynccontextmanager` are gated on "if generator gaps solved," but generator support is neither scoped in this plan nor tracked as a prerequisite task. This makes M6 a potential no-op with no fallback path defined. Either add a generator-support prerequisite milestone or explicitly waive generator-based context managers and document the class-based-only alternative (ExitStack/AsyncExitStack remain, decorator forms do not).
+
+**6. M5 multiprocessing "if safe" is not actionable**
+"If safe" is undefined. Ownership semantics across process boundaries, fork vs. spawn vs. forkserver start methods, and shared memory safety in Sifr's type system are non-trivial design questions. Pre-flag which start methods are in scope, what "safe" means (no shared mutable references across process boundary?), or waive multiprocessing entirely with rationale. The current wording blocks the implementor.
+
+**7. Signal handler design unspecified**
+"Cautious handler registration" is not defined. Signal handlers in CPython are process-global, fire on arbitrary threads, and interact with the event loop. In Sifr's ownership model, a closure capturing state in a signal handler raises lifetime questions. The plan needs either a concrete design (handler signatures, allowed captures, interaction with the async runtime) or a narrowed scope (signal constants + `raise_signal` only, no custom handlers).
+
+**8. M8 has no acceptance criteria**
+"Production gate docs/demos/validation" is a milestone with zero defined deliverables. What demos are required? What validation suite must pass? What documentation must exist? Without this, M8 cannot be declared done.
+
+---
+
+### Significant gaps (will cause mid-milestone rework)
+
+**9. No milestone dependency graph**
+M3 depends on M1 (sockets) and M2 (TLS). M4 async subprocess depends on M1's async runtime. M5 `ThreadPoolExecutor`/`ProcessPoolExecutor` depends on M4 subprocess. M6 `asynccontextmanager` depends on async from M1. None of these are stated. Teams starting M3 or M5 in parallel with M1 will hit blockers.
+
+**10. No cross-cutting error type mapping decision**
+CPython raises `OSError` subclasses across all of M1–M4 (`socket.error`, `ssl.SSLError`, `ssl.CertificateError`, `subprocess.CalledProcessError`, `TimeoutExpired`, etc.). Sifr uses `Result`/`Option` instead of exceptions. How each error type maps to Sifr `Result` variants is a design decision that cuts across every milestone. If left until implementation, it will produce inconsistent APIs. This needs a single design note or a shared error-type spec before M1 begins.
+
+**11. `concurrent.futures` test package complexity understated**
+The CPython evidence shows `test_concurrent_futures` is a package (multiple files), indicating broad test coverage. The plan should explicitly state that the test suite will be mirrored for all executor types, not just the happy-path APIs, and that fork/spawn/forkserver variants in `multiprocessing` tests are accounted for.
+
+**12. `warnings` global-state concurrency design missing**
+M6 mentions "concurrency-safe state" for `warnings` but gives no mechanism. CPython's `warnings` module uses process-global mutable filter lists and per-module `__warningregistry__` dicts. Sifr's ownership model requires an explicit choice (e.g., `Mutex`-guarded global, thread-local registries). This needs a design note.
+
+**13. `locale` process-global hazard unaddressed**
+M7 acknowledges locale is process-global but does not address how Sifr exposes it in a concurrent/async context. At minimum, locale-mutating functions must be flagged as unsafe to call concurrently, or the scope must be narrowed to read-only locale queries.
+
+---
+
+### Minor gaps (can be resolved during implementation)
+
+- `urllib.response` vs. `urllib.request`'s response object are conflated in the target list — clarify which is in scope.
+- M0 "adopted/adapted/waived matrix" needs a defined output format and owner before M1 starts, otherwise M1 begins without the inventory.
+- `asyncio.Queue` is placed in M5 but depends on the async runtime established in M1; note the dependency explicitly.
+
+---
+
+**FAIL**
+
+The plan cannot be handed to an implementor as written. Seven items are blocking: missing `socketserver` scope, undefined socket C module waive decisions, absent async SSL design, undefined async HTTP deliverables, unresolved generator prerequisite for M6, vague multiprocessing safety criteria, and absent M8 acceptance criteria. These must be resolved before M1 begins.

--- a/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-2.md
+++ b/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-2.md
@@ -1,0 +1,26 @@
+## Remaining Blockers
+
+**1. Async runtime unnamed (M2, M3, any async module)**
+Neither M2 nor M3 names the backing async runtime or Rust crate (tokio, async-std, custom). Sifr requires "real async suspension" and the codegen/driver crates need a concrete decision before any async module can be implemented. This is architecturally prior to both milestones.
+
+**2. `contextmanager` class-based fallback conflicts with Sifr's no-fallback rule**
+AGENTS.md states "Do NOT create fallback paths or solutions unless explicitly requested." The remediation proposes a class-based fallback if generators aren't ready. Either the fallback is removed (contextmanager is simply unsupported until generators ship) or an explicit owner exception must appear in the plan. As written it violates a hard constraint.
+
+**3. `signal.signal` decision deferred, not made**
+"Defaults to intentional-diff unless a design note proves..." is not a decision — it is a conditional that leaves the milestone scope open at implementation start. The plan must state: supported with these semantics, or unsupported. Deferring to a future design note is not implementation-ready.
+
+**4. M3 HTTP ↔ M2 TLS dependency not declared**
+HTTPS in M3 depends on `AsyncTlsStream` from M2. The milestone dependency graph should make this explicit; without it, M3 cannot be scheduled and the graph is incomplete.
+
+**5. `socketserver` mixin safety unaddressed**
+`ThreadingMixIn` and `ForkingMixIn` are the primary composition points for socketserver. `ForkingMixIn` intersects M5's fork safety rules directly. Neither mixin's status (supported/unsupported/scoped) is named, leaving a surface area gap in the module scope.
+
+**6. `wrap_socket` async-overload approval path is undefined**
+"Sync-only unless typed async overload is approved" — approved by whom, in what process, before or during M2? For implementation-ready, this must be a committed decision, not a gate to an undefined process.
+
+**7. `multiprocessing.Pool` absent from typed-IPC scope**
+`Pool` is the primary high-level multiprocessing API. Its work-item and result channels need typed IPC, but M5 only addresses `Value`/`Array`/`shared_memory`. Pool's scope (in or out, and under what constraints) must be stated.
+
+---
+
+FAIL

--- a/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-3.md
+++ b/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-3.md
@@ -1,0 +1,19 @@
+Reviewing each remediation against the original blocker:
+
+1. **Tokio named** — Closed. Runtime is unambiguous, M0 scope is concrete, and the "no public Tokio types" guardrail prevents future leakage.
+
+2. **contextmanager** — Mostly closed, but one residual sharpness issue: "unsupported *if* generator semantics are not production-ready" is conditional. Implementors need to know generator semantics status *now* to scope their work. If the answer is already known, the plan should state it flatly ("decorator-based contextmanager is out of scope for this phase" or "in scope"). A live conditional invites scope drift mid-implementation. Minor, but worth a one-line resolution before handoff.
+
+3. **signal.signal deferred** — Closed. Async signal stream as conditional canonical alternative is acceptable.
+
+4. **M3 HTTP/TLS dependency** — Closed. Dependency graph is unambiguous.
+
+5. **socketserver mixins** — Closed. Unsupported with clear alternative stated.
+
+6. **wrap_socket async gate** — Closed. Sync-only boundary is crisp.
+
+7. **multiprocessing.Pool** — Closed. Gating on the same typed IPC contract as ProcessPoolExecutor is a strong, enforceable condition; the "otherwise unsupported" fallback is consistent with Sifr's no-fallback rule.
+
+**Remaining issue**: Blocker 2's conditional phrasing on contextmanager decorator support. It is not a design gap — the underlying logic is correct — but it is an open branch that implementors cannot resolve from the document alone.
+
+FAIL

--- a/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-4.md
+++ b/reviews/ad-hoc-production-stdlib-platform-parity-planning-review-pass-4.md
@@ -1,0 +1,19 @@
+Reviewing the stated resolutions against the phase scope:
+
+**contextmanager/asynccontextmanager** — Clean. Unsupported + revisit rule, no partial generator path, class-based APIs stand independently. No leakage between the two tracks.
+
+**Tokio named backing runtime** — Clean. Naming resolves the async executor identity/lifecycle ambiguity.
+
+**M3 HTTPS / M2 AsyncTlsStream dependency** — Clean. Explicit milestone sequencing, no premature stub.
+
+**signal.signal custom handlers** — Clean. Unsupported with no fallback; default-signal behavior remains in scope if implemented separately.
+
+**socketserver ThreadingMixIn/ForkingMixIn** — Clean. These require OS-level fork/thread dispatch semantics that belong outside this phase.
+
+**SSLContext.wrap_socket sync-only** — Clean. Sync constraint is consistent with no async TLS path in this phase.
+
+**multiprocessing.Pool / ProcessPoolExecutor typed IPC gate** — Clean. Sharing the gate avoids duplicated typed-channel infrastructure without coupling semantics.
+
+No gaps are left unresolved or partially resolved. All unsupported items have explicit revisit rules rather than stub implementations, which is consistent with the no-fallback-path requirement.
+
+PASS

--- a/reviews/ad-hoc-stdlib-namespace-contract-corpus-review-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-corpus-review-pass-1.md
@@ -1,0 +1,25 @@
+## Verdict: READY
+
+## Assessment
+
+The final corpus milestone (`milestone_stdlib_namespace_3: Corpus Adoption And Closeout`) satisfies all three stated requirements:
+
+**1. All LeetCode examples work** — covered by:
+- Explicit per-file discovery listing 11 fixtures requiring updates (defaultdict, Counter, heapq forms), plus 11 explicitly named fixtures that must remain green.
+- Sweeping requirement: "All checked-in LeetCode `.sifr` fixtures must compile and run under the post-cleanup namespace contract."
+- Validation command requirement, with explicit guidance not to depend on `audits/leetcode/run_audit.py` unless it is fixed to validate the checked-in corpus without regenerating from external paths.
+- Exit Gate 6 locks this: "All checked-in LeetCode `.sifr` fixtures compile and run."
+
+**2. All demos work** — covered by:
+- Explicit per-file discovery for `demos/defaultdict/main.sifr`, `demos/collections_and_argparse/main.sifr`, and five "must remain green" demos.
+- Comment/label cleanup items called out explicitly (`core_libraries`, `stdlib_classes`, `advanced_class_libraries`) and a false positive (`subscript_assignment`) classified.
+- Validation command requirement with a documented exclusion list constraint: "all non-negative demo `main.sifr` entrypoints must work."
+- Exit Gate 7 locks this: "All runnable demos compile and run."
+
+**3. Full discovery of what needs updating** — covered by:
+- Quantified scope (416 LeetCode fixtures, 389 demo files including 310 `main.sifr` entrypoints).
+- Per-file named impact for both corpora plus e2e fixture grep ownership in M2.
+- Explicit re-discovery requirement in M3: "Repeat namespace-impact discovery across `audits/leetcode/src`, `demos`, `crates/sifr/tests/e2e/pass`, and `crates/sifr/tests/e2e/fail` after M2 lands," with the rationale recorded ("new checked-in examples may appear while earlier milestones are landing").
+- Validation ledger evidence requirement (repeated discovery must show no unclassified bare stdlib uses).
+
+The final corpus milestone is implementation-ready.

--- a/reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-1.md
@@ -1,0 +1,9 @@
+1. **Verdict: READY**
+
+2. **Blocking gaps:** None.
+
+3. **Non-blocking observations:**
+   - The `collections_and_argparse/main.sifr` direction ("either remain a real `sifr.collections` API call or be rewritten") leaves the implementer a small judgment call, but the contract makes the constraint clear: it must compile under the post-cleanup namespace, so the outcome is bounded.
+   - The phase relies on `is_compat_stdlib_alias` remaining in place "unless the implementation proves no retained path can reach it" — the implementer is permitted to remove it conditionally, which is appropriately scoped and not a hidden policy decision.
+
+4. The phase is implementation-ready and no hidden decisions remain. The namespace contract, diagnostic code/ownership/transport, atomic-removal scope (including class-field inference, synthetic-import consumers, `__compat_defaultdict_*` rename, and codegen test cleanup), explicit `defaultdict` binding state, exact-tail/root-fallback matching, duplicate-prevention rule, corpus adoption scope for LeetCode and demos, guardrail greps, and validation gates are all locked. No legacy/compat loopholes, flags, or staged-deprecation bridges remain.

--- a/reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-2.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-final-implementation-readiness-pass-2.md
@@ -1,0 +1,11 @@
+1. **Verdict: READY**
+
+2. **Blocking gaps:** None.
+
+3. **Non-blocking observations:**
+   - The phase now explicitly resolves the prior pass-1 judgment call: `demos/collections_and_argparse/main.sifr` is to be rewritten to either the typed `defaultdict(int)` surface or an ordinary `dict` helper, and the older `defaultdict(0)` class-style API in `lib/sifr/collections.sifr` is removed/renamed in the same M2 milestone. No ad-hoc policy decision is left for the implementer.
+   - The `Defaultdict Contract` section, M2 task list, and Exit Gate 4 are now mutually consistent on "no transitional support for bare `defaultdict(...)` or `collections.defaultdict(...)`" and on the single public meaning of `from sifr.collections import defaultdict`.
+   - Layer ownership, duplicate-prevention rule, diagnostic transport (`HirDiagnostic.args` + `imported_names` as comma-separated string), exact-tail/root-fallback matching, explicit defaultdict binding state, class-field inference cleanup, synthetic-import consumer removal, `__compat_defaultdict_*` -> `__sifr_defaultdict_*` rename, guardrail greps, and corpus adoption with explicit validation commands are all locked.
+   - Discovery-vs-lowering carveouts for `Stmt::Import` (lowering-owned in all modes) and `compile_order.rs` / dependency collectors (no `SIFR-IMPORT-0008` emission) are explicit, so no implementer has to invent a policy.
+
+4. **The phase is implementation-ready and no hidden decisions remain.** The plan locks the `defaultdict(int/list/set)` typed factory contract as the sole public `sifr.collections.defaultdict` surface, removes the older `defaultdict(0)` API atomically, and gives the implementer a complete, contradiction-free contract for diagnostics, lowering, codegen, guardrails, and corpus validation.

--- a/reviews/ad-hoc-stdlib-namespace-contract-final-readiness-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-final-readiness-pass-1.md
@@ -1,0 +1,24 @@
+Verdict: READY
+
+The phase is implementation-ready and no hidden compatibility-call shim decisions remain.
+
+Blocking gaps: none. The plan resolves every code path surfaced in the local scan:
+
+- `resolve_python_compat_call_alias` (math/heapq/collections non-defaultdict) → removed in M2; `collections.defaultdict` and bare `defaultdict` short-circuits → removed in M3; transitional helper named.
+- `resolve_bare_python_compat_call_alias` (deque/Counter) → removed in M2; bare `defaultdict` → M3 via `explicit_defaultdict_bindings`.
+- `synthetic_imports` / `synthetic_import_aliases` / `ensure_synthetic_stdlib_import` and the `mod_impl.rs` consumer → producer and consumer removal both pinned in M2, with M4 grep guardrail.
+- `mod_impl.rs` generic `Stmt::Import` unsupported diagnostic → replaced by lowering-owned `SIFR-IMPORT-0008` only when the module matches a stdlib tail.
+- `call_builtins.rs` unconditional bare `defaultdict` → removed in M3, gated on explicit binding state.
+- `class_field_inference.rs` bare deque/Counter and bare defaultdict inference → deque/Counter removed in M2, defaultdict gated on the explicit binding state in M3.
+- `HirDiagnostic` lacking args → M1 adds `args` plus `LowerCtx::error_with_code_args_at` and frontend rendering thread-through; scalar-only `DiagnosticArg` handled by the comma-separated `imported_names` decision (with explicit empty-string rule for `Stmt::Import`).
+- Driver `discovery` / `package_discovery` `ImportFrom` ownership and `Stmt::Import` exclusion → explicitly assigned, with duplicate-prevention rule.
+- `compile_order.rs`, `query_diagnostics.rs`, `module_signatures.rs` → explicitly carved out as non-emitters.
+- `STDLIB_SOURCES`-derived tail set with exact-then-root matching and `_sifr.*` exclusion → fully specified via shared `sifr_stdlib` helpers.
+- `__compat_sifr_math/heapq/collections` codegen canonicalization and tests → M2 removal; retained async/task aliases carved out in Decision 8 with the generic `is_compat_stdlib_alias` guard intentionally kept.
+- `__compat_defaultdict_*` → renamed to `__sifr_defaultdict_*` in M3, with M4 guardrail.
+- Demos/e2e bare usage → M2 grep-driven classification across the three named directories.
+
+Non-blocking observations:
+
+- M4's first guardrail grep covers `math|heapq|collections` synthetic aliases but not bare `deque`/`Counter` synthetic generation. The producers (`resolve_bare_python_compat_call_alias`, `synthetic_imports`, `synthetic_import_aliases`) are already covered by the second M4 grep, so this is not a gap, just worth noting that bare-class compat regressions are caught via the producer grep rather than an alias-name grep.
+- Decision 8 retains `__compat_sifr_sync_*` and `__compat_sifr_concurrent_*`; the renaming sweep that aligns `__compat_*` semantics with "compatibility paths only" is intentionally deferred. The plan states this explicitly, so no edit needed.

--- a/reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-1.md
@@ -1,0 +1,170 @@
+# CHANGES_REQUESTED
+
+The previous READY was premature. The plan has a load‑bearing API impossibility and several unmade cross‑layer decisions. Below is what must be locked in before this becomes implementable.
+
+---
+
+## 1. Machine-readable diagnostic args — currently impossible from lowering
+
+The plan says SIFR-IMPORT-0008 "must include machine-readable diagnostic data: `bare_module`, `suggested_module`, and `imported_names`". The lowering pipeline cannot do this today:
+
+- `HirDiagnostic` (`crates/sifr_ir/src/diagnostic_types.rs:6`) is `{ code, message, primary_range, line, col }` — **no args/data field**.
+- `LowerCtx::error_with_code_at` (`crates/sifr_lowering/src/lower/mod_context.rs:180`) takes only `(code: DiagnosticCode, message: String, range: TextRange)`. There is no template/args plumbing.
+- Driver-level callers (`discovery.rs:268-337`, `package_discovery.rs:152-275`) emit through `DiagnosticBuilder::source(...).arg(name, DiagnosticArg::String(...))` because they construct rendered diagnostics directly. Lowering does not.
+
+Lock one of these in the plan, with the API change spelled out:
+
+- **(A) Extend the HIR diagnostic transport** — add `args: Vec<(String, DiagnosticArg)>` (or equivalent) to `HirDiagnostic` and a sibling `error_with_code_args_at` (or expand `error_with_code_at`) on `LowerCtx`. Then thread args through `hir_diagnostic_to_rendered` in `query_diagnostics.rs:117-128`+ to land on the rendered diagnostic. List the touched files; this is not a trivial extension and currently has no decision in the plan.
+- **(B) Emit SIFR-IMPORT-0008 only from the driver layer** — keep lowering's diagnostic message-only (or drop it entirely) and centralize structured emission in `discovery.rs` / `package_discovery.rs` where `DiagnosticBuilder` is already in use. This implies single-file lowering can't carry the structured args; you must decide whether that's acceptable.
+- **(C) Drop the machine-readable args requirement** and update the contract harness expectations.
+
+The current plan paper-shuffles past this. As written, M1 is unimplementable.
+
+---
+
+## 2. Layer ownership of SIFR-IMPORT-0008 is undecided
+
+The plan says "top-level user/package resolution comes before bare-stdlib diagnostics" but never says **which layer** emits the diagnostic in each mode. The real layer matrix today:
+
+| Mode | `from math import sqrt` | `import math` |
+|---|---|---|
+| Single-file | `mod_impl.rs:468` → `unknown_import_target` (`IMPORT_UNKNOWN_SOURCE_MODULE`) | `mod_impl.rs:611-620` → `unsupported_form` (`IMPORT_UNSUPPORTED_FORM`) |
+| Project | `discovery.rs:268-285` → `IMPORT_UNKNOWN_SOURCE_MODULE` with `tried_paths` (before lowering ever runs) | discovery silently ignores `Stmt::Import`; lowering then emits `IMPORT_UNSUPPORTED_FORM` |
+| Package | `package_discovery.rs:152-207` → `IMPORT_UNKNOWN_SOURCE_MODULE` | silently dropped (package code only walks `Stmt::ImportFrom`) |
+
+Pick the ownership rule explicitly. Recommended:
+
+- Project mode: discovery emits SIFR-IMPORT-0008 **after** workspace resolution returns `Unresolved` AND the unresolved module name matches a bare stdlib tail. Mention `discovery.rs:159-164` (Unresolved arm) as the patch site and `discovery.rs:268-285` (`to_source_diagnostic` unresolved arm) as where the args/template change.
+- Package mode: same as project — `package_discovery.rs:152-207` checks tail set before falling through to generic `IMPORT_UNKNOWN_SOURCE_MODULE`.
+- Single-file: lowering owns it (`mod_impl.rs:460-468` for `Stmt::ImportFrom`, `mod_impl.rs:611-620` for `Stmt::Import`). Specify whether structured args land here (depends on decision in §1).
+
+Without naming the patch sites, M1 has no scope.
+
+---
+
+## 3. `Stmt::Import` is invisible to four out of five collectors
+
+You correctly flagged five collectors today, but the plan never says how to fix the `Stmt::Import` asymmetry:
+
+- `crates/sifr_driver/src/project/discovery.rs:528-558` — `collect_import_closure_module_dependencies` destructures `Stmt::ImportFrom` only.
+- `crates/sifr_driver/src/project/compile_order.rs:21-83` — same.
+- `crates/sifr_driver/src/project/package_discovery.rs:432-505` — same.
+- `crates/sifr_frontend/src/query_diagnostics.rs:48-78` — same.
+- `crates/sifr_frontend/src/module_signatures.rs:91-120` — same.
+
+So in project/package mode, `import math` is invisible to discovery, **never gets a tried_paths diagnostic, and currently falls through to lowering's `IMPORT_UNSUPPORTED_FORM`**. The plan's stated intent ("SIFR-IMPORT-0008 covers both `Stmt::Import` and `Stmt::ImportFrom`") cannot be honored in project mode unless either:
+
+- discovery starts walking `Stmt::Import` (at least for the bare-stdlib detection — not for dependency edges, since `import math` doesn't import a module-object today), OR
+- lowering's `Stmt::Import` branch at `mod_impl.rs:611-620` is explicitly rewritten to detect bare stdlib tails and emit SIFR-IMPORT-0008 instead of (or in addition to) `IMPORT_UNSUPPORTED_FORM`, **and** discovery is documented as intentionally silent for `Stmt::Import`.
+
+Pick one and name the file. The plan does not currently mention `mod_impl.rs` at all even though that's where the existing unsupported-form text lives.
+
+For the frontend collectors (`query_diagnostics.rs`, `module_signatures.rs`), state explicitly that no change is needed because they don't emit user-facing diagnostics and bare-stdlib imports legitimately do not contribute to local dependency edges or signature hashes. Otherwise reviewers will keep flagging them.
+
+---
+
+## 4. Duplicate-diagnostic prevention rule is missing
+
+In project mode, `from math import sqrt` hits both:
+
+1. `discovery.rs` (resolver fails → emits some import diagnostic), and
+2. lowering's `resolve_imports_early` + `mod_impl.rs` ImportFrom path (which today emits `IMPORT_UNKNOWN_SOURCE_MODULE` again via `external_module_exists` returning false).
+
+If both layers add bare-stdlib detection, both will emit SIFR-IMPORT-0008 for the same statement. Lock down a single-emitter rule, e.g.:
+
+> In project/package mode, discovery emits SIFR-IMPORT-0008 and short-circuits closure traversal for that module. Lowering's `resolve_imports_early` and `mod_impl.rs` ImportFrom path treat a known bare stdlib tail as a recognized import that has already been diagnosed at the discovery layer — they skip the `external_module_exists` check, do not register any bindings, and do not push to `imports`, leaving subsequent name resolution to fail at the use site under the existing missing-name diagnostics.
+
+Either that, or the inverse (lowering owns it; discovery filters bare-stdlib tails the same way it filters `sifr.*` / `_sifr.*` and never tries to resolve them). The plan needs the rule written down.
+
+---
+
+## 5. Probe-then-diagnose order vs. tail short-circuit
+
+You explicitly asked about this. The phase doc already says "User or package modules named `math`, `json`, or similar therefore keep priority once they are real import targets" — that resolution-then-diagnose order is correct and should stay. Re-state it as a concrete rule for `discovery.rs`:
+
+> `ResolutionFailureKind::Unresolved` for `module_name` shall be reclassified into `BareStdlib` (a new `ResolutionFailureKind` variant) if `module_name`, or its leading dotted root, is a bare stdlib tail and no workspace candidate file matched. The reclassification happens **after** all workspace candidates have been probed, preserving today's behavior when a real `math.sifr` exists. The reclassification site is `resolve_with_provider` at `discovery.rs:159-164`, and `to_source_diagnostic` gains a corresponding arm emitting `IMPORT_BARE_STDLIB` with `bare_module`, `suggested_module`, `imported_names`.
+
+Package mode needs the symmetrical reclassification site in `package_discovery.rs`.
+
+---
+
+## 6. Tail-set construction and matching semantics
+
+The phase doc gestures at "stripping the leading `sifr.` from each embedded stdlib module name" and "dotted tails such as `collections.abc` are matched as full tails and by their root". This is not implementable as written. Lock down:
+
+- The tail set is derived from `sifr_stdlib::STDLIB_SOURCES` at compile time. Add a helper, e.g. `sifr_stdlib::bare_stdlib_tails() -> &'static BTreeSet<&'static str>` (or a `is_bare_stdlib_tail(&str) -> bool` predicate), so discovery and lowering share the same source of truth.
+- Matching is **exact full-tail first**, then **leading-root fallback**. Concretely, for input `m`:
+  - if `m` ∈ tail_set → match `m`, suggest `sifr.m`;
+  - else if any prefix `r` of `m.split('.')` with `r` ∈ tail_set → match `r`, suggest `sifr.r`;
+  - else not a bare stdlib import.
+- For `from collections.abc import Iterable`, the `module_name` is `collections.abc`. State explicitly which behavior the plan wants: (a) if `collections.abc` is in `STDLIB_SOURCES`, suggest `from sifr.collections.abc import Iterable`; (b) otherwise fall back to root match and suggest `from sifr.collections.abc import Iterable` with `bare_module = "collections.abc"`, `suggested_module = "sifr.collections.abc"` — **do not** rewrite to `from sifr.collections import abc`, which would be wrong. Today `STDLIB_SOURCES` likely does not have `sifr.collections.abc`, so name the current behavior explicitly so M1 tests can assert it.
+- For `import collections.abc`, the suggestion text in the phase doc says "suggest the corresponding `sifr.collections.abc` path only if that embedded stdlib module exists; otherwise report `collections` with `sifr.collections`". Reconcile this with the `from collections.abc import Iterable` form so the two forms agree.
+
+---
+
+## 7. The plan's framing of today's behavior is wrong in places
+
+The phase doc says bare stdlib imports "either silently no-op and fail later at the use site or hit generic unsupported-import diagnostics". In reality:
+
+- Single-file `from math import sqrt` does **not** silently no-op — `mod_impl.rs:468` emits `IMPORT_UNKNOWN_SOURCE_MODULE` "unknown import target: 'math'".
+- Single-file `import math` emits `IMPORT_UNSUPPORTED_FORM`, not "unknown".
+- Project `from math import sqrt` emits `IMPORT_UNKNOWN_SOURCE_MODULE` with a workspace-path tried list (not at the use site, and not unsupported-form).
+
+Fix the framing so subsequent reviewers don't have to re-derive it. This also affects M1's test matrix — you need an explicit "before/after" pair for each of (single-file × project × package) × (`Stmt::Import` × `Stmt::ImportFrom`), with the existing diagnostic code (`IMPORT_UNKNOWN_SOURCE_MODULE` / `IMPORT_UNSUPPORTED_FORM`) named in the "before" column.
+
+---
+
+## 8. M1 test scope under-specifies the layer coverage
+
+M1 lists test cases at the diagnostic level but not at the layer level. Required additions:
+
+- Project-mode test: place a `main.sifr` with `from math import sqrt` under a workspace that does **not** contain `math.sifr` → expect `SIFR-IMPORT-0008`, not `IMPORT_UNKNOWN_SOURCE_MODULE`. Pair with a positive test that places `math.sifr` in a source root and asserts that `from math import sqrt` resolves to the user file (proves the resolution-priority decision).
+- Package-mode test: same shape, under `package_discovery.rs`.
+- Single-file test: covers both `Stmt::Import` and `Stmt::ImportFrom`.
+- A `cargo run -- check` CLI fixture under the verification harness producing the human/json/compact tri-output, since the existing diagnostic-contract harness (`crates/sifr_driver/src/bin/diagnostic_contract_harness.rs:34-60`) enforces the args set. New args (`bare_module`, `suggested_module`, `imported_names`) need to be registered there explicitly.
+
+M1 must also state whether `SIFR-IMPORT-0008` shares args with `IMPORT_UNKNOWN_SOURCE_MODULE` or defines its own arg set — the harness contract is structural.
+
+---
+
+## 9. M1/M2/M3 sequencing has a hidden cross-layer dependency
+
+M1 is "policy and diagnostics" only, but if the diagnostic is partly owned by `discovery.rs`/`package_discovery.rs`, M1 must also patch:
+
+- `collect_import_closure_module_dependencies` (or a sibling pass) to detect the bare-stdlib tail.
+- A new `ResolutionFailureKind::BareStdlib` variant and its `to_source_diagnostic` arm.
+- `package_import_source_diagnostic` reclassification.
+- Frontend layer documentation that explicitly says "no change needed here".
+
+If you keep M1 strictly lowering-side and defer the discovery/package patches, then in project mode the new diagnostic literally cannot fire for `from math import sqrt`, since discovery will short-circuit with `IMPORT_UNKNOWN_SOURCE_MODULE` before lowering runs. Decide:
+
+- **(i)** Expand M1 to include the discovery+package patches, OR
+- **(ii)** Split off a new milestone M1.5 (or fold into M1) that explicitly does the discovery+package work; keep M2 (synthetic-import removal) and M3 (defaultdict) where they are; renumber M4 → M5.
+
+Option (ii) keeps M1 focused but the phase doc currently does neither — it leaves the discovery layer unaddressed.
+
+---
+
+## 10. Smaller things still worth pinning down
+
+- M2 says "Remove the consuming site in `crates/sifr_lowering/src/lower/mod_impl.rs` that extends final `imports` with `ctx.synthetic_imports`". Reference the exact line (`mod_impl.rs:647`) and note that `imports::report_unknown_stdlib_module` (line 460) is the related path that emits the deferred-compat module diagnostic — confirm whether `deferred_compat_module` paths are retained or also rewritten under the bare-stdlib contract for `sifr.*` deferred modules (e.g., `sifr.selectors`, `sifr.contextvars`).
+- M3's "record explicit imported special constructors in lowering state" needs to name the state field (`ctx.defaultdict_bindings: HashMap<String, ()>` or similar) and the lookup point in `lower_call` / `call_builtins.rs`. The call site is in `call_builtins.rs` based on the phase doc, but the field is unspecified.
+- The plan should clarify whether `from sifr.collections import defaultdict, deque` (mixed factory + non-factory) is allowed in M3 or kept as today's behavior. Currently `deque(...)` works through synthetic-import compat (which M2 removes), so the M2 → M3 transition needs an explicit "after M2 lands, `deque(...)` requires `from sifr.collections import deque`; this is exercised by the explicit-import demos updated in M2".
+- The M4 guardrail grep `rg "__compat_sifr_(math|heapq|collections)_"` should also cover `crates/sifr_type_system/src` since type-rendering code might still mention old aliases.
+- Decision 7 says the `__compat_defaultdict_*` → `__sifr_defaultdict_*` rename happens in M3, but the M4 grep `rg "__compat_defaultdict_"` will only pass if M3 finishes the rename across `sifr_codegen` type rendering too. State the file set: lowering, type rendering, codegen, snapshot fixtures.
+
+---
+
+## Required edits to mark the phase READY
+
+In `issues/ad-hoc-stdlib-namespace-contract-and-compat-cleanup.md`:
+
+1. **Diagnostics Contract** section: add an explicit "Layer ownership" subsection naming the patch sites for single-file / project / package modes and the duplicate-emitter rule.
+2. **Diagnostics Contract** section: replace "include machine-readable diagnostic data" with the chosen option from §1 above, including any required `HirDiagnostic` / `LowerCtx` API extension (with the touched files listed) or the explicit "structured args only emitted from the driver layer" carveout.
+3. **Namespace Policy** section: replace the prose tail-set description with the exact-match-then-leading-root rule and reference the new `sifr_stdlib` helper.
+4. **Context** section: correct the "silently no-op or generic unsupported-import" framing using the today-state table above.
+5. **Milestones / M1**: expand to include the discovery+package work (or add a dedicated milestone) with file-level patch sites; expand the test list to cover all three modes for both `Stmt::Import` and `Stmt::ImportFrom`; add the diagnostic-contract-harness arg registration.
+6. **Milestones / M3**: name the lowering state field and the call lookup site for explicit defaultdict bindings; declare the M2 → M3 transition state for `deque`/`Counter` post-synthetic-removal.
+7. **Exit Gates** / **M4 guardrails**: extend grep scope to `sifr_type_system` and confirm the renamed-name guardrail.
+
+After those edits I expect the phase to be implementable without further cross-layer surprises. Until they're in, this is **CHANGES_REQUESTED**.

--- a/reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-2.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-gap-audit-pass-2.md
@@ -1,0 +1,30 @@
+I've read the plan, execution doc, gap audit pass 1, and verified against the actual source. Now the brutal verdict.
+
+# READY
+
+All pass 1 blockers are now locked. Spot-checked each decision against the code that has to change:
+
+| Pass 1 blocker | Pass 2 resolution | Verified against |
+|---|---|---|
+| §1 args plumbing impossible | "Diagnostic Transport" subsection: add `args` field to `HirDiagnostic`, `LowerCtx::error_with_code_args_at`, thread through `query_diagnostics.rs` | `sifr_ir/src/diagnostic_types.rs:6` confirms the field is missing today; `query_diagnostics.rs:117-148` already supports arg passthrough on top of `"{message}"`, so the template question is non-blocking |
+| §2 layer ownership undecided | "Layer Ownership" subsection splits project/package `ImportFrom`→discovery, single-file `ImportFrom`→lowering, all-mode `Import`→lowering | `discovery.rs:589-628` already `return Err(...)` short-circuits before lowering, making the rule mechanically realizable |
+| §3 `Stmt::Import` asymmetry | Explicit: lowering owns `Stmt::Import` in `mod_impl.rs`; discovery intentionally silent; frontend collectors carved out | `mod_impl.rs:611-620` is the named site; carveout text covers `query_diagnostics.rs` + `module_signatures.rs` |
+| §4 duplicate prevention | "Duplicate prevention rule" paragraph + discovery fail-fast | Confirmed by `parse_import_closure_source_modules` early return |
+| §5 probe-then-diagnose | "Bare module names ... are rejected ... only after normal top-level user/package resolution fails" + project mode probes workspace candidates first | Matches existing `Unresolved` path |
+| §6 tail matching | Exact-tail-first then leading-root, with concrete `is_bare_stdlib_tail` helper and three worked examples | Implementable from `STDLIB_SOURCES` |
+| §7 today-state framing | "Current bare stdlib import diagnostics are inconsistent" table in Context | Matches actual emission sites |
+| §8 M1 test scope | M1 enumerates project/package/single-file × `Import`/`ImportFrom`, plus harness arg registration | Matches `diagnostic_contract_harness.rs:30-75` shape |
+| §9 cross-layer sequencing | M1 explicitly owns discovery+package+lowering+frontend rendering | Single milestone, no orphan |
+| §10 smaller items | `explicit_defaultdict_bindings` named, M4 grep extended to `sifr_type_system`, deque/Counter transition stated | All present |
+
+## Non-blocking nits (not gating)
+
+These are clarity improvements I'd accept post-implementation, not blockers:
+
+- `crates/sifr_driver/src/project/compile_order.rs:22,58` walks `Stmt::ImportFrom` only and filters by `local_modules` — never emits diagnostics, never contributes bare-stdlib edges. The "no change needed" carveout only names the two frontend collectors; `compile_order.rs` rides the same reasoning but isn't explicitly listed. Trivial to derive.
+- Single-file `Stmt::ImportFrom` patch site isn't pinpointed to `mod_impl.rs:460-468` / `import_diagnostics::unknown_import_target`, but "the import resolution path" is unambiguous given the only relevant site is right there.
+- `imports::report_unknown_stdlib_module` for unknown `sifr.*` modules (e.g. `sifr.selectors`) is implicitly retained — Non-Goals and the SIFR-IMPORT-0008 scope (bare names only) make this clear, but the plan doesn't restate it.
+- `imported_names` arg semantics for `import math` (empty) vs `from math import sqrt as s` (alias preservation) is left to the implementer.
+- "Add an `args` field … or an equivalent typed diagnostic payload" leaves the exact shape to the implementer; acceptable design latitude.
+
+None of these block M1. Proceed.

--- a/reviews/ad-hoc-stdlib-namespace-contract-no-legacy-review-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-no-legacy-review-pass-1.md
@@ -1,0 +1,22 @@
+# Review: Stdlib Namespace Contract And Compatibility Cleanup
+
+## 1. Verdict
+
+**READY**
+
+## 2. Loophole check
+
+The phase has no backward-compatibility or legacy-support loopholes for CPython-style bare stdlib calls. Specifically:
+
+- **Objective and contract**: explicitly disclaims backward compatibility, legacy support, staged deprecation, compatibility warnings, and temporary bridges for Python-shaped stdlib calls. The "no intermediate production state" sentence locks this in.
+- **Locked Decisions 1, 2, 7**: bare CPython names are not aliases "in any edition, manifest option, warning mode, migration mode, or deprecation track," and compatibility is removed atomically with no transitional production bridge.
+- **Non-Goals**: explicitly bars `--python-compat` mode, `sifr.toml` opt-in, transitional support, compatibility warnings, deprecation periods, and legacy fallback.
+- **M2 (Atomic Compatibility Removal)**: removes `math.*`, `heapq.*`, non-`defaultdict` `collections.*`, bare `deque(...)`, bare `Counter(...)`, `collections.defaultdict(...)`, and bare `defaultdict(...)` in a single milestone. The class-field inference compatibility paths for `deque`, `Counter`, and bare `defaultdict` are removed in the same milestone, and `__compat_defaultdict_*` is renamed to `__sifr_defaultdict_*` atomically with the binding change — so no `__compat_defaultdict_*` survives the explicit-binding cutover.
+- **Planning review pass 2 note**: the previously requested transitional defaultdict helper is explicitly superseded by the no-legacy-support clarification; the prior M2/M3 split is no longer in effect.
+- **Retained surfaces (Locked Decision 9)**: `__compat_sifr_sync_*`, `__compat_sifr_concurrent_*`, generic async/task defensive codegen checks, and the `is_compat_stdlib_alias` codegen guard are intentionally retained, but they support **explicitly imported** `sifr.asyncio` / `sifr.task` / `sifr.sync` / `sifr.concurrent` — not CPython-style bare stdlib calls. They do not constitute a bare-stdlib compatibility loophole; they are out-of-scope internal bookkeeping for already-explicit `sifr.*` imports.
+- **`import sifr.math` keeps unsupported-import-form behavior**: this is not legacy bare-stdlib preservation; module-object imports are simply unsupported at the language level, and the diagnostic reflects that.
+- **M3 guardrails**: ripgrep-driven checks fail the build if any production code still synthesizes `__compat_sifr_(math|heapq|collections)_*`, `__compat_defaultdict_*`, `resolve_python_compat_call_alias`, `resolve_bare_python_compat_call_alias`, `synthetic_imports`, or `synthetic_import_aliases`.
+
+## 3. Confirmation
+
+The phase has no backward-compatibility or legacy-support loopholes for CPython-style bare stdlib calls. All hidden compatibility surfaces (`math.*`, `heapq.*`, `collections.*`, bare `deque`, bare `Counter`, bare `defaultdict`, `collections.defaultdict`, synthetic stdlib imports, class-field inference compat, and `__compat_defaultdict_*` naming) are removed or converted directly to explicit `sifr.*` binding inside a single atomic milestone, with grep-based guardrails enforcing the removal at closeout.

--- a/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-1.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-1.md
@@ -1,0 +1,115 @@
+# Planning Review — Stdlib Namespace Contract And Compatibility Cleanup
+
+## Verdict: `CHANGES_REQUESTED`
+
+The plan's locked decisions, exit gates, and milestone shape are sound, and the no-codemod / no-bare-alias posture is consistent throughout. But there are concrete code-reality mismatches and underspecified surfaces that would force the implementer to make non-trivial judgment calls. Fix the items below before declaring `READY`.
+
+---
+
+## Blocking findings
+
+### 1. Phase intro misstates the current contract
+> "lowering still contains a hidden call-expression compatibility path... while equivalent bare stdlib imports are rejected."
+
+Bare stdlib imports are **not actually rejected today**. `resolve_imports_early` in `crates/sifr_lowering/src/lower/imports.rs:58–189` only iterates `Stmt::ImportFrom`, and for any `module_key` not present in `externals.*` (e.g. `"math"`, `"collections"`, `"json"`) it simply no-ops. There is no `IMPORT_BARE_STDLIB` diagnostic in `import_diagnostics.rs`; bare imports silently succeed and the failure surfaces downstream as an unknown-name error at the use site (or, today, succeeds via the compat path for `math.fmod` / `deque(...)` / etc.).
+
+**Fix:** Reword the framing as "bare stdlib imports today silently no-op and only fail downstream; this phase makes them an explicit diagnostic." Then state in M1 that a new diagnostic is being *added*, not rerouted.
+
+### 2. `Stmt::Import` is entirely unaddressed
+Every example in the Diagnostics Contract is a `from X import Y` form. `resolve_imports_early` only handles `Stmt::ImportFrom`, so plain `import math`, `import collections`, `import json` go completely unvisited. After M2 removes the compat path, `math.fmod(x)` becomes a name-error on `math` rather than producing the promised "use `sifr.math`" diagnostic.
+
+**Fix:** In M1, explicitly cover both shapes:
+- `import math` / `import math as m`
+- `from math import sqrt`
+- `import collections.abc` (dotted) — specify whether this is also matched and how the suggestion reads.
+
+Add positive coverage for at least one `Stmt::Import` case.
+
+### 3. The two `defaultdict` early returns bypass `ensure_synthetic_stdlib_import` and are not removed by M2's stated scope
+Inspect `crates/sifr_lowering/src/lower/compat_imports.rs:21–23` and `:44–45`:
+
+```rust
+if name.id.as_str() == "collections" && attr.attr.as_str() == "defaultdict" {
+    return Some("defaultdict".to_string());           // collections.defaultdict(...)
+}
+...
+"defaultdict" => return Some("defaultdict".to_string()), // bare defaultdict(...)
+```
+
+These short-circuit before ever calling `ensure_synthetic_stdlib_import` and route directly to `lower_defaultdict_constructor_call`. M2's bullet ("Remove the lowering path that maps `math.*`, `heapq.*`, `collections.*`, `deque(...)`, and `Counter(...)` to hidden `sifr.*` imports") technically covers `collections.*` but the implementer cannot tell whether removing the `collections.defaultdict` short-circuit belongs to M2 (since it is under `collections.*`) or M3 (since it is the defaultdict binding work).
+
+**Fix:** Explicitly say:
+- M2 removes only synthetic-import-producing paths: `math.*`, `heapq.*`, `collections.*` non-defaultdict, bare `deque`, bare `Counter`.
+- M3 removes the two defaultdict short-circuits (`collections.defaultdict` attribute call and bare `defaultdict` name) together with the unconditional builtin recognition, and replaces them with the imported-binding check.
+
+This sequencing also matters because between M2 and M3 the bare `defaultdict(list)` form must keep working (otherwise the in-tree fixtures temporarily break across PRs).
+
+### 4. No registry of "known stdlib module tails" — the diagnostic has nothing to decide against
+The Diagnostics Contract requires the diagnostic to only fire when the bare root "match[es] a known Sifr stdlib module tail," and to *not* mask future user/package modules with the same name. Today there is no centralized list of public `sifr.*` module names — `sifr_stdlib::STDLIB_SOURCES` is the closest thing, but its keys are full `sifr.foo` paths.
+
+**Fix:** Specify in M1:
+- The diagnostic consults the set of module tails derived from `sifr_stdlib::STDLIB_SOURCES` keys (strip `sifr.` prefix), with explicit handling for dotted submodules (e.g. `sifr.collections.abc` → tail `collections.abc`).
+- Internal-only modules and `_sifr.*` are filtered out of this set.
+- Resolution order: top-level user/package resolution attempted first; bare-stdlib diagnostic fires only when top-level resolution fails. State this ordering in the contract — the current bullet ("unless they are resolved as user or package modules through normal top-level resolution") is correct but not pinned to an order.
+
+### 5. Missing diagnostic code name and machine-readable shape
+> "include machine-readable diagnostic data for the bare module and suggested `sifr.<module>` path"
+
+The codebase has a consistent diagnostic-code convention (e.g. `IMPORT_FORBIDDEN_INTRINSIC` for `_sifr.*` rejection). The plan does not pin a code name or JSON field shape, leaving both as PR-time bikeshedding.
+
+**Fix:** Specify the code (`IMPORT_BARE_STDLIB` or equivalent) and the structured fields (e.g. `data.bare_module`, `data.suggested_module`, `data.symbols: [...]`). Reference how it mirrors `IMPORT_FORBIDDEN_INTRINSIC` so the implementer can copy the registration shape.
+
+### 6. M2 leaves the consumer of `synthetic_imports` undocumented
+The `synthetic_imports` field is *consumed* at `crates/sifr_lowering/src/lower/mod_impl.rs:647` (`imports.extend(ctx.synthetic_imports.clone())`), and `synthetic_import_aliases` is consumed inside `ensure_synthetic_stdlib_import` itself. The bullet "Remove `synthetic_imports` and `synthetic_import_aliases` from lowering if no remaining producer uses them" only addresses producers.
+
+**Fix:** Add a bullet to M2: "Remove the consuming site that extends final `imports` with `ctx.synthetic_imports`, and verify by grep there are no other readers/writers of either field across the workspace." Cite the file path.
+
+### 7. M4 guardrail grep won't match what the plan intends
+> `rg "__compat_sifr_|resolve_python_compat_call_alias|resolve_bare_python_compat_call_alias" crates/sifr_lowering/src crates/sifr_codegen/src -g '*.rs'` returns no production hits except intentionally documented guardrail tests
+
+After M2/M3, `resolve_python_compat_call_alias` and `resolve_bare_python_compat_call_alias` are *deleted*, so they cannot appear in guardrail tests; the grep needs no exception. The `__compat_sifr_` prefix is the only stable invariant. Separately, the "except intentionally documented guardrail tests" carve-out is vague — there is no such test today.
+
+**Fix:**
+- Narrow the guardrail to just `__compat_sifr_` substring in production lowering/codegen.
+- Either drop the "guardrail tests" exception or specify exactly which file is the documented guardrail (e.g. `crates/sifr_lowering/tests/no_synthetic_stdlib_imports.rs`).
+- Note that `__compat_defaultdict_*` is intentionally *not* in the regex (decision 7).
+
+### 8. `__compat_defaultdict_*` naming becomes misleading after this phase
+Decision 7 keeps `__compat_defaultdict_int|list|set` as typed representation aliases until a later phase. Once every other `__compat_*` is removed, the `__compat_` prefix is misleading — it now names typed-representation aliases, not compat shims. This is a documentation hazard for future readers.
+
+**Fix:** Add a one-sentence note in the Defaultdict Contract section explicitly acknowledging that the `__compat_defaultdict_*` alias names are inherited from the prior compat scheme, are *not* a namespace-compat artifact, and will be renamed when the data-structure representation phase replaces them. Or, better, rename them in M3 (`__sifr_defaultdict_int` etc.) since you are already touching that lowering.
+
+---
+
+## Non-blocking but worth tightening
+
+### 9. Specify the defaultdict factory whitelist explicitly
+The plan repeats "`defaultdict(int/list/set)`" four times but never says what happens for `defaultdict(dict)`, `defaultdict(MyClass)`, `defaultdict(lambda: 0)`. Today `lower_defaultdict_constructor_call` matches `Expr::Name` then calls `defaultdict_alias_and_value_type(factory_name)` which only knows `int|list|set`. Anything else is silently rejected.
+
+**Fix:** Add one sentence to the Defaultdict Contract: "Only `int`, `list`, and `set` factories are recognized; other factory expressions continue to produce the existing unsupported-factory diagnostic. Expanding the factory set is out of scope for this phase."
+
+### 10. `from sifr.collections import defaultdict as defaultdict` aliased-to-self
+Mention this is treated identically to a plain import (no aliasing). Trivial but worth pinning to avoid a follow-up question.
+
+### 11. `import sifr.math` (statement form, dotted) under `sifr.*`
+The plan covers `from sifr.math import ...` but not `import sifr.math` or `import sifr.math as m`. Specify whether these are accepted and how member access is resolved — this could otherwise become a follow-up issue immediately after M2.
+
+### 12. Validation commands name non-existent test modules
+M1 cites `cargo test -p sifr_lowering name_import_diagnostics_tests`. There is no such test file today (the existing diagnostic helpers live in `name_diagnostics.rs` and `import_diagnostics.rs`). Either rename to the *new* test file being added in M1 (e.g. `bare_stdlib_import_diagnostics`) and say so, or drop the specific name and say "the bare-stdlib diagnostic tests added in this milestone."
+
+### 13. Existing demos/e2e relying on bare forms — count is non-trivial
+The exploration counted roughly 20 e2e fixtures using bare `deque(`, `Counter(`, `defaultdict(`, `math.fmod(`, `heapq.*`. M2 and M3 both say "Update `.sifr` fixtures and demos to import stdlib symbols explicitly" without scoping. Spell out:
+- Which milestone owns which file (e.g. M2 covers fixtures using `math.fmod`, `heapq.*`, bare `deque`, bare `Counter`; M3 covers fixtures using `defaultdict` or `collections.defaultdict`).
+- Whether `crates/sifr/tests/e2e/fail/` needs *new* fixtures for the rejected forms (which it does — see M1 validation, which currently only says "verification fixture update for human/json/compact output if a CLI diagnostic fixture is added").
+
+### 14. M1 docs target
+"Add a concise user-facing docs page" — specify the path (e.g. `docs/language/stdlib-imports.md`) and whether it gets indexed from the docs nav. Otherwise the implementer has to make a navigation decision and may inadvertently orphan the page.
+
+### 15. `typing` / `enum` exemption documentation
+Locked decision 5 says `typing`/`enum` remain closed frontend imports. The current short-circuit lives at `imports.rs:74` (`if is_absolute_import && (module_name == "typing" || module_name == "enum") { continue; }`). The architecture-doc invariant table should call this exemption out explicitly so readers don't infer that *all* CPython names are rejected.
+
+---
+
+## Summary
+
+Tighten the framing (1), close the `Stmt::Import` gap (2), pin the M2/M3 split for defaultdict (3), specify the stdlib-tail registry and resolution order (4), name the diagnostic code and shape (5), document the synthetic-imports consumer removal (6), make the guardrail grep match reality (7), and decide on the `__compat_defaultdict_*` naming (8). Once those are in, the plan is implementable with low ambiguity.

--- a/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-2.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-2.md
@@ -1,0 +1,75 @@
+I've verified the revised plan against the codebase. The blocking findings from pass 1 are addressed (framing corrected, both `Stmt::Import` and `Stmt::ImportFrom` covered, `SIFR-IMPORT-0008`/`IMPORT_BARE_STDLIB` is the next free code, stdlib tails derived from `STDLIB_SOURCES`, M2/M3 split is now explicit, synthetic-imports consumer removal called out at `mod_impl.rs:647`, `__compat_defaultdict_*` rename folded into M3). But re-reading M4 against the code surfaces a new unreachable guardrail that I'm calling out as the remaining blocker.
+
+# Planning Review — Stdlib Namespace Contract — Pass 2
+
+## Verdict: `CHANGES_REQUESTED`
+
+The plan is close to implementation-ready and most pass-1 findings landed cleanly. One concrete blocker remains in M4, plus a couple of small tightenings that affect implementability.
+
+---
+
+## Blocking findings
+
+### B1. M4 guardrail `rg "__compat_sifr_" ... -g '*.rs'` is unreachable
+
+Per locked decision 8, async/task compatibility for `sifr.sync` / `sifr.concurrent` / `sifr.asyncio` / `sifr.task` is **explicitly out of scope**. Current code retains these consumers:
+
+- `crates/sifr_lowering/src/lower/task_scope_calls.rs:391` — `name.strip_prefix("__compat_sifr_sync_")`
+- `crates/sifr_lowering/src/lower/blocking_executor_calls.rs:121` — `name.strip_prefix("__compat_sifr_concurrent_")`
+- `crates/sifr_codegen/src/lower_expr/leaves_and_plain_calls.rs:48` — `is_compat_stdlib_alias` uses `starts_with("__compat_sifr_")` as a generic prefix check
+
+These will continue to match the M4 guardrail forever, so the bullet "returns no production hits" is unsatisfiable as written.
+
+**Fix:** Either narrow the regex to the namespaces this phase actually eliminates, or pin an explicit exception list. Recommended:
+
+```text
+rg "__compat_sifr_(math|heapq|collections)_" crates/sifr_lowering/src crates/sifr_codegen/src -g '*.rs'
+```
+
+…and add a one-line note in M4 / decision 8 that `__compat_sifr_sync_`, `__compat_sifr_concurrent_`, and the generic `is_compat_stdlib_alias` prefix check are intentionally retained because the async/task compat scheme is out of scope, and will be revisited in a future async cleanup phase.
+
+### B2. M2 codegen-removal bullet doesn't cover the Rust unit tests that hard-code compat names
+
+The bullet "Remove codegen canonicalization for `__compat_sifr_math_*`, `__compat_sifr_heapq_*`, and `__compat_sifr_collections_*`" addresses the production strip-prefix sites, but the following Rust tests literally construct or assert on those names and will fail to compile / fail at runtime once the prefix is gone:
+
+- `crates/sifr_codegen/src/lib_codegen_tests/collections_and_stdlib_codegen_tests.rs:281,305` — builds a `HirCall { func: "__compat_sifr_heapq_heapify", ... }` and asserts the alias appears in emitted output
+- `crates/sifr_codegen/src/intrinsic_method_emitters/narrowing_helpers.rs:66,71` — asserts canonicalization of `__compat_sifr_math_fmod` / `__compat_sifr_heapq_heappush`
+- `crates/sifr_codegen/src/lower_expr/leaves_and_compound_tests.rs:162` — string literal `"__compat_sifr_math_fmod"` in a test
+
+The plan currently lumps these under "focused lowering/codegen tests touched by this milestone." Without explicit scope, an implementer might attempt M2 expecting the production deletion alone and discover four test-module breakages PR-time.
+
+**Fix:** Add a bullet under M2: "Remove or rewrite the Rust unit tests in `sifr_codegen` that construct or assert on `__compat_sifr_math_*` / `__compat_sifr_heapq_*` / `__compat_sifr_collections_*` aliases — they lose meaning once the compat path is deleted." This is a routine cleanup but it should be in-scope explicitly so the M2 PR diff is anticipated.
+
+---
+
+## Non-blocking but worth tightening
+
+### N1. Disposition of the generic `is_compat_stdlib_alias` fast-path skip
+
+`crates/sifr_codegen/src/lower_expr/leaves_and_plain_calls.rs:47-48` and its caller at `:633` skip the fast plain-call path for any name starting with `__compat_sifr_`. After M2/M3, the only producers of that prefix in the codebase are the async/task surfaces (which never reach this codegen path with bare names anyway). The helper effectively becomes dead defensive scaffolding.
+
+The plan doesn't take a position on this. It's fine to leave it (it's harmless and decision 8 keeps async/task off-table), but a one-sentence note in M2 — "the generic `is_compat_stdlib_alias` codegen guard remains, scoped to retained async/task aliases" — would prevent an implementer from rethinking it during the PR.
+
+### N2. M2 fixture-update bullet is still file-list-free
+
+Pass 1's finding 13 noted ~20 e2e fixtures touch the patterns this phase removes. The revised M2 keeps the bullet as "Update `.sifr` fixtures and demos that rely on …" without enumerating. Not a blocker — `rg` can find them — but worth saying "the implementer is expected to grep `deque(`, `Counter(`, `math\.`, `heapq\.` under `crates/sifr/tests/e2e/pass/` and `demos/` and update each one explicitly" so this doesn't become a hidden scope expander.
+
+### N3. Verify behavior between M2 and M3 PRs for `collections.defaultdict(list)`
+
+The plan correctly says M2 leaves `collections.defaultdict(...)` and bare `defaultdict(...)` working, and M3 removes both. But after M2 deletes the `collections.*` non-defaultdict synthesis (lines 24-31 of `compat_imports.rs`), the `collections.defaultdict` short-circuit at lines 21-23 of the same file becomes unreachable code if the entire `resolve_python_compat_call_alias` body collapses to just the early return. Either:
+- Keep the early-return form intact in M2 and delete the rest of the function body (leaving an obviously-incomplete function), or
+- Restructure so the defaultdict short-circuit moves to its own helper before M2 starts deleting.
+
+The implementer can figure this out, but the plan should pick one to avoid a half-deleted function in an intermediate PR.
+
+---
+
+## What's fixed since pass 1
+
+For the record: framing corrected at line 9; `Stmt::Import` + `Stmt::ImportFrom` both covered at line 106; resolution order pinned at lines 76 + 84; diagnostic code `SIFR-IMPORT-0008` / `IMPORT_BARE_STDLIB` pinned (verified next-free in `crates/sifr_diagnostics/src/codes/registry.rs:28-34`); machine-readable fields `bare_module` / `suggested_module` / `imported_names` pinned at line 113; M2/M3 split for defaultdict pinned at line 147; synthetic-imports consumer removal explicit at line 169; `__compat_defaultdict_*` → `__sifr_defaultdict_*` rename folded into M3 at line 186 with the secondary grep extended to `sifr_type_system` at line 206; factory whitelist + `defaultdict as defaultdict` pinned in the Defaultdict Contract; `typing` / `enum` exemption documented at line 80.
+
+---
+
+## Summary
+
+Two concrete blockers remain: the M4 guardrail regex needs to be scoped to `math|heapq|collections` (B1), and the M2 scope needs to explicitly cover the Rust unit tests that hard-code compat names (B2). Once those are in, plus the three small tightenings (N1–N3), the plan is implementable with low ambiguity.

--- a/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-3.md
+++ b/reviews/ad-hoc-stdlib-namespace-contract-planning-review-pass-3.md
@@ -1,0 +1,23 @@
+I've verified the plan against the codebase. All Pass 2 blocking findings and non-blocking tightenings are now reflected.
+
+# Planning Review — Stdlib Namespace Contract — Pass 3
+
+## Verdict: `READY`
+
+## Pass 2 follow-ups verified
+
+- **M4 guardrail narrowed to `math|heapq|collections`** — `issue.md:209` now uses `rg "__compat_sifr_(math|heapq|collections)_" crates/sifr_lowering/src crates/sifr_codegen/src -g '*.rs'`. The retained async/task aliases (`task_scope_calls.rs:391` `strip_prefix("__compat_sifr_sync_")`, `blocking_executor_calls.rs:121` `strip_prefix("__compat_sifr_concurrent_")`) and the generic `is_compat_stdlib_alias` (`leaves_and_plain_calls.rs:47-49`) are no longer caught by this regex.
+- **M2 Rust unit test cleanup in scope** — `issue.md:172` explicitly requires removing/rewriting the tests that hard-code `__compat_sifr_math_*`/`__compat_sifr_heapq_*`/`__compat_sifr_collections_*`. Verified the impacted call sites exist at `narrowing_helpers.rs:66,71`, `leaves_and_compound_tests.rs:162`, and `collections_and_stdlib_codegen_tests.rs:281,305`.
+- **Generic `is_compat_stdlib_alias` retention noted** — `issue.md:173` keeps it intentionally for retained async/task aliases.
+- **Grep-driven fixture classification required** — `issue.md:175` requires grepping `math\.`, `heapq\.`, `deque(`, `Counter(` under e2e pass/fail and demos, classifying every hit.
+- **Dedicated transitional defaultdict helper** — `issue.md:168` specifies extracting the `collections.defaultdict(...)` and bare `defaultdict(...)` short-circuits into a small dedicated helper during M2 to avoid a half-deleted `resolve_python_compat_call_alias` body.
+
+## Spot-checked code anchors
+
+- `SIFR-IMPORT-0008` is the next free code (`registry.rs:34` ends at `IMPORT_CYCLE` = SIFR-IMPORT-0007).
+- `compat_imports.rs:21-23` and `:44-45` carry the defaultdict short-circuits that route to typed lowering without synthetic imports — M3-owned.
+- `compat_imports.rs:24-29` and the `deque`/`Counter` arms at `:46-47` are the synthetic-producing paths — M2-owned.
+- `mod_impl.rs:647` is the sole synthetic-imports consumer — M2 explicitly removes it.
+- Production strip-prefix sites enumerated by grep: `narrowing_helpers.rs:25-29`, `expr_call_and_literal_helpers.rs:3-13`, `queries_impl.rs:322`. All covered by M2's "remove codegen canonicalization" bullet.
+
+The plan is implementable with low ambiguity. Proceed.

--- a/reviews/stdlib-import-contract-claude-opus-round-1.md
+++ b/reviews/stdlib-import-contract-claude-opus-round-1.md
@@ -1,0 +1,101 @@
+I have enough context. The review file is empty — this is round 1 of analysis. The repo's actual stance: `from x import ...` is the only supported import form (bare `import x` is already a hard error), `sifr.*` is current canonical, `typing`/`enum` are bare-named exceptions, ~50 stdlib modules under `sifr.*`, multiple intentional name divergences (`sifr.os.remove_file`, `sifr.math.abs_val`, Result/Option vs exceptions), and Phase 37 anticipates future Python interop.
+
+# Sifr stdlib import contract — design analysis
+
+## Framing
+
+Three real options, not two:
+
+- **A. Bare-only**: `from math import sqrt`. Drop `sifr.*` entirely.
+- **B. `sifr.*`-only** (status quo): `from sifr.math import sqrt`. Bare stdlib names rejected.
+- **C. Dual / aliased**: both work, one canonical.
+
+The status quo already has a wart: `from typing import ...` and `from enum import ...` are bare and "non-activating support imports" (phase 17). So Sifr today is technically option C-with-asymmetry, scoped narrowly to type-system support.
+
+## Multi-angle analysis
+
+### 1. User ergonomics
+- **Bare**: 5–8 fewer characters per import, matches muscle memory of every Python dev. Real but small.
+- **`sifr.*`**: Constant visual signal "this is Sifr, not Python." Forces deliberate engagement — desirable when names *and semantics* diverge.
+- Verdict: **bare wins narrowly**; not decisive.
+
+### 2. Migration / parity from Python
+- The *dangerous* failure mode isn't typing `sifr.` — it's a user copying `os.remove("x")` from Python, hitting `sifr.os.remove_file` (renamed), `Result[None, IoError]` instead of an exception, or a missing API. Bare imports make the code *look* portable when it isn't.
+- Aliasing the namespace fakes parity that doesn't exist behaviorally. The architecture doc has a whole table of divergences (`abs_val`, `pow_val`, `move_file`, `is_match`, `remove_file`, `shuffle returns new list`, etc.). Bare names amplify the surprise.
+- A **codemod** (`sifr migrate`) that rewrites Python source into Sifr — translating `import math` → `from sifr.math import …`, flagging untranslatable APIs with diagnostics — is a *strictly better* migration story than aliasing. It produces correct code instead of code that compiles and lies.
+- Verdict: **`sifr.*` wins**. Bare imports lower a real safety barrier for a small ergonomic gain.
+
+### 3. Semantic honesty
+- "Python syntax, Rust semantics, Sifr safety lens" is the language identity. The namespace prefix encodes that: `sifr.math.sin` ≠ `math.sin`. Different return shape, different error model, no panic.
+- `sifr.*` is a name-mangling that mirrors the actual semantic divergence. Bare names assert an equivalence that isn't true.
+- Verdict: **`sifr.*` wins decisively**.
+
+### 4. Package / import resolution
+- Resolver currently has clean three-tier ownership: `_sifr.*` (intrinsics), `sifr.*` (stdlib), top-level (user / future third-party). Each tier has one owner.
+- Bare stdlib **collapses two tiers into one** — stdlib and third-party packages now share the top-level namespace. CPython lives with this and it's a known wart (consider what happens when a user wants a module named `string.sifr` or `time.sifr` locally).
+- Demos already show `from helper import …` for local modules. Adding bare stdlib means resolution has to disambiguate `from math import …` between a hypothetical local `math.sifr`, a third-party `math` package, and embedded stdlib. Resolution rules become longer; diagnostics get worse.
+- Verdict: **`sifr.*` wins strongly**. Three-tier separation is architecturally sound and worth preserving.
+
+### 5. Future package manager (Phase 37)
+- `sifr.toml` already exists; packages will arrive. With `sifr.*` reserved, third-party packages own the bare top-level cleanly. Without it, every new stdlib module *forever* removes a viable top-level package name.
+- Phase 37 also mentions deferred Python interop (`pyproject.toml`, `uv.lock`). If Sifr ever wraps real CPython modules via a bridge, the *natural* spelling for "actually use CPython's math" is `from math import …` — i.e., bare. Squatting that namespace now with Sifr-flavored wrappers burns the most ergonomic door we have for future interop.
+- Verdict: **`sifr.*` wins strongly**. This is the highest-leverage long-term argument.
+
+### 6. Namespace collision
+- Bare names that collide with built-ins, common variables, or user modules: `string`, `time`, `os`, `re`, `json`, `csv`, `io`, `bytes`, `random`, `secrets`. Several of these are extremely common as local variable / module names.
+- `sifr.*` makes collisions impossible by construction.
+- Verdict: **`sifr.*` wins**.
+
+### 7. Teaching / docs
+- Bare: docs read like CPython. Easier "first hour." Hides divergence.
+- `sifr.*`: every example carries the prefix. Constant reminder of "this is Sifr." Slightly heavier first impression.
+- Net: bare wins lesson 1, loses lessons 2–N when divergences surface unexpectedly.
+- Verdict: roughly **even**, leans `sifr.*` once you account for the long tail.
+
+### 8. Implementation complexity
+- Status quo (`sifr.*`-only) is what's built. Already enforced via embedded registry, codegen, resolver precedence.
+- Bare-only: rewrite resolver, codegen module paths (`crate::sifr::math` → ?), update ~50 modules + ~100 demos + docs + intrinsic mapping. Touches `mod_impl.rs`, `module_prescan.rs`, `lib_modules_and_codegen.rs`, frontend, driver, package discovery. Sweeping but tractable.
+- Dual / aliased: simplest patch (canonicalize bare → `sifr.*` at name resolution), but you now permanently maintain two spellings, must teach users which is canonical, every diagnostic must pick one, search/grep yields mixed hits, codemods must canonicalize. High *ongoing* cost for the lifetime of the language.
+- Verdict: **`sifr.*`-only is cheapest**; dual is the most expensive long-term despite the smallest initial diff.
+
+### 9. Language identity (long-term)
+- Sifr's pitch: "Python you can trust; if it compiles, it works." The pitch is *not* "Python that secretly compiles." The prefix encodes that distinction at the import line — the place users look 50 times a day.
+- Languages that tried to be source-compatible with another (e.g. CoffeeScript→JS, Crystal→Ruby) found that hiding the semantic gap caused real confusion. Languages that owned the distinction (Elixir/Erlang, Kotlin/Java, TypeScript/JS) thrived.
+- Verdict: **`sifr.*` wins**.
+
+### 10. Ecosystem expectations
+- Python devs *expect* `from math import sqrt` to mean Python's math. If we give them that spelling for a non-Python module, we are setting up a "looks like a duck, ships exceptions" trap.
+- Rust, Go, Swift, Kotlin, .NET — every modern stdlib namespaces under a vendor/language prefix (`std::`, `core::`, `Foundation.`, `kotlin.`, `System.`). Python is the outlier, and a notoriously contentious one.
+- Verdict: **`sifr.*` wins**.
+
+## Hidden risks
+
+1. **Typing/enum precedent** — the existing bare-name exceptions can be cited as "you already broke the rule, finish the job." Address head-on by classifying them as *type-system support imports*, not runtime stdlib: they emit no Rust, have no embedded source, are processed by the frontend's typing layer. This is a principled distinction, not a fudge. Document it explicitly. Optionally rename to `sifr.typing` / `sifr.enum` later, but it's not worth churn — the precedent doesn't generalize.
+
+2. **Codemod debt** — if you ever onboard real Python code, you owe a translator. If you skip building it, users will hand-translate badly and bug reports about silent semantic divergence will dominate. The codemod is the migration story; aliasing is a *substitute* for that story and a worse one.
+
+3. **Phase 31.5 framing** — the question references "phase 31.5 closure of Python source parity." If "parity" is taken to mean *source-level lookalikeness*, that's a different goal than what the architecture actually pursues (behavioral parity through the safety lens). Lock the definition: **parity = behavioral, not lexical**. Source remains `sifr.*`; behavior matches CPython where safe, diverges where Sifr's invariants demand it. Otherwise this debate will recur every phase.
+
+4. **Discoverability regression** — `sifr.<TAB>` in an editor is *better* than bare names for discovery (one prefix → list of all modules). Don't give that up.
+
+5. **`_sifr.*` blocked → `sifr.*` deprecated → bare canonical** would imply the second tier becomes useless. Don't let aliasing slide into a deprecation track for `sifr.*`; if you ever ship dual, the docs must be unambiguous that `sifr.*` is canonical and bare is the alias, not the reverse.
+
+## Recommendation
+
+**Keep `sifr.*` as the permanent public contract. Do not add bare-name aliasing.** Close it as a deliberate language design decision.
+
+Concrete actions:
+
+1. **Promote the decision to the architecture doc** as a permanent invariant alongside the `_sifr.*`/`sifr.*`/user three-tier ownership model. Cite: behavioral semantic divergence, future Python interop preservation, third-party package namespace cleanliness.
+2. **Reframe the typing/enum exceptions** in `internal_docs/architecture.md` and `internal_docs/phases/17_import_and_externals_correctness.md` as *type-system support imports*, not stdlib. Make the classification principled. (Renaming is optional; not worth the churn.)
+3. **Improve the diagnostic** for `from math import sqrt`-style attempts. Currently this hits "unsupported import statement" or "unknown module". Make it a dedicated, suggestion-bearing error:
+   `error: bare stdlib import 'math' — Sifr stdlib lives under 'sifr.*'`
+   `help: use 'from sifr.math import sqrt' (note: names and error semantics diverge from CPython, see <link>)`
+4. **Plan a Python-to-Sifr codemod** as the official migration story (own phase or milestone in 38 docs / 43 interop). Rewrites bare → `sifr.*`, flags untranslatable APIs, surfaces Result/Option contract differences. This is the *real* answer to "how do Python devs migrate."
+5. **Document in user-facing docs** (`docs/`): one short page titled "Why `sifr.*`?" — explains the three-tier model, the semantic-honesty rationale, and the future-interop point. So this question doesn't get re-litigated.
+
+## Migration / deprecation path
+
+None needed. The recommendation preserves the status quo. The single deliverable that flows out is the improved diagnostic + docs page + (longer-term) the codemod tool. If at some future phase Python interop ships and the team wants bare `import math` to mean *real CPython's math via a bridge*, the bare namespace is still free to take on that meaning — which is exactly the optionality we'd lose by aliasing now.
+
+**Bottom line**: the ergonomic case for bare is real but small; the long-term costs (semantic dishonesty, lost interop namespace, three-tier collapse, dual-spelling maintenance, collision surface) are large and irreversible. `sifr.*` is the right permanent contract.

--- a/reviews/stdlib-import-contract-claude-opus-round-2.md
+++ b/reviews/stdlib-import-contract-claude-opus-round-2.md
@@ -1,0 +1,161 @@
+# Sifr stdlib import contract — Round 2 (stress-test)
+
+## What changed since Round 1
+
+Round 1 closed on **keep `sifr.*` as the permanent contract; reject bare stdlib imports; build a codemod for migration; improve the diagnostic; document the three-tier model.**
+
+Two facts surfaced in re-grounding that sharpen Round 2:
+
+1. **The compat layer is louder than Round 1 acknowledged.** `crates/sifr_lowering/src/lower/compat_imports.rs:11-52` already auto-synthesizes stdlib imports for *call sites* — bare `math.sqrt(x)`, `heapq.*`, `collections.defaultdict`, and bare names `defaultdict`/`deque`/`Counter`. This means today's policy is **internally inconsistent**: `math.sqrt(x)` compiles with no import, but `from math import sqrt` is rejected as `unknown import target: 'math'`. A Python user copying code experiences randomized success/failure depending on whether they imported.
+2. **The bare-import diagnostic is generic** (`IMPORT_UNKNOWN_SOURCE_MODULE` → `"unknown import target: 'math'"`). No hint about `sifr.math`. The promised "dedicated diagnostic" from Round 1 has not landed.
+
+These two facts shift the question. Round 2 isn't "should we add bare imports?" — it's "do we close the bare-name leak, or widen it?"
+
+---
+
+## Best case for CPython-style bare stdlib imports
+
+Steelman, no hedging:
+
+- **Adoption funnel.** The first line of nearly every Python file is `import …`. That line is also the most common thing a Python dev pastes into a Sifr file when evaluating the language. Every `sifr.` prefix is a "this isn't really Python" signal at the moment of evaluation. If Sifr's growth depends on Python developers, the import line is where you keep the friction lowest.
+- **The compat-call shim is already evidence of intent.** The lowering layer already accepts `math.sqrt(x)` without imports. Symmetric treatment for `from math import sqrt` only finishes a job we've half-started. The asymmetry today is the worst of both policies.
+- **The "future CPython interop namespace" argument is speculative.** Phase 37 interop is unbuilt. If a CPython bridge never ships, we paid a permanent ergonomic tax to reserve a door nobody walks through. Even if it does ship, the bridge could use a different spelling (`from cpython.math import …` or `from py.math`) without losing anything material.
+- **Collisions are rare.** CPython has lived with bare stdlib in a global namespace for 30 years. The actual reported pain is small and tooling-tractable (linters flag shadowing).
+- **A codemod is real engineering work.** A robust `sifr migrate` translator competes with stdlib coverage, language features, and tooling for the same team-hours. Bare aliasing solves the most common migration case (the import line) with effectively zero ongoing cost beyond the alias table.
+- **Teaching.** "Look — your Python file compiles, but Sifr caught these bugs." That demo only works if the imports look like Python. `sifr.*` breaks the spell on line one.
+
+That is the strongest honest case. It is non-trivial. Round 2's job is to test it against Sifr's guarantees.
+
+---
+
+## Variant-by-variant evaluation
+
+### Variant 1 — bare aliases only for CPython-compatible modules/members
+
+Curated allowlist of "identical name + identical signature + identical semantics" entries gets bare spelling; everything else stays `sifr.*`.
+
+- **Runtime panics / Result-Option contract.** `math.sqrt(-1.0)` in CPython returns `nan` or raises `ValueError`. Sifr's safety lens routes domain errors through `Result`. Almost every interesting stdlib function diverges *somewhere* — return shape, error model, naming (`abs_val`, `pow_val`, `remove_file`, `move_file`, `is_match`). The set of "truly identical" calls is small and gets smaller as Sifr matures.
+- **Docs / discoverability.** The rule becomes "it depends on the function." Users learn the allowlist by trial and error. That's a strict regression in clarity over today.
+- **Maintenance.** Every new stdlib module ships with a classification step ("is this CPython-compatible?"). Every safety refinement (turn a panic-on-bad-input into a `Result`) potentially *removes* a name from the allowlist — a quiet breaking change. The allowlist becomes a permanent governance artifact.
+- **Resolver.** Two name spaces now overlap (top-level user/third-party and a curated subset of stdlib bare names). Diagnostics must disambiguate.
+
+**Verdict: worst of the five.** Maximum complexity, minimum honesty, no clear migration story.
+
+### Variant 2 — bare aliases gated by `sifr.toml` setting or edition
+
+`[language] python_compat_imports = true` (or an edition string) opts a package into bare names.
+
+- **Ecosystem stability.** Packages with the flag look syntactically different from packages without. A reader of one package can't tell which spelling is in force without flipping to the manifest. Code review, search, refactor tooling, and LSP all have to track the per-package mode.
+- **Cross-package dependencies.** A package with the flag on, depending on a package with the flag off, is fine at runtime but jarring at the source level. The first time a user imports a function from a flag-off package and has to switch styles mid-file, the rationale collapses.
+- **Permanence.** Once any third-party package adopts the flag, removing it is a breaking change in the ecosystem. The "edition" is forever, like Python 2/3 `__future__`. Sifr does not have the user base to absorb that kind of split.
+- **Package-manager namespace stability.** With the flag on, the bare top-level is occupied by stdlib *for that package's source*, which means a third-party package literally named `math` either can't be installed there or must shadow stdlib. The package manager must take a position; either choice is bad.
+- **Interop reservation.** Same problem as universal bare imports, with extra surface area.
+
+**Verdict: the Python 2/3 trap dressed as flexibility.** Don't ship.
+
+### Variant 3 — bare aliases only in `--python-compat` migration mode, with warnings
+
+CLI/env flag, not a per-package setting. Compiler accepts bare stdlib imports but emits warnings.
+
+- **Strictly weaker than a codemod.** A `--python-compat` mode lets users *run* unmodified Python source. A codemod (`sifr migrate`) *transforms* it into canonical Sifr source. The codemod's output is reviewable, diffable, and lives in source control. The compiler mode's output is invisible. Every problem the mode solves, the codemod solves better.
+- **Warnings rot.** "Deprecated from day one" warnings get silenced or ignored. Code written under the mode escapes into production via "I'll fix it later."
+- **Diagnostic clarity.** When a user runs Sifr without the flag, they get a different result for the same source. Bug reports become "works on my machine + my flag."
+- **One legitimate use:** running upstream Python during a *single* migration session, then turning the flag off. But that's exactly what the codemod does, and the codemod produces durable source artifacts instead of an ephemeral flag state.
+
+**Verdict: dominated by the codemod.** Build the codemod; don't build this.
+
+### Variant 4 — bare aliases as deprecated transitional sugar with canonical diagnostics
+
+Bare `from math import sqrt` is accepted, emits a `DEPRECATED_BARE_STDLIB_IMPORT` diagnostic, points at `sifr.math`.
+
+- **Either you remove it on a date or you don't.** If you remove it on a date, you're Variant 3 (a migration mode, with the same codemod-dominates problem). If you don't, you've shipped permanent dual spelling with a guilt label.
+- **Search / grep / refactor.** Two spellings in the wild, forever. Every diagnostic must pick one canonical form. Every doc example must pick one. Code review picks fights about it. New contributors ask which is "right."
+- **Adoption pressure.** Third-party packages that pick the deprecated form ("looks like Python") resist removal because their users have written code against it.
+- **Better than Variant 1** only because it's uniform across the stdlib, not curated. That's a low bar.
+
+**Verdict: permanent dual-spelling with extra steps.** Don't ship.
+
+### Variant 5 — bare imports reserved for future real CPython interop
+
+Status quo, formalized as policy. `sifr.*` is the only spelling for Sifr stdlib. Bare top-level names are reserved for: (a) user/third-party packages today, (b) eventual real-CPython-via-bridge imports if Phase 37 ships interop.
+
+- **Runtime guarantees.** Untouched. `sifr.*` is the only spelling that lowers into Sifr's Result/Option API; no path exists where a user accidentally hits a CPython-shaped API thinking it's Sifr's.
+- **Resolver.** The clean three-tier (`_sifr.*` / `sifr.*` / top-level) holds. Each tier has one owner. Diagnostics stay sharp.
+- **Package-manager.** Third-party packages own bare top-level cleanly forever.
+- **Interop optionality.** If Phase 37 ever lands a CPython bridge, `from math import sqrt` is the *natural* spelling for "real CPython's math," and that door is still open. If the bridge never ships, the door cost nothing.
+- **Docs.** One rule, one example, one canonical spelling.
+- **Cost.** The ergonomic loss on the import line. The codemod debt. The need for a proper diagnostic.
+
+**Verdict: this is the right policy.** It's what we already do *for imports*. The work is to (a) fix the diagnostic, (b) ship the codemod, (c) **decide what to do about the compat-call shim**, because that shim is silently widening the contract in a direction we just rejected.
+
+---
+
+## The compat-call shim — the unforced wart
+
+The thing Round 1 underweighted: `compat_imports.rs` makes bare `math.sqrt(x)`, `heapq.*`, `collections.defaultdict`, and bare `defaultdict`/`deque`/`Counter` *just work* without imports. That's a hidden form of Variant 1, scoped to call expressions, undocumented as policy.
+
+It's worse than explicit bare aliasing because:
+- It's invisible at the source level (no import statement to grep for).
+- Users learn it works for calls, then are surprised that `from math import sqrt` is rejected — exactly the inconsistency that motivates this whole debate.
+- It silently establishes "bare CPython names are fine" for a subset of the stdlib, which leaks the namespace reservation we want to keep for future interop.
+- It contradicts the architecture doc the moment we write the `sifr.*`-only rule down.
+
+Two viable answers:
+
+- **(A) Remove it.** Force `from sifr.math import sqrt` and `from sifr.collections import deque`. Demos and stdlib internals get updated; the codemod handles upstream Python during migration. Cleanest.
+- **(B) Keep it as a *typed lint* (warn but compile) that the codemod will rewrite.** Pragmatic if removing it churns too many demos/docs in one PR. Must be on a removal clock, otherwise it becomes Variant 4.
+
+Either way, the shim's behavior must be reconciled with the headline policy — leaving it in its current undocumented form is the worst option.
+
+**Recommendation:** ship (A) in the same milestone as the dedicated diagnostic and `sifr.*` documentation, sequenced behind the codemod's first pass over `demos/` so the changes are mechanical, not hand-edited.
+
+---
+
+## Firm recommendation
+
+**Adopt Variant 5 as written policy. Close the compat-call shim. Ship the dedicated diagnostic. Plan the codemod.**
+
+Nothing in Round 2 weakens Round 1's conclusion; the stress-test strengthens it. The best case for bare imports is real but small (adoption friction on the import line) and is better solved by a codemod than by a permanent contract change. The compat-call shim is a silent leak in the same direction we just rejected and should be closed.
+
+---
+
+## Exact policy wording for `internal_docs/architecture.md`
+
+Drop this block under the import-resolution / module-ownership section:
+
+> ### Module namespace ownership (permanent invariant)
+>
+> Sifr reserves three tiers of import namespace, each with a single owner:
+>
+> | Prefix          | Owner                          | Resolution                                   |
+> | --------------- | ------------------------------ | -------------------------------------------- |
+> | `_sifr.*`       | Compiler intrinsics            | Embedded; never resolves to filesystem.      |
+> | `sifr.*`        | Sifr standard library          | Embedded registry (`sifr_stdlib::STDLIB_SOURCES`); never resolves to filesystem. |
+> | (top-level)     | User code and third-party packages | Filesystem / package-manager resolution.  |
+>
+> **Sifr stdlib is reachable only through the `sifr.*` prefix.** Bare module names (`math`, `os`, `collections`, etc.) are never aliased to `sifr.*` in any compilation mode, edition, manifest setting, or deprecation track. Code that writes `from math import sqrt` is rejected with `IMPORT_BARE_STDLIB_PREFIX` (see diagnostics), regardless of whether `math` matches an embedded stdlib module name.
+>
+> **Rationale.**
+> - Sifr stdlib diverges from CPython in name (`sifr.math.abs_val`, `sifr.os.remove_file`), error model (`Result`/`Option` instead of exceptions), and ownership semantics. Bare spelling asserts an equivalence that does not hold.
+> - The top-level namespace belongs to user code and third-party packages. Aliasing stdlib into it removes ~50 names from the available top-level forever and forces the package manager to disambiguate on every install.
+> - If a future CPython interop layer ships (see Phase 37), `from math import sqrt` is the natural spelling for "real CPython's math." Reserving bare top-level keeps that option open at zero cost.
+>
+> **Type-system support imports.** `typing` and `enum` are bare-named *by exception* and do not contradict the rule above: they emit no Rust, have no embedded stdlib source, and are processed entirely by the frontend's type layer. They are not runtime stdlib and are not aliases for `sifr.typing` / `sifr.enum`. This classification is closed — no other bare-named modules are accepted on these grounds.
+>
+> **Migration.** Translation of pre-existing Python source into canonical `sifr.*` form is the responsibility of the `sifr migrate` codemod (Phase 37 / interop work), not the compiler. The compiler does not accept Python-shaped imports under any flag or mode.
+>
+> **Compat-call lowering.** Implicit synthesis of `sifr.*` imports for bare *call expressions* (`math.sqrt(x)`, `defaultdict(...)`, etc.) is **not** an exception to this policy and is being removed (see issue `ad-hoc-stdlib-bare-call-compat-removal`). Such calls will require explicit `from sifr.<module> import <name>` statements once the migration lands.
+
+And in `internal_docs/phases/17_import_and_externals_correctness.md`, reframe the typing/enum carve-out from "bare imports allowed for these" to "type-system support imports, processed before the stdlib resolver."
+
+---
+
+## Action items (ordered)
+
+1. **Dedicated diagnostic.** Replace the generic `unknown import target: 'math'` with `IMPORT_BARE_STDLIB_PREFIX` for any bare module name that matches an entry in `sifr_stdlib::STDLIB_SOURCES` after stripping the `sifr.` prefix. Suggestion text: `use 'from sifr.<module> import …' — Sifr stdlib lives under 'sifr.*' (semantics diverge from CPython; see <link>)`. Touches `crates/sifr_lowering/src/lower/import_diagnostics.rs:14` and the import-handling site that currently routes through `unknown_import_target`.
+2. **Policy commit.** Land the architecture-doc block above and the phase-17 reframing.
+3. **User-facing doc.** One-page `docs/` entry titled "Why `sifr.*`?" — three-tier model, semantic-honesty rationale, future-interop point. So this debate doesn't recur.
+4. **Compat-call shim removal.** Issue + milestone to delete `resolve_python_compat_call_alias` and `resolve_bare_python_compat_call_alias` in `crates/sifr_lowering/src/lower/compat_imports.rs:11-52`. Update demos and stdlib-internal callers to use explicit `from sifr.<module> import <name>`. Sequence behind the codemod's first pass so the demo updates are mechanical.
+5. **Codemod scoping.** Add `sifr migrate` to the Phase 37 / interop milestone with explicit scope: (a) rewrite bare stdlib imports → `sifr.*`, (b) flag CPython APIs without Sifr equivalents, (c) surface Result/Option contract differences at call sites it can detect. This is the migration story; aliasing is not.
+
+No backwards-compatibility track, no flag, no deprecation window. The contract is set today.


### PR DESCRIPTION
## Summary

- add ad hoc phase planning and execution records for stdlib production parity work
- add review pass records for split stdlib phases, platform parity planning, namespace contract readiness, and import contract stress testing

## Validation

- Not run; Markdown-only documentation changes per request.