### PR TITLE
Record M5 closeout merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -891,6 +891,14 @@ M5 closeout classification review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m5-closeout-review-pass-2.md`: `PASS`; reviewer verified that M5 completion is valid after merged work through PR #2433/#2434, non-Unix signal delivery is not overclaimed, signal codegen tests pin both Unix and non-Unix branches for `terminate()` and `shutdown_stream().next()`, cleanup scope wording is honest, M5 artifacts are consistent, and M6/M7 remain pending. The reviewer noted overlapping cleanup wording in open PR #2430 as merge-sequence context, not a blocker for this closeout.
 
+M5 closeout classification merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2435
+- Merge commit: `a87cb2f279530f7d245f1601252e32f782b70297`
+- Merged at: `2026-06-08T22:36:25Z`
+- Scope: M5 completion classification, signal codegen cfg-branch evidence, non-Unix host-limited signal delivery boundary, cleanup-scope support classification, closeout validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m5-closeout-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m5-closeout-ledger-review-pass-1.md
@@ -1,0 +1,13 @@
+## PASS
+
+**Diff scope** — Only `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` is modified (8 insertions), adding a single new "M5 closeout classification merge ledger:" block at lines 894–900. Untracked review file is not part of the diff.
+
+**Metadata verification**
+- PR URL: `https://github.com/sifr-lang/sifr/pull/2435` ✓ matches.
+- Merge commit `a87cb2f279530f7d245f1601252e32f782b70297` ✓ matches, and `git log` confirms commit time `2026-06-09T00:36:25+02:00`, equivalent to the documented `2026-06-08T22:36:25Z` UTC.
+- Scope items (M5 completion classification, signal codegen cfg-branch evidence, non-Unix host-limited signal delivery boundary, cleanup-scope support classification, closeout validation evidence, reviewer artifact) align with the prior implementation/validation/review blocks at lines 875–892 — no overclaim of new work.
+- Validation claim (`git diff --check` PASS; `check_file_size_guardrails.py` PASS, 2246 files / 900-line limit) ✓ matches the known docs-only ledger validation.
+
+**Status block** — Lines 458–460 confirm `M5: complete.`, `M6: pending.`, `M7: pending.` — unchanged by this diff.
+
+Diff is docs-only, faithful to the merged PR #2435 metadata, and does not modify the M5/M6/M7 status.


### PR DESCRIPTION
## Summary
- record the merged M5 closeout classification PR #2435 in the execution ledger
- include merge commit, mergedAt timestamp, scope, and docs-only validation
- add the Claude ledger review artifact

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m5-closeout-ledger-review-pass-1.md: PASS