### PR TITLE
Record M6 IPC value model merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -971,6 +971,14 @@ M6 typed IPC value model review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-value-model-review-pass-1.md`: `PASS`; reviewer verified the new `sifr.ipc` module is limited to host-independent schema/frame/backpressure values and helpers, reuses prior dependency metadata, covers value behavior and CPython-shaped missing-member diagnostics, updates both e2e manifests, keeps frame transport blocked, and does not overclaim M6 completion.
 
+M6 typed IPC value model merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2441
+- Merge commit: `d696146d0ccad063e0e5c4213bec7b3e25f4709d`
+- Merged at: `2026-06-08T23:12:23Z`
+- Scope: `sifr.ipc` schema/frame/backpressure value model, stdlib source registration, pass/fail fixtures, create-pr/merge manifest entries, M6 traceability, supported-host matrix, validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-value-model-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-value-model-ledger-review-pass-1.md
@@ -1,0 +1,9 @@
+PASS.
+
+Verified:
+- **Docs-only diff**: Only `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` is modified (+8 lines, ledger entry only).
+- **Metadata match**: PR URL `#2441`, merge commit `d696146d0ccad063e0e5c4213bec7b3e25f4709d`, and merged-at `2026-06-08T23:12:23Z` all match (commit `Tue Jun 9 01:12:23 2026 +0200` = `2026-06-08T23:12:23Z`).
+- **Scope match**: The ledger lists `sifr.ipc` schema/frame/backpressure value model, stdlib source registration, pass/fail fixtures, create-pr/merge manifest entries, M6 traceability, supported-host matrix, validation evidence, and reviewer artifact — every item is present in `git show d696146d0` (`lib/sifr/ipc.sifr`, `sifr_stdlib/src/sources.rs`, `ipc_value_model_basic.sifr`, two `*_unsupported.sifr` fail fixtures, both manifest JSONs, `concurrency_runtime_m6_typed_ipc_design.md`, `supported_host_matrix.md`, reviewer pass-1 file).
+- **Validation claim**: Matches the known docs-only validation (`git diff --check` PASS; file-size guardrail PASS).
+- **No overclaim**: Entry restricts itself to "schema/frame/backpressure value model" — it does not claim frame encoding, process-pipe transport, runtime backpressure, payload eligibility enforcement, public process-worker APIs, host transport support, or M6 completion. The "supported-host matrix" item refers to the matrix doc update only, and the actual matrix row explicitly disclaims encoding/transport/backpressure/eligibility.
+- **Status lines unchanged**: Lines 460–461 still read `M6: pending.` and `M7: pending.`.


### PR DESCRIPTION
## Summary
- record the merged M6 IPC value-model PR #2441 in the execution ledger
- include merge commit, mergedAt timestamp, scope, and docs-only validation
- add the Claude ledger review artifact

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-value-model-ledger-review-pass-1.md: PASS