### PR TITLE
Add M6 IPC schema hash support

### DIFF
--- a/crates/sifr_stdlib/src/ipc_schema.rs
+++ b/crates/sifr_stdlib/src/ipc_schema.rs
@@ -1,0 +1,265 @@
+const FNV_128_OFFSET: u128 = 0x6c62_272e_07bb_0142_62b8_2175_6295_c58d;
+const FNV_128_PRIME: u128 = 0x0000_0000_0100_0000_0000_0000_0000_013b;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IpcSchemaDescriptor {
+    pub protocol_schema_version: u32,
+    pub module_path: String,
+    pub schema_name: String,
+    pub compatible_version_min: u32,
+    pub compatible_version_max: u32,
+    pub request: IpcSchemaType,
+    pub response: IpcSchemaType,
+    pub error: IpcSchemaType,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IpcSchemaField {
+    pub name: String,
+    pub ty: IpcSchemaType,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IpcSchemaVariant {
+    pub name: String,
+    pub payload: Option<IpcSchemaType>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IpcSchemaType {
+    Bool,
+    Int,
+    Float,
+    Str,
+    Bytes,
+    None,
+    Option(Box<IpcSchemaType>),
+    Result(Box<IpcSchemaType>, Box<IpcSchemaType>),
+    List(Box<IpcSchemaType>),
+    DictStr(Box<IpcSchemaType>),
+    Tuple(Vec<IpcSchemaType>),
+    Record {
+        name: String,
+        fields: Vec<IpcSchemaField>,
+    },
+    Enum {
+        name: String,
+        variants: Vec<IpcSchemaVariant>,
+    },
+}
+
+#[must_use]
+pub fn canonical_schema_descriptor(descriptor: &IpcSchemaDescriptor) -> String {
+    let mut output = String::new();
+    output.push_str("sifr-ipc-schema-v1\nprotocol_schema_version=");
+    output.push_str(&descriptor.protocol_schema_version.to_string());
+    output.push_str("\nmodule=");
+    push_escaped(&mut output, &descriptor.module_path);
+    output.push_str("\nschema=");
+    push_escaped(&mut output, &descriptor.schema_name);
+    output.push_str("\ncompatible=");
+    output.push_str(&descriptor.compatible_version_min.to_string());
+    output.push_str("..");
+    output.push_str(&descriptor.compatible_version_max.to_string());
+    output.push_str("\nrequest=");
+    push_type(&mut output, &descriptor.request);
+    output.push_str("\nresponse=");
+    push_type(&mut output, &descriptor.response);
+    output.push_str("\nerror=");
+    push_type(&mut output, &descriptor.error);
+    output
+}
+
+#[must_use]
+pub fn schema_hash_v1(descriptor: &IpcSchemaDescriptor) -> u128 {
+    fnv1a_128(canonical_schema_descriptor(descriptor).as_bytes())
+}
+
+#[must_use]
+pub fn schema_hash_hex_v1(descriptor: &IpcSchemaDescriptor) -> String {
+    format!("{:032x}", schema_hash_v1(descriptor))
+}
+
+#[must_use]
+pub fn fnv1a_128(bytes: &[u8]) -> u128 {
+    let mut hash = FNV_128_OFFSET;
+    for byte in bytes {
+        hash ^= u128::from(*byte);
+        hash = hash.wrapping_mul(FNV_128_PRIME);
+    }
+    hash
+}
+
+fn push_type(output: &mut String, ty: &IpcSchemaType) {
+    match ty {
+        IpcSchemaType::Bool => output.push_str("bool"),
+        IpcSchemaType::Int => output.push_str("int"),
+        IpcSchemaType::Float => output.push_str("float"),
+        IpcSchemaType::Str => output.push_str("str"),
+        IpcSchemaType::Bytes => output.push_str("bytes"),
+        IpcSchemaType::None => output.push_str("none"),
+        IpcSchemaType::Option(inner) => {
+            output.push_str("option(");
+            push_type(output, inner);
+            output.push(')');
+        }
+        IpcSchemaType::Result(ok, err) => {
+            output.push_str("result(");
+            push_type(output, ok);
+            output.push(',');
+            push_type(output, err);
+            output.push(')');
+        }
+        IpcSchemaType::List(inner) => {
+            output.push_str("list(");
+            push_type(output, inner);
+            output.push(')');
+        }
+        IpcSchemaType::DictStr(value) => {
+            output.push_str("dict(str,");
+            push_type(output, value);
+            output.push(')');
+        }
+        IpcSchemaType::Tuple(items) => {
+            output.push_str("tuple(");
+            push_types(output, items);
+            output.push(')');
+        }
+        IpcSchemaType::Record { name, fields } => {
+            output.push_str("record(");
+            push_escaped(output, name);
+            output.push('{');
+            for (index, field) in fields.iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                push_escaped(output, &field.name);
+                output.push(':');
+                push_type(output, &field.ty);
+            }
+            output.push_str("})");
+        }
+        IpcSchemaType::Enum { name, variants } => {
+            output.push_str("enum(");
+            push_escaped(output, name);
+            output.push('{');
+            for (index, variant) in variants.iter().enumerate() {
+                if index > 0 {
+                    output.push(',');
+                }
+                push_escaped(output, &variant.name);
+                if let Some(payload) = &variant.payload {
+                    output.push('(');
+                    push_type(output, payload);
+                    output.push(')');
+                }
+            }
+            output.push_str("})");
+        }
+    }
+}
+
+fn push_types(output: &mut String, items: &[IpcSchemaType]) {
+    for (index, item) in items.iter().enumerate() {
+        if index > 0 {
+            output.push(',');
+        }
+        push_type(output, item);
+    }
+}
+
+fn push_escaped(output: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            '(' | ')' | '{' | '}' | ':' | ',' | '=' => {
+                output.push('\\');
+                output.push(ch);
+            }
+            _ => output.push(ch),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        canonical_schema_descriptor, schema_hash_hex_v1, IpcSchemaDescriptor, IpcSchemaField,
+        IpcSchemaType, IpcSchemaVariant,
+    };
+
+    fn sample_descriptor() -> IpcSchemaDescriptor {
+        IpcSchemaDescriptor {
+            protocol_schema_version: 1,
+            module_path: "demo.worker".to_string(),
+            schema_name: "Echo".to_string(),
+            compatible_version_min: 1,
+            compatible_version_max: 1,
+            request: IpcSchemaType::Record {
+                name: "EchoRequest".to_string(),
+                fields: vec![
+                    IpcSchemaField {
+                        name: "message".to_string(),
+                        ty: IpcSchemaType::Str,
+                    },
+                    IpcSchemaField {
+                        name: "attempt".to_string(),
+                        ty: IpcSchemaType::Int,
+                    },
+                ],
+            },
+            response: IpcSchemaType::Record {
+                name: "EchoResponse".to_string(),
+                fields: vec![IpcSchemaField {
+                    name: "accepted".to_string(),
+                    ty: IpcSchemaType::Bool,
+                }],
+            },
+            error: IpcSchemaType::Enum {
+                name: "EchoError".to_string(),
+                variants: vec![
+                    IpcSchemaVariant {
+                        name: "Rejected".to_string(),
+                        payload: Some(IpcSchemaType::Str),
+                    },
+                    IpcSchemaVariant {
+                        name: "Closed".to_string(),
+                        payload: None,
+                    },
+                ],
+            },
+        }
+    }
+
+    #[test]
+    fn canonical_descriptor_is_stable_and_ordered() {
+        let descriptor = sample_descriptor();
+
+        assert_eq!(
+            canonical_schema_descriptor(&descriptor),
+            "sifr-ipc-schema-v1\nprotocol_schema_version=1\nmodule=demo.worker\nschema=Echo\ncompatible=1..1\nrequest=record(EchoRequest{message:str,attempt:int})\nresponse=record(EchoResponse{accepted:bool})\nerror=enum(EchoError{Rejected(str),Closed})"
+        );
+    }
+
+    #[test]
+    fn schema_hash_v1_is_stable_and_sensitive_to_shape() {
+        let descriptor = sample_descriptor();
+        let mut changed = sample_descriptor();
+        let IpcSchemaType::Record { fields, .. } = &mut changed.request else {
+            panic!("sample request should be a record");
+        };
+        fields[1].ty = IpcSchemaType::Float;
+
+        assert_eq!(
+            schema_hash_hex_v1(&descriptor),
+            "4733c89fb23a40ecb5f3bcda99fb34da"
+        );
+        assert_ne!(
+            schema_hash_hex_v1(&descriptor),
+            schema_hash_hex_v1(&changed)
+        );
+    }
+}

--- a/crates/sifr_stdlib/src/lib.rs
+++ b/crates/sifr_stdlib/src/lib.rs
@@ -12,6 +12,7 @@ mod crypto_regex_uuid;
 mod features;
 mod i18n_core;
 mod io_json;
+mod ipc_schema;
 mod math_test;
 mod platform_misc;
 mod process;
@@ -31,6 +32,10 @@ pub use features::{
 };
 use i18n_core::intrinsic_i18n;
 use io_json::{intrinsic_io, intrinsic_json};
+pub use ipc_schema::{
+    canonical_schema_descriptor, fnv1a_128, schema_hash_hex_v1, schema_hash_v1,
+    IpcSchemaDescriptor, IpcSchemaField, IpcSchemaType, IpcSchemaVariant,
+};
 use math_test::{intrinsic_math, intrinsic_test};
 use platform_misc::{
     intrinsic_calendar, intrinsic_compress, intrinsic_datetime, intrinsic_html, intrinsic_logging,

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -979,6 +979,25 @@ M6 typed IPC value model merge ledger:
 - Scope: `sifr.ipc` schema/frame/backpressure value model, stdlib source registration, pass/fail fixtures, create-pr/merge manifest entries, M6 traceability, supported-host matrix, validation evidence, and reviewer artifact.
 - Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
 
+M6 typed IPC schema hash implementation:
+
+- Added internal `sifr_stdlib::ipc_schema` descriptor types for generated IPC schemas, fields, variants, and eligible type shapes.
+- Added deterministic canonical descriptor rendering for module path, schema name, compatible version range, request/response/error types, record fields, enum variants, and nested container types.
+- Added dependency-free FNV-1a-128 schema hash v1 helpers (`schema_hash_v1`, `schema_hash_hex_v1`) for compatibility evidence, not cryptographic trust.
+- Updated M6 typed IPC traceability to record schema descriptor/hash evidence while keeping compiler integration and generated schema extraction as follow-up work.
+
+M6 typed IPC schema hash targeted local validation:
+
+- `cargo test -p sifr_stdlib ipc_schema -- --nocapture` -> PASS.
+- `cargo fmt` and `cargo fmt --check` -> PASS.
+- `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS; file-size guardrail reported `2250 files` and the `900` line limit.
+- Touched file line counts after formatting: `crates/sifr_stdlib/src/ipc_schema.rs` `265`, `crates/sifr_stdlib/src/lib.rs` `430`, `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md` `243`, and this ledger `1964`.
+
+M6 typed IPC schema hash review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-1.md`: `PASS` with minor advisories; reviewer verified the internal-only schema descriptor/hash scope, deterministic canonical rendering, dependency-free FNV-1a-128 hash, traceability framing, and file-size guardrail, while asking to strengthen the sensitivity test and refresh stale line counts.
+- `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-2.md`: `PASS`; reviewer verified the sensitivity test now mutates an actual request-record field type, ledger line counts match current files, scope remains internal-only, traceability still leaves compiler integration as follow-up work, and validation stayed green.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-1.md
@@ -1,0 +1,28 @@
+I've reviewed the diff against `origin/main`. The change consists of one new file (`crates/sifr_stdlib/src/ipc_schema.rs`, 262 lines), a re-export in `lib.rs`, and traceability/ledger entries.
+
+**Scope verification**
+- `ipc_schema.rs` only declares descriptor types (`IpcSchemaDescriptor`, `IpcSchemaField`, `IpcSchemaVariant`, `IpcSchemaType`) plus canonical-rendering and FNV-1a-128 hash helpers. No frame encode/decode, no pipe transport, no payload eligibility enforcement, no public worker APIs.
+- The new items are `pub use`'d at the `sifr_stdlib` crate root, but `grep` shows no compiler/codegen/sources/intrinsic registrations referencing them — nothing user-facing in `.sifr`.
+
+**Descriptor and canonical rendering (`ipc_schema.rs:52-71`, `93-160`)**
+- Eligible shapes cover Bool/Int/Float/Str/Bytes/None, Option, Result, List, DictStr, Tuple, Record, Enum (with optional variant payload).
+- Canonical rendering deterministically emits protocol schema version, module path, schema name, compatible version range (`min..max`), request/response/error types, record fields (in declared order), enum variants (in declared order), and recurses for nested containers. `push_escaped` escapes structural delimiters and control chars so descriptor content cannot collide with delimiters.
+
+**Schema hash v1 (`ipc_schema.rs:74-91`)**
+- FNV-1a-128 implemented inline; constants match the canonical offset basis `0x6c62272e07bb014262b821756295c58d` and prime `0x0000000001000000000000000000013b`. No external crates added.
+- Golden test pins `4733c89fb23a40ecb5f3bcda99fb34da`. Sensitivity test mutates the descriptor and asserts the hash differs.
+
+  *Minor advisory:* the sensitivity test mutates `compatible_version_max`, which is metadata, not record/enum shape. It does prove descriptor-sensitivity (the version range is part of the canonical bytes), but a stricter "shape" test would also mutate e.g. a field name/type or variant order. Not a blocker; just worth strengthening when compiler integration lands.
+
+**Traceability / ledger (`issues/...md:982-995`, `verification/...md:30`)**
+- Both explicitly note "Compiler integration and generated schema extraction remain follow-up work." No overclaim of M6 completion or compiler wiring.
+
+  *Minor advisory:* the ledger's "Touched file line counts" reports `1950` for the ledger and `242` for the verification doc; actual `wc -l` is `1964` and `243`. Cosmetic, but the numbers are slightly stale.
+
+**File-size guardrail**
+- `crates/sifr_stdlib/src/ipc_schema.rs` 262, `lib.rs` 430, verification doc 243 — all under 900. Issue ledger (1964) is outside the guardrail's `crates/scripts/verification/demos` scope. `python3 scripts/check_file_size_guardrails.py` reports PASS.
+
+**Validation note**
+- I could not re-run `cargo test -p sifr_stdlib ipc_schema` locally because `third_party/ruff/crates/ruff_text_size/Cargo.toml` is missing (submodule not populated in this worktree). Relying on the user-reported PASS for the targeted test command.
+
+**PASS** — with two minor advisories (sensitivity test exercises version metadata rather than record/enum shape; ledger's quoted line counts are slightly stale vs. current files). Neither is a correctness or scope concern.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-2.md
@@ -1,0 +1,24 @@
+I re-reviewed the diff against `origin/main` after the pass-1 advisories.
+
+**Pass-1 advisory #1 — sensitivity test exercises record shape (RESOLVED)**
+- `ipc_schema.rs:248-264` (`schema_hash_v1_is_stable_and_sensitive_to_shape`) now mutates `fields[1].ty` of the request record from `Int` to `Float`, then asserts the hash differs. This exercises an actual request-record field type rather than `compatible_version_max` metadata. The golden hex `4733c89fb23a40ecb5f3bcda99fb34da` is still pinned against the unmodified descriptor.
+
+**Pass-1 advisory #2 — stale ledger line counts (RESOLVED)**
+- Issue ledger entry `issues/...md:993` now reports `crates/sifr_stdlib/src/ipc_schema.rs 265`, `crates/sifr_stdlib/src/lib.rs 430`, `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md 243`, and the ledger itself `1964`. `wc -l` on the current tree returns exactly the same numbers (265 / 430 / 243 / 1964). No drift.
+
+**Scope unchanged**
+- The diff still touches only `crates/sifr_stdlib/src/ipc_schema.rs` (new, 265 lines), `crates/sifr_stdlib/src/lib.rs` (5-line re-export), and the two doc files. `grep` for `ipc_schema|IpcSchema|schema_hash` across `crates/` returns only those two files — no compiler/codegen/source registrations.
+- No frame encode/decode, no process-pipe transport, no payload eligibility enforcement, and no public worker API surface have been added.
+
+**Traceability / ledger framing**
+- `verification/.../concurrency_runtime_m6_typed_ipc_design.md:30` describes the addition as "Internal schema descriptor and hash v1" and explicitly notes "Compiler integration and generated schema extraction remain follow-up work."
+- `issues/...md:982-995` records this as a discrete schema-hash slice within M6, not as M6 completion. No overclaim of compiler integration.
+
+**Validation**
+- `cargo test -p sifr_stdlib ipc_schema -- --nocapture`: 2 passed (`canonical_descriptor_is_stable_and_ordered`, `schema_hash_v1_is_stable_and_sensitive_to_shape`), 0 failed.
+- `cargo fmt --check`: PASS (no diff).
+- `git diff --check`: PASS (no whitespace issues).
+- `python3 scripts/check_file_size_guardrails.py`: PASS (2250 files, limit 900 lines).
+- (For local reproduction the `third_party/ruff` submodule needed `git submodule update --init third_party/ruff` first; pass-1 hit the same missing-submodule blocker.)
+
+**PASS** — both pass-1 advisories addressed, scope and traceability framing unchanged, all four targeted validation commands green.

--- a/verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md
+++ b/verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md
@@ -27,6 +27,7 @@ This design does not ship a public process-worker pool. A future worker API rema
 | `sifr.ipc.ProtocolVersion` / `protocol_version(...)` | `ipc_value_model_basic` | Host-independent value model for negotiated protocol version bounds. |
 | `sifr.ipc.FrameKind` and frame-family constants | `ipc_value_model_basic` | Covers bootstrap, work, control, health, and protocol-error frame names as values. It does not encode or decode wire frames yet. |
 | `sifr.ipc.BackpressurePolicy` / `default_backpressure()` | `ipc_value_model_basic` | Pins the default in-flight request window (`64`) and default max frame bytes (`16777216`) from the design. Runtime backpressure enforcement remains follow-up work. |
+| Internal schema descriptor and hash v1 | `cargo test -p sifr_stdlib ipc_schema -- --nocapture` | `sifr_stdlib::ipc_schema` renders canonical schema descriptors and stable FNV-1a-128 schema hashes without adding a new hash dependency. Compiler integration and generated schema extraction remain follow-up work. |
 | `ProcessPoolExecutor` and `Process` under `sifr.ipc` | `ipc_process_pool_executor_unsupported`; `ipc_multiprocessing_process_unsupported` | Missing-member diagnostics keep CPython-shaped process-pool and multiprocessing names out of the native IPC module. |
 
 ## Transport Boundary


### PR DESCRIPTION
## Summary
- add internal typed IPC schema descriptor types and canonical descriptor rendering
- add dependency-free FNV-1a-128 schema hash v1 helpers with golden and shape-sensitivity tests
- update M6 traceability and execution ledger without claiming compiler integration or runtime frame support
- include two Claude review passes, with pass-1 advisories resolved in pass 2

## Validation
- cargo test -p sifr_stdlib ipc_schema -- --nocapture
- cargo fmt
- cargo fmt --check
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-1.md: PASS with minor advisories
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-2.md: PASS