### PR TITLE
Record M6 IPC dependency metadata merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -944,6 +944,14 @@ M6 typed IPC dependency metadata review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-review-pass-1.md`: `PASS`; reviewer verified the change is limited to Ring 4 typed IPC dependency metadata and grouped e2e Cargo.toml inference, locked Postcard/Serde specs match the approved design, IPC does not pull `serde_json`, runtime diagnostics wiring is unchanged, file-size guardrails are respected, and the ledger does not overclaim M6 completion.
 
+M6 typed IPC dependency metadata merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2439
+- Merge commit: `5d00e813691b7cae62f2ef7fc280b3bb0c6ebd2d`
+- Merged at: `2026-06-08T22:59:11Z`
+- Scope: internal typed IPC stdlib feature metadata, locked Postcard/Serde dependency specs, `sifr.ipc` / `_sifr.ipc` / `ipc` / `postcard` requirement mapping, grouped e2e generated Cargo.toml inference, validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-ledger-review-pass-1.md
@@ -1,0 +1,12 @@
+PASS
+
+Verified findings:
+
+- **Docs-only**: Single file change (`issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md`), +8 lines, no other files touched.
+- **PR URL**: `https://github.com/sifr-lang/sifr/pull/2439` matches.
+- **Merge commit**: `5d00e813691b7cae62f2ef7fc280b3bb0c6ebd2d` matches and exists in local history with subject "Wire M6 typed IPC dependency metadata".
+- **Merged at**: `2026-06-08T22:59:11Z` matches.
+- **Scope**: Limited to "internal typed IPC stdlib feature metadata, locked Postcard/Serde dependency specs, `sifr.ipc` / `_sifr.ipc` / `ipc` / `postcard` requirement mapping, grouped e2e generated Cargo.toml inference, validation evidence, and reviewer artifact" — accurately describes a compile-time dependency metadata wiring change.
+- **No overclaiming**: Entry does not claim runtime IPC implementation, host support, public process-worker APIs, or M6 completion. Language stays in the "internal stdlib feature metadata / dependency requirement mapping" lane.
+- **Validation claims**: Ledger-only validation (`git diff --check` + `check_file_size_guardrails.py`) matches the known docs-only validation evidence.
+- **Milestone status preserved**: Line 459 still records "M6 typed IPC design gate: in progress.", line 460 "M6: pending.", line 461 "M7: pending." — unchanged by this diff.


### PR DESCRIPTION
## Summary
- record the merged M6 IPC dependency metadata PR #2439 in the execution ledger
- include merge commit, mergedAt timestamp, scope, and docs-only validation
- add the Claude ledger review artifact

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-dependency-metadata-ledger-review-pass-1.md: PASS