### PR TITLE
Record M4 timeout status merge

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -415,6 +415,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M3: complete.
 - M4 sync process foundation: https://github.com/sifr-lang/sifr/pull/2331
 - M4 sync child wait: https://github.com/sifr-lang/sifr/pull/2334
+- M4 timeout status evidence: https://github.com/sifr-lang/sifr/pull/2336
 - M4: in progress.
 - M5: pending.
 - M6: pending.
@@ -644,6 +645,7 @@ M4 timeout status evidence wave review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m4-timeout-status-review-pass-1.md`: `CHANGES_REQUESTED`; reviewer found a user-triggerable panic for positive finite timeout values too large for `Duration::from_secs_f64`. The wave was remediated by switching generated timeout conversion to checked `Duration::try_from_secs_f64`, adding an overflow `ProcessError` regression fixture, and tightening traceability.
 - `reviews/ad-hoc-production-concurrency-runtime-m4-timeout-status-review-pass-2.md`: `PASS`; reviewer verified the pass-1 overflow blocker was fixed and noted a non-blocking theoretical host-clock overflow band in `Instant + Duration`.
 - `reviews/ad-hoc-production-concurrency-runtime-m4-timeout-status-review-pass-3.md`: `PASS`; reviewer verified the additional `Instant::checked_add(...).ok_or_else(ProcessError)?` hardening closes the host-clock deadline overflow path and no timeout-path data-dependent panic blocker remains.
+- Merged as PR #2336: https://github.com/sifr-lang/sifr/pull/2336
 
 M0 targeted local validation:
 

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -2,7 +2,7 @@
 
 Milestone: `milestone_concurrency_runtime_4`
 
-Status: In progress; sync process foundation merged in PR #2331 and sync child wait merged in PR #2334.
+Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, and timeout status evidence merged in PR #2336.
 
 ## Production Surface Traceability
 


### PR DESCRIPTION
## Summary
- record PR #2336 as the merged M4 timeout status evidence wave
- update M4 process traceability status to include the timeout status merge

## Validation
- scripts/run_all_tests.sh --profile create-pr (PASS; advisory: warm wall-time budget exceeded; report target/validation_lane_reports/create-pr.latest.json; e2e 94 passed, 0 failed, cache_hits=23/25, report_signature=e656d8db94f60742)