### PR TITLE
Record M6 IPC frame codec merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -1028,6 +1028,14 @@ M6 typed IPC frame codec review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-frame-codec-review-pass-1.md`: `PASS`; reviewer verified the Ring 4 Postcard/Serde dependency scope, internal-only frame helper surface, length-prefix encode/decode correctness, oversize-before-decode handling, typed malformed-frame errors, redacted error text, no runtime unwrap/expect/panic path for malformed input, frame-family test coverage, host-matrix and traceability honesty, and no overclaim beyond host-independent codec helpers.
 
+M6 typed IPC frame codec merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2445
+- Merge commit: `fb06126a0ad1239a54bfbc73125b7b04b77510a7`
+- Merged at: `2026-06-08T23:57:31Z`
+- Scope: Ring 4 workspace Postcard dependency, `sifr_stdlib` Serde/Postcard dependency wiring, internal IPC envelope and length-prefixed Postcard encode/decode helpers, malformed-frame tests, M6 traceability, supported-host matrix, validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-frame-codec-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-frame-codec-ledger-review-pass-1.md
@@ -1,0 +1,12 @@
+PASS
+
+All claims in the ledger entry at `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:1031-1037` verify against repo state and GitHub PR metadata:
+
+- **PR URL** `https://github.com/sifr-lang/sifr/pull/2445` — matches `gh pr view 2445` (state `MERGED`, base `main`, title "Add M6 typed IPC frame codec").
+- **Merge commit** `fb06126a0ad1239a54bfbc73125b7b04b77510a7` — matches `gh pr view` `mergeCommit.oid` and is the tip of the branch.
+- **Merged at** `2026-06-08T23:57:31Z` — matches `gh pr view` `mergedAt` and equals the commit's `2026-06-09T01:57:31+02:00` in UTC.
+- **Scope** accurately summarizes the merge: Ring 4 workspace `postcard` dependency (`Cargo.toml`), `sifr_stdlib` Serde/Postcard wiring (`crates/sifr_stdlib/Cargo.toml`), envelope and length-prefixed Postcard encode/decode helpers (`crates/sifr_stdlib/src/ipc_frame.rs` new, `lib.rs` re-exports), traceability (issue file), supported-host matrix update, validation evidence and reviewer artifact — all present in `git show fb06126a0 --stat`.
+- **Remaining M6 work** (process-pipe transport, connection-state handling, payload-eligibility enforcement, cancellation/close, runtime backpressure) is correctly kept open in the preceding implementation section (`:1014-1015`); the new ledger entry does not claim them.
+- **Merge-ledger validation** matches the user-reported pre-checks (`git diff --check` and `check_file_size_guardrails.py` PASS for 2251 files / 900-line limit).
+
+No blocking findings.


### PR DESCRIPTION
## Summary

- record PR #2445 merge evidence for the M6 typed IPC frame codec wave
- include the docs-only ledger review artifact

## Validation

- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`

## Review

- `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-frame-codec-ledger-review-pass-1.md`: PASS
