### PR TITLE
Enforce M4 process child method workloads

### DIFF
--- a/crates/sifr/tests/e2e/fail/process_child_kill_method_direct_async_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/process_child_kill_method_direct_async_rejected.sifr
@@ -1,0 +1,7 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.process import Child
+
+
+async def stop(child: Child):
+    _ = child.kill()
+    await task.sleep(0.0)

--- a/crates/sifr/tests/e2e/fail/process_child_wait_method_direct_async_rejected.sifr
+++ b/crates/sifr/tests/e2e/fail/process_child_wait_method_direct_async_rejected.sifr
@@ -1,0 +1,8 @@
+# expect-error: SIFR-ASYNC-0003
+from sifr.process import Child
+
+
+async def observe(child: Child):
+    status = child.wait()
+    await task.sleep(0.0)
+    return status

--- a/crates/sifr_driver/src/stdlib/bootstrap.rs
+++ b/crates/sifr_driver/src/stdlib/bootstrap.rs
@@ -104,6 +104,14 @@ fn compile_stdlib_uncached_impl() -> Result<StdlibCompiled, Vec<RenderedDiagnost
                 }
             }
         }
+        for (callable_name, label) in &result.function_workloads {
+            let Some((owner_name, _)) = callable_name.split_once('.') else {
+                continue;
+            };
+            if should_export_callable(module_name, owner_name) {
+                workload_exports.insert(callable_name.clone(), label.clone());
+            }
+        }
 
         for (callable_name, defaults) in &result.function_defaults {
             if should_export_callable(module_name, callable_name) {

--- a/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
+++ b/crates/sifr_lowering/src/lower/classes/class_type_collection.rs
@@ -16,6 +16,7 @@ use super::protocol_diagnostics;
 use super::simple_expr::lower_expr_simple;
 use super::typing_and_functions::resolve_annotation_expr;
 use super::{parse_typevar_bound_expr, LowerCtx};
+use crate::lower::workload_annotations;
 
 pub(super) fn class_method_signature<'a>(
     methods: &'a [(String, FunctionType)],
@@ -647,6 +648,12 @@ pub(in crate::lower) fn collect_class_type(
                     if !defaults.is_empty() {
                         ctx.function_defaults
                             .insert(format!("{class_name}.{method_name}"), defaults);
+                    }
+                    if let Some(workload) =
+                        workload_annotations::annotation_for_decorators(func.decorator_list.iter())
+                    {
+                        ctx.function_workload_annotations
+                            .insert(format!("{class_name}.{method_name}"), workload);
                     }
                     methods.push((
                         method_name,

--- a/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
+++ b/crates/sifr_lowering/src/lower/expressions/methods_lambdas_and_comprehensions.rs
@@ -123,6 +123,12 @@ pub(in crate::lower) fn lower_method_call(
         }
     }
     let object_ty_for_args = canonicalize_class_surface_type(object.ty().resolve_alias());
+    super::workload_annotations::reject_async_direct_method_call(
+        ctx,
+        &object_ty_for_args,
+        &method_name,
+        attr.attr.range(),
+    );
     let args = match &object_ty_for_args {
         Type::Class { name, methods, .. } => {
             if let Some((_, ft)) = methods

--- a/crates/sifr_lowering/src/lower/imported_defaults.rs
+++ b/crates/sifr_lowering/src/lower/imported_defaults.rs
@@ -75,3 +75,23 @@ pub(in crate::lower) fn import_class_method_varargs(
         }
     }
 }
+
+pub(in crate::lower) fn import_class_method_workloads(
+    ctx: &mut LowerCtx,
+    module_workloads: &HashMap<String, String>,
+    external_name: &str,
+    local_name: &str,
+) {
+    import_callable_workload(ctx, module_workloads, external_name, local_name);
+    let method_prefix = format!("{external_name}.");
+    for (workload_name, label) in module_workloads {
+        if let Some(suffix) = workload_name.strip_prefix(&method_prefix) {
+            if let Some(workload) = WorkloadKind::from_label(label) {
+                ctx.function_workload_annotations
+                    .insert(format!("{local_name}.{suffix}"), workload);
+                ctx.function_workload_annotations
+                    .insert(format!("{external_name}.{suffix}"), workload);
+            }
+        }
+    }
+}

--- a/crates/sifr_lowering/src/lower/imports.rs
+++ b/crates/sifr_lowering/src/lower/imports.rs
@@ -112,6 +112,16 @@ pub(in crate::lower) fn resolve_imports_early(
                             if externals.error_types.contains(name) {
                                 ctx.error_types.insert(local.clone());
                             }
+                            if let Some(module_workloads) =
+                                externals.function_workloads.get(&module_key)
+                            {
+                                super::imported_defaults::import_class_method_workloads(
+                                    ctx,
+                                    module_workloads,
+                                    name,
+                                    &local,
+                                );
+                            }
                             // Register constructor
                             if let Type::Class {
                                 fields, methods, ..

--- a/crates/sifr_lowering/src/lower/mod_impl.rs
+++ b/crates/sifr_lowering/src/lower/mod_impl.rs
@@ -449,6 +449,16 @@ pub(in crate::lower) fn lower_module_impl(
                                                 &local,
                                             );
                                         }
+                                        if let Some(module_workloads) =
+                                            externals.function_workloads.get(&stdlib_module_key)
+                                        {
+                                            imported_defaults::import_class_method_workloads(
+                                                &mut ctx,
+                                                module_workloads,
+                                                name,
+                                                &local,
+                                            );
+                                        }
                                     }
                                     // Import class type parameter bounds
                                     if let Some(module_bounds) =
@@ -632,6 +642,16 @@ pub(in crate::lower) fn lower_module_impl(
                                     imported_defaults::import_class_method_varargs(
                                         &mut ctx,
                                         module_varargs,
+                                        name,
+                                        &local,
+                                    );
+                                }
+                                if let Some(module_workloads) =
+                                    externals.function_workloads.get(&module_name)
+                                {
+                                    imported_defaults::import_class_method_workloads(
+                                        &mut ctx,
+                                        module_workloads,
                                         name,
                                         &local,
                                     );

--- a/crates/sifr_lowering/src/lower/workload_annotations.rs
+++ b/crates/sifr_lowering/src/lower/workload_annotations.rs
@@ -2,6 +2,7 @@ use super::LowerCtx;
 use ruff_text_size::{Ranged, TextRange};
 use sifr_diagnostics::DiagnosticCode;
 use sifr_python_ast::{Expr, StmtFunctionDef};
+use sifr_type_system::Type;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::lower) enum WorkloadKind {
@@ -113,6 +114,19 @@ pub(in crate::lower) fn reject_async_direct_call(
         ),
         range,
     );
+}
+
+pub(in crate::lower) fn reject_async_direct_method_call(
+    ctx: &mut LowerCtx,
+    object_ty: &Type,
+    method: &str,
+    range: TextRange,
+) {
+    let qualified = match object_ty.resolve_alias() {
+        Type::Class { name, .. } | Type::Protocol { name, .. } => format!("{name}.{method}"),
+        _ => return,
+    };
+    reject_async_direct_call(ctx, &qualified, range);
 }
 
 pub(in crate::lower) fn reject_unclassified_offload_target(

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -757,6 +757,31 @@ M4 stdin append semantics evidence review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m4-stdin-append-semantics-review-pass-1.md`: `PASS`; reviewer verified the two-call fixture uniquely distinguishes append-in-call-order from replace-with-first or replace-with-last semantics, traceability honestly closes only the stdin append decision, no out-of-scope process lifecycle APIs are introduced, and the validation set is sufficient for this evidence slice.
 - Merged as PR #2348: https://github.com/sifr-lang/sifr/pull/2348 (`afffaa3f8e40b9af0bbdffe13bafb61e053afb03`).
 
+M4 method-form blocking workload diagnostics implementation:
+
+- Extended workload annotation collection to record class method annotations as qualified names such as `Child.wait` and `Child.kill`.
+- Preserved qualified class-method workload metadata through stdlib bootstrap and external class imports, mirroring existing class-method default/vararg propagation.
+- Checked method calls in async contexts against the qualified workload metadata, so imported stdlib process methods now trigger the same direct-async diagnostics as top-level workload functions.
+- Added fail fixtures for `child.wait()` and `child.kill()` inside async functions.
+- Updated M4 process traceability to close the method-form `@blocking_io` enforcement follow-up.
+
+M4 method-form blocking workload diagnostics targeted local validation:
+
+- `cargo check -p sifr_lowering -p sifr_driver -p sifr --quiet` -> PASS.
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_child_wait_method_direct_async_rejected.sifr` -> expected FAIL with `SIFR-ASYNC-0003` at `child.wait()`.
+- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_child_kill_method_direct_async_rejected.sifr` -> expected FAIL with `SIFR-ASYNC-0003` at `child.kill()`.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr` -> PASS; sync `Child.wait()` remains accepted outside async contexts.
+- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr` -> PASS; sync `Child.kill()` remains accepted outside async contexts.
+- `cargo fmt --check` -> PASS.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; 2180 files checked, 900-line limit.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `cargo test -p sifr test_e2e_fail -- --nocapture` -> PASS; fail suite reported 422 fail tests completed.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`417.65s`, warm target `<=2m`). Included guardrails, diagnostic contracts, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`97 passed`, `0 failed`, `cache_hits=24/26`, `report_signature=36054c952f8fafec`).
+
+M4 method-form blocking workload diagnostics review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m4-process-method-workloads-review-pass-1.md`: `PASS`; reviewer verified qualified class-method workload collection, stdlib/project import propagation, method-call async diagnostics, bounded false-positive risk, new fail fixtures, and traceability honesty. Non-blocking note: keep unrelated network-phase files out of this PR.
+
 M0 targeted local validation:
 
 - `python3 scripts/generate_concurrency_runtime_inventory.py` -> PASS; generated 135 CPython evidence entries from the phase source-of-truth list.

--- a/reviews/ad-hoc-production-concurrency-runtime-m4-process-method-workloads-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m4-process-method-workloads-review-pass-1.md
@@ -1,0 +1,26 @@
+Findings:
+
+**Correctness — clean**
+- `class_type_collection.rs:649-655`: class-method workload collection is gated by the same decorator pass as top-level functions, producing qualified `Child.wait` / `Child.kill` keys in `ctx.function_workload_annotations`. The qualified keys flow into `LoweringResult.function_workloads` via `mod_impl.rs:755`.
+- `workload_annotations.rs:119-130`: `reject_async_direct_method_call` early-returns unless `object_ty` is `Type::Class` or `Type::Protocol`, then delegates to `reject_async_direct_call` which gates on `current_function_is_async` and explicit workload presence. Non-annotated methods and sync contexts are no-ops.
+- `methods_lambdas_and_comprehensions.rs:126-131`: the new check runs after `parallel_calls`, `task_join_set_calls`, `task_scope_offload_calls`, `task_scope_spawn`, and `is_task_handle_type` paths, so async-wrapper method handling is not affected.
+
+**Import propagation — clean**
+- `bootstrap.rs:107-114` filters by `should_export_callable(module_name, owner_name)`, correctly preserving the `_Child` exclusion semantics.
+- `imports.rs:115-124` and `mod_impl.rs:452-461`/`649-658` only call `import_class_method_workloads` inside the `module_classes.get(name)` arm, so workload propagation is anchored to actual class imports.
+- `imported_defaults.rs:79-97`: dual-inserts under both `{local_name}.{suffix}` and `{external_name}.{suffix}`. The external-name insert is what makes the diagnostic fire after `from sifr.process import Child` (since `Type::Class { name }` carries the external `"Child"`). This is intentional — `import_class_method_varargs`/`defaults` would actually have been broken for aliased class imports for the same reason, but that's pre-existing behavior not touched here.
+
+**Tests — clean**
+- Both fail fixtures produce `SIFR-ASYNC-0003` exactly at the method name token (`child.wait()` line 6 col 20; `child.kill()` line 6 col 15).
+- Pass fixtures `process_spawn_wait_status.sifr` and `process_child_kill_wait.sifr` (both call these methods inside `def main()`) still type-check clean — no false-positive regression.
+- Stdlib grep confirms only `Child.wait` and `Child.kill` are class-method-annotated in `lib/sifr/`, so the diagnostic surface is bounded.
+
+**Doc honesty — clean**
+- `concurrency_runtime_m4_process_traceability.md` removes the method-form follow-up bullet, adds both new fixtures to the fail-suite row, and threads "method-form `Child.wait()`/`Child.kill()` are `@blocking_io` and direct async calls are rejected" through the relevant traceability rows.
+- Does not claim owned pipes, async spawn/wait/communicate, terminate/escalation, scoped supervision, or text-mode closeout — those remain explicitly listed as follow-up work.
+- `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` adds an honest implementation + validation block scoped to method-form diagnostics.
+
+**One non-blocker note (operational, not correctness)**
+- Working tree also contains unrelated edits: `issues/ad-hoc-production-network-http-platform-substrate-execution.md`, `issues/ad-hoc-production-network-http-platform-substrate.md`, and two untracked `reviews/ad-hoc-production-network-http-platform-substrate-implementation-readiness-review-pass-{1,2}.md` files. These are clearly from a parallel HTTP-substrate slice and must not be committed with this slice's PR. Not a correctness or regression issue for the M4 process diagnostics — just a staging reminder.
+
+RESULT: PASS

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -2,7 +2,7 @@
 
 Milestone: `milestone_concurrency_runtime_4`
 
-Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, timeout status evidence merged in PR #2336, sync child kill support merged in PR #2337, Unix signal-status evidence merged in PR #2341, legacy subprocess intrinsic cleanup merged in PR #2344, and async run/output loopback is in progress.
+Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, timeout status evidence merged in PR #2336, sync child kill support merged in PR #2337, Unix signal-status evidence merged in PR #2341, legacy subprocess intrinsic cleanup merged in PR #2344, async run/output loopback merged in PR #2345, stdin append semantics merged in PR #2348, and method-form blocking diagnostics are in progress.
 
 ## Production Surface Traceability
 
@@ -15,11 +15,11 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 | Sync `run`, `output`, `output_text` | `process_sync_output_text`; `process_sync_bytes_env_cwd_stdin`; `process_blocking_direct_async_rejected` | Sync process APIs are `@blocking_io`, return typed `Result[..., ProcessError]`, and direct async calls are rejected through imported stdlib workload metadata. |
 | Async `async_run`, `async_output` | `process_async_run_output` | Async argv process APIs lower to `tokio::process::Command` on the current-thread runtime and are not marked `@blocking_io`. This wave covers async run/output loopback and typed stdin-deferral errors only; async spawn/wait/communicate, owned pipes, shell async APIs, timeout, cancellation, and scoped supervision remain later M4 work. |
 | Sync `run_timeout`, `output_timeout` | `process_timeout_status` | Timeout APIs kill and reap timed-out children, return typed `Status` evidence instead of panicking, and reject invalid negative, non-finite, or out-of-range timeout values through `ProcessError`. |
-| Sync `spawn`, `wait`, `Child.wait` | `process_spawn_wait_status`; `process_wait_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)` and `Child.wait()` are one-shot observation paths; top-level `wait(child)` is `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work. |
-| Sync `kill`, `Child.kill` | `process_child_kill_wait`; `process_kill_direct_async_rejected` | Sync kill requests forceful immediate-child termination through `std::process::Child::kill`; it does not provide process-group or descendant supervision. Callers must still observe the final status with `wait`. Top-level `kill(child)` is `@blocking_io` and direct async calls are rejected. Graceful `terminate`, timeout escalation, structured cancellation, and non-Unix signal-status evidence remain later M4 work. |
+| Sync `spawn`, `wait`, `Child.wait` | `process_spawn_wait_status`; `process_wait_direct_async_rejected`; `process_child_wait_method_direct_async_rejected` | Sync child lifecycle stores `std::process::Child` behind a private generated handle table. `wait(child)` and `Child.wait()` are one-shot observation paths; top-level `wait(child)` and method-form `Child.wait()` are `@blocking_io` and direct async calls are rejected. Owned pipe access, async wait, termination, timeout, and scoped supervision remain later M4 work. |
+| Sync `kill`, `Child.kill` | `process_child_kill_wait`; `process_kill_direct_async_rejected`; `process_child_kill_method_direct_async_rejected` | Sync kill requests forceful immediate-child termination through `std::process::Child::kill`; it does not provide process-group or descendant supervision. Callers must still observe the final status with `wait`. Top-level `kill(child)` and method-form `Child.kill()` are `@blocking_io` and direct async calls are rejected. Graceful `terminate`, timeout escalation, structured cancellation, and non-Unix signal-status evidence remain later M4 work. |
 | Sync `run_shell`, `output_shell`, `output_shell_text` | `process_shell_exec_output`; `process_shell_exec_direct_async_rejected` | Shell execution is explicit and classified as `@shell_exec` in addition to source-level `@blocking_io`; direct async calls use `SIFR-ASYNC-0007`. |
 | Sync `output_shell_timeout` | `process_timeout_status`; `process_shell_timeout_direct_async_rejected` | Shell timeout execution preserves the explicit shell-exec effect and timeout status evidence. |
-| Imported workload metadata | `process_blocking_direct_async_rejected`; `process_shell_exec_direct_async_rejected` | Lowering exports workload labels from stdlib/project modules and reimports them for user modules, so stdlib process APIs participate in the existing direct-async/offload diagnostic model. |
+| Imported workload metadata | `process_blocking_direct_async_rejected`; `process_shell_exec_direct_async_rejected`; `process_child_wait_method_direct_async_rejected`; `process_child_kill_method_direct_async_rejected` | Lowering exports workload labels from stdlib/project modules and reimports them for user modules, including qualified class-method workload labels, so stdlib process APIs participate in the existing direct-async/offload diagnostic model. |
 
 ## CPython Family Mapping
 
@@ -35,7 +35,7 @@ Status: In progress; sync process foundation merged in PR #2331, sync child wait
 | --- | --- |
 | Create PR | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_signal_status`, `process_async_run_output`, `process_child_kill_wait` |
 | Merge | `process_sync_output_text`, `process_sync_bytes_env_cwd_stdin`, `process_shell_exec_output`, `process_spawn_wait_status`, `process_timeout_status`, `process_signal_status`, `process_async_run_output`, `process_child_kill_wait` |
-| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, `process_kill_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
+| Fail suite | `process_blocking_direct_async_rejected`, `process_shell_exec_direct_async_rejected`, `process_wait_direct_async_rejected`, `process_child_wait_method_direct_async_rejected`, `process_shell_timeout_direct_async_rejected`, `process_kill_direct_async_rejected`, `process_child_kill_method_direct_async_rejected`, existing `legacy_sifr_subprocess_removed`, existing `async_popen_unsupported`, existing `bare_cpython_subprocess_import` |
 
 ## Follow-up Boundaries
 
@@ -45,7 +45,6 @@ Intentional remaining M4 work after this foundation wave:
 - Native async spawn/wait/communicate, async stdin/owned pipes, async process timeout, and cancellation-safe process observation.
 - Graceful `terminate`, termination escalation, non-Unix signal status evidence, parent cancellation evidence, and supported-host matrix updates for process termination behavior.
 - Scoped process supervision entry point accepted by M0: `TaskGroup.spawn_process` returns a distinct `ProcessHandle` preserving pipe access.
-- Method-form `@blocking_io` enforcement for `Child.wait()` / `Child.kill()` direct async calls remains a compiler follow-up; this wave verifies top-level `wait(child)` / `kill(child)` imported workload diagnostics.
 - Full subprocess text mode closeout beyond UTF-8-only text output, consuming the text/i18n M1 evidence explicitly.
 - Dropping an unwaited sync `Child` keeps the private `std::process::Child` table entry for the process lifetime and may leave host child reaping to a later lifecycle wave; termination, timeout, cancellation, and drop cleanup semantics remain M4 follow-up work.
 - If a future stdlib module re-exports a workload-annotated callable, mirror project-module re-export workload metadata in stdlib bootstrap export collection before relying on that shape.


### PR DESCRIPTION
## Summary
- Propagate qualified class-method workload annotations through lowering, stdlib bootstrap, and imports.
- Reject direct async calls to process child method forms `child.wait()` and `child.kill()` with `SIFR-ASYNC-0003`.
- Add fail fixtures, traceability updates, and Claude review evidence for the M4 method-form blocking diagnostics slice.

## Review
- `reviews/ad-hoc-production-concurrency-runtime-m4-process-method-workloads-review-pass-1.md`: RESULT: PASS

## Validation
- `cargo check -p sifr_lowering -p sifr_driver -p sifr --quiet`
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_child_wait_method_direct_async_rejected.sifr` (expected `SIFR-ASYNC-0003`)
- `cargo run -q -p sifr -- check crates/sifr/tests/e2e/fail/process_child_kill_method_direct_async_rejected.sifr` (expected `SIFR-ASYNC-0003`)
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_spawn_wait_status.sifr`
- `cargo run -q -p sifr -- run crates/sifr/tests/e2e/pass/process_child_kill_wait.sifr`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `cargo test -p sifr test_e2e_fail -- --nocapture` (422 fail tests completed)
- `scripts/run_all_tests.sh --profile create-pr` (97 passed, 0 failed; report_signature=36054c952f8fafec; advisory: warm wall-time budget exceeded)
