### PR TITLE
Record async output timeout merge

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -422,7 +422,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M4 sync stdout/stderr pipe readers: https://github.com/sifr-lang/sifr/pull/2352
 - M4 async process run timeout: https://github.com/sifr-lang/sifr/pull/2354
 - M4 sync stdin pipe writer: https://github.com/sifr-lang/sifr/pull/2357
-- M4 async process output timeout: in progress.
+- M4 async process output timeout: https://github.com/sifr-lang/sifr/pull/2362
 - M4: in progress.
 - M5: pending.
 - M6: pending.
@@ -914,6 +914,8 @@ M4 async process output timeout targeted local validation:
 M4 async process output timeout review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m4-async-output-timeout-review-pass-1.md`: `PASS`; reviewer verified the public wrapper, stdlib metadata, intrinsic lowering, and generated helper agree on 8-argument ordering; async output timeout validates timeout values, rejects unsupported stdin modes with typed `ProcessError`s, drains stdout/stderr asynchronously on normal completion, kills and waits on timeout, returns typed timeout `Output` evidence, gates independently from plain async output, propagates Tokio `io-util` through generated projects and grouped e2e harness crates, and keeps docs honest about remaining async spawn/wait/communicate, public async pipes, cancellation, scoped supervision, text-mode, and Windows follow-ups.
+- Merged as PR #2362: https://github.com/sifr-lang/sifr/pull/2362 (`2a3cefce45ea1a4ed7ab3eb414affc42471f3844`).
+- Merge-ledger validation: `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`183.33s`, warm target `<=2m`). Included guardrails, diagnostic contracts, developer tooling, performance budgets, generated-code quality, crate tests, platform golden (`pass=5`, `skip=2`), and create-pr e2e pass suite (`101 passed`, `0 failed`, `cache_hits=25/26`, `report_signature=9212e77abfa82acc`).
 
 M0 targeted local validation:
 

--- a/verification/stdlib/concurrency_runtime_m4_process_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m4_process_traceability.md
@@ -2,7 +2,7 @@
 
 Milestone: `milestone_concurrency_runtime_4`
 
-Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, timeout status evidence merged in PR #2336, sync child kill support merged in PR #2337, Unix signal-status evidence merged in PR #2341, legacy subprocess intrinsic cleanup merged in PR #2344, async run/output loopback merged in PR #2345, stdin append semantics merged in PR #2348, method-form blocking diagnostics merged in PR #2350, sync stdout/stderr pipe readers merged in PR #2352, async run timeout merged in PR #2354, sync stdin pipe writer support merged in PR #2357, stdin guardrails merged in PR #2359, and async output timeout is in the current implementation wave.
+Status: In progress; sync process foundation merged in PR #2331, sync child wait merged in PR #2334, timeout status evidence merged in PR #2336, sync child kill support merged in PR #2337, Unix signal-status evidence merged in PR #2341, legacy subprocess intrinsic cleanup merged in PR #2344, async run/output loopback merged in PR #2345, stdin append semantics merged in PR #2348, method-form blocking diagnostics merged in PR #2350, sync stdout/stderr pipe readers merged in PR #2352, async run timeout merged in PR #2354, sync stdin pipe writer support merged in PR #2357, stdin guardrails merged in PR #2359, and async output timeout merged in PR #2362.
 
 ## Production Surface Traceability
 


### PR DESCRIPTION
## Summary
- record PR #2362 as the merged M4 async output timeout wave
- update M4 process traceability status and merge-ledger validation evidence

## Validation
- scripts/run_all_tests.sh --profile create-pr (101 passed, 0 failed, report_signature=9212e77abfa82acc; warm wall-time advisory only)