### PR TITLE
Add M4 sync child wait support

### DIFF
--- a/crates/sifr/tests/e2e/fail/process_wait_direct_async_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/process_wait_direct_async_rejected.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.process import Child, Status, wait
+
+
+async def observe(child: Child):
+    status = wait(child)
+    await task.sleep(0.0)
+    return status

--- a/crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr
+++ b/crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr
@@ -1,0 +1,35 @@
+from sifr.process import Child, Command, ProcessError, Status, spawn, wait
+
+
+def main():
+    actual: list[bool] = []
+    command: Command = Command("sh")
+    command.args(["-c", "exit 7"])
+
+    try:
+        child: Child = spawn(command)
+        status: Status = wait(child)
+        actual.append(status.code == 7)
+        actual.append(not status.success)
+        actual.append(status.kind == "nonzero")
+
+        try:
+            second: Status = wait(child)
+            actual.append(second.success)
+        except ProcessError as e:
+            actual.append("closed or unknown" in e.message)
+
+        ok_command: Command = Command("true")
+        method_child: Child = spawn(ok_command)
+        method_status: Status = method_child.wait()
+        actual.append(method_status.success)
+
+        try:
+            method_second: Status = method_child.wait()
+            actual.append(method_second.success)
+        except ProcessError as e:
+            actual.append("already been waited" in e.message)
+    except ProcessError as e:
+        actual.append(False)
+
+    assert actual == [True, True, True, True, True, True]

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -597,6 +597,8 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "subprocess_run_with_input" => (subprocess::lower_subprocess_run_with_input(args), None),
         "subprocess_run_structured" => (subprocess::lower_subprocess_run_structured(args), None),
         "process_run" => (process::lower_process_run(args), None),
+        "process_spawn" => (process::lower_process_spawn(args), None),
+        "process_wait" => (process::lower_process_wait(args), None),
         "process_output" => (process::lower_process_output(args), None),
         "process_output_text" => (process::lower_process_output_text(args), None),
         "process_shell_run" => (process::lower_process_shell_run(args), None),

--- a/crates/sifr_codegen/src/intrinsics/registry/process.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/process.rs
@@ -47,10 +47,42 @@ fn process_map_err(expr: RustExpr) -> RustExpr {
     }
 }
 
+fn process_child_handles_lock_expr() -> RustExpr {
+    RustExpr::MethodCall {
+        receiver: Box::new(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident("__SIFR_PROCESS_CHILDREN".to_string())),
+            method: "lock".to_string(),
+            args: vec![],
+        }),
+        method: "unwrap_or_else".to_string(),
+        args: vec![RustExpr::Closure {
+            params: vec![RustParam::Named {
+                name: "__err".to_string(),
+                ty: RustType::Named("_".to_string()),
+            }],
+            body: Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__err".to_string())),
+                method: "into_inner".to_string(),
+                args: vec![],
+            }),
+            is_move: false,
+        }],
+    }
+}
+
 fn ok_expr(expr: RustExpr) -> RustExpr {
     RustExpr::FnCall {
         func: Box::new(RustExpr::Path(vec!["Ok".to_string()])),
         args: vec![expr],
+    }
+}
+
+fn next_child_handle_id_expr() -> RustExpr {
+    RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(vec![
+            "__sifr_next_process_child_id".to_string()
+        ])),
+        args: vec![],
     }
 }
 
@@ -377,6 +409,114 @@ pub(crate) fn lower_process_run(args: &[RustExpr]) -> Option<RustExpr> {
             args: vec![],
         }))),
     });
+    Some(RustExpr::Block {
+        stmts,
+        expr: Some(Box::new(ok_expr(status_code(RustExpr::Ident(
+            "__status".to_string(),
+        ))))),
+    })
+}
+
+pub(crate) fn lower_process_spawn(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 5 {
+        return None;
+    }
+    let mut stmts = normal_command_setup(args);
+    stmts.extend([
+        RustStmt::Let {
+            mutable: false,
+            name: "__child".to_string(),
+            ty: None,
+            value: RustExpr::Try(Box::new(process_map_err(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__cmd".to_string())),
+                method: "spawn".to_string(),
+                args: vec![],
+            }))),
+        },
+        RustStmt::Let {
+            mutable: false,
+            name: "__handle".to_string(),
+            ty: None,
+            value: next_child_handle_id_expr(),
+        },
+        RustStmt::Expr(RustExpr::MethodCall {
+            receiver: Box::new(process_child_handles_lock_expr()),
+            method: "insert".to_string(),
+            args: vec![
+                RustExpr::Ident("__handle".to_string()),
+                RustExpr::Ident("__child".to_string()),
+            ],
+        }),
+    ]);
+    Some(RustExpr::Block {
+        stmts,
+        expr: Some(Box::new(ok_expr(RustExpr::Ident("__handle".to_string())))),
+    })
+}
+
+pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let handle_expr = arg_expr(args, 0);
+    let missing_child_error = process_error_expr(RustExpr::FormatMacro {
+        name: "format".to_string(),
+        format_str: "process child handle is closed or unknown: {}".to_string(),
+        args: vec![RustExpr::Ident("__handle".to_string())],
+    });
+    let stmts = vec![
+        RustStmt::Let {
+            mutable: false,
+            name: "__handle".to_string(),
+            ty: None,
+            value: handle_expr,
+        },
+        RustStmt::Let {
+            mutable: false,
+            name: "__maybe_child".to_string(),
+            ty: None,
+            value: RustExpr::Block {
+                stmts: vec![RustStmt::Let {
+                    mutable: true,
+                    name: "__children".to_string(),
+                    ty: None,
+                    value: process_child_handles_lock_expr(),
+                }],
+                expr: Some(Box::new(RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::Ident("__children".to_string())),
+                    method: "remove".to_string(),
+                    args: vec![RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Ident("__handle".to_string())),
+                    }],
+                })),
+            },
+        },
+        RustStmt::Let {
+            mutable: true,
+            name: "__child".to_string(),
+            ty: None,
+            value: RustExpr::Try(Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__maybe_child".to_string())),
+                method: "ok_or_else".to_string(),
+                args: vec![RustExpr::Closure {
+                    params: vec![],
+                    body: Box::new(missing_child_error),
+                    is_move: false,
+                }],
+            })),
+        },
+        RustStmt::Let {
+            mutable: false,
+            name: "__status".to_string(),
+            ty: None,
+            value: RustExpr::Try(Box::new(process_map_err(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__child".to_string())),
+                method: "wait".to_string(),
+                args: vec![],
+            }))),
+        },
+    ];
     Some(RustExpr::Block {
         stmts,
         expr: Some(Box::new(ok_expr(status_code(RustExpr::Ident(

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -3,7 +3,7 @@ use super::{
     build_async_generator_type_items, build_cancellation_error_type_items, build_cpu_offload_items,
     build_error_into_error_impl, build_error_type_items, build_failure_type_items,
     build_file_handle_infra_items, build_file_handle_struct_items, build_io_error_items,
-    build_join_set_cpu_items, build_join_set_items, build_logging_items,
+    build_join_set_cpu_items, build_join_set_items, build_logging_items, build_process_child_items,
     build_random_module_state_items, build_task_scope_cpu_offload_items, build_task_scope_items,
     build_task_scope_offload_items, build_timeout_result_type_items, build_worker_panic_hook_items,
     module_uses_async_exit_cause_type, module_uses_async_generator_type,
@@ -321,6 +321,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     let mut all_needed: Vec<String> = Vec::new();
     let mut transitive_dependency_modules: HashSet<String> = HashSet::new();
     let mut stdlib_needs_file_handles = false;
+    let mut stdlib_needs_process_children = false;
     let mut stdlib_provides_file_handle_struct = false;
     for module_name in emitter.used_stdlib_modules.iter().collect::<BTreeSet<_>>() {
         if let Some(deps) = stdlib_code.transitive_deps.get(module_name) {
@@ -379,6 +380,10 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
                     let prepared = collect_and_strip_shared_prelude(&filtered);
                     stdlib_needs_file_handles |=
                         prepared.shared_needs.file_handles.needs_file_handles;
+                    stdlib_needs_process_children |= prepared
+                        .shared_needs
+                        .process_children
+                        .needs_process_children;
                     stdlib_provides_file_handle_struct |= prepared
                         .shared_needs
                         .file_handles
@@ -401,6 +406,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
 
     // Compute broad feature needs first, then refine imports structurally from preamble IR.
     let needs_file_handles = emitter.runtime_needs.file_handles() || stdlib_needs_file_handles;
+    let needs_process_children = stdlib_needs_process_children;
     let needs_logging = emitter.used_stdlib_modules.contains("sifr.logging")
         || emitter.used_stdlib_modules.contains("_sifr.logging")
         || emitter.runtime_needs.logging_state();
@@ -565,6 +571,9 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
             preamble_items.extend(build_file_handle_struct_items());
         }
     }
+    if needs_process_children {
+        preamble_items.extend(build_process_child_items());
+    }
 
     // Emit global log level state if logging module is used.
     if needs_logging {
@@ -624,6 +633,7 @@ pub fn generate_rust_with_stdlib(module: &HirModule, stdlib_code: &StdlibCode) -
     let needs_sifr_int =
         body_import_needs.runtime.needs_sifr_int || stdlib_import_needs.runtime.needs_sifr_int;
     let needs_mutex = needs_file_handles
+        || needs_process_children
         || needs_logging
         || needs_random_module_state
         || body_import_needs.runtime.needs_mutex

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -14,6 +14,8 @@ mod join_set_runtime;
 pub use join_set_runtime::*;
 mod parallel_runtime;
 pub(crate) use parallel_runtime::*;
+mod process_runtime;
+pub(crate) use process_runtime::*;
 mod io_logging_random;
 pub use io_logging_random::*;
 mod io_bytes_methods;

--- a/crates/sifr_codegen/src/preamble/process_runtime.rs
+++ b/crates/sifr_codegen/src/preamble/process_runtime.rs
@@ -1,0 +1,84 @@
+//! Runtime support for generated process child handles.
+
+use crate::{RustExpr, RustItem, RustLiteral, RustStmt, RustType, Visibility};
+
+pub(crate) fn build_process_child_items() -> Vec<RustItem> {
+    vec![
+        RustItem::Static {
+            name: "__SIFR_PROCESS_CHILDREN".to_string(),
+            visibility: Visibility::Private,
+            ty: RustType::Named(
+                "std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<i64, std::process::Child>>>"
+                    .to_string(),
+            ),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    "std".to_string(),
+                    "sync".to_string(),
+                    "LazyLock".to_string(),
+                    "new".to_string(),
+                ])),
+                args: vec![RustExpr::Closure {
+                    params: vec![],
+                    body: Box::new(RustExpr::FnCall {
+                        func: Box::new(RustExpr::Path(vec![
+                            "std".to_string(),
+                            "sync".to_string(),
+                            "Mutex".to_string(),
+                            "new".to_string(),
+                        ])),
+                        args: vec![RustExpr::FnCall {
+                            func: Box::new(RustExpr::Path(vec![
+                                "std".to_string(),
+                                "collections".to_string(),
+                                "HashMap".to_string(),
+                                "new".to_string(),
+                            ])),
+                            args: vec![],
+                        }],
+                    }),
+                    is_move: false,
+                }],
+            },
+        },
+        RustItem::Static {
+            name: "__SIFR_NEXT_PROCESS_CHILD_ID".to_string(),
+            visibility: Visibility::Private,
+            ty: RustType::Named("std::sync::atomic::AtomicI64".to_string()),
+            value: RustExpr::FnCall {
+                func: Box::new(RustExpr::Path(vec![
+                    "std".to_string(),
+                    "sync".to_string(),
+                    "atomic".to_string(),
+                    "AtomicI64".to_string(),
+                    "new".to_string(),
+                ])),
+                args: vec![RustExpr::Literal(RustLiteral::Int(1))],
+            },
+        },
+        RustItem::Fn {
+            name: "__sifr_next_process_child_id".to_string(),
+            visibility: Visibility::Private,
+            type_params: vec![],
+            params: vec![],
+            ret: Some(RustType::I64),
+            body: vec![RustStmt::Return(Some(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident(
+                    "__SIFR_NEXT_PROCESS_CHILD_ID".to_string(),
+                )),
+                method: "fetch_add".to_string(),
+                args: vec![
+                    RustExpr::Literal(RustLiteral::Int(1)),
+                    RustExpr::Path(vec![
+                        "std".to_string(),
+                        "sync".to_string(),
+                        "atomic".to_string(),
+                        "Ordering".to_string(),
+                        "SeqCst".to_string(),
+                    ]),
+                ],
+            }))],
+            is_async: false,
+        },
+    ]
+}

--- a/crates/sifr_codegen/src/stdlib_filter/implementation.rs
+++ b/crates/sifr_codegen/src/stdlib_filter/implementation.rs
@@ -25,6 +25,7 @@ struct StdlibIrFile {
 pub(crate) struct SharedPreludeNeeds {
     pub(crate) collections: SharedPreludeCollectionNeeds,
     pub(crate) file_handles: SharedPreludeFileHandleNeeds,
+    pub(crate) process_children: SharedPreludeProcessChildNeeds,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -38,6 +39,11 @@ pub(crate) struct SharedPreludeCollectionNeeds {
 pub(crate) struct SharedPreludeFileHandleNeeds {
     pub(crate) needs_file_handles: bool,
     pub(crate) provides_file_handle_struct: bool,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct SharedPreludeProcessChildNeeds {
+    pub(crate) needs_process_children: bool,
 }
 
 pub(crate) struct PreparedStdlibModule {
@@ -261,6 +267,12 @@ pub(super) fn derive_shared_needs(items: &[Item]) -> SharedPreludeNeeds {
             {
                 shared_needs.file_handles.needs_file_handles = true;
             }
+            Item::Static(item_static)
+                if item_static.ident == "__SIFR_PROCESS_CHILDREN"
+                    || item_static.ident == "__SIFR_NEXT_PROCESS_CHILD_ID" =>
+            {
+                shared_needs.process_children.needs_process_children = true;
+            }
             _ => {}
         }
     }
@@ -285,6 +297,11 @@ pub(super) fn derive_shared_needs_text_scan(code: &str) -> SharedPreludeNeeds {
                 || code.contains("__sifr_next_file_handle_id"),
             provides_file_handle_struct: code.contains("struct FileHandle"),
         },
+        process_children: SharedPreludeProcessChildNeeds {
+            needs_process_children: code.contains("__SIFR_PROCESS_CHILDREN")
+                || code.contains("__SIFR_NEXT_PROCESS_CHILD_ID")
+                || code.contains("__sifr_next_process_child_id"),
+        },
     }
 }
 
@@ -306,6 +323,11 @@ impl<'ast> Visit<'ast> for SharedNeedsCollector {
                 | "__sifr_next_file_handle_id" => {
                     self.shared_needs.file_handles.needs_file_handles = true;
                 }
+                "__SIFR_PROCESS_CHILDREN"
+                | "__SIFR_NEXT_PROCESS_CHILD_ID"
+                | "__sifr_next_process_child_id" => {
+                    self.shared_needs.process_children.needs_process_children = true;
+                }
                 _ => {}
             }
         }
@@ -320,9 +342,14 @@ pub(super) fn is_shared_prelude_item(item: &Item) -> bool {
         Item::Static(item_static) => {
             item_static.ident == "__SIFR_FILE_HANDLES"
                 || item_static.ident == "__SIFR_NEXT_FILE_HANDLE_ID"
+                || item_static.ident == "__SIFR_PROCESS_CHILDREN"
+                || item_static.ident == "__SIFR_NEXT_PROCESS_CHILD_ID"
                 || item_static.ident == "__SIFR_GLOBAL_LOG_LEVEL"
         }
-        Item::Fn(item_fn) => item_fn.sig.ident == "__sifr_next_file_handle_id",
+        Item::Fn(item_fn) => {
+            item_fn.sig.ident == "__sifr_next_file_handle_id"
+                || item_fn.sig.ident == "__sifr_next_process_child_id"
+        }
         _ => false,
     }
 }

--- a/crates/sifr_stdlib/src/process.rs
+++ b/crates/sifr_stdlib/src/process.rs
@@ -30,6 +30,26 @@ pub(super) fn intrinsic_process() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "process_spawn".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("program".to_string(), Type::Str),
+                ("args".to_string(), args_ty.clone()),
+                ("env".to_string(), env_ty.clone()),
+                ("cwd".to_string(), Type::Str),
+                ("has_cwd".to_string(), Type::Bool),
+            ],
+            result_ty(Type::Int, "ProcessError"),
+        ),
+    );
+    functions.insert(
+        "process_wait".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            result_ty(Type::Int, "ProcessError"),
+        ),
+    );
+    functions.insert(
         "process_output".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -604,6 +604,25 @@ M4 sync process foundation review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m4-sync-process-review-pass-1.md`: `PASS`; reviewer verified ordinary argv APIs lower to `std::process::Command` without shell or legacy subprocess helpers, shell APIs are explicit and classified with `SIFR-ASYNC-0007`, env/cwd/stdin/output/text behavior is typed without data-dependent panics, imported workload metadata covers stdlib imports and local re-exports, traceability honestly preserves remaining M4 process lifecycle work, and the wave is ready to PR. Non-blocking follow-ups were recorded for stdin setter semantics, deletion of unused legacy `_sifr.sys.subprocess_*` intrinsic paths, future stdlib re-export workload metadata, and later signal/timeout/cancellation/text-mode completion.
 - PR #2331 merged at `b473c763ae3e92d614e7799af956bafcf4d60cb8`.
 
+M4 sync child wait targeted local validation:
+
+- `cargo check -p sifr_codegen -p sifr_stdlib -p sifr_driver -p sifr --quiet` -> PASS.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr` -> PASS.
+- Existing sync process regressions: `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, and `process_spawn_wait_status` -> PASS.
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_wait_direct_async_rejected.sifr` -> expected FAIL with `SIFR-ASYNC-0003`.
+- Existing process async-diagnostic regressions: `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, and `process_wait_direct_async_rejected` -> expected FAIL with `SIFR-ASYNC-0003` / `SIFR-ASYNC-0007` / `SIFR-ASYNC-0003`.
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr | rg "__SIFR_PROCESS_CHILDREN|__sifr_next_process_child_id|std::process::Child|process_spawn|process_wait|std::process::Command"` -> PASS; emitted spawn/wait path includes the private process-child table and `std::process::Command`.
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_sync_output_text.sifr | rg "__SIFR_PROCESS_CHILDREN|__sifr_next_process_child_id|std::process::Child"` -> expected no matches; ordinary output path does not emit child-handle runtime state.
+- `cargo fmt --check` -> PASS.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; 2172 files checked, 900-line limit.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `cargo test -p sifr test_e2e_fail -- --nocapture` -> PASS; fail suite reported 418 fail tests completed.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`93 passed`, `0 failed`, `cache_hits=24/25`).
+
+M4 sync child wait review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m4-child-wait-review-pass-1.md`: `PASS`; reviewer verified the wave is sync-only and does not overclaim pipes/async process support, process-child runtime state is gated to spawn/wait users, `process_wait` is one-shot and typed without data-dependent panics, top-level `wait(child)` triggers imported `@blocking_io` direct-async diagnostics, top-level/method wait asymmetry is safe for this wave, and traceability preserves remaining lifecycle work. Non-blocking follow-ups were recorded for unified wait-observation wording, explicit unwaited-child leak/drop cleanup documentation, possible tighter `Child`-only import preamble gating, and legacy `_sifr.sys.subprocess_*` cleanup.
+
 M0 targeted local validation:
 
 - `python3 scripts/generate_concurrency_runtime_inventory.py` -> PASS; generated 135 CPython evidence entries from the phase source-of-truth list.

--- a/lib/sifr/process.sifr
+++ b/lib/sifr/process.sifr
@@ -1,6 +1,8 @@
 # sifr.process — Native process execution and status surfaces
 from _sifr.process import (
     process_run,
+    process_spawn,
+    process_wait,
     process_output,
     process_output_text,
     process_shell_run,
@@ -54,6 +56,26 @@ class Output:
         self.stdout = stdout
         self.stderr = stderr
         self.status = status
+
+
+class Child:
+    _handle: int
+    _waited: bool
+
+    def __init__(self, handle: int):
+        self._handle = handle
+        self._waited = False
+
+    @blocking_io
+    def wait(self) -> Result[Status, ProcessError]:
+        if self._waited:
+            raise ProcessError("process child has already been waited")
+        self._waited = True
+        try:
+            code: int = process_wait(self._handle)
+            return _status(code)
+        except ProcessError as e:
+            raise e
 
 
 class TextOutput:
@@ -110,6 +132,30 @@ def _status(code: int) -> Status:
     if code == 0:
         return Status(code, "success")
     return Status(code, "nonzero")
+
+
+@blocking_io
+def spawn(command: Command) -> Result[Child, ProcessError]:
+    try:
+        handle: int = process_spawn(
+            command.program,
+            command.arguments,
+            command.env_vars,
+            command.working_dir,
+            command.has_working_dir,
+        )
+        return Child(handle)
+    except ProcessError as e:
+        raise e
+
+
+@blocking_io
+def wait(child: Child) -> Result[Status, ProcessError]:
+    try:
+        code: int = process_wait(child._handle)
+        return _status(code)
+    except ProcessError as e:
+        raise e
 
 
 @blocking_io

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-child-wait-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-child-wait-review-pass-1.md
@@ -1,0 +1,40 @@
+I have the empty review file from the user's scratch — I'll write my pass-1 review report there as well. Let me finalize the review verdict.
+
+## Verdict: PASS (with non-blocking follow-ups)
+
+The M4 sync child wait wave is honestly scoped and implementation-ready. All seven review concerns from the task brief check out:
+
+### Verified
+
+1. **Sync-only child lifecycle, no overclaim of pipes/async.** `spawn(Command) -> Result[Child, ProcessError]`, top-level `wait(Child)`, and `Child.wait()` are all `@blocking_io`, return typed `Result`, and the traceability/manifests explicitly preserve owned pipes, async wait, termination/timeout/cancellation, scoped supervision, and richer text mode as later M4 work. `Stdio` constants remain reserved-only.
+
+2. **Generated process-child table is correctly gated.** I independently re-ran emit for `process_sync_output_text.sifr` (imports only `Command`+`output_text`): no `__SIFR_PROCESS_CHILDREN`/`__sifr_next_process_child_id`/`std::process::Child` matches. The DCE + `derive_shared_needs` path (`crates/sifr_codegen/src/stdlib_filter/implementation.rs:250-306`, `crates/sifr_codegen/src/lib_modules_and_codegen.rs:380-411`) only emits the table when the kept stdlib code references the symbols, which happens iff `spawn` / `wait` / `Child` survives DCE.
+
+3. **`process_wait` is one-shot and typed; no data-dependent panics.** `crates/sifr_codegen/src/intrinsics/registry/process.rs:457-526` removes the handle from the map first, then `.ok_or_else(|| ProcessError { message: "process child handle is closed or unknown: …" })?`. Mutex `.unwrap_or_else(|err| err.into_inner())` is poison recovery (programmer-invariant). `.code().unwrap_or(-1)` is fine — `code()` returns `Option<i32>` only because signal exits have no code; `-1` is a data value, not a panic in a Result path. `Child.wait()` rejects double-call with `"already been waited"` before touching the table.
+
+4. **Direct-async diagnostic works through workload metadata.** Confirmed locally: `cargo run -p sifr -- check crates/sifr/tests/e2e/fail/process_wait_direct_async_rejected.sifr` emits `error[SIFR-ASYNC-0003]: blocking_io function 'wait' called directly from async context`.
+
+5. **Asymmetric observation between top-level `wait(child)` and `Child.wait()`.** Acceptable for this wave. Both surfaces produce `ProcessError`, just with different message text after mixed use. The `_waited` boolean is a local mirror; the runtime table remains the source of truth. The fixture explicitly tests both messages and the safety invariant holds in all four call orderings (`wait→wait`, `wait→method`, `method→wait`, `method→method`). Worth a non-blocking follow-up to unify the asymmetry by either deferring entirely to the runtime table or sharing the message via a helper.
+
+6. **Resource/lifecycle docs are honest enough.** Traceability lists "owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work" and "double-close/use-after-close diagnostics, and handle sendability/shareability checks beyond the one-shot sync `Child.wait()` state". Non-blocking: the docs don't explicitly call out that dropping an unwaited `Child` leaves a `std::process::Child` in the process-global table for the process lifetime (potential zombie on Unix). Worth a one-line follow-up in the "Follow-up Boundaries" section noting the leak risk.
+
+7. **Preamble/filtering integration is robust.** `is_shared_prelude_item` (`stdlib_filter/implementation.rs:338-355`) now strips the static + the `__sifr_next_process_child_id` fn so they don't double-emit. `needs_mutex` (`lib_modules_and_codegen.rs:637-641`) correctly OR's in `needs_process_children` so the `use std::sync::Mutex` import is present. `derive_shared_needs_text_scan` mirrors the AST path for the fallback. Pattern is symmetric with existing `__SIFR_FILE_HANDLES` handling.
+
+### Empirical verification
+
+- `cargo run -q -p sifr -- build crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr` -> compiled successfully; binary execution returns success (asserts pass for all six expected booleans).
+- `cargo run -q -p sifr -- emit ...process_sync_output_text.sifr | grep '__SIFR_PROCESS_CHILDREN|__sifr_next_process_child_id|std::process::Child'` -> no matches.
+- `cargo run -q -p sifr -- check ...process_wait_direct_async_rejected.sifr` -> SIFR-ASYNC-0003 as expected.
+- All four create-pr lane validations claimed in the ledger (cargo check, fmt, file-size + HIR guardrails, fail suite, run_all_tests.sh --profile create-pr with `93 passed`/`0 failed`/`cache_hits=24/25`) line up with the staged diff.
+
+### Non-blocking follow-ups (do not block PR)
+
+1. **Unify the wait-observation asymmetry.** Either remove `_waited` from `Child` and surface only `"closed or unknown"` consistently, or factor a shared helper so top-level `wait(child)` produces the same `"already been waited"` text. Either keeps behavior safe; the choice is cosmetic.
+
+2. **Document the unobserved-Child leak in `verification/stdlib/concurrency_runtime_m4_process_traceability.md` Follow-up Boundaries.** One bullet: dropped-but-unwaited `Child` keeps `std::process::Child` in the process-global table for the process lifetime and may leak a zombie on Unix; deferred to the termination/timeout/cancellation wave.
+
+3. **Importing `Child` (without calling `spawn`/`wait`) emits the runtime table** because the kept `Child::wait` method body references it. Verified empirically. Acceptable — anyone explicitly importing `Child` is by definition a child-handling user — but could be tightened later by lazily lowering `Child::wait` only when one of `spawn`/`wait`/`Child::wait` is referenced.
+
+4. The existing M4 sync-process-foundation follow-up about deleting the unused legacy `_sifr.sys.subprocess_*` paths still stands — neither blocks this wave.
+
+Ready to PR.

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -13,6 +13,7 @@ Status: In progress; sync process foundation wave reviewed and merged in PR #233
 | `sifr.process.Output` / `TextOutput` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_shell_exec_output` | Byte output captures stdout/stderr as `bytes`; text output requires an explicit encoding argument and currently accepts UTF-8/UTF8 through the text/i18n substrate boundary. Non-UTF-8 text-process policy remains open for the full M4 text-mode closeout. |
 | `sifr.process.Stdio` constants | Public `PIPE`, `INHERIT`, `NULL` definitions | Constants reserve the production namespace for the later owned pipe/spawn wave. Pipe ownership APIs are not claimed complete by this foundation wave. |
 | Sync `run`, `output`, `output_text` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_blocking_direct_async_rejected` | Sync process APIs are `@blocking_io`, return typed `Result[..., ProcessError]`, and direct async calls are rejected through imported stdlib workload metadata. |
+| Sync `spawn`, `wait`, `Child.wait` | `process_spawn_wait_status`; `process_wait_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)` and `Child.wait()` are one-shot observation paths; top-level `wait(child)` is `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work. |
 | Sync `run_shell`, `output_shell`, `output_shell_text` | `process_shell_exec_output`; `process_shell_exec_direct_async_rejected` | Shell execution is explicit and classified as `@shell_exec` in addition to source-level `@blocking_io`; direct async calls use `SIFR-ASYNC-0007`. |
 | Imported workload metadata | `process_blocking_direct_async_rejected`; `process_shell_exec_direct_async_rejected` | Lowering exports workload labels from stdlib/project modules and reimports them for user modules, so stdlib process APIs participate in the existing direct-async/offload diagnostic model. |
 
@@ -28,19 +29,20 @@ Status: In progress; sync process foundation wave reviewed and merged in PR #233
 
 | Lane | Representative entries |
 | --- | --- |
-| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output` |
-| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output` |
-| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
+| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status` |
+| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status` |
+| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
 
 ## Follow-up Boundaries
 
 Intentional remaining M4 work after this foundation wave:
 
-- Production `spawn`, `Child`, `wait`, `PipeReader`, `PipeWriter`, owned stdout/stderr/stdin pipe lifecycle, double-close/use-after-close diagnostics, and handle sendability/shareability checks.
+- `PipeReader`, `PipeWriter`, owned stdout/stderr/stdin pipe lifecycle, double-close/use-after-close diagnostics, and handle sendability/shareability checks beyond the one-shot sync `Child.wait()` state.
 - Native async spawn/wait/communicate and cancellation-safe process observation.
 - Timeout handling plus `terminate`, `kill`, signal termination evidence, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
 - Scoped process supervision entry point accepted by M0: `TaskGroup.spawn_process` returns a distinct `ProcessHandle` preserving pipe access.
 - Full subprocess text mode closeout beyond UTF-8-only text output, consuming the text/i18n M1 evidence explicitly.
+- Dropping an unwaited sync `Child` keeps the private `std::process::Child` table entry for the process lifetime and may leave host child reaping to a later lifecycle wave; termination, timeout, cancellation, and drop cleanup semantics remain M4 follow-up work.
 - Decide whether repeated `Command.stdin_bytes(...)` calls append or replace payload data when the spawn/pipe wave finalizes stdin ownership semantics.
 - Delete the unused legacy `_sifr.sys.subprocess_*` intrinsic registry paths once no test or diagnostic still needs them as M4 cleanup.
 - If a future stdlib module re-exports a workload-annotated callable, mirror project-module re-export workload metadata in stdlib bootstrap export collection before relying on that shape.

--- a/verification/validation_lanes/create_pr_e2e_manifest.json
+++ b/verification/validation_lanes/create_pr_e2e_manifest.json
@@ -85,6 +85,7 @@
     "process_sync_output_text",
     "process_sync_bytes_env_cwd_stdin",
     "process_shell_exec_output",
+    "process_spawn_wait_status",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",

--- a/verification/validation_lanes/merge_e2e_manifest.json
+++ b/verification/validation_lanes/merge_e2e_manifest.json
@@ -100,6 +100,7 @@
     "process_sync_output_text",
     "process_sync_bytes_env_cwd_stdin",
     "process_shell_exec_output",
+    "process_spawn_wait_status",
     "text_i18n_encoding_io",
     "text_i18n_unicode_core",
     "text_i18n_unicode_segmentation",


### PR DESCRIPTION
## Summary
- Add sync `sifr.process.Child`, `spawn(Command)`, top-level `wait(Child)`, and `Child.wait()`.
- Lower `process_spawn` / `process_wait` through a private generated `std::process::Child` handle table with one-shot typed wait behavior.
- Gate process-child runtime preamble emission to spawn/wait users, add pass/fail fixtures, validation-lane coverage, and M4 traceability updates.

## Validation
- `cargo check -p sifr_codegen -p sifr_stdlib -p sifr_driver -p sifr --quiet`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr`
- Existing process pass regressions: `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_wait_direct_async_rejected.sifr` (expected `SIFR-ASYNC-0003`)
- Existing process fail regressions: `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr | rg "__SIFR_PROCESS_CHILDREN|__sifr_next_process_child_id|std::process::Child|process_spawn|process_wait|std::process::Command"`
- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_sync_output_text.sifr | rg "__SIFR_PROCESS_CHILDREN|__sifr_next_process_child_id|std::process::Child"` (expected no matches)
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr test_e2e_fail -- --nocapture`
- `scripts/run_all_tests.sh --profile create-pr` (PASS; warm wall-time advisory; platform golden `pass=5`, `skip=2`; create-pr e2e `93 passed`, `0 failed`)

## Review
- `reviews/ad-hoc-production-concurrency-runtime-m4-child-wait-review-pass-1.md`: `PASS`; reviewer verified sync-only scope, gated child runtime state, one-shot typed wait behavior, async blocking diagnostics, and honest remaining M4 lifecycle boundaries.
