### PR TITLE
Wire M6 typed IPC dependency metadata

### DIFF
--- a/crates/sifr/tests/e2e_support/fixture_compilation.rs
+++ b/crates/sifr/tests/e2e_support/fixture_compilation.rs
@@ -1,4 +1,12 @@
 use super::*;
+const POSTCARD_DEP: &str =
+    "postcard = { version = \"1.1.3\", default-features = false, features = [\"use-std\"] }";
+const SERDE_DEP: &str = "serde = { version = \"1.0.228\", features = [\"derive\"] }";
+const SERDE_JSON_DEP: &str =
+    "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }";
+const TRACING_DEP: &str =
+    "tracing = { version = \"0.1.44\", default-features = false, features = [\"std\"] }";
+
 pub(crate) fn failure_matches_expectation(
     failure: &CompiledFailure,
     expectation: &CompileFailureExpectation,
@@ -253,13 +261,8 @@ pub(crate) fn generate_cargo_toml(
     for module_name in stdlib_modules {
         match module_name.as_str() {
             "sifr.json" | "sifr.collections" | "_sifr.json" | "_sifr.collections" => {
-                deps.insert(
-                    "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                        .to_string(),
-                );
-                deps.insert(
-                    "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
-                );
+                deps.insert(SERDE_JSON_DEP.to_string());
+                deps.insert(SERDE_DEP.to_string());
             }
             "sifr.time" | "_sifr.time" | "sifr.datetime" | "_sifr.datetime" => {
                 deps.insert("chrono = \"0.4.44\"".to_string());
@@ -306,10 +309,11 @@ pub(crate) fn generate_cargo_toml(
             }
             "sifr.runtime" | "_sifr.runtime" => {
                 deps.insert("metrics = \"0.24.6\"".to_string());
-                deps.insert(
-                    "tracing = { version = \"0.1.44\", default-features = false, features = [\"std\"] }"
-                        .to_string(),
-                );
+                deps.insert(TRACING_DEP.to_string());
+            }
+            "sifr.ipc" | "_sifr.ipc" => {
+                deps.insert(POSTCARD_DEP.to_string());
+                deps.insert(SERDE_DEP.to_string());
             }
             "sifr.tomllib" | "_sifr.toml" => {
                 deps.insert(
@@ -345,13 +349,12 @@ pub(crate) fn generate_cargo_toml(
     for crate_name in required_crates {
         match crate_name.as_str() {
             "serde_json" => {
-                deps.insert(
-                    "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }"
-                        .to_string(),
-                );
-                deps.insert(
-                    "serde = { version = \"1.0.228\", features = [\"derive\"] }".to_string(),
-                );
+                deps.insert(SERDE_JSON_DEP.to_string());
+                deps.insert(SERDE_DEP.to_string());
+            }
+            "postcard" | "ipc" => {
+                deps.insert(POSTCARD_DEP.to_string());
+                deps.insert(SERDE_DEP.to_string());
             }
             "chrono" => {
                 deps.insert("chrono = \"0.4.44\"".to_string());
@@ -430,10 +433,7 @@ pub(crate) fn generate_cargo_toml(
                 deps.insert("metrics = \"0.24.6\"".to_string());
             }
             "tracing" => {
-                deps.insert(
-                    "tracing = { version = \"0.1.44\", default-features = false, features = [\"std\"] }"
-                        .to_string(),
-                );
+                deps.insert(TRACING_DEP.to_string());
             }
             _ => {}
         }

--- a/crates/sifr/tests/e2e_support/harness_contract_tests.rs
+++ b/crates/sifr/tests/e2e_support/harness_contract_tests.rs
@@ -542,6 +542,26 @@ pub(crate) fn test_generate_cargo_toml_runtime_diagnostics_use_locked_observabil
     assert!(from_required_crate.contains(tracing_spec));
 }
 
+#[test]
+pub(crate) fn test_generate_cargo_toml_ipc_uses_locked_postcard_specs() {
+    let ipc_modules = normalize_dependency_set(vec!["sifr.ipc".to_string()].into_iter());
+    let no_required_crates = BTreeSet::new();
+    let from_module = generate_cargo_toml(&ipc_modules, &no_required_crates, "sifr_output");
+    let postcard_spec =
+        "postcard = { version = \"1.1.3\", default-features = false, features = [\"use-std\"] }";
+    let serde_spec = "serde = { version = \"1.0.228\", features = [\"derive\"] }";
+    assert!(from_module.contains(postcard_spec));
+    assert!(from_module.contains(serde_spec));
+    assert!(!from_module.contains("serde_json = "));
+
+    let no_modules = BTreeSet::new();
+    let required_crates = normalize_dependency_set(vec!["postcard".to_string()]);
+    let from_required_crate = generate_cargo_toml(&no_modules, &required_crates, "sifr_output");
+    assert!(from_required_crate.contains(postcard_spec));
+    assert!(from_required_crate.contains(serde_spec));
+    assert!(!from_required_crate.contains("serde_json = "));
+}
+
 pub(crate) fn sample_cache_entry(
     group: &BatchGroup,
     toolchain: &ToolchainInfo,

--- a/crates/sifr/tests/e2e_support/harness_model.rs
+++ b/crates/sifr/tests/e2e_support/harness_model.rs
@@ -460,6 +460,9 @@ pub(crate) fn infer_dependencies(
     if rust_source.contains("metrics::") || rust_source.contains("use metrics") {
         crates.insert("metrics".to_string());
     }
+    if rust_source.contains("postcard::") || rust_source.contains("use postcard") {
+        crates.insert("postcard".to_string());
+    }
 
     (modules, crates)
 }

--- a/crates/sifr_stdlib/src/features.rs
+++ b/crates/sifr_stdlib/src/features.rs
@@ -15,6 +15,7 @@ pub enum StdlibFeature {
     IcuDecimal,
     IcuLocale,
     IcuPlurals,
+    Ipc,
     Md5,
     Metrics,
     NumBigint,
@@ -53,6 +54,7 @@ impl StdlibFeature {
             Self::IcuDecimal => "icu_decimal",
             Self::IcuLocale => "icu_locale",
             Self::IcuPlurals => "icu_plurals",
+            Self::Ipc => "ipc",
             Self::Md5 => "md5",
             Self::Metrics => "metrics",
             Self::NumBigint => "num-bigint",
@@ -134,6 +136,17 @@ const ICU_PLURALS_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency
     package: "icu_plurals",
     spec: "icu_plurals = \"2.2.0\"",
 }];
+const IPC_DEPS: &[GeneratedCargoDependency] = &[
+    GeneratedCargoDependency {
+        package: "postcard",
+        spec:
+            "postcard = { version = \"1.1.3\", default-features = false, features = [\"use-std\"] }",
+    },
+    GeneratedCargoDependency {
+        package: "serde",
+        spec: "serde = { version = \"1.0.228\", features = [\"derive\"] }",
+    },
+];
 const MD5_DEPS: &[GeneratedCargoDependency] = &[GeneratedCargoDependency {
     package: "md5",
     spec: "md5 = \"0.8.0\"",
@@ -271,6 +284,10 @@ pub const STDLIB_FEATURE_SPECS: &[StdlibFeatureSpec] = &[
         cargo_dependencies: ICU_PLURALS_DEPS,
     },
     StdlibFeatureSpec {
+        feature: StdlibFeature::Ipc,
+        cargo_dependencies: IPC_DEPS,
+    },
+    StdlibFeatureSpec {
         feature: StdlibFeature::Md5,
         cargo_dependencies: MD5_DEPS,
     },
@@ -370,6 +387,7 @@ pub fn feature_for_codegen_requirement(name: &str) -> Option<StdlibFeature> {
         "icu_decimal" | "icu-decimal" => Some(StdlibFeature::IcuDecimal),
         "icu_locale" | "icu-locale" => Some(StdlibFeature::IcuLocale),
         "icu_plurals" | "icu-plurals" => Some(StdlibFeature::IcuPlurals),
+        "ipc" | "postcard" => Some(StdlibFeature::Ipc),
         "md5" => Some(StdlibFeature::Md5),
         "metrics" => Some(StdlibFeature::Metrics),
         "num-bigint" => Some(StdlibFeature::NumBigint),
@@ -431,6 +449,7 @@ pub fn features_for_stdlib_module(module_name: &str) -> &'static [StdlibFeature]
             StdlibFeature::IcuPlurals,
         ],
         "sifr.base64" => &[StdlibFeature::Base64],
+        "sifr.ipc" | "_sifr.ipc" => &[StdlibFeature::Ipc],
         "sifr.parallel" => &[StdlibFeature::Rayon],
         "sifr.runtime" | "_sifr.runtime" => &[StdlibFeature::Metrics, StdlibFeature::Tracing],
         "sifr.tomllib" | "_sifr.toml" => &[StdlibFeature::Toml],
@@ -604,7 +623,7 @@ fn compile_time_sifr_runtime_path() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{generated_cargo_dependencies, StdlibFeature};
+    use super::{feature_for_codegen_requirement, generated_cargo_dependencies, StdlibFeature};
     use std::collections::HashSet;
 
     fn normalize_runtime_dependency(dependency: &str) -> String {
@@ -667,6 +686,31 @@ mod tests {
             .iter()
             .any(|dep| dep.starts_with("sifr_runtime = ") && !dep.contains("features")));
         assert!(deps.iter().any(|dep| dep.starts_with("tokio = ")));
+    }
+
+    #[test]
+    fn ipc_feature_renders_locked_postcard_specs_without_json() {
+        let deps = generated_cargo_dependencies(
+            &HashSet::from(["sifr.ipc".to_string(), "_sifr.ipc".to_string()]),
+            &HashSet::from([StdlibFeature::Ipc]),
+        );
+
+        assert_eq!(
+            deps,
+            vec![
+                "postcard = { version = \"1.1.3\", default-features = false, features = [\"use-std\"] }",
+                "serde = { version = \"1.0.228\", features = [\"derive\"] }",
+            ]
+        );
+        assert!(!deps.iter().any(|dep| dep.starts_with("serde_json = ")));
+        assert_eq!(
+            feature_for_codegen_requirement("ipc"),
+            Some(StdlibFeature::Ipc)
+        );
+        assert_eq!(
+            feature_for_codegen_requirement("postcard"),
+            Some(StdlibFeature::Ipc)
+        );
     }
 
     #[test]

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -926,6 +926,24 @@ M6 typed IPC design gate merge ledger:
 - Scope: named M6 typed IPC design artifact, process-pipe layering, wire format, schema/version negotiation, frame families, payload eligibility, backpressure, cancellation/close, malformed-frame behavior, CPython-shaped API classification, host-matrix boundary, validation evidence, and reviewer artifact.
 - Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
 
+M6 typed IPC dependency metadata implementation:
+
+- Added the internal `StdlibFeature::Ipc` feature that emits the locked Ring 4 typed-IPC dependencies: `postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }` plus `serde = { version = "1.0.228", features = ["derive"] }`.
+- Mapped `sifr.ipc`, `_sifr.ipc`, and explicit `ipc` / `postcard` codegen requirements to the IPC feature without adding public process-worker APIs.
+- Updated grouped e2e generated Cargo.toml dependency inference so generated Rust containing `postcard::` receives the locked IPC dependency pair, and so `sifr.ipc` module metadata uses Postcard/Serde without pulling `serde_json`.
+- Kept `crates/sifr/tests/e2e_support/fixture_compilation.rs` at the 900-line file-size cap after the change.
+
+M6 typed IPC dependency metadata targeted local validation:
+
+- `cargo test -p sifr_stdlib ipc_feature_renders_locked_postcard_specs_without_json -- --nocapture` -> PASS.
+- `cargo test -p sifr --test e2e test_generate_cargo_toml_ipc_uses_locked_postcard_specs -- --nocapture` -> PASS.
+- `cargo fmt --check`, `git diff --check`, and `python3 scripts/check_file_size_guardrails.py` -> PASS; file-size guardrail reported `2246 files` and the `900` line limit.
+- Touched file line counts after formatting: `crates/sifr_stdlib/src/features.rs` `894`, `crates/sifr/tests/e2e_support/fixture_compilation.rs` `900`, `crates/sifr/tests/e2e_support/harness_model.rs` `790`, and `crates/sifr/tests/e2e_support/harness_contract_tests.rs` `872`.
+
+M6 typed IPC dependency metadata review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-review-pass-1.md`: `PASS`; reviewer verified the change is limited to Ring 4 typed IPC dependency metadata and grouped e2e Cargo.toml inference, locked Postcard/Serde specs match the approved design, IPC does not pull `serde_json`, runtime diagnostics wiring is unchanged, file-size guardrails are respected, and the ledger does not overclaim M6 completion.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-review-pass-1.md
@@ -1,0 +1,51 @@
+# M6 typed IPC dependency metadata — review pass 1
+
+Verdict: **PASS**
+
+Branch: `codex/concurrency-runtime-m6-ipc-deps`
+Diff base: `origin/main`
+Touched files: 4 source + 1 ledger (`crates/sifr_stdlib/src/features.rs`, `crates/sifr/tests/e2e_support/fixture_compilation.rs`, `crates/sifr/tests/e2e_support/harness_model.rs`, `crates/sifr/tests/e2e_support/harness_contract_tests.rs`, `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md`).
+
+## Scope discipline
+
+- The diff is limited to dependency-metadata plumbing and the grouped e2e harness's generated-Cargo.toml inference for typed IPC. No public process-worker APIs are added; no runtime IPC frame/encoder/decoder implementation lands here.
+- `StdlibFeature::Ipc` is introduced as an internal feature variant alongside its `cargo_name`, `cargo_dependencies`, codegen-requirement aliases, and module mapping — no exported runtime surface.
+- Runtime diagnostics wiring is preserved: `sifr.runtime` / `_sifr.runtime` still resolve to `[StdlibFeature::Metrics, StdlibFeature::Tracing]`, and the `sifr.runtime` / `tracing` arms in `generate_cargo_toml` are only refactored to share the existing `TRACING_DEP` constant (no version, feature-flag, or default-features change).
+
+## Locked dependency specs
+
+- `IPC_DEPS` in `crates/sifr_stdlib/src/features.rs` renders exactly:
+  - `postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }`
+  - `serde = { version = "1.0.228", features = ["derive"] }`
+- These match the approved design and phase doc; no `serde_json`, `bincode`, or alternative codec slips in.
+- `feature_for_codegen_requirement` aliases both `"ipc"` and `"postcard"` onto `StdlibFeature::Ipc`, and `features_for_stdlib_module` maps both `"sifr.ipc"` and `"_sifr.ipc"` onto `[StdlibFeature::Ipc]`.
+
+## Grouped e2e harness inference
+
+- `crates/sifr/tests/e2e_support/harness_model.rs::infer_dependencies` now detects `postcard::` and `use postcard` in generated Rust and adds `"postcard"` to the required-crate set — mirroring the existing `serde_json` / `metrics` detection style.
+- `crates/sifr/tests/e2e_support/fixture_compilation.rs::generate_cargo_toml` adds:
+  - a `sifr.ipc` / `_sifr.ipc` module arm that inserts `POSTCARD_DEP` + `SERDE_DEP` (no `serde_json`), and
+  - a `"postcard" | "ipc"` required-crate arm that inserts the same locked pair.
+- The four spec strings (`POSTCARD_DEP`, `SERDE_DEP`, `SERDE_JSON_DEP`, `TRACING_DEP`) are de-duplicated into file-level constants without changing the rendered strings.
+- The new contract test `test_generate_cargo_toml_ipc_uses_locked_postcard_specs` exercises both the module-driven and required-crate-driven paths and asserts `serde_json` is absent in both renders.
+
+## File-size guardrail
+
+- `wc -l` confirms touched-file line counts match the brief: `fixture_compilation.rs` 900, `features.rs` 894, `harness_model.rs` 790, `harness_contract_tests.rs` 872 — all within the 900-line cap (fixture_compilation sits exactly at the cap; the constant extraction makes that headroom honest rather than monkey-patched).
+- `python3 scripts/check_file_size_guardrails.py` PASS was reported on 2246 files at the 900-line limit.
+
+## Ledger
+
+- The issue file appends two clearly scoped sections: "M6 typed IPC dependency metadata implementation" and "M6 typed IPC dependency metadata targeted local validation". Wording is explicit that this wave covers dependency metadata only — no claim of full M6 typed IPC completion, no claim about runtime frame APIs, and no claim that downstream wiring is in place. Validation commands quoted match the runs reported in the task brief.
+
+## Validation re-checked from artifacts
+
+- `cargo test -p sifr_stdlib ipc_feature_renders_locked_postcard_specs_without_json -- --nocapture`: PASS (reported).
+- `cargo test -p sifr --test e2e test_generate_cargo_toml_ipc_uses_locked_postcard_specs -- --nocapture`: PASS (reported).
+- `cargo fmt --check`, `git diff --check`, `python3 scripts/check_file_size_guardrails.py`: PASS (reported).
+
+## Findings
+
+None. The change is tightly scoped to internal dependency-metadata plumbing for Ring 4 typed IPC, the locked specs match the approved design, the grouped e2e harness now infers and renders the IPC pair from both module metadata and explicit required crates, no `serde_json` is pulled in, runtime diagnostics wiring is unaltered, the 900-line file-size cap is respected, and the ledger records implementation and validation without overclaiming M6 completion.
+
+Verdict: **PASS**.


### PR DESCRIPTION
## Summary
- add the internal M6 typed IPC stdlib feature for locked Postcard/Serde dependency metadata
- map sifr.ipc, _sifr.ipc, and explicit ipc/postcard codegen requirements to that feature
- update grouped e2e Cargo.toml inference for postcard-generated Rust without pulling serde_json
- record validation and reviewer evidence in the execution ledger

## Validation
- cargo test -p sifr_stdlib ipc_feature_renders_locked_postcard_specs_without_json -- --nocapture
- cargo test -p sifr --test e2e test_generate_cargo_toml_ipc_uses_locked_postcard_specs -- --nocapture
- cargo fmt --check
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-review-pass-1.md: PASS