### PR TITLE
Close M4 text i18n translation bundles

### DIFF
--- a/issues/ad-hoc-production-text-i18n-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-text-i18n-platform-substrate-execution.md
@@ -25,7 +25,7 @@ Execution order: this is the first phase in the split production-stdlib sequence
 - [x] `milestone_text_i18n_2`: Unicode Core
 - [x] `milestone_text_i18n_2_5`: Unicode Segmentation
 - [x] `milestone_text_i18n_3`: Locale Identifiers And Locale-Sensitive Formatting
-- [ ] `milestone_text_i18n_4`: Translation Bundles
+- [x] `milestone_text_i18n_4`: Translation Bundles
 - [ ] `milestone_text_i18n_5`: Integration, Documentation, And Production Gate
 
 ## Planning Reviews
@@ -191,7 +191,7 @@ Execution order: this is the first phase in the split production-stdlib sequence
 - M2: https://github.com/sifr-lang/sifr/pull/2299
 - M2.5: https://github.com/sifr-lang/sifr/pull/2300
 - M3: https://github.com/sifr-lang/sifr/pull/2302
-- M4: pending.
+- M4: https://github.com/sifr-lang/sifr/pull/2304
 - M5: pending.
 
 ## Implementation Reviews

--- a/verification/stdlib/text_i18n_dependency_decisions.md
+++ b/verification/stdlib/text_i18n_dependency_decisions.md
@@ -1,6 +1,6 @@
 # Text/I18n Dependency Decisions
 
-Status: M4 in progress. Encoding versions were checked during M0/M1; Unicode core versions and generated Unicode 17.0.0 tables were locked during M2 on 2026-06-06; segmentation is aligned to Unicode 17.0.0 during M2.5. Locale IDs, formatting, plural rules, and collation use ICU4X 2.2 compiled data from M3 onward. Translation bundles use a first-party `.mo` compatibility parser from M4 onward.
+Status: M4 complete. Encoding versions were checked during M0/M1; Unicode core versions and generated Unicode 17.0.0 tables were locked during M2 on 2026-06-06; segmentation is aligned to Unicode 17.0.0 during M2.5. Locale IDs, formatting, plural rules, and collation use ICU4X 2.2 compiled data from M3 onward. Translation bundles use a first-party `.mo` compatibility parser from M4 onward.
 
 | Family | Crate(s) | Sifr abstraction | Unicode/version alignment | Panic/unsafe audit | Typed error mapping | License/MSRV/binary/platform impact | Deterministic tests | Supply-chain signal |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/verification/stdlib/text_i18n_substrate_inventory.json
+++ b/verification/stdlib/text_i18n_substrate_inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "status": "m4-in-progress",
+  "status": "m4-complete",
   "platform_contract": "verification/platform/platform_contract.json",
   "cpython_checkout": {
     "path": "/Users/yaseralnajjar/work/sifr/cpython",

--- a/verification/stdlib/text_i18n_substrate_inventory.md
+++ b/verification/stdlib/text_i18n_substrate_inventory.md
@@ -1,6 +1,6 @@
 # Text/I18n Substrate Inventory
 
-Status: M4 in progress.
+Status: M4 complete.
 
 Platform contract: [platform_contract.md](../platform/platform_contract.md)
 


### PR DESCRIPTION
## Summary\n- Mark M4 translation bundles complete in the execution tracker.\n- Link merged implementation PR #2304.\n- Update text/i18n inventory and dependency-decision statuses to M4 complete.\n\n## Validation\n- scripts/run_all_tests.sh --profile create-pr (pass; report target/validation_lane_reports/create-pr.latest.json; advisory: warm wall-time budget exceeded)\n- python3 -m json.tool verification/stdlib/text_i18n_substrate_inventory.json >/dev/null\n- git diff --check for closeout files