### PR TITLE
Record M6 IPC schema hash merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -998,6 +998,14 @@ M6 typed IPC schema hash review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-1.md`: `PASS` with minor advisories; reviewer verified the internal-only schema descriptor/hash scope, deterministic canonical rendering, dependency-free FNV-1a-128 hash, traceability framing, and file-size guardrail, while asking to strengthen the sensitivity test and refresh stale line counts.
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-review-pass-2.md`: `PASS`; reviewer verified the sensitivity test now mutates an actual request-record field type, ledger line counts match current files, scope remains internal-only, traceability still leaves compiler integration as follow-up work, and validation stayed green.
 
+M6 typed IPC schema hash merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2443
+- Merge commit: `f5a03ee0b646b2e04624cc0377066ad20f8913b4`
+- Merged at: `2026-06-08T23:28:56Z`
+- Scope: internal IPC schema descriptor types, canonical descriptor rendering, dependency-free FNV-1a-128 schema hash v1 helpers, schema hash tests, M6 traceability, validation evidence, and two review artifacts.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-ledger-review-pass-1.md
@@ -1,0 +1,21 @@
+## PASS
+
+### Diff scope verification
+- Single-file docs-only diff: `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md`, +8/-0 lines, inserted directly after the existing "M6 typed IPC schema hash review loop" block.
+- No code, no test, no doc-outside-issue changes.
+
+### Metadata cross-check
+- PR URL `https://github.com/sifr-lang/sifr/pull/2443` — matches.
+- Merge commit `f5a03ee0b646b2e04624cc0377066ad20f8913b4` — matches `git log` HEAD (subject "Add M6 IPC schema hash support").
+- `mergedAt` `2026-06-08T23:28:56Z` — matches the supplied known metadata. (For info: git committer-date on the merge commit is `2026-06-08T23:28:55Z`; the 1-second offset is the normal `git`-vs-GitHub-merge-event variance and the entry uses the authoritative GitHub value.)
+- Validation claim ("`git diff --check` + `check_file_size_guardrails.py` → PASS") matches the provided ledger validation.
+
+### Overclaim check (all clear)
+- Scope wording stays inside "schema descriptor types, canonical rendering, FNV-1a-128 hash v1 helpers, schema hash tests, traceability, validation evidence, two review artifacts." No claim of:
+  - compiler integration,
+  - runtime frame encoding,
+  - process-pipe transport,
+  - payload eligibility enforcement,
+  - public process-worker APIs,
+  - M6 completion.
+- Status block (`issues/...md:459-461`) still reads `M6 typed IPC design gate: in progress`, `M6: pending`, `M7: pending` — untouched by this diff.


### PR DESCRIPTION
## Summary
- record the merged M6 IPC schema-hash PR #2443 in the execution ledger
- include merge commit, mergedAt timestamp, scope, and docs-only validation
- add the Claude ledger review artifact

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-schema-hash-ledger-review-pass-1.md: PASS