### PR TITLE
Close M3 text i18n locale formatting milestone

### DIFF
--- a/issues/ad-hoc-production-text-i18n-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-text-i18n-platform-substrate-execution.md
@@ -24,7 +24,7 @@ Execution order: this is the first phase in the split production-stdlib sequence
 - [x] `milestone_text_i18n_1`: Encoding And Explicit Text I/O
 - [x] `milestone_text_i18n_2`: Unicode Core
 - [x] `milestone_text_i18n_2_5`: Unicode Segmentation
-- [ ] `milestone_text_i18n_3`: Locale Identifiers And Locale-Sensitive Formatting
+- [x] `milestone_text_i18n_3`: Locale Identifiers And Locale-Sensitive Formatting
 - [ ] `milestone_text_i18n_4`: Translation Bundles
 - [ ] `milestone_text_i18n_5`: Integration, Documentation, And Production Gate
 
@@ -190,7 +190,7 @@ Execution order: this is the first phase in the split production-stdlib sequence
 - M1: https://github.com/sifr-lang/sifr/pull/2298
 - M2: https://github.com/sifr-lang/sifr/pull/2299
 - M2.5: https://github.com/sifr-lang/sifr/pull/2300
-- M3: pending.
+- M3: https://github.com/sifr-lang/sifr/pull/2302
 - M4: pending.
 - M5: pending.
 

--- a/verification/stdlib/text_i18n_dependency_decisions.md
+++ b/verification/stdlib/text_i18n_dependency_decisions.md
@@ -1,6 +1,6 @@
 # Text/I18n Dependency Decisions
 
-Status: M3 in progress. Encoding versions were checked during M0/M1; Unicode core versions and generated Unicode 17.0.0 tables were locked during M2 on 2026-06-06; segmentation is aligned to Unicode 17.0.0 during M2.5. Locale IDs, formatting, plural rules, and collation use ICU4X 2.2 compiled data during M3.
+Status: M3 complete. Encoding versions were checked during M0/M1; Unicode core versions and generated Unicode 17.0.0 tables were locked during M2 on 2026-06-06; segmentation is aligned to Unicode 17.0.0 during M2.5. Locale IDs, formatting, plural rules, and collation use ICU4X 2.2 compiled data from M3 onward.
 
 | Family | Crate(s) | Sifr abstraction | Unicode/version alignment | Panic/unsafe audit | Typed error mapping | License/MSRV/binary/platform impact | Deterministic tests | Supply-chain signal |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/verification/stdlib/text_i18n_substrate_inventory.json
+++ b/verification/stdlib/text_i18n_substrate_inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "status": "m3-in-progress",
+  "status": "m3-complete",
   "platform_contract": "verification/platform/platform_contract.json",
   "cpython_checkout": {
     "path": "/Users/yaseralnajjar/work/sifr/cpython",

--- a/verification/stdlib/text_i18n_substrate_inventory.md
+++ b/verification/stdlib/text_i18n_substrate_inventory.md
@@ -1,6 +1,6 @@
 # Text/I18n Substrate Inventory
 
-Status: M3 in progress.
+Status: M3 complete.
 
 Platform contract: [platform_contract.md](../platform/platform_contract.md)
 


### PR DESCRIPTION
## Summary
- mark M3 locale identifiers and locale-sensitive formatting complete in the text/i18n execution tracker
- record the merged M3 implementation PR link
- update text/i18n dependency and substrate inventory status from M3 in-progress to M3 complete

## Validation
- `python3 -m json.tool verification/stdlib/text_i18n_substrate_inventory.json >/dev/null`
- `scripts/run_all_tests.sh --profile create-pr` (pass; report `target/validation_lane_reports/create-pr.latest.json`; warm wall-time advisory only)