### PR TITLE
Record M5 signal stream ledger review

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -620,6 +620,7 @@ M5 signal stream shape and lowering merge ledger:
 
 - Merged as PR #2418 (`abdd8674b9a51dc88260782283b6f47c4c7791ff`) on 2026-06-08.
 - Merge-ledger validation: `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`571.40s`, warm target `<=2m`). Included guardrails, diagnostic contracts, frontend/syntax guardrails, developer tooling, performance budgets, verification hardening, generated-code quality, crate tests, platform golden (`pass=6`, `skip=1`), and create-pr e2e pass suite (`120 passed`, `0 failed`, `cache_hits=34/34`, `report_signature=293aaf3695dc42f8`).
+- `reviews/ad-hoc-production-concurrency-runtime-m5-signal-stream-ledger-review-pass-2.md`: `PASS`; reviewer verified PR #2418 metadata, merge SHA/date, final validation metrics and advisory wording, review artifact references, branch hygiene, and no overclaim beyond stream shape/lowering.
 
 M5 warnings global-filter rejection implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m5-signal-stream-ledger-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m5-signal-stream-ledger-review-pass-2.md
@@ -1,0 +1,13 @@
+## Verdict: PASS
+
+**Verified:**
+
+- **PR #2418 metadata** matches GitHub: state `MERGED`, mergeCommit `abdd8674b9a51dc88260782283b6f47c4c7791ff`, mergedAt `2026-06-08T17:40:16Z`, title "Add M5 signal stream lowering", URL `github.com/sifr-lang/sifr/pull/2418`. Ledger entry "Merged as PR #2418 (`abdd8674b9a51dc88260782283b6f47c4c7791ff`) on 2026-06-08" matches all fields (UTC date aligns).
+- **Merge SHA exists on main**: `git log` confirms `abdd8674b Add M5 signal stream lowering (#2418)` is on `origin/main`; the merge ledger commit `70a32118a Record M5 signal stream merge ledger` is the only branch-only commit.
+- **Pending → merged link swap** at line 452 is a clean one-line replacement; no other index entries touched.
+- **Validation metrics internally consistent**: post-rebase create-pr lane (`120 passed, 0 failed, cache_hits=27/34, sig=293aaf3695dc42f8`, warm `959.65s`) → merge-ledger re-run (`120 passed, 0 failed, cache_hits=34/34, sig=293aaf3695dc42f8`, warm `571.40s`). Same fixture count and signature; cache hits rising to 34/34 and wall-time dropping on the warm re-run is coherent. Platform golden `pass=6, skip=1` matches across both runs.
+- **Review references resolve**: pass-1, pass-2, and pass-3 review files all exist on disk under `reviews/`. Pass-3 was added in the same ledger commit and its content matches the excerpt in the packet (verified opening lines).
+- **No scope overclaim**: ledger says "stream shape and lowering" — matches PR title, PR diff (`signal_stream_shape_strsignal.sifr` is shape-only), pass-3 review's "shape pin only" framing, and the umbrella row in `supported_host_matrix.md` staying at `in-progress`. Advisories (warm wall-time, cache-hit rate) recorded honestly rather than suppressed. No claim of deterministic delivery, non-Unix SIGTERM, or constants beyond SIGINT/SIGTERM.
+- **Branch hygiene**: actual `git status` shows the ledger change has been committed (commit `70a32118a`) and only an unrelated untracked review file (`...-ledger-review-pass-2.md`, the review of this ledger PR itself) is present. The packet's quoted git status reflects the pre-commit working tree of the ledger PR, which is consistent with what was committed.
+
+No discrepancies found.


### PR DESCRIPTION
## Summary
- add the post-merge ledger review artifact for the M5 signal stream wave
- record the reviewer PASS in the phase execution ledger

## Review
- `reviews/ad-hoc-production-concurrency-runtime-m5-signal-stream-ledger-review-pass-2.md`: PASS

## Local validation
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- Prior ledger gate already recorded in this section: `scripts/run_all_tests.sh --profile create-pr` PASS with report_signature=293aaf3695dc42f8
