### PR TITLE
Record M6 IPC stream helpers merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -1058,6 +1058,14 @@ M6 typed IPC stream read/write review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-transport-review-pass-1.md`: `PASS`; reviewer verified clean EOF versus partial-prefix behavior, oversize-prefix rejection before payload allocation, truncated-payload handling, opaque read/write I/O error mapping, write/flush error mapping, no unwrap/expect/panic path, stream helper scope discipline, and traceability/host-matrix honesty. Non-blocking follow-ups remain for read-error, flush-error, interrupted-read, zero-length-frame, multi-frame-stream, copy-avoidance, `Display`/`Error`, and unreachable length-sentinel hardening.
 
+M6 typed IPC stream read/write merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2447
+- Merge commit: `019fd05a55dd5c1631021086aad50f89842c39a0`
+- Merged at: `2026-06-09T00:22:23Z`
+- Scope: internal `sifr_stdlib::ipc_transport` read/write helpers over `std::io::Read`/`Write` pipe-shaped byte streams, typed clean-EOF/truncated-prefix/truncated-payload/oversize/read/write error handling, M6 traceability, supported-host matrix, validation evidence, and reviewer artifact.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-transport-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-transport-ledger-review-pass-1.md
@@ -1,0 +1,15 @@
+PASS
+
+Verification summary:
+- `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:1061-1067` is the only source change (`git diff --stat` confirms a single file, +8 / -0).
+- PR metadata matches GitHub (`gh pr view 2447 --json url,mergeCommit,mergedAt,state`):
+  - URL `https://github.com/sifr-lang/sifr/pull/2447` ✓
+  - `mergeCommit.oid` = `019fd05a55dd5c1631021086aad50f89842c39a0` (also matches `HEAD`) ✓
+  - `mergedAt` = `2026-06-09T00:22:23Z` ✓
+  - `state` = `MERGED` ✓
+- Scope summary in line 1066 matches PR #2447 files (`crates/sifr_stdlib/src/ipc_transport.rs`, `lib.rs`, `verification/platform/supported_host_matrix.md`, `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md`, reviewer artifact) and PR body (clean-EOF/truncated-prefix/truncated-payload/oversize/read/write typed errors over `std::io::Read`/`Write` pipe-shaped streams).
+- Open-scope caveats for the M6 wave are preserved at line 1044 (and the traceability/host-matrix note at line 1045): child-process fixture transport, connection-state, payload eligibility, cancellation, close protocol, and runtime backpressure remain explicitly out-of-scope, consistent with the review pass-1 artifact at line 1059.
+- Ledger entry format matches prior M6 merge ledgers (PR #2443 at line 1001, PR #2445 at line 1031).
+- Validation claims in the ledger (`git diff --check`, `check_file_size_guardrails.py`) match the PASS results provided.
+
+No blocking findings.


### PR DESCRIPTION
## Summary

- record PR #2447 merge evidence for the M6 typed IPC stream helper wave
- include the docs-only ledger review artifact

## Validation

- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`

## Review

- `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-transport-ledger-review-pass-1.md`: PASS
