### PR TITLE
Record M5 signal delivery merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -451,7 +451,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M5 resource value-carrying nullcontext: https://github.com/sifr-lang/sifr/pull/2419
 - M5 signal stream shape and lowering: https://github.com/sifr-lang/sifr/pull/2418
 - M5 resource cleanup helper diagnostics: https://github.com/sifr-lang/sifr/pull/2423
-- M5 signal stream Unix delivery harness: pending PR.
+- M5 signal stream Unix delivery harness: https://github.com/sifr-lang/sifr/pull/2426
 - M6: pending.
 - M7: pending.
 
@@ -755,6 +755,18 @@ M5 signal stream Unix delivery harness targeted local validation:
 M5 signal stream Unix delivery harness review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m5-signal-delivery-review-pass-1.md`: `PASS`; reviewer verified deterministic child-sent Unix signal delivery for `ctrl_c()`, `terminate()`, and `shutdown_stream().next()`, Windows gating, child wait observation, traceability/host-matrix honesty, no public API addition, and no overclaim for Unix-only constants or non-Unix semantics.
+
+M5 signal stream Unix delivery harness merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2426
+- Merge commit: `1f04c697dccd358384de73eeb09aceda7417563e`
+- Merged at: `2026-06-08T20:14:56Z`
+- Scope: deterministic Unix signal delivery pass coverage for `ctrl_c()`, `terminate()`, and `shutdown_stream().next()`, with Windows host gating and updated traceability/host-matrix boundaries.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` -> PASS.
+
+M5 signal stream Unix delivery harness merge-ledger review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m5-signal-delivery-ledger-review-pass-1.md`: `PASS`; reviewer verified PR #2426 URL, merge commit/date, review-loop citation, local validation evidence, Windows host gating, and no scope overclaim for Unix-only constants or non-Unix delivery semantics.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m5-signal-delivery-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m5-signal-delivery-ledger-review-pass-1.md
@@ -1,0 +1,34 @@
+## Review: M5 signal stream Unix delivery harness merge ledger
+
+**Verdict: PASS**
+
+### Verifications
+
+| Claim | Source | Verified |
+|---|---|---|
+| PR URL `https://github.com/sifr-lang/sifr/pull/2426` | `gh pr view 2426` | PASS; title "Add M5 Unix signal delivery harness", state MERGED |
+| Merge commit `1f04c697dccd358384de73eeb09aceda7417563e` | `gh pr view` + `git log -1 1f04c697...` | PASS; matches both sources |
+| `mergedAt: 2026-06-08T20:14:56Z` | `gh pr view` JSON | PASS; matches GitHub-reported value (local committer time `22:14:55+02:00` = `20:14:55Z`, 1 s earlier - normal merge skew) |
+| Review-loop citation `reviews/.../m5-signal-delivery-review-pass-1.md` | file present, PASS verdict | PASS; review verifies fixture honesty (`signal_stream_delivery_unix.sifr:1-62`), lowering parity, traceability/host-matrix honesty, and matches the recorded `cache_hits=23/28, report_signature=d760194c89dbc954` |
+| Cross-reference list entry (line 454) | issues ledger | PASS; present under correct M5 wave label |
+| Scope: "deterministic Unix signal delivery for `ctrl_c()`, `terminate()`, `shutdown_stream().next()`; Windows host gating; traceability/host-matrix updates" | fixture + review | PASS; no overclaim - Windows-gated via `system() == "Windows"`, no new public API, Unix-only constants and non-Unix delivery semantics remain `host-limited` in traceability/host matrix |
+
+### Local validation evidence
+
+Recorded in the pre-merge "targeted local validation" block (lines 747-753):
+
+- `signal_stream_delivery_unix.sifr` run -> PASS
+- `python3 -m json.tool` on both manifests -> PASS
+- `git diff --check`, file-size guardrails -> PASS
+- `scripts/run_e2e_pass.sh --profile create-pr` -> 121 passed, 0 failed, `cache_hits=23/28`, `report_signature=d760194c89dbc954`
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS, platform golden pass=6/skip=1, e2e 121 passed/0 failed, `cache_hits=28/35`, same `report_signature`, dual advisories (warm wall-time, cache hit rate)
+
+Numbers match what review-pass-1 independently verified.
+
+### Actionable findings
+
+**Non-blocking - pattern deviation, not an inaccuracy:**
+
+- The merge-ledger section (lines 759-764) omits an explicit `Merge-ledger validation:` line, unlike sibling M5 merge ledgers (`strsignal` line 787, task context line 816, signal constants ledger later, M4 scoped process line 484). All those record a post-merge `scripts/run_all_tests.sh --profile create-pr` rerun under the merge-ledger header. The Unix delivery ledger relies on the pre-merge run from the adjacent block instead. This is consistency, not honesty - flag if you want symmetry across M5 ledgers, otherwise leave as-is.
+
+No blocking issues. Merge ledger metadata, scope wording, host-gating, and review citation are all accurate and do not overclaim.


### PR DESCRIPTION
## Summary
- replace the M5 signal stream Unix delivery pending marker with PR #2426
- record PR #2426 merge SHA/date/scope in the execution ledger
- add the merge-ledger reviewer PASS artifact

## Local validation
- `git diff --check`

## Review
- `reviews/ad-hoc-production-concurrency-runtime-m5-signal-delivery-ledger-review-pass-1.md`: PASS