### PR TITLE
Add first native process runtime surface

### DIFF
--- a/crates/sifr/tests/e2e/pass/process_sync_output_status.sifr
+++ b/crates/sifr/tests/e2e/pass/process_sync_output_status.sifr
@@ -1,0 +1,36 @@
+from sifr.bytes import decode_utf8
+from sifr.process import Command, Output, ProcessError, Status, command, output, run, shell
+
+
+def text(data: bytes) -> str:
+    try:
+        decoded: str = decode_utf8(data)
+        return decoded
+    except ParseError as e:
+        return e.message
+
+
+def main():
+    native_cmd: Command = command("printf").arg("native-ok")
+    try:
+        native_out: Output = output(native_cmd)
+        assert native_out.status.success()
+        assert native_out.status.code == 0
+        assert text(native_out.stdout) == "native-ok"
+        assert len(native_out.stderr) == 0
+    except ProcessError as e:
+        assert str(e.message) == "process output should succeed"
+
+    shell_cmd: Command = shell("printf shell-ok")
+    try:
+        shell_out: Output = output(shell_cmd)
+        assert shell_out.status.success()
+        assert text(shell_out.stdout) == "shell-ok"
+    except ProcessError as e:
+        assert str(e.message) == "shell output should succeed"
+
+    try:
+        status: Status = run(command("printf").arg(""))
+        assert status.success()
+    except ProcessError as e:
+        assert str(e.message) == "process run should succeed"

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -21,6 +21,7 @@ mod open_text_handles;
 mod os;
 mod pathlib;
 mod platform;
+mod process;
 mod random;
 mod re;
 mod subprocess;
@@ -571,6 +572,7 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "platform_release" => (platform::lower_platform_release(args), None),
         "platform_version" => (platform::lower_platform_version(args), None),
         "platform_processor" => (platform::lower_platform_processor(args), None),
+        "process_output" => (process::lower_process_output(args), None),
         "uuid4" => (uuid::lower_uuid4(args), Some(StdlibFeature::Rand)),
         "uuid3_text" => (uuid::lower_uuid3(args), Some(StdlibFeature::Uuid)),
         "uuid5_text" => (uuid::lower_uuid5(args), Some(StdlibFeature::Uuid)),

--- a/crates/sifr_codegen/src/intrinsics/registry/process.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/process.rs
@@ -1,0 +1,45 @@
+//! Native process intrinsic lowerers for registry lowering.
+
+use crate::{RustExpr, RustStmt};
+
+fn arg_expr(args: &[RustExpr], idx: usize) -> RustExpr {
+    args[idx].clone()
+}
+
+pub(crate) fn lower_process_output(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 4 {
+        return None;
+    }
+    Some(RustExpr::Block {
+        stmts: vec![
+            RustStmt::Let {
+                mutable: false,
+                name: "__program".to_string(),
+                ty: None,
+                value: arg_expr(args, 0),
+            },
+            RustStmt::Let {
+                mutable: false,
+                name: "__args".to_string(),
+                ty: None,
+                value: arg_expr(args, 1),
+            },
+            RustStmt::Let {
+                mutable: false,
+                name: "__cwd".to_string(),
+                ty: None,
+                value: arg_expr(args, 2),
+            },
+            RustStmt::Let {
+                mutable: false,
+                name: "__shell".to_string(),
+                ty: None,
+                value: arg_expr(args, 3),
+            },
+        ],
+        expr: Some(Box::new(RustExpr::Ident(
+            "{\n    let mut __command = if __shell {\n        if cfg!(target_os = \"windows\") {\n            let mut __cmd = std::process::Command::new(\"cmd\");\n            __cmd.arg(\"/C\").arg(&__program).args(&__args);\n            __cmd\n        } else {\n            let mut __cmd = std::process::Command::new(\"sh\");\n            __cmd.arg(\"-c\").arg(&__program).args(&__args);\n            __cmd\n        }\n    } else {\n        let mut __cmd = std::process::Command::new(&__program);\n        __cmd.args(&__args);\n        __cmd\n    };\n    if let Some(__dir) = __cwd {\n        __command.current_dir(__dir);\n    }\n    let __output = __command\n        .output()\n        .map_err(|__err| ProcessError::new(__err.to_string()))?;\n    Ok((\n        __output.stdout,\n        __output.stderr,\n        __output.status.code().unwrap_or(-1) as i64,\n    ))\n}"
+                .to_string(),
+        ))),
+    })
+}

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -113,6 +113,28 @@ pub(crate) fn lowers_subprocess_intrinsics_via_registry() {
 }
 
 #[test]
+pub(crate) fn lowers_process_intrinsics_via_registry() {
+    let output = lower_intrinsic(
+        "process_output",
+        &[
+            "program".to_string(),
+            "args".to_string(),
+            "cwd".to_string(),
+            "shell".to_string(),
+        ],
+    )
+    .expect("process_output");
+    let rendered = render_expr(&output.expr);
+    assert!(rendered.contains("std::process::Command::new(&__program)"));
+    assert!(rendered.contains("__cmd.args(&__args)"));
+    assert!(rendered.contains("std::process::Command::new(\"sh\")"));
+    assert!(rendered.contains("std::process::Command::new(\"cmd\")"));
+    assert!(rendered.contains("ProcessError::new(__err.to_string())"));
+    assert!(rendered.contains("__output.stdout"));
+    assert!(rendered.contains("__output.stderr"));
+}
+
+#[test]
 pub(crate) fn lowers_html_intrinsics_via_registry() {
     let esc = lower_intrinsic("html_escape", &["s".to_string()]).expect("html_escape");
     assert!(render_expr(&esc.expr).contains("replace('&', \"&amp;\")"));

--- a/crates/sifr_stdlib/src/lib.rs
+++ b/crates/sifr_stdlib/src/lib.rs
@@ -14,6 +14,7 @@ mod i18n_core;
 mod io_json;
 mod math_test;
 mod platform_misc;
+mod process;
 mod sources;
 mod sys_fs;
 mod text_encoding;
@@ -32,6 +33,7 @@ use platform_misc::{
     intrinsic_calendar, intrinsic_compress, intrinsic_datetime, intrinsic_html, intrinsic_logging,
     intrinsic_platform, intrinsic_toml,
 };
+use process::intrinsic_process;
 pub use sources::{StdlibSource, STDLIB_SOURCES};
 use sys_fs::{intrinsic_fs, intrinsic_sys};
 use text_encoding::intrinsic_encoding;
@@ -98,6 +100,7 @@ pub fn get_intrinsic_module(module_name: &str) -> Option<IntrinsicModule> {
         "_sifr.regex" => Some(intrinsic_regex()),
         "_sifr.uuid" => Some(intrinsic_uuid()),
         "_sifr.platform" => Some(intrinsic_platform()),
+        "_sifr.process" => Some(intrinsic_process()),
         "_sifr.toml" => Some(intrinsic_toml()),
         "_sifr.datetime" => Some(intrinsic_datetime()),
         "_sifr.html" => Some(intrinsic_html()),

--- a/crates/sifr_stdlib/src/process.rs
+++ b/crates/sifr_stdlib/src/process.rs
@@ -1,0 +1,27 @@
+use super::{error_class, IntrinsicModule};
+use sifr_type_system::{FunctionType, Type};
+use std::collections::HashMap;
+
+pub(super) fn intrinsic_process() -> IntrinsicModule {
+    let mut functions = HashMap::new();
+    let output_tuple = Type::Tuple(vec![Type::Bytes, Type::Bytes, Type::Int]);
+    let process_error = error_class("ProcessError");
+
+    functions.insert(
+        "process_output".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("program".to_string(), Type::Str),
+                ("args".to_string(), Type::List(Box::new(Type::Str))),
+                ("cwd".to_string(), Type::Union(vec![Type::Str, Type::None])),
+                ("shell".to_string(), Type::Bool),
+            ],
+            Type::Result(Box::new(output_tuple), Box::new(process_error)),
+        ),
+    );
+
+    IntrinsicModule {
+        functions,
+        constants: HashMap::new(),
+    }
+}

--- a/crates/sifr_stdlib/src/sources.rs
+++ b/crates/sifr_stdlib/src/sources.rs
@@ -79,6 +79,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("../../../lib/sifr/parallel.sifr"),
     },
     StdlibSource {
+        module: "sifr.process",
+        source: include_str!("../../../lib/sifr/process.sifr"),
+    },
+    StdlibSource {
         module: "sifr.string",
         source: include_str!("../../../lib/sifr/string.sifr"),
     },

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -583,6 +583,22 @@ M3 closeout wave review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m3-closeout-review-pass-4.md`: `PASS`; final post-PR-#2326 reviewer verified the branch preserves the canonical lazy default pool fixture and default-pool implementation, removes the duplicate closeout fixture, routes all five CPU/Rayon surfaces through the shared worker panic-hook guard, and is ready to force-push and merge with no strict M3 closure blockers.
 - PR #2325 merged at `9edf51988475ce6711bb42e79b01e96c8e34e9b5`; M3 is closed.
 
+M4 native sync process first-wave targeted local validation:
+
+- `cargo fmt --check` -> PASS.
+- `cargo check -p sifr_stdlib -p sifr_codegen` -> PASS.
+- `python3 -m json.tool verification/validation_lanes/create_pr_e2e_manifest.json` and `python3 -m json.tool verification/validation_lanes/merge_e2e_manifest.json` -> PASS.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_sync_output_status.sifr` -> PASS.
+- `cargo test -p sifr_codegen lowers_process_intrinsics_via_registry -- --nocapture` -> PASS.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; 2165 files checked, 900-line limit.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisories: warm wall-time budget exceeded and warm-cache hit rate below advisory target. Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`90 passed`, `0 failed`, `cache_hits=7/24`, `report_signature=47d408939555ab52`).
+
+M4 native sync process first-wave review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-1.md`: `PASS`; reviewer verified the first-wave `sifr.process` surface does not reintroduce `sifr.subprocess` compatibility, binary stdout/stderr plus `Status` is a defensible M4 boundary, process startup errors remain typed `ProcessError`, shell execution is explicit, and fixtures/manifests are sufficient for the narrow slice. Non-blocking follow-ups were recorded for structured-IR lowerer cleanup, signal-status modeling, shell argument semantics, and broader fixture coverage.
+- `reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-2.md`: `PASS`; reviewer verified inert `Stdio`/`PIPE`/`INHERIT`/`NULL` were removed from the first wave, shell command arguments are forwarded rather than silently ignored, focused validation reran, and no new blocker exists before create-pr validation.
+
 M0 targeted local validation:
 
 - `python3 scripts/generate_concurrency_runtime_inventory.py` -> PASS; generated 135 CPython evidence entries from the phase source-of-truth list.

--- a/lib/sifr/process.sifr
+++ b/lib/sifr/process.sifr
@@ -1,0 +1,75 @@
+# sifr.process — Native process execution and binary output.
+from _sifr.process import process_output
+
+
+class ProcessError(Error):
+    message: str
+
+
+class Status:
+    code: int
+
+    def __init__(self, code: int) -> None:
+        self.code = code
+
+    def success(self) -> bool:
+        return self.code == 0
+
+    def __str__(self) -> str:
+        return "Status(" + str(self.code) + ")"
+
+
+class Output:
+    stdout: bytes
+    stderr: bytes
+    status: Status
+
+    def __init__(self, stdout: bytes, stderr: bytes, status: Status) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.status = status
+
+
+class Command:
+    program: str
+    args: list[str]
+    cwd: str | None
+    shell: bool
+
+    def __init__(self, program: str, args: list[str], cwd: str | None, shell: bool) -> None:
+        self.program = program
+        self.args = args
+        self.cwd = cwd
+        self.shell = shell
+
+    def arg(self, value: str) -> Command:
+        next_args: list[str] = self.args
+        next_args.append(value)
+        return Command(self.program, next_args, self.cwd, self.shell)
+
+    def current_dir(self, cwd: str) -> Command:
+        return Command(self.program, self.args, cwd, self.shell)
+
+
+def command(program: str) -> Command:
+    return Command(program, [], None, False)
+
+
+def shell(command_line: str) -> Command:
+    return Command(command_line, [], None, True)
+
+
+def output(own cmd: Command) -> Result[Output, ProcessError]:
+    try:
+        raw: tuple[bytes, bytes, int] = process_output(cmd.program, cmd.args, cmd.cwd, cmd.shell)
+        return Output(raw[0], raw[1], Status(raw[2]))
+    except ProcessError as e:
+        raise e
+
+
+def run(own cmd: Command) -> Result[Status, ProcessError]:
+    try:
+        out: Output = output(cmd)
+        return out.status
+    except ProcessError as e:
+        raise e

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-1.md
@@ -1,0 +1,31 @@
+I have enough to write a focused review. Let me compose it.
+
+---
+
+# Review: M4 Process Runtime — First Sync Wave
+
+**RESULT: PASS** (non-blocking follow-ups recorded; first-wave PR is shippable to create-pr lane.)
+
+## Verdict against the six review questions
+
+1. **No CPython-shaped re-introduction.** `lib/sifr/process.sifr:1-87` exposes only native names (`Command`, `Output`, `Status`, `Stdio`, `command()`, `shell()`, `output()`, `run()`). No `CompletedProcess`, no `subprocess.run(..., capture_output=True)` flag mash. Legacy/bare `subprocess` paths remain rejected via `unsupported_legacy_stdlib_module`/`cpython_stdlib_reserved_suggestion` in `crates/sifr_codegen/src/intrinsics/registry.rs:175,210-214,234` and asserted by `registry.rs:344-389`.
+2. **`Result[Output, ProcessError]` with binary stdout/stderr is a defensible first boundary.** `Output.stdout: bytes`/`Output.stderr: bytes` (process.sifr:30-31) plus typed `ProcessError` lets text decoding be layered through `sifr.bytes.decode_utf8` (exactly how `process_sync_output_status.sifr:5-10` uses it). This honours the M4 phase doc's "binary pipe mode first" direction and keeps `milestone_text_i18n_1` integration as future work.
+3. **No user-triggerable panic paths.** Lowered Rust uses `?` + `map_err(|__err| ProcessError::new(__err.to_string()))` and `status.code().unwrap_or(-1)` — no `unwrap()`/`expect()` on data-dependent values. `process_output` is typed `Result[(bytes, bytes, int), ProcessError]` at the intrinsic registry (`registry/process.rs:19`).
+4. **Shell path is explicit.** Separate `shell()` constructor (process.sifr:65-66) drives the `__shell` branch in the lowerer (registry/process.rs:41). The cross-platform `cmd /C` vs `sh -c` selection is in-IR and tested (`registry_extended_tests.rs:130-131`). Traceability honestly lists `@shell_exec`/`@blocking_io` diagnostics and async-context rejection as follow-ups (`concurrency_runtime_m4_process_traceability.md:18-27`).
+5. **Validation fixtures are minimally sufficient for this slice.** One fixture exercises native command + `.arg`, shell command, and `run()` returning `Status`; both manifests include it. Negative coverage relies on existing `legacy_sifr_subprocess_removed` / `bare_cpython_subprocess_import` fixtures.
+6. **No blocking issues before create-pr.** All findings below are follow-ups for later M4 waves.
+
+## Non-blocking findings (recommended follow-ups)
+
+1. **Lowerer embeds verbatim Rust as `RustExpr::Ident(...)` (`crates/sifr_codegen/src/intrinsics/registry/process.rs:40-43`).** Every other intrinsic — including the existing `subprocess.rs:100-257` you're replacing — composes structured `RustExpr` nodes. Stuffing a multiline Rust block into `Ident` works (it renders verbatim via `render_identifier` at `render_expr_and_blocks.rs:576-577`) but it bypasses the structured IR, defeats pretty-printing, and will be painful to extend when async/timeout/pipe variants land. Refactor to structured `RustExpr::If`/`MethodCall`/`Try` before the next M4 wave that adds spawn/pipe lowerers.
+2. **`shell("…").arg("x")` silently drops the arg.** `Command.arg` appends to `args`, but the lowerer ignores `args` when `__shell` is true (registry/process.rs:41 emits only `__cmd.arg("/C"|"-c").arg(&__program)`). No fixture catches this. Either reject `.arg()` on a shell-built `Command`, fold extra args into the shell command line, or at minimum record the trap in `concurrency_runtime_m4_process_traceability.md` follow-ups so users aren't surprised.
+3. **Signal termination collapses into exit code `-1`.** `__output.status.code().unwrap_or(-1) as i64` (registry/process.rs:41) merges `code()==None` (signal termination) with a legitimate `-1` exit. Already listed as "Host-matrix evidence for signal/termination behavior" follow-up in the traceability — but consider returning a typed `ProcessError::Signal { signal: i32 }` variant or distinguishing in `Status` rather than reserving `-1` as a sentinel, so the M5 signal/shutdown work doesn't have to redesign `Status`.
+4. **`Stdio`, `PIPE`, `INHERIT`, `NULL` are exposed but inert.** `output()`/`run()` never consume `Stdio`; the constants are publicly importable surface that does nothing yet. Either drop them from this wave or wire them through `process_output` so the API doesn't misrepresent what controls users have. The traceability already lists `Stdio`/`PipeReader`/`PipeWriter` follow-ups; mirroring that disposition in the `.sifr` file (or gating exports) would prevent users from writing code that compiles but is silently ignored.
+5. **Mild: `Stdio.mode: str` with no enum/validation.** A `Literal["pipe","inherit","null"]` or dedicated enum would catch typos at compile time consistent with Sifr's "if it compiles, it works" guarantee.
+6. **Minor: fixture coverage gaps.** `process_sync_output_status.sifr` does not exercise: command-not-found error path (`ProcessError` surface), `current_dir`, non-zero exit (`status.success()==false`), or non-UTF8 binary stdout. Reasonable for first wave; flagging so the next M4 PR doesn't ship pipes without filling these.
+
+## Summary
+
+The implementation cleanly establishes the native `sifr.process` surface contract, keeps the typed `Result` boundary intact, and explicitly defers Stdio/pipe/async/signal/text-mode work in `verification/stdlib/concurrency_runtime_m4_process_traceability.md`. The structured-IR regression in the lowerer (finding 1) and the silent shell-arg drop (finding 2) are the most concrete follow-ups worth landing before M4's spawn/pipe wave.
+
+**RESULT: PASS**

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-2.md
@@ -1,0 +1,20 @@
+I've verified both pass-1 follow-ups landed cleanly and no new blockers exist.
+
+**RESULT: PASS**
+
+## Verification of pass-1 follow-up fixes
+
+**Finding 4 (inert `Stdio`/`PIPE`/`INHERIT`/`NULL`) — fixed by removal.** `lib/sifr/process.sifr:1-76` now exposes only the live surface (`ProcessError`, `Status`, `Output`, `Command`, `command()`, `shell()`, `output()`, `run()`). Grep confirms no orphan references in the new process files — the only remaining `Stdio/PIPE/INHERIT` hits in the repo are unrelated (third_party ruff, legacy `demos/subprocess`, etc.).
+
+**Finding 2 (silent shell-arg drop) — fixed by forwarding.** `crates/sifr_codegen/src/intrinsics/registry/process.rs:41` now emits `.args(&__args)` in all three branches (Windows `cmd /C`, POSIX `sh -c`, and native). The targeted unit test (`registry_extended_tests.rs:129`) asserts `__cmd.args(&__args)` is present, and `cargo test … lowers_process_intrinsics_via_registry` passes.
+
+## No new blockers
+
+- Six review questions from pass 1 still hold: no CPython re-introduction, typed `Result[Output, ProcessError]` boundary, no user-triggerable panics, explicit `shell()` opt-in, fixture+manifest coverage (`process_sync_output_status` present in both `create_pr_e2e_manifest.json:85` and `merge_e2e_manifest.json:100`), and intentional follow-ups recorded in `verification/stdlib/concurrency_runtime_m4_process_traceability.md:18-27`.
+- The structured-IR refactor (pass-1 finding 1), `-1` signal-collapse (finding 3), and fixture coverage gaps (finding 6) remain as non-blocking follow-ups for later M4 waves — unchanged from pass 1.
+
+## One subtle non-blocking observation on the shell-args fix
+
+POSIX `sh -c PROGRAM args...` assigns the trailing args to `$0`, `$1`, … of the spawned shell — they are **not** appended to the command line. So `shell("echo hi").arg("there")` will run `sh -c "echo hi" there`, where `there` becomes `$0` (typically unused by the command string), not `echo hi there`. On Windows, `cmd /C` does concatenate. The forwarded-args fix is strictly better than silent drop, but the cross-platform semantic asymmetry is worth noting in the traceability follow-ups (alongside `@shell_exec` diagnostics) so users writing `shell(...).arg(...)` aren't surprised. Not a blocker; flag for the next M4 wave's documentation/diagnostics work.
+
+**RESULT: PASS** — first-wave PR is shippable to the create-pr lane.

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -1,0 +1,28 @@
+# Concurrency Runtime M4 Process Traceability
+
+Milestone: `milestone_concurrency_runtime_4`
+
+Status: In progress; first sync native-process wave.
+
+## Production Surface Traceability
+
+| Surface | M4 evidence | Notes |
+| --- | --- | --- |
+| `sifr.process.Command` | `process_sync_output_status` | Native process command object records program, argv, optional current directory, and whether shell execution is explicit. |
+| `sifr.process.output` | `process_sync_output_status` | Sync process output returns typed `Result[Output, ProcessError]`; `Output.stdout` and `Output.stderr` are binary `bytes`, and `Output.status` wraps the exit status. |
+| `sifr.process.run` | `process_sync_output_status` | Sync process run returns typed `Result[Status, ProcessError]` without throwing host subprocess failures as panics. |
+| `sifr.process.shell` | `process_sync_output_status` | Shell execution requires an explicit constructor and does not reintroduce `sifr.subprocess` compatibility. |
+| `sifr.subprocess` and bare `subprocess` | `legacy_sifr_subprocess_removed`; `bare_cpython_subprocess_import` | Legacy CPython-shaped process modules remain rejected or unsupported with diagnostics. |
+
+## Follow-up Boundaries
+
+Intentional remaining M4 work:
+
+- Async process spawn/wait/communicate.
+- Owned `Child`, `PipeReader`, and `PipeWriter` resources.
+- Timeout, termination, kill, structured cancellation, and scoped process supervision.
+- Environment override support beyond inherited process environment.
+- Text-mode subprocess integration through text/i18n APIs.
+- Shell-effect diagnostics integrated with async/offload validation.
+- Cross-platform shell argument semantics: POSIX `sh -c` treats forwarded args as shell positional parameters, while Windows `cmd /C` appends command arguments differently. Later M4 docs/diagnostics must define or reject `shell(...).arg(...)` portability before shell APIs are considered closed.
+- Host-matrix evidence for signal/termination behavior.

--- a/verification/validation_lanes/create_pr_e2e_manifest.json
+++ b/verification/validation_lanes/create_pr_e2e_manifest.json
@@ -82,6 +82,7 @@
     "parallel_try_map_user_error_typed",
     "parallel_pool_map_basic",
     "parallel_default_pool_reused",
+    "process_sync_output_status",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",

--- a/verification/validation_lanes/merge_e2e_manifest.json
+++ b/verification/validation_lanes/merge_e2e_manifest.json
@@ -97,6 +97,7 @@
     "parallel_try_map_user_error_typed",
     "parallel_pool_map_basic",
     "parallel_default_pool_reused",
+    "process_sync_output_status",
     "text_i18n_encoding_io",
     "text_i18n_unicode_core",
     "text_i18n_unicode_segmentation",


### PR DESCRIPTION
## Summary
- Add the first `sifr.process` native sync process surface with `Command`, `Status`, `Output`, `output`, `run`, `command`, and explicit `shell` construction.
- Wire `_sifr.process.process_output` through stdlib intrinsic metadata and codegen lowering to `std::process::Command`.
- Add a process sync e2e fixture, create-pr/merge lane manifest coverage, M4 traceability, and reviewer artifacts.

## Validation
- `cargo fmt --check`
- `cargo check -p sifr_stdlib -p sifr_codegen`
- `python3 -m json.tool verification/validation_lanes/create_pr_e2e_manifest.json`
- `python3 -m json.tool verification/validation_lanes/merge_e2e_manifest.json`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_sync_output_status.sifr`
- `cargo test -p sifr_codegen lowers_process_intrinsics_via_registry -- --nocapture`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` (PASS; report `target/validation_lane_reports/create-pr.latest.json`; platform golden `pass=5`, `skip=2`; e2e `90 passed`, `0 failed`; advisories: warm wall-time budget exceeded and warm-cache hit rate below target)

## Reviews
- `reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-1.md`: PASS
- `reviews/ad-hoc-production-concurrency-runtime-m4-process-sync-review-pass-2.md`: PASS

M4 remains open after this first sync-native-process wave; async process supervision, pipes, typed exit modeling, shell-effect diagnostics, and broader fixture coverage remain tracked follow-ups.
