### PR TITLE
Record M3 parallel first-wave merge

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -402,6 +402,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M0a: https://github.com/sifr-lang/sifr/pull/2311
 - M1: https://github.com/sifr-lang/sifr/pull/2313
 - M2: https://github.com/sifr-lang/sifr/pull/2315
+- M3 first wave: https://github.com/sifr-lang/sifr/pull/2316
 - M3: pending.
 - M4: pending.
 - M5: pending.


### PR DESCRIPTION
Records the merged PR link for the M3 `sifr.parallel` first-wave implementation in the concurrency-runtime execution ledger.

Validation: documentation-only PR link update.