### PR TITLE
Record M6 IPC request tracker merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -1123,6 +1123,14 @@ M6 typed IPC request tracker review loop:
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-request-tracker-review-pass-1.md`: `PASS`; reviewer verified request-id lifecycle dispatch, duplicate-before-capacity evidence ordering, unknown request-id handling, started/cancel non-terminal behavior, drain versus cancel-in-flight shutdown, terminating close, redacted error text, re-export wiring, and traceability/host-matrix honesty. Non-blocking hardening requested closed-state terminal behavior and additional dispatch-boundary tests.
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-request-tracker-review-pass-2.md`: `PASS`; reviewer verified `begin_shutdown(...)` now preserves `Closed`, `shutdown_after_terminating_keeps_tracker_closed`, `Run` dispatch through `apply_frame`, non-request frame pass-through coverage, reconciled validation evidence and line counts, and no new blockers.
 
+M6 typed IPC request tracker merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2450
+- Merge commit: `5bba51a72acf7ab264035c9a6a4e68dddcae31d0`
+- Merged at: `2026-06-09T00:47:12Z`
+- Scope: internal `sifr_stdlib::ipc_request_tracker` request-id lifecycle state machine, bounded in-flight backpressure, typed duplicate/unknown/full/draining/closed errors, M6 traceability, supported-host matrix, validation evidence, and two reviewer artifacts.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
 M5 signal `strsignal` value-helper implementation:
 
 - Added `sifr.signal.strsignal(signal)` as a pure Sifr value helper that returns the signal name without consulting process-global host signal state or claiming stream delivery.

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-request-tracker-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-request-tracker-ledger-review-pass-1.md
@@ -1,0 +1,11 @@
+**PASS**
+
+Verification summary:
+
+1. **PR metadata consistency** — `gh pr view 2450` returns: `url=https://github.com/sifr-lang/sifr/pull/2450`, `mergeCommit.oid=5bba51a72acf7ab264035c9a6a4e68dddcae31d0`, `mergedAt=2026-06-09T00:47:12Z`, `state=MERGED`. Git also confirms commit `5bba51a72…` is dated `2026-06-09 02:47:12 +0200` (= `00:47:12Z`). All three values match the ledger entry exactly.
+
+2. **Scope honesty** — Ledger scope lists: request-id lifecycle state machine, bounded in-flight backpressure, typed duplicate/unknown/full/draining/closed errors, M6 traceability, supported-host matrix, validation evidence, and two reviewer artifacts. The merge actually adds `sifr_stdlib::ipc_request_tracker` (with `Open/Draining/Closed` states and `DuplicateRequestId/UnknownRequestId/BackpressureFull/Closing/Closed` errors), a re-export in `lib.rs`, one row in `supported_host_matrix.md`, a traceability bump in `concurrency_runtime_m6_typed_ipc_design.md`, and two `reviews/*` files. No claim is made of child-process transport, schema negotiation, payload eligibility, or generated worker integration — and the matching matrix row explicitly disclaims those same items.
+
+3. **Validation statement** — "docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS" is appropriate; both re-run clean locally (`git diff --check`: PASS; file-size guardrail: PASS, 2253 files).
+
+4. **No extraneous changes** — `git status` shows only `issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md` modified; the lone untracked file (`reviews/…-ledger-review-pass-1.md`) is the review artifact, not a source/verification file. `git diff --stat`: 1 file, +8/-0.


### PR DESCRIPTION
## Summary
- record the PR #2450 merge metadata for the M6 IPC request tracker wave
- add a reviewer PASS artifact for the docs-only ledger update

## Validation
- git diff --check
- python3 scripts/check_file_size_guardrails.py

## Review
- reviews/ad-hoc-production-concurrency-runtime-m6-ipc-request-tracker-ledger-review-pass-1.md: PASS