### PR TITLE
Record M5 cancellation cleanup traceability merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -455,7 +455,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M5 structured runtime diagnostics: https://github.com/sifr-lang/sifr/pull/2428
 - M5 explicit task context propagation: https://github.com/sifr-lang/sifr/pull/2431
 - M5 runtime diagnostic metrics policy: https://github.com/sifr-lang/sifr/pull/2433
-- M5 cancellation cleanup traceability addendum: pending PR.
+- M5 cancellation cleanup traceability addendum: https://github.com/sifr-lang/sifr/pull/2430
 - M5: complete.
 - M6 typed IPC design gate: in progress.
 - M6: pending.
@@ -923,6 +923,16 @@ M5 cancellation cleanup traceability addendum review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-review-pass-4.md`: `FAIL`; reviewer found the branch had fallen behind the latest M6 frame-codec merge ledger and that the committed validation metrics were stale versus the refreshed post-rebase runs. Addressed by rebasing onto the M6 IPC stream helpers merge and committing refreshed validation metrics before the next review pass.
 - `reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-review-pass-5.md`: `FAIL`; reviewer found the branch had fallen behind the M6 IPC stream-helper merge ledger after the previous rebase. Addressed by rebasing onto the stream-helper merge ledger commit before the next review pass.
 - `reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-review-pass-6.md`: `PASS`; reviewer verified the branch is rebased onto the latest M6 stream-helper merge ledger, M5 remains closed, M6 docs and ledgers from main are preserved, `cancellation_cleanup_runs` is honestly recorded, unsupported cleanup helpers remain diagnostic-only, final validation metrics match the committed ledger, and pass-4/pass-5 failures are documented as addressed.
+
+M5 cancellation cleanup traceability addendum merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2430
+- Merge commit: `41e376fc27963e4e3bfd0550487e213a9647f293`
+- Merged at: `2026-06-09T00:35:01Z`
+- Scope: cancellation cleanup traceability addendum, merge-lane fixture coverage, closed M5 traceability/host-matrix wording, and reviewer artifacts.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- Merge-ledger review: `reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-1.md` -> `PASS`; reviewer verified the PR link, merge commit, merged timestamp, scope, docs-only validation claim, and unchanged M5/M6 status.
+- Merge-ledger review: `reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-2.md` -> `PASS`; reviewer verified the current ledger diff, expanded validation line, review artifact link, and unchanged M5/M6 status.
 
 M6 typed IPC design gate implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-1.md
@@ -1,0 +1,13 @@
+PASS
+
+Verification of each blocker:
+
+- **Pending marker replaced** — `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:458` now reads `M5 cancellation cleanup traceability addendum: https://github.com/sifr-lang/sifr/pull/2430` (was "pending PR.").
+- **Merge commit recorded correctly** — `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:929` records `41e376fc27963e4e3bfd0550487e213a9647f293`, which matches the actual merge commit (`git log -1 41e376fc…` → "Merge pull request #2430 from sifr-lang/codex/concurrency-runtime-m5-cleanup-traceability").
+- **Merged-at timestamp** — `issues/…execution.md:930` records `2026-06-09T00:35:01Z`. Git CommitDate is `2026-06-09T02:35:00+02:00` (= `00:35:00Z`); the 1-second offset is consistent with GitHub's recorded `merged_at` lagging the commit timestamp and is not a blocker.
+- **Scope matches the addendum** — Addendum commit `2e6b1e7d6` touched: substrate execution doc, six review-pass files, `supported_host_matrix.md`, `concurrency_runtime_m5_shutdown_traceability.md`, and `verification/validation_lanes/merge_e2e_manifest.json`. Ledger scope at `issues/…execution.md:931` ("cancellation cleanup traceability addendum, merge-lane fixture coverage, closed M5 traceability/host-matrix wording, and reviewer artifacts") cleanly covers all of these.
+- **Validation line** — `issues/…execution.md:932` records "docs-only ledger update; `git diff --check` -> PASS", matching the stated criterion.
+- **M5/M6 status not overclaimed** — Lines 459–461 still read `M5: complete.`, `M6 typed IPC design gate: in progress.`, `M6: pending.` The addendum is a traceability backfill against an already-closed M5, so no M6 progression is claimed.
+- **Docs-only diff confirmed** — `git diff --stat` shows the ledger change is limited to `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` (+9/-1); the untracked empty `reviews/...ledger-review-pass-1.md` is the reviewer slot and is unrelated to the ledger payload.
+
+No blockers.

--- a/reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m5-cancellation-cleanup-traceability-ledger-review-pass-2.md
@@ -1,0 +1,13 @@
+## PASS
+
+Verified the docs-only ledger diff at `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` and the review artifact:
+
+- **Pending marker replaced** — Line 458: `M5 cancellation cleanup traceability addendum: https://github.com/sifr-lang/sifr/pull/2430` ✓
+- **Merge commit** — Line 930: `41e376fc27963e4e3bfd0550487e213a9647f293`, matches `git log` HEAD for "Merge pull request #2430" ✓
+- **Merged-at timestamp** — Line 931: `2026-06-09T00:35:01Z` ✓ (review pass-1 already reconciled the 1s lag vs. CommitDate as GitHub `merged_at` skew, non-blocking)
+- **Scope** — Line 932: covers addendum, merge-lane fixture, closed-M5 traceability/host-matrix wording, reviewer artifacts; matches addendum commit `2e6b1e7d6` touched paths per pass-1 ✓
+- **Validation** — Line 933 includes both `git diff --check` and `python3 scripts/check_file_size_guardrails.py -> PASS`; script exists at `scripts/check_file_size_guardrails.py`; claim is plausible for a docs-only ledger update ✓
+- **Review line** — Line 934 points at `reviews/...ledger-review-pass-1.md`; that file exists and records `PASS` with item-by-item verification ✓
+- **M5/M6 status** — Lines 459–461 unchanged: `M5: complete.`, `M6 typed IPC design gate: in progress.`, `M6: pending.` ✓
+
+One non-blocker note: review pass-1 (line 9) quotes the validation line as only `git diff --check -> PASS`, but the current ledger expands it to also include `check_file_size_guardrails.py`. The expanded claim isn't falsified (script exists, change is docs-only), but pass-1 didn't explicitly verify the guardrail addition. Not a blocker for this docs-only ledger diff.


### PR DESCRIPTION
## Summary
- Replaces the M5 cancellation cleanup traceability addendum pending marker with PR #2430.
- Records the #2430 merge commit, merged-at timestamp, scope, and docs-only validation.
- Adds two focused Opus ledger review artifacts.

## Validation
- `git diff --check` -> PASS.
- `python3 scripts/check_file_size_guardrails.py` -> PASS (`2252 files`, limit `900`).

## Reviews
- Opus ledger pass 1: PASS.
- Opus ledger pass 2: PASS.