### PR TITLE
Record M6 typed IPC design merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -918,6 +918,14 @@ M6 typed IPC design gate review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-design-review-pass-1.md`: `PASS`; reviewer verified the named design artifact is sufficient for the M6 entry gate, covers typed payload eligibility, serialization format, schema/version negotiation, process-pipe layering, bootstrap, result/error frames, cancellation, backpressure, close, malformed-frame behavior, CPython-shaped API classification, and makes no implementation-support, dependency-wiring, or process-worker pool overclaim.
 
+M6 typed IPC design gate merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2437
+- Merge commit: `624248d058f166562148749243f5140358cde4e1`
+- Merged at: `2026-06-08T22:46:03Z`
+- Scope: named M6 typed IPC design artifact, process-pipe layering, wire format, schema/version negotiation, frame families, payload eligibility, backpressure, cancellation/close, malformed-frame behavior, CPython-shaped API classification, host-matrix boundary, validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-design-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-design-ledger-review-pass-1.md
@@ -1,0 +1,11 @@
+PASS
+
+Verified:
+- **Docs-only diff**: Only `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` changed vs `origin/main` (+8 lines). The untracked `reviews/...review-pass-1.md` is outside this diff.
+- **Metadata matches known values**:
+  - PR URL `https://github.com/sifr-lang/sifr/pull/2437` ✓
+  - Merge commit `624248d058f166562148749243f5140358cde4e1` ✓ (`git log` confirms: "Approve M6 typed IPC design gate")
+  - `mergedAt` `2026-06-08T22:46:03Z` ✓ (commit timestamp `2026-06-09T00:46:03+02:00` = `2026-06-08T22:46:03Z`)
+  - Validation claim ("docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS") matches the known ledger validation.
+- **No overclaim**: Scope is bounded to the *named design artifact* and adjacent design items (wire format, schema/version negotiation, frame families, payload eligibility, backpressure, cancellation/close, malformed-frame behavior, CPython-shaped API *classification*, host-matrix *boundary*, validation evidence, reviewer artifact). No runtime implementation, dependency wiring, host-support delivery, or public process-worker pool claims appear.
+- **Milestone status preserved**: Lines 460–461 still read `- M6: pending.` / `- M7: pending.`.


### PR DESCRIPTION
## Summary
- record the merged M6 typed IPC design-gate PR #2437 in the execution ledger
- include merge commit, mergedAt timestamp, scope, and docs-only validation
- add the Claude ledger review artifact

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-design-ledger-review-pass-1.md: PASS