### PR TITLE
Add M4 process child kill evidence

### DIFF
--- a/crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/process_kill_direct_async_rejected.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.process import Child, Status, kill
+
+
+async def stop(child: Child):
+    status: Status = kill(child)
+    await task.sleep(0.0)
+    return status

--- a/crates/sifr/tests/e2e/pass/process_child_kill_status.sifr
+++ b/crates/sifr/tests/e2e/pass/process_child_kill_status.sifr
@@ -1,0 +1,38 @@
+from sifr.process import Child, Command, ProcessError, Status, kill, spawn
+
+
+def main():
+    actual: list[bool] = []
+
+    try:
+        command: Command = Command("sleep")
+        command.arg("5")
+        child: Child = spawn(command)
+        status: Status = kill(child)
+        actual.append(not status.success)
+        actual.append(status.kind == "signal")
+        actual.append(status.signal is not None)
+        actual.append(not status.exited())
+
+        try:
+            waited: Status = child.wait()
+            actual.append(waited.success)
+        except ProcessError as e:
+            actual.append("already been waited" in e.message)
+
+        method_command: Command = Command("sleep")
+        method_command.arg("5")
+        method_child: Child = spawn(method_command)
+        method_status: Status = method_child.kill()
+        actual.append(method_status.kind == "signal")
+        actual.append(method_status.signal is not None)
+
+        try:
+            second_kill: Status = kill(method_child)
+            actual.append(second_kill.success)
+        except ProcessError as e:
+            actual.append("already been waited" in e.message)
+    except ProcessError as e:
+        actual.append(False)
+
+    assert actual == [True, True, True, True, True, True, True, True]

--- a/crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr
+++ b/crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr
@@ -17,7 +17,7 @@ def main():
             second: Status = wait(child)
             actual.append(second.success)
         except ProcessError as e:
-            actual.append("closed or unknown" in e.message)
+            actual.append("already been waited" in e.message)
 
         ok_command: Command = Command("true")
         method_child: Child = spawn(ok_command)

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -599,6 +599,7 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "process_run" => (process::lower_process_run(args), None),
         "process_spawn" => (process::lower_process_spawn(args), None),
         "process_wait" => (process::lower_process_wait(args), None),
+        "process_kill" => (process::lower_process_kill(args), None),
         "process_output" => (process::lower_process_output(args), None),
         "process_output_text" => (process::lower_process_output_text(args), None),
         "process_output_timeout" => (process::lower_process_output_timeout(args), None),

--- a/crates/sifr_codegen/src/intrinsics/registry/process.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/process.rs
@@ -106,6 +106,57 @@ fn next_child_handle_id_expr() -> RustExpr {
     }
 }
 
+fn take_child_stmts(handle_expr: RustExpr) -> Vec<RustStmt> {
+    let missing_child_error = process_error_expr(RustExpr::FormatMacro {
+        name: "format".to_string(),
+        format_str: "process child handle is closed or unknown: {}".to_string(),
+        args: vec![RustExpr::Ident("__handle".to_string())],
+    });
+    vec![
+        RustStmt::Let {
+            mutable: false,
+            name: "__handle".to_string(),
+            ty: None,
+            value: handle_expr,
+        },
+        RustStmt::Let {
+            mutable: false,
+            name: "__maybe_child".to_string(),
+            ty: None,
+            value: RustExpr::Block {
+                stmts: vec![RustStmt::Let {
+                    mutable: true,
+                    name: "__children".to_string(),
+                    ty: None,
+                    value: process_child_handles_lock_expr(),
+                }],
+                expr: Some(Box::new(RustExpr::MethodCall {
+                    receiver: Box::new(RustExpr::Ident("__children".to_string())),
+                    method: "remove".to_string(),
+                    args: vec![RustExpr::Ref {
+                        mutable: false,
+                        expr: Box::new(RustExpr::Ident("__handle".to_string())),
+                    }],
+                })),
+            },
+        },
+        RustStmt::Let {
+            mutable: true,
+            name: "__child".to_string(),
+            ty: None,
+            value: RustExpr::Try(Box::new(RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__maybe_child".to_string())),
+                method: "ok_or_else".to_string(),
+                args: vec![RustExpr::Closure {
+                    params: vec![],
+                    body: Box::new(missing_child_error),
+                    is_move: false,
+                }],
+            })),
+        },
+    ]
+}
+
 fn command_new(program: RustExpr) -> RustExpr {
     path_call(&["std", "process", "Command", "new"], vec![program])
 }
@@ -172,6 +223,12 @@ fn status_code(status_expr: RustExpr) -> RustExpr {
         }),
         ty: RustType::I64,
     }
+}
+
+fn status_signal(status_ident: &str) -> RustExpr {
+    RustExpr::Ident(format!(
+        "{{ #[cfg(unix)] {{ std::os::unix::process::ExitStatusExt::signal(&{status_ident}).unwrap_or(-1) as i64 }} #[cfg(not(unix))] {{ -1i64 }} }}"
+    ))
 }
 
 fn normal_command_setup(args: &[RustExpr]) -> Vec<RustStmt> {
@@ -632,54 +689,38 @@ pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
     if args.len() != 1 {
         return None;
     }
-    let handle_expr = arg_expr(args, 0);
-    let missing_child_error = process_error_expr(RustExpr::FormatMacro {
-        name: "format".to_string(),
-        format_str: "process child handle is closed or unknown: {}".to_string(),
-        args: vec![RustExpr::Ident("__handle".to_string())],
+    let mut stmts = take_child_stmts(arg_expr(args, 0));
+    stmts.push(RustStmt::Let {
+        mutable: false,
+        name: "__status".to_string(),
+        ty: None,
+        value: RustExpr::Try(Box::new(process_map_err(RustExpr::MethodCall {
+            receiver: Box::new(RustExpr::Ident("__child".to_string())),
+            method: "wait".to_string(),
+            args: vec![],
+        }))),
     });
-    let stmts = vec![
-        RustStmt::Let {
-            mutable: false,
-            name: "__handle".to_string(),
-            ty: None,
-            value: handle_expr,
-        },
-        RustStmt::Let {
-            mutable: false,
-            name: "__maybe_child".to_string(),
-            ty: None,
-            value: RustExpr::Block {
-                stmts: vec![RustStmt::Let {
-                    mutable: true,
-                    name: "__children".to_string(),
-                    ty: None,
-                    value: process_child_handles_lock_expr(),
-                }],
-                expr: Some(Box::new(RustExpr::MethodCall {
-                    receiver: Box::new(RustExpr::Ident("__children".to_string())),
-                    method: "remove".to_string(),
-                    args: vec![RustExpr::Ref {
-                        mutable: false,
-                        expr: Box::new(RustExpr::Ident("__handle".to_string())),
-                    }],
-                })),
+    Some(RustExpr::Block {
+        stmts,
+        expr: Some(Box::new(ok_expr(status_code(RustExpr::Ident(
+            "__status".to_string(),
+        ))))),
+    })
+}
+
+pub(crate) fn lower_process_kill(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    let mut stmts = take_child_stmts(arg_expr(args, 0));
+    stmts.extend([
+        RustStmt::Expr(RustExpr::Try(Box::new(process_map_err(
+            RustExpr::MethodCall {
+                receiver: Box::new(RustExpr::Ident("__child".to_string())),
+                method: "kill".to_string(),
+                args: vec![],
             },
-        },
-        RustStmt::Let {
-            mutable: true,
-            name: "__child".to_string(),
-            ty: None,
-            value: RustExpr::Try(Box::new(RustExpr::MethodCall {
-                receiver: Box::new(RustExpr::Ident("__maybe_child".to_string())),
-                method: "ok_or_else".to_string(),
-                args: vec![RustExpr::Closure {
-                    params: vec![],
-                    body: Box::new(missing_child_error),
-                    is_move: false,
-                }],
-            })),
-        },
+        )))),
         RustStmt::Let {
             mutable: false,
             name: "__status".to_string(),
@@ -690,12 +731,13 @@ pub(crate) fn lower_process_wait(args: &[RustExpr]) -> Option<RustExpr> {
                 args: vec![],
             }))),
         },
-    ];
+    ]);
     Some(RustExpr::Block {
         stmts,
-        expr: Some(Box::new(ok_expr(status_code(RustExpr::Ident(
-            "__status".to_string(),
-        ))))),
+        expr: Some(Box::new(ok_expr(RustExpr::Tuple(vec![
+            status_code(RustExpr::Ident("__status".to_string())),
+            status_signal("__status"),
+        ])))),
     })
 }
 

--- a/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs
@@ -156,6 +156,20 @@ pub(crate) fn lowers_process_timeout_intrinsics_via_registry() {
 }
 
 #[test]
+pub(crate) fn lowers_process_kill_intrinsic_via_registry() {
+    let kill = lower_intrinsic("process_kill", &["handle".to_string()]).expect("process_kill");
+    let rendered = render_expr(&kill.expr);
+    assert!(rendered.contains("__children.remove(&__handle)"));
+    assert!(rendered.contains("__child.kill()"));
+    assert!(rendered.contains("__child.wait()"));
+    assert!(rendered.contains("#[cfg(unix)]"));
+    assert!(rendered.contains("std::os::unix::process::ExitStatusExt::signal(&__status)"));
+    assert!(rendered.contains("#[cfg(not(unix))]"));
+    assert!(rendered.contains("-1i64"));
+    assert!(rendered.contains("(__status.code().unwrap_or(-1) as i64"));
+}
+
+#[test]
 pub(crate) fn lowers_html_intrinsics_via_registry() {
     let esc = lower_intrinsic("html_escape", &["s".to_string()]).expect("html_escape");
     assert!(render_expr(&esc.expr).contains("replace('&', \"&amp;\")"));

--- a/crates/sifr_stdlib/src/process.rs
+++ b/crates/sifr_stdlib/src/process.rs
@@ -10,6 +10,10 @@ fn process_bytes_timeout_output_tuple() -> Type {
     Type::Tuple(vec![Type::Bytes, Type::Bytes, Type::Int, Type::Bool])
 }
 
+fn process_status_signal_tuple() -> Type {
+    Type::Tuple(vec![Type::Int, Type::Int])
+}
+
 fn process_text_output_tuple() -> Type {
     Type::Tuple(vec![Type::Str, Type::Str, Type::Int])
 }
@@ -51,6 +55,13 @@ pub(super) fn intrinsic_process() -> IntrinsicModule {
         FunctionType::all_borrow(
             vec![("handle".to_string(), Type::Int)],
             result_ty(Type::Int, "ProcessError"),
+        ),
+    );
+    functions.insert(
+        "process_kill".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            result_ty(process_status_signal_tuple(), "ProcessError"),
         ),
     );
     functions.insert(

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -647,6 +647,31 @@ M4 timeout status evidence wave review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m4-timeout-status-review-pass-3.md`: `PASS`; reviewer verified the additional `Instant::checked_add(...).ok_or_else(ProcessError)?` hardening closes the host-clock deadline overflow path and no timeout-path data-dependent panic blocker remains.
 - Merged as PR #2336: https://github.com/sifr-lang/sifr/pull/2336
 
+M4 child kill evidence wave implementation:
+
+- Added sync `kill(child)` and `Child.kill()` as one-shot forced child termination/observation paths over the existing generated child-handle table.
+- `process_kill` removes the child handle before calling Rust `Child::kill()` and then reaps with `wait()`, returning `(status_code, signal)` to `sifr.process.Status`.
+- `Status.kind == "signal"` and `Status.signal is not None` now represent forced child kill evidence; graceful `terminate`, async process cancellation, and scoped supervision remain follow-up M4 work.
+- Added positive coverage in `process_child_kill_status` and direct-async rejection coverage in `process_kill_direct_async_rejected`; the create-pr and merge e2e manifests include `process_child_kill_status`.
+
+M4 child kill evidence wave targeted local validation:
+
+- `cargo fmt --check && cargo check -p sifr_stdlib -p sifr_codegen -p sifr --quiet` -> PASS.
+- `cargo test -p sifr_codegen lowers_process_kill_intrinsic_via_registry -- --nocapture` -> PASS.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_status.sifr` -> PASS.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr` -> PASS.
+- `cargo test -p sifr test_e2e_fail -- --nocapture` -> PASS; fail suite reported 420 fail tests completed.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; 2176 files checked, 900-line limit.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `python3 -m json.tool verification/validation_lanes/create_pr_e2e_manifest.json` and `python3 -m json.tool verification/validation_lanes/merge_e2e_manifest.json` -> PASS.
+- `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_child_kill_status.sifr | rg "cfg\\(unix\\)|cfg\\(not\\(unix\\)\\)|__child\\.kill\\(\\)|__child\\.wait\\(\\)|__children\\.remove|kind.*signal|already been waited"` -> PASS; emitted forced-kill paths remove the child handle, kill and reap the child, and use platform-gated signal extraction with a non-Unix `-1` sentinel.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`95 passed`, `0 failed`, `cache_hits=23/25`, `report_signature=d8d730bd5475756c`).
+
+M4 child kill evidence wave review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md`: `CHANGES_REQUESTED`; reviewer found the initial generated signal extraction unconditionally referenced `std::os::unix`, which would not compile on non-Unix hosts.
+- `reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-2.md`: `PASS`; reviewer verified the `#[cfg(unix)]` / `#[cfg(not(unix))]` generated signal branch closes the host-portability blocker and no remaining child-kill blocker remains.
+
 M0 targeted local validation:
 
 - `python3 scripts/generate_concurrency_runtime_inventory.py` -> PASS; generated 135 CPython evidence entries from the phase source-of-truth list.

--- a/lib/sifr/process.sifr
+++ b/lib/sifr/process.sifr
@@ -3,6 +3,7 @@ from _sifr.process import (
     process_run,
     process_spawn,
     process_wait,
+    process_kill,
     process_output,
     process_output_text,
     process_output_timeout,
@@ -37,12 +38,19 @@ class Status:
     cancelled: bool
     kind: str
 
-    def __init__(self, code: int, kind: str):
+    def __init__(
+        self,
+        code: int,
+        kind: str,
+        signal: int | None = None,
+        timed_out: bool = False,
+        cancelled: bool = False,
+    ):
         self.code = code
         self.success = code == 0
-        self.signal = None
-        self.timed_out = False
-        self.cancelled = False
+        self.signal = signal
+        self.timed_out = timed_out
+        self.cancelled = cancelled
         self.kind = kind
 
     def exited(self) -> bool:
@@ -76,6 +84,17 @@ class Child:
         try:
             code: int = process_wait(self._handle)
             return _status(code)
+        except ProcessError as e:
+            raise e
+
+    @blocking_io
+    def kill(self) -> Result[Status, ProcessError]:
+        if self._waited:
+            raise ProcessError("process child has already been waited")
+        self._waited = True
+        try:
+            raw: tuple[int, int] = process_kill(self._handle)
+            return _signal_status(raw[0], raw[1])
         except ProcessError as e:
             raise e
 
@@ -145,6 +164,12 @@ def _status_from(code: int, timed_out: bool) -> Status:
     return _status(code)
 
 
+def _signal_status(code: int, signal: int) -> Status:
+    status: Status = Status(code, "signal", signal)
+    status.success = False
+    return status
+
+
 @blocking_io
 def spawn(command: Command) -> Result[Child, ProcessError]:
     try:
@@ -161,10 +186,25 @@ def spawn(command: Command) -> Result[Child, ProcessError]:
 
 
 @blocking_io
-def wait(child: Child) -> Result[Status, ProcessError]:
+def wait(mut child: Child) -> Result[Status, ProcessError]:
+    if child._waited:
+        raise ProcessError("process child has already been waited")
+    child._waited = True
     try:
         code: int = process_wait(child._handle)
         return _status(code)
+    except ProcessError as e:
+        raise e
+
+
+@blocking_io
+def kill(mut child: Child) -> Result[Status, ProcessError]:
+    if child._waited:
+        raise ProcessError("process child has already been waited")
+    child._waited = True
+    try:
+        raw: tuple[int, int] = process_kill(child._handle)
+        return _signal_status(raw[0], raw[1])
     except ProcessError as e:
         raise e
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md
@@ -1,0 +1,36 @@
+Now I have enough context. Writing the review.
+
+RESULT: CHANGES_REQUESTED
+
+## Findings
+
+### 1. (Medium / blocker) Unconditional Unix-only signal extraction breaks Windows compile
+**Files**: `crates/sifr_codegen/src/intrinsics/registry/process.rs:228-240` and the assertion at `crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs:165`.
+
+`status_signal()` emits `std::os::unix::process::ExitStatusExt::signal(&__status).unwrap_or(-1) as i64` with no `#[cfg(unix)]` gate. Grepping confirms this is the **first and only** unconditional `std::os::unix::*` emission in the entire codegen (`grep std::os::unix crates/{sifr_codegen,sifr_runtime,sifr_stdlib}/src/` returns only this path). All prior M4 work — including the timeout poll loop's `__child.kill()` — uses cross-platform `std::process::Child::kill()` and stays host-portable.
+
+`verification/platform/supported_host_matrix.md:18` lists Windows x86_64 alongside macOS and Linux for "Subprocess spawning and termination" as `blocked-on-concurrency-runtime-m4`, i.e. M4 is the milestone that is supposed to unblock those rows. A Sifr program that calls `sifr.process.kill(child)` or `Child.kill()` would now emit Rust that fails to compile on Windows, breaking the project's "if it compiles, it works" guarantee for the M4 surface.
+
+`verification/stdlib/concurrency_runtime_m4_process_traceability.md` does **not** declare a Unix-only constraint for `kill`/`Child.kill`, and the "Follow-up Boundaries" list does not include a Windows signal-representation deferral. So today the slice is silently Unix-only.
+
+**Options to address (either is acceptable):**
+- Gate the signal lookup with `#[cfg(unix)]` in the emitted Rust (e.g., a small `{ #[cfg(unix)] { …signal()…unwrap_or(-1) } #[cfg(not(unix))] { -1i64 } }` block) so the generated code compiles on Windows while `signal` still surfaces on Unix.
+- Explicitly add a follow-up boundary in `verification/stdlib/concurrency_runtime_m4_process_traceability.md` noting that Windows signal representation is deferred, and document the host scope of `kind == "signal"` evidence honestly (current Unix-only).
+
+The reviewer's question (4) is exactly this; the slice as-checked-in is honest only if the traceability is updated, otherwise codegen needs a guard.
+
+---
+
+## Non-blocking observations (no change required)
+
+- **One-shot consumption is correct**: `take_child_stmts` at `crates/sifr_codegen/src/intrinsics/registry/process.rs:109-158` removes the handle from `__SIFR_PROCESS_CHILDREN` before `kill()`/`wait()`, and the Sifr-side `_waited = True` is set before the intrinsic call. A failed `process_kill` still consumes the Child (the underlying `std::process::Child` was already removed) — that's the right behavior so the user can't retry on a half-killed handle. Cross-references between top-level `wait`/`kill` and `Child.wait`/`Child.kill` are symmetric (`lib/sifr/process.sifr:80-99, 188-209`).
+
+- **Panic surfaces are clean**: every `Result` is mapped via `process_map_err` to a typed `ProcessError`; `.code()` and `ExitStatusExt::signal(...)` are wrapped in `.unwrap_or(-1)`; mutex acquisition uses `.unwrap_or_else(|err| err.into_inner())`. No new `unwrap`/`expect`/panic paths reach generated runtime code.
+
+- **Top-level `wait(child)` mutation is the right fix**: changing `wait(child: Child)` → `wait(mut child: Child)` with the `_waited` guard (`lib/sifr/process.sifr:188-198`) brings the module-level function in line with `Child.wait()` and gives a clean `"already been waited"` diagnostic instead of the underlying `"closed or unknown"` handle message. The fixture update (`crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr:20`) tracks this and is the right semantic.
+
+- **Test coverage is adequate for the slice**: `process_child_kill_status.sifr` covers both `kill(child)` and `Child.kill()` happy paths, the post-kill `child.wait()` rejection, and the post-`Child.kill()` `kill(method_child)` rejection — 8 assertions match the milestone scope. The fail fixture `process_kill_direct_async_rejected.sifr` follows the same `task.sleep(0.0)`-without-import convention as `process_wait_direct_async_rejected.sifr` and `process_blocking_direct_async_rejected.sifr`, so SIFR-ASYNC-0003 fires before name resolution. Both manifests (create-PR and merge) include `process_child_kill_status`.
+
+- **Traceability is otherwise honest**: deferrals for graceful `terminate`, async process lifecycle, pipe ownership, and scoped supervision are explicit in `verification/stdlib/concurrency_runtime_m4_process_traceability.md:40-51`, and `Status` kind/signal mapping is described correctly. Only the host-scope gap (above) is missing.
+
+- **Stylistic nit (not raised as a finding)**: `try: …; except ProcessError as e: raise e` blocks in `kill`, `wait`, `Child.kill`, `Child.wait` are no-op wrappers. Pre-existing pattern, not introduced by this wave.

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-2.md
@@ -1,0 +1,40 @@
+RESULT: PASS
+
+## Findings
+
+### Pass-1 blocker is resolved
+**Fixed at** `crates/sifr_codegen/src/intrinsics/registry/process.rs:228-232`.
+
+`status_signal()` now emits a Rust block that branches on `#[cfg(unix)]` / `#[cfg(not(unix))]`, so the previously unconditional `std::os::unix::process::ExitStatusExt::signal(...)` is no longer compiled on non-Unix targets. Confirmed by inspecting the rendered Rust from `cargo run -q -p sifr -- emit crates/sifr/tests/e2e/pass/process_child_kill_status.sifr`:
+
+```rust
+Ok((
+    __status.code().unwrap_or(-1) as i64,
+    {
+        #[cfg(unix)]
+        {
+            std::os::unix::process::ExitStatusExt::signal(&__status)
+                .unwrap_or(-1) as i64
+        }
+        #[cfg(not(unix))] { -1i64 }
+    },
+))
+```
+
+Both arms type to `i64`, the Unix-only path stays out of the Windows build, and the surrounding `_signal_status(raw.0, raw.1)` consumer is unchanged. The emit appears for both top-level `kill(child)` and `method_child.kill()` call sites (lines ~139 and ~310 of the emitted file), matching the symmetric Sifr-side wrappers in `lib/sifr/process.sifr`.
+
+### Tests cover the gate
+`crates/sifr_codegen/src/intrinsics/registry_extended_tests.rs:159-170` now asserts the presence of `#[cfg(unix)]`, `#[cfg(not(unix))]`, `-1i64`, and the `ExitStatusExt::signal(&__status)` path — preventing regression on the host-portability gate.
+
+### Sanity-checks on the implementation choice
+The fix injects raw Rust source via `RustExpr::Ident`. `render_identifier` at `crates/sifr_codegen/src/render/render_expr_and_blocks.rs:575-584` returns non-ASCII-identifier strings verbatim, and the other IR consumers (`ir_imports.rs:230`, `ir_validate.rs:232`, `ir_optimize/*`) treat `RustExpr::Ident` as a leaf symbol with no parse/rewrite expectations, so this string passes through downstream passes safely. Prettyplease formats the embedded block exactly as written (verified in the emit above).
+
+No remaining blocking issues in the child-kill wave.
+
+---
+
+## Non-blocking follow-ups (do not gate merge)
+
+- **Structured-IR escape hatch.** `status_signal()` uses `RustExpr::Ident` as a raw-Rust injection point. It works because of how `render_identifier` falls through, but it's the only such use in the registry. Consider introducing a `RustExpr::CfgBlock { unix, non_unix }` (or similar) variant in the IR if more cross-platform branching arrives, so the pattern is explicit rather than hidden inside an `Ident` payload. Not required for this wave.
+- **Traceability could spell out Windows `kind == "signal"` semantics.** With the fix, Windows builds will return `Status { kind: "signal", signal: Some(-1) }` after `kill()`. That's an honest representation given Rust's `std::process::Child::kill()` is cross-platform, but the e2e fixture (`crates/sifr/tests/e2e/pass/process_child_kill_status.sifr:14,28`) only asserts `status.signal is not None`, which `Some(-1)` satisfies. Adding a one-liner under "Follow-up Boundaries" in `verification/stdlib/concurrency_runtime_m4_process_traceability.md:38-51` noting "Windows signal value is the `-1` sentinel; richer Windows termination representation is deferred" would close the host-scope gap that pass-1 raised as the alternative remediation. Optional, since the pass-1 review accepted either code gate *or* traceability note.
+- **Pre-existing stylistic nit (not introduced by this wave).** `try: …; except ProcessError as e: raise e` no-op wrappers in `lib/sifr/process.sifr` `kill`/`wait`/`Child.kill`/`Child.wait` are still there; left as-is per pass-1.

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -9,12 +9,12 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 | Surface | M4 evidence | Notes |
 | --- | --- | --- |
 | `sifr.process.Command` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin` | Native argv command builder with ordered arguments, explicit env entries, cwd selection, and owned stdin byte payload capture. This is the production `sifr.process` path and does not use `sifr.subprocess` or legacy shell-shaped helpers. |
-| `sifr.process.Status` | `process_sync_output_text`; `process_shell_exec_output`; `process_spawn_wait_status`; `process_timeout_status` | Sync status evidence distinguishes normal success from nonzero exit through `success`, `code`, and `kind`. Child wait reuses the same status evidence for one-shot sync observation. Timeout status evidence sets `kind == "timeout"` and `timed_out == True`; signal and cancellation fields remain open for later lifecycle waves. |
+| `sifr.process.Status` | `process_sync_output_text`; `process_shell_exec_output`; `process_spawn_wait_status`; `process_timeout_status`; `process_child_kill_status` | Sync status evidence distinguishes normal success from nonzero exit through `success`, `code`, and `kind`. Child wait reuses the same status evidence for one-shot sync observation. Timeout status evidence sets `kind == "timeout"` and `timed_out == True`; forced child kill sets `kind == "signal"` and records signal evidence. Cancellation fields remain open for later lifecycle waves. |
 | `sifr.process.Output` / `TextOutput` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_shell_exec_output` | Byte output captures stdout/stderr as `bytes`; text output requires an explicit encoding argument and currently accepts UTF-8/UTF8 through the text/i18n substrate boundary. Non-UTF-8 text-process policy remains open for the full M4 text-mode closeout. |
 | `sifr.process.Stdio` constants | Public `PIPE`, `INHERIT`, `NULL` definitions | Constants reserve the production namespace for the later owned pipe/spawn wave. Pipe ownership APIs are not claimed complete by this foundation wave. |
 | Sync `run`, `output`, `output_text` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_blocking_direct_async_rejected` | Sync process APIs are `@blocking_io`, return typed `Result[..., ProcessError]`, and direct async calls are rejected through imported stdlib workload metadata. |
 | Sync `run_timeout`, `output_timeout` | `process_timeout_status` | Timeout APIs kill and reap timed-out children, return typed `Status` evidence instead of panicking, and reject invalid negative, non-finite, or out-of-range timeout values through `ProcessError`. |
-| Sync `spawn`, `wait`, `Child.wait` | `process_spawn_wait_status`; `process_wait_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)` and `Child.wait()` are one-shot observation paths; top-level `wait(child)` is `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work. |
+| Sync `spawn`, `wait`, `Child.wait`, `kill`, `Child.kill` | `process_spawn_wait_status`; `process_child_kill_status`; `process_wait_direct_async_rejected`; `process_kill_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)`, `Child.wait()`, `kill(child)`, and `Child.kill()` are one-shot observation paths; sync observation/termination APIs are `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, graceful terminate, timeout on spawned children, and scoped supervision remain later M4 work. |
 | Sync `run_shell`, `output_shell`, `output_shell_text` | `process_shell_exec_output`; `process_shell_exec_direct_async_rejected` | Shell execution is explicit and classified as `@shell_exec` in addition to source-level `@blocking_io`; direct async calls use `SIFR-ASYNC-0007`. |
 | Sync `output_shell_timeout` | `process_timeout_status`; `process_shell_timeout_direct_async_rejected` | Shell timeout execution preserves the explicit shell-exec effect and timeout status evidence. |
 | Imported workload metadata | `process_blocking_direct_async_rejected`; `process_shell_exec_direct_async_rejected` | Lowering exports workload labels from stdlib/project modules and reimports them for user modules, so stdlib process APIs participate in the existing direct-async/offload diagnostic model. |
@@ -31,9 +31,9 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 
 | Lane | Representative entries |
 | --- | --- |
-| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status` |
-| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status` |
-| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
+| Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_child_kill_status` |
+| Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_child_kill_status` |
+| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_kill_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
 
 ## Follow-up Boundaries
 
@@ -41,7 +41,8 @@ Intentional remaining M4 work after this foundation wave:
 
 - `PipeReader`, `PipeWriter`, owned stdout/stderr/stdin pipe lifecycle, double-close/use-after-close diagnostics, and handle sendability/shareability checks beyond the one-shot sync `Child.wait()` state.
 - Native async spawn/wait/communicate and cancellation-safe process observation.
-- `terminate`, explicit `kill`, signal termination evidence, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
+- Graceful `terminate`, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
+- Non-Unix forced-kill signal evidence currently uses the `-1` sentinel; richer host-specific termination representation remains a supported-host matrix follow-up.
 - Scoped process supervision entry point accepted by M0: `TaskGroup.spawn_process` returns a distinct `ProcessHandle` preserving pipe access.
 - Full subprocess text mode closeout beyond UTF-8-only text output, consuming the text/i18n M1 evidence explicitly.
 - Dropping an unwaited sync `Child` keeps the private `std::process::Child` table entry for the process lifetime and may leave host child reaping to a later lifecycle wave; termination, timeout, cancellation, and drop cleanup semantics remain M4 follow-up work.

--- a/verification/validation_lanes/create_pr_e2e_manifest.json
+++ b/verification/validation_lanes/create_pr_e2e_manifest.json
@@ -85,6 +85,7 @@
     "process_sync_output_text",
     "process_sync_bytes_env_cwd_stdin",
     "process_shell_exec_output",
+    "process_child_kill_status",
     "process_timeout_status",
     "process_spawn_wait_status",
     "stdlib_json_consolidated",

--- a/verification/validation_lanes/merge_e2e_manifest.json
+++ b/verification/validation_lanes/merge_e2e_manifest.json
@@ -100,6 +100,7 @@
     "process_sync_output_text",
     "process_sync_bytes_env_cwd_stdin",
     "process_shell_exec_output",
+    "process_child_kill_status",
     "process_timeout_status",
     "process_spawn_wait_status",
     "text_i18n_encoding_io",


### PR DESCRIPTION
## Summary
- add sync forced child termination via sifr.process.kill(child) and Child.kill()
- lower process_kill through the private child handle table, kill + reap, and typed signal status evidence
- add pass/fail fixtures, manifest coverage, traceability, and two-pass Claude review artifacts

## Review
- reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-1.md: CHANGES_REQUESTED for unconditional Unix signal extraction
- reviews/ad-hoc-production-concurrency-runtime-m4-child-kill-review-pass-2.md: PASS after cfg-gated Unix/non-Unix signal extraction

## Validation
- cargo fmt --check && cargo check -p sifr_stdlib -p sifr_codegen -p sifr --quiet
- cargo test -p sifr_codegen lowers_process_kill_intrinsic_via_registry -- --nocapture
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_status.sifr
- cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr
- cargo test -p sifr test_e2e_fail -- --nocapture (420 fail tests)
- python3 scripts/check_file_size_guardrails.py
- python3 scripts/check_hir_maintainability_guardrails.py
- scripts/run_all_tests.sh --profile create-pr (PASS; advisory: warm wall-time budget exceeded; report target/validation_lane_reports/create-pr.latest.json; e2e 95 passed, 0 failed, cache_hits=23/25, report_signature=d8d730bd5475756c)