### PR TITLE
Add M4 sync child kill support

### DIFF
--- a/crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.process import Child, kill
+
+
+async def stop(child: Child):
+    _ = kill(child)
+    await task.sleep(0.0)

--- a/crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr
+++ b/crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr
@@ -1,0 +1,33 @@
+from sifr.process import Child, Command, ProcessError, Status, kill, spawn, wait
+
+
+def sleeping_command() -> Command:
+    command: Command = Command("sleep")
+    command.arg("30")
+    return command
+
+
+def main():
+    actual: list[bool] = []
+
+    try:
+        child: Child = spawn(sleeping_command())
+        _killed: None = kill(child)
+        status: Status = wait(child)
+        actual.append(not status.success)
+        actual.append(status.kind == "nonzero")
+
+        method_child: Child = spawn(sleeping_command())
+        _method_killed: None = method_child.kill()
+        method_status: Status = method_child.wait()
+        actual.append(not method_status.success)
+
+        try:
+            _after_wait_kill: None = kill(child)
+            actual.append(False)
+        except ProcessError as e:
+            actual.append("closed or unknown" in e.message)
+    except ProcessError as e:
+        actual.append(False)
+
+    assert actual == [True, True, True, True]

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -598,6 +598,7 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "subprocess_run_structured" => (subprocess::lower_subprocess_run_structured(args), None),
         "process_run" => (process::lower_process_run(args), None),
         "process_spawn" => (process::lower_process_spawn(args), None),
+        "process_kill" => (process::lower_process_kill(args), None),
         "process_wait" => (process::lower_process_wait(args), None),
         "process_output" => (process::lower_process_output(args), None),
         "process_output_text" => (process::lower_process_output_text(args), None),

--- a/crates/sifr_codegen/src/intrinsics/registry/process.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/process.rs
@@ -106,6 +106,14 @@ fn next_child_handle_id_expr() -> RustExpr {
     }
 }
 
+fn missing_child_error_expr() -> RustExpr {
+    process_error_expr(RustExpr::FormatMacro {
+        name: "format".to_string(),
+        format_str: "process child handle is closed or unknown: {}".to_string(),
+        args: vec![RustExpr::Ident("__handle".to_string())],
+    })
+}
+
 fn command_new(program: RustExpr) -> RustExpr {
     path_call(&["std", "process", "Command", "new"], vec![program])
 }
@@ -633,11 +641,6 @@ pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
         return None;
     }
     let handle_expr = arg_expr(args, 0);
-    let missing_child_error = process_error_expr(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "process child handle is closed or unknown: {}".to_string(),
-        args: vec![RustExpr::Ident("__handle".to_string())],
-    });
     let stmts = vec![
         RustStmt::Let {
             mutable: false,
@@ -675,7 +678,7 @@ pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
                 method: "ok_or_else".to_string(),
                 args: vec![RustExpr::Closure {
                     params: vec![],
-                    body: Box::new(missing_child_error),
+                    body: Box::new(missing_child_error_expr()),
                     is_move: false,
                 }],
             })),
@@ -696,6 +699,58 @@ pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
         expr: Some(Box::new(ok_expr(status_code(RustExpr::Ident(
             "__status".to_string(),
         ))))),
+    })
+}
+
+pub(crate) fn lower_process_kill(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let stmts = vec![
+        RustStmt::Let {
+            mutable: false,
+            name: "__handle".to_string(),
+            ty: None,
+            value: arg_expr(args, 0),
+        },
+        RustStmt::Let {
+            mutable: true,
+            name: "__children".to_string(),
+            ty: None,
+            value: process_child_handles_lock_expr(),
+        },
+        RustStmt::Let {
+            mutable: true,
+            name: "__child".to_string(),
+            ty: None,
+            value: RustExpr::Try(Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::Ident("__children".to_string())),
+                    method: "get_mut".to_string(),
+                    args: vec![RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Ident("__handle".to_string())),
+                    }],
+                }),
+                method: "ok_or_else".to_string(),
+                args: vec![RustExpr::Closure {
+                    params: vec![],
+                    body: Box::new(missing_child_error_expr()),
+                    is_move: false,
+                }],
+            })),
+        },
+        RustStmt::Expr(RustExpr::Try(Box::new(process_map_err(
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__child".to_string())),
+                method: "kill".to_string(),
+                args: vec![],
+            },
+        )))),
+    ];
+    Some(RustExpr::Block {
+        stmts,
+        expr: Some(Box::new(ok_expr(RustExpr::Literal(RustLiteral::Unit)))),
     })
 }
 

--- a/crates/sifr_stdlib/src/process.rs
+++ b/crates/sifr_stdlib/src/process.rs
@@ -54,6 +54,13 @@ pub(super) fn intrinsic_process() -> IntrinsicModule {
         ),
     );
     functions.insert(
+        "process_kill".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            result_ty(Type::None, "ProcessError"),
+        ),
+    );
+    functions.insert(
         "process_output".to_string(),
         FunctionType::all_borrow(
             vec![

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -647,6 +647,24 @@ M4 timeout status evidence wave review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m4-timeout-status-review-pass-3.md`: `PASS`; reviewer verified the additional `Instant::checked_add(...).ok_or_else(ProcessError)?` hardening closes the host-clock deadline overflow path and no timeout-path data-dependent panic blocker remains.
 - Merged as PR #2336: https://github.com/sifr-lang/sifr/pull/2336
 
+M4 sync child kill targeted local validation:
+
+- `cargo check -p sifr_codegen -p sifr_stdlib -p sifr_driver -p sifr --quiet` -> PASS.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr` -> PASS.
+- Existing process pass regressions: `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, and `process_child_kill_wait` -> PASS.
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr` -> expected FAIL with `SIFR-ASYNC-0003`.
+- `cargo fmt --check` -> PASS.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; 2174 files checked, 900-line limit.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `cargo test -p sifr test_e2e_fail -- --nocapture` -> PASS; fail suite reported 419 fail tests completed.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisories: warm wall-time budget exceeded (`129.98s`, warm target `<=2m`) and warm-cache hit rate below advisory target. Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`94 passed`, `0 failed`, `cache_hits=22/25`).
+- Post-`origin/main` rebase rerun over the timeout status evidence wave: `cargo check -p sifr_codegen -p sifr_stdlib -p sifr_driver -p sifr --quiet`, `process_child_kill_wait`, `process_timeout_status`, expected `process_kill_direct_async_rejected` `SIFR-ASYNC-0003`, `cargo fmt --check`, file-size guardrails (`2176` files), HIR guardrails, and `cargo test -p sifr test_e2e_fail -- --nocapture` (`420` fail tests) -> PASS.
+- Post-`origin/main` rebase rerun: `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`152.56s`, warm target `<=2m`). Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`95 passed`, `0 failed`, `cache_hits=24/25`, `report_signature=d8d730bd5475756c`).
+
+M4 sync child kill review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md`: `PASS`; reviewer verified the wave is an honest sync forceful-kill slice, `process_kill` returns typed `ProcessError` for closed/unknown handles without data-dependent panics, kill preserves the child handle for later `wait`, top-level `kill(child)` triggers `SIFR-ASYNC-0003`, process-child runtime gating remains intact, and docs do not overclaim graceful termination, timeout escalation, structured cancellation, or signal evidence. Non-blocking feedback was applied before PR by changing the fixture from `sh -c "sleep 5"` to direct `sleep 30`, documenting that kill targets only the immediate child handle, and tracking method-form `@blocking_io` enforcement for `Child.wait()` / `Child.kill()` as later compiler work.
+
 M0 targeted local validation:
 
 - `python3 scripts/generate_concurrency_runtime_inventory.py` -> PASS; generated 135 CPython evidence entries from the phase source-of-truth list.

--- a/lib/sifr/process.sifr
+++ b/lib/sifr/process.sifr
@@ -2,6 +2,7 @@
 from _sifr.process import (
     process_run,
     process_spawn,
+    process_kill,
     process_wait,
     process_output,
     process_output_text,
@@ -67,6 +68,10 @@ class Child:
     def __init__(self, handle: int):
         self._handle = handle
         self._waited = False
+
+    @blocking_io
+    def kill(self) -> Result[None, ProcessError]:
+        return process_kill(self._handle)
 
     @blocking_io
     def wait(self) -> Result[Status, ProcessError]:
@@ -158,6 +163,11 @@ def spawn(command: Command) -> Result[Child, ProcessError]:
         return Child(handle)
     except ProcessError as e:
         raise e
+
+
+@blocking_io
+def kill(child: Child) -> Result[None, ProcessError]:
+    return process_kill(child._handle)
 
 
 @blocking_io

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md
@@ -1,0 +1,55 @@
+# M4 Sync Child Kill Review — Pass 1
+
+Verdict: **PASS** (with non-blocking follow-ups)
+
+## Scope verified
+
+This wave adds sync forceful child termination only:
+
+- `lib/sifr/process.sifr:62-72,157-159` exposes `Child.kill()` and top-level `kill(child)` as `@blocking_io` returning `Result[None, ProcessError]`. No `terminate`, timeout, signal, or cancellation surface is claimed.
+- `_sifr.process` registers `process_kill(handle: int) -> Result[None, ProcessError]` (`crates/sifr_stdlib/src/process.rs:52-58`).
+- `crates/sifr_codegen/src/intrinsics/registry/process.rs:531-581` lowers `process_kill` using `__SIFR_PROCESS_CHILDREN.lock()...get_mut(&__handle).ok_or_else(...)` and then `__child.kill().map_err(...)`. The handle is **not** removed — only `wait` consumes the entry. This matches the requested "kill preserves child for later `wait`" contract.
+- `crates/sifr_codegen/src/intrinsics/registry.rs:601` registers the new lowerer in alphabetical order.
+- New fixtures `crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr` and `crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr`.
+- Validation lane manifests gain `process_child_kill_wait` in both `create_pr_e2e_manifest.json:89` and `merge_e2e_manifest.json:104`. The fail fixture is recognized by the lex-discovered fail suite (no manifest edit needed; brief confirms 419 fail tests).
+- Traceability (`verification/stdlib/concurrency_runtime_m4_process_traceability.md:17`) adds a dedicated `Sync kill, Child.kill` row that explicitly defers graceful `terminate`, timeout escalation, structured cancellation, and host-specific signal evidence; the follow-up boundaries list refines the open item from "`terminate`, `kill`" to "graceful `terminate`, termination escalation, signal termination evidence, …".
+
+## Concrete blocker checks
+
+1. **Honest sync forceful slice.** No claim of `terminate`, timeout escalation, structured cancellation, or signal evidence in either the public process surface or the traceability table. The traceability row states "forceful child termination through `std::process::Child::kill`; callers must still observe the final status with `wait`" and explicitly defers the rest. ✅
+2. **Typed `ProcessError` for closed/unknown handles, no user-path panics.** Generated code for `kill` (see `emit` of `process_child_kill_wait.sifr`):
+   - Handle lookup: `__children.get_mut(&__handle).ok_or_else(|| ProcessError { message: format!("process child handle is closed or unknown: {}", __handle) })?`
+   - `std::process::Child::kill` failure: `.map_err(|e| ProcessError { message: e.to_string() })?`
+   - The only `unwrap*` calls are `unwrap_or_else(|__err| __err.into_inner())` (mutex poison recovery; cannot panic) and `unwrap_or(-1)` on absent exit codes. No data-dependent `unwrap`/`expect` on user input. ✅
+3. **Kill preserves handle for later `wait`.** `lower_process_kill` uses `get_mut` (not `remove`); `lower_process_wait` (`process.rs:465-529`) is the only path that `remove`s. The pass fixture exercises this exactly — `kill(child)` then `wait(child)` then `kill(child)` again, expecting the third call to fail with `closed or unknown`. Confirmed in the emitted Rust and `cargo run` succeeds. ✅
+4. **Direct async `kill(child)` triggers SIFR-ASYNC-0003.** Verified locally — `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr` emits `error[SIFR-ASYNC-0003]: blocking_io function 'kill' called directly from async context`. The mechanism is imported workload metadata on the top-level `@blocking_io kill(child)` definition in `lib/sifr/process.sifr:157-159`, consistent with the existing wait/blocking fail fixtures. The method form `Child.kill()` is intentionally not gated (parallel to `Child.wait()`); the traceability says only "Top-level `kill(child)` is `@blocking_io` and direct async calls are rejected," so the asymmetry is documented, not overclaimed. ✅
+5. **Preamble/runtime gating intact.** `__SIFR_PROCESS_CHILDREN` and `__sifr_next_process_child_id` are emitted only when the stdlib filter detects references in the consumed stdlib code (`crates/sifr_codegen/src/stdlib_filter/implementation.rs:264-336`, `lib_modules_and_codegen.rs:574-576`). The new `process_kill` lowering uses the same identifiers, so any module that imports `kill` or `Child.kill` pulls the table in; modules that only use output-style process APIs (e.g., `run_command`, `output`) continue not to emit the child table. Confirmed by emitting the new fixture (single `__SIFR_PROCESS_CHILDREN` static, no duplication) and noting `process_runtime_and_platform.sifr` imports `sifr.os` not `sifr.process`. ✅
+6. **No data-dependent panics introduced elsewhere.** Grep of generated code for the kill fixture shows only the safe `unwrap*` patterns above. The new lowerer adds no `unwrap`/`expect` on a user-controlled value. ✅
+7. **Docs honest about portability.** The traceability names `std::process::Child::kill` explicitly (which has documented host-specific semantics: SIGKILL on Unix, `TerminateProcess` on Windows). Signal termination evidence and supported-host matrix updates are explicitly listed as remaining M4 follow-up work in the follow-up boundaries. ✅
+
+## Fixture robustness (item 5 in brief)
+
+`process_child_kill_wait.sifr` spawns `sh -c "sleep 5"`. The functional behavior is fine: `kill` returns `Ok(None)` regardless of whether `sleep` becomes orphaned, `wait` then observes the killed `sh` (or, more commonly, the exec-optimized `sleep`) and the test asserts only `not status.success` and `status.kind == "nonzero"`. On the supported hosts in practice, POSIX shells (`bash` on macOS in `/bin/sh`, `dash` on Linux) exec the single command following `-c`, so `Child::kill()` lands on the `sleep` process directly and no orphan is created. This matches the existing convention used by `process_spawn_wait_status.sifr` (`sh -c "exit 7"`), so I am not treating it as a blocker. See non-blocking follow-up #1 for an optional hardening.
+
+## Empirical verification done in-review
+
+- Inspected diff of all 8 touched files; no incidental edits.
+- Read the generated Rust for `process_child_kill_wait.sifr` (via `sifr emit`) and confirmed:
+  - `fn kill(child: &Child) -> Result<(), ProcessError>` uses `get_mut` and propagates `ok_or_else(...)` and `.map_err(...)?` — no panics.
+  - `Child::kill(&self)` does the same.
+  - `__SIFR_PROCESS_CHILDREN` and `__sifr_next_process_child_id` appear exactly once.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr` → exit 0 (cache hit).
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr` → expected `SIFR-ASYNC-0003`.
+
+Brief-supplied evidence (`cargo check`, full fail suite 419/419, `cargo fmt --check`, file-size + HIR guardrails, `scripts/run_all_tests.sh --profile create-pr` with 94/0 e2e pass) is internally consistent with the diff.
+
+## Non-blocking follow-ups
+
+1. **Test fixture hardening.** Prefer `Command("sleep")` with `args(["30"])` over `sh -c "sleep 5"`. This removes a layer of shell-fork-exec semantics entirely (no dependence on the host shell's single-command exec optimization) and eliminates the theoretical "sleep orphan briefly running on the host" tail risk on shells that don't optimize. Functionally a no-op for the current assertions.
+2. **Doc precision on kill scope.** The traceability row could note (in one phrase) that `std::process::Child::kill` targets only the immediate child handle and does not propagate to descendant processes (no process-group / supervision semantics) — this is implicit from the named API but explicitly stating it would forestall future readers reading "forceful child termination" as transitive. Pair this with the existing "Scoped process supervision entry point accepted by M0" follow-up bullet so the contrast is visible.
+3. **Method-form async diagnostic gap.** `Child.kill()` (and `Child.wait()` from the prior wave) is not subject to `SIFR-ASYNC-0003` because the workload-metadata gate is only wired for the top-level function. The traceability is honest about this slice, but the asymmetry between top-level and method-form `@blocking_io` is a real lifecycle wave concern. Worth carrying as a tracked follow-up (e.g., "method-form `@blocking_io` enforcement" under the structured cancellation / supervision work).
+4. **Pre-PR housekeeping.** `reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md` was committed as an empty placeholder; this pass now fills it. Confirm the issue-execution doc's "M4 sync child kill review loop" entry is updated to reference this review and the eventual PR # / merge SHA before/after merge, mirroring the prior wave's pattern.
+
+## Verdict
+
+**PASS.** The wave is a clean, honest sync forceful-kill slice. The implementation respects all the stated guardrails (typed errors, preserved handles, gated preamble, imported async metadata), and the surface/docs do not overclaim beyond `std::process::Child::kill`. Recommend addressing follow-up #1 opportunistically before PR, but it is not a blocker.

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -2,7 +2,7 @@
 
 Milestone: `milestone_concurrency_runtime_4`
 
-Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, and timeout status evidence merged in PR #2336.
+Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, and timeout status evidence merged in PR #2336. Sync child kill support is implemented in the current M4 follow-up wave.
 
 ## Production Surface Traceability
 
@@ -15,6 +15,7 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 | Sync `run`, `output`, `output_text` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_blocking_direct_async_rejected` | Sync process APIs are `@blocking_io`, return typed `Result[..., ProcessError]`, and direct async calls are rejected through imported stdlib workload metadata. |
 | Sync `run_timeout`, `output_timeout` | `process_timeout_status` | Timeout APIs kill and reap timed-out children, return typed `Status` evidence instead of panicking, and reject invalid negative, non-finite, or out-of-range timeout values through `ProcessError`. |
 | Sync `spawn`, `wait`, `Child.wait` | `process_spawn_wait_status`; `process_wait_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)` and `Child.wait()` are one-shot observation paths; top-level `wait(child)` is `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work. |
+| Sync `kill`, `Child.kill` | `process_child_kill_wait`; `process_kill_direct_async_rejected` | Sync kill requests forceful immediate-child termination through `std::process::Child::kill`; it does not provide process-group or descendant supervision. Callers must still observe the final status with `wait`. Top-level `kill(child)` is `@blocking_io` and direct async calls are rejected. Graceful `terminate`, timeout escalation, structured cancellation, and host-specific signal evidence remain later M4 work. |
 | Sync `run_shell`, `output_shell`, `output_shell_text` | `process_shell_exec_output`; `process_shell_exec_direct_async_rejected` | Shell execution is explicit and classified as `@shell_exec` in addition to source-level `@blocking_io`; direct async calls use `SIFR-ASYNC-0007`. |
 | Sync `output_shell_timeout` | `process_timeout_status`; `process_shell_timeout_direct_async_rejected` | Shell timeout execution preserves the explicit shell-exec effect and timeout status evidence. |
 | Imported workload metadata | `process_blocking_direct_async_rejected`; `process_shell_exec_direct_async_rejected` | Lowering exports workload labels from stdlib/project modules and reimports them for user modules, so stdlib process APIs participate in the existing direct-async/offload diagnostic model. |
@@ -31,9 +32,9 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 
 | Lane | Representative entries |
 | --- | --- |
-| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status` |
-| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status` |
-| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
+| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_child_kill_wait` |
+| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_child_kill_wait` |
+| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, `process_kill_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
 
 ## Follow-up Boundaries
 
@@ -41,8 +42,9 @@ Intentional remaining M4 work after this foundation wave:
 
 - `PipeReader`, `PipeWriter`, owned stdout/stderr/stdin pipe lifecycle, double-close/use-after-close diagnostics, and handle sendability/shareability checks beyond the one-shot sync `Child.wait()` state.
 - Native async spawn/wait/communicate and cancellation-safe process observation.
-- `terminate`, explicit `kill`, signal termination evidence, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
+- Graceful `terminate`, termination escalation, signal termination evidence, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
 - Scoped process supervision entry point accepted by M0: `TaskGroup.spawn_process` returns a distinct `ProcessHandle` preserving pipe access.
+- Method-form `@blocking_io` enforcement for `Child.wait()` / `Child.kill()` direct async calls remains a compiler follow-up; this wave verifies top-level `wait(child)` / `kill(child)` imported workload diagnostics.
 - Full subprocess text mode closeout beyond UTF-8-only text output, consuming the text/i18n M1 evidence explicitly.
 - Dropping an unwaited sync `Child` keeps the private `std::process::Child` table entry for the process lifetime and may leave host child reaping to a later lifecycle wave; termination, timeout, cancellation, and drop cleanup semantics remain M4 follow-up work.
 - Decide whether repeated `Command.stdin_bytes(...)` calls append or replace payload data when the spawn/pipe wave finalizes stdin ownership semantics.

--- a/verification/validation_lanes/create_pr_e2e_manifest.json
+++ b/verification/validation_lanes/create_pr_e2e_manifest.json
@@ -87,6 +87,7 @@
     "process_shell_exec_output",
     "process_timeout_status",
     "process_spawn_wait_status",
+    "process_child_kill_wait",
     "stdlib_json_consolidated",
     "stdlib_tomllib",
     "stdlib_random",

--- a/verification/validation_lanes/merge_e2e_manifest.json
+++ b/verification/validation_lanes/merge_e2e_manifest.json
@@ -102,6 +102,7 @@
     "process_shell_exec_output",
     "process_timeout_status",
     "process_spawn_wait_status",
+    "process_child_kill_wait",
     "text_i18n_encoding_io",
     "text_i18n_unicode_core",
     "text_i18n_unicode_segmentation",


### PR DESCRIPTION
## Summary
- add sync process child kill support via top-level kill(child) and Child.kill()
- lower process_kill to std::process::Child::kill while preserving the child handle for later wait
- add pass/fail fixtures, validation lane manifest coverage, traceability, execution ledger evidence, and Opus PASS review artifact

## Validation
- cargo check -p sifr_codegen -p sifr_stdlib -p sifr_driver -p sifr --quiet
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr
- cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr (expected SIFR-ASYNC-0003)
- cargo fmt --check
- python3 scripts/check_file_size_guardrails.py
- python3 scripts/check_hir_maintainability_guardrails.py
- cargo test -p sifr test_e2e_fail -- --nocapture
- scripts/run_all_tests.sh --profile create-pr (PASS; 94 pass fixtures, 0 failed; warm wall-time/cache advisories)

## Review
- reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md: PASS