### PR TITLE
Add M6 IPC CPython-shaped diagnostics

### DIFF
--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_fork_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_fork_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import fork
+
+
+def main():
+    pass

--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_forkserver_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_forkserver_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import forkserver
+
+
+def main():
+    pass

--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_pipe_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_pipe_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import Pipe
+
+
+def main():
+    pass

--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_pool_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_pool_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import Pool
+
+
+def main():
+    pass

--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_queue_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_queue_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import Queue
+
+
+def main():
+    pass

--- a/crates/sifr/tests/e2e/fail/ipc_multiprocessing_shared_memory_unsupported.sifr
+++ b/crates/sifr/tests/e2e/fail/ipc_multiprocessing_shared_memory_unsupported.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.ipc import shared_memory
+
+
+def main():
+    pass

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -469,6 +469,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M6 typed IPC Unix process-pipe fixture: https://github.com/sifr-lang/sifr/pull/2455
 - M6 typed IPC process-pipe backpressure and unsupported-payload evidence: https://github.com/sifr-lang/sifr/pull/2458
 - M6 typed IPC payload diagnostics: https://github.com/sifr-lang/sifr/pull/2460
+- M6 typed IPC CPython-shaped multiprocessing diagnostics: pending PR.
 - M6: pending.
 - M7: pending.
 
@@ -1307,6 +1308,20 @@ M6 typed IPC payload diagnostics merge ledger:
 M6 typed IPC payload diagnostics merge-ledger review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-payload-diagnostics-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged-at timestamp, pending M6 status, docs-only validation evidence, line-count tally, and diff containment.
+
+M6 typed IPC CPython-shaped multiprocessing diagnostics implementation:
+
+- Added focused `sifr.ipc` missing-member fixtures for the remaining CPython-shaped process-pool and multiprocessing names called out by the M6 design: `Queue`, `Pipe`, `Pool`, `fork`, `forkserver`, and `shared_memory`.
+- Updated the M6 typed IPC design evidence row to list the full focused fixture family alongside the existing `ProcessPoolExecutor` and `Process` fixtures, while preserving the boundary that these are diagnostics only and not public IPC worker APIs.
+
+M6 typed IPC CPython-shaped multiprocessing diagnostics targeted local validation:
+
+- Direct `cargo run -q -p sifr -- check ...` checks for `ipc_multiprocessing_queue_unsupported`, `ipc_multiprocessing_pipe_unsupported`, `ipc_multiprocessing_pool_unsupported`, `ipc_multiprocessing_fork_unsupported`, `ipc_multiprocessing_forkserver_unsupported`, and `ipc_multiprocessing_shared_memory_unsupported` -> expected `SIFR-NAME-0004` for each missing `sifr.ipc` member.
+- `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture` -> PASS; fail harness reported `461 fail tests completed`.
+- `cargo fmt --check`, `git diff --check`, and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`530.61s`, warm target `<=2m`). Included guardrails, diagnostic contracts, frontend/syntax guardrails, developer tooling, performance budgets, verification hardening, generated-code quality, crate tests, platform golden (`pass=6`, `skip=1`), and create-pr e2e pass suite (`125 passed`, `0 failed`, `cache_hits=0/37`, `report_signature=50edc954137c87b4`).
+- Reviewer pass 1: `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-cpython-shape-diagnostics-review-pass-1.md` -> PASS; reviewer verified fixture column markers, the full focused fixture family in the M6 design row, missing-member diagnostic scope, pending M6 status, validation evidence, and diff containment.
+- Touched file line counts: `crates/sifr/tests/e2e/fail/ipc_multiprocessing_queue_unsupported.sifr` `6`, `crates/sifr/tests/e2e/fail/ipc_multiprocessing_pipe_unsupported.sifr` `6`, `crates/sifr/tests/e2e/fail/ipc_multiprocessing_pool_unsupported.sifr` `6`, `crates/sifr/tests/e2e/fail/ipc_multiprocessing_fork_unsupported.sifr` `6`, `crates/sifr/tests/e2e/fail/ipc_multiprocessing_forkserver_unsupported.sifr` `6`, `crates/sifr/tests/e2e/fail/ipc_multiprocessing_shared_memory_unsupported.sifr` `6`, `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md` `255`, `reviews/ad-hoc-production-concurrency-runtime-m6-ipc-cpython-shape-diagnostics-review-pass-1.md` `8`, and this ledger `2294`.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-cpython-shape-diagnostics-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-ipc-cpython-shape-diagnostics-review-pass-1.md
@@ -1,0 +1,8 @@
+PASS
+
+Verification notes:
+- Column math: `from sifr.ipc import ` is 21 chars, so the imported member begins at col 22 for all six new fixtures (`Queue`, `Pipe`, `Pool`, `fork`, `forkserver`, `shared_memory`) — matches the existing `ProcessPoolExecutor`/`Process` fixtures.
+- Design row at `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md` now lists all eight focused fixtures and retains the "Missing-member diagnostics keep CPython-shaped process-pool and multiprocessing names out of the native IPC module." boundary statement; no public API additions implied.
+- The follow-up paragraph in the same doc swaps the speculative "M6 may add focused fixtures…" sentence for a factual one that points at the new `sifr.ipc` fixtures — consistent with the row.
+- Ledger entries record pending PR (no PR URL yet, no merge ledger), targeted `cargo run -- check` per fixture, full `test_e2e_fail` count (461), `cargo fmt --check`, `git diff --check`, file-size guardrail, and per-file line counts. M6 status line remains `pending`.
+- Diff is scoped to the two docs plus the six new fixture files (the seventh `ipc_multiprocessing_process_unsupported.sifr` shown in the listing is the pre-existing Process fixture, not introduced here).

--- a/verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md
+++ b/verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md
@@ -35,7 +35,7 @@ This design does not ship a public process-worker pool. A future worker API rema
 | Internal payload eligibility validator | `cargo test -p sifr_stdlib ipc_payload -- --nocapture` | `sifr_stdlib::ipc_payload` recursively validates the initially accepted `IpcSerializable` schema families and returns typed `UnsupportedPayload` evidence for unsupported process/task/resource-like shapes without rendering payload values. Generated schema extraction and runtime foreign-peer payload handling remain follow-up work. |
 | Compile-time payload eligibility diagnostics | `ipc_payload_require_serializable_basic`; `ipc_payload_process_resource_rejected`; `ipc_payload_sync_endpoint_rejected`; `cargo test -p sifr_lowering ipc_payload_calls -- --nocapture` | `sifr.ipc.require_serializable(...)` is a compiler-erased marker that accepts representative primitive/container/record payloads and emits `SIFR-OWN-0013` for concrete process-local resources and synchronization endpoints. This is diagnostic evidence only; generated schema extraction and public worker/connection APIs remain follow-up work. |
 | Unix child-process pipe fixture transport | `cargo test -p sifr_stdlib --test ipc_process_pipe_fixture -- --nocapture` | A fixture worker binary behind the internal `__test_fixture` feature validates real child-process stdin/stdout frame transport on Unix hosts for bootstrap, request completion, in-flight cancellation, shutdown/terminating close, bounded backpressure, malformed-frame reporting, and unsupported-payload evidence. Windows fixtures, generated schema extraction, and generated worker integration remain follow-up work. |
-| `ProcessPoolExecutor` and `Process` under `sifr.ipc` | `ipc_process_pool_executor_unsupported`; `ipc_multiprocessing_process_unsupported` | Missing-member diagnostics keep CPython-shaped process-pool and multiprocessing names out of the native IPC module. |
+| CPython-shaped process-pool and multiprocessing names under `sifr.ipc` | `ipc_process_pool_executor_unsupported`; `ipc_multiprocessing_process_unsupported`; `ipc_multiprocessing_queue_unsupported`; `ipc_multiprocessing_pipe_unsupported`; `ipc_multiprocessing_pool_unsupported`; `ipc_multiprocessing_fork_unsupported`; `ipc_multiprocessing_forkserver_unsupported`; `ipc_multiprocessing_shared_memory_unsupported` | Missing-member diagnostics keep CPython-shaped process-pool and multiprocessing names out of the native IPC module. |
 
 ## Transport Boundary
 
@@ -224,7 +224,7 @@ M6 keeps CPython multiprocessing and process-pool families as evidence sources o
 - `fork` and `forkserver`: `rejected` unless a future host-limited ownership proof is recorded.
 - `shared_memory`: `rejected` until explicit ownership, unlink, drop, aliasing, and host cleanup rules are proven.
 
-The existing bare CPython import diagnostics and legacy `sifr.multiprocessing` diagnostic routing remain valid evidence. M6 may add focused fixtures for ProcessPoolExecutor and multiprocessing members that are not already covered.
+The existing bare CPython import diagnostics and legacy `sifr.multiprocessing` diagnostic routing remain valid evidence. Focused `sifr.ipc` missing-member fixtures now cover the CPython-shaped process-pool and multiprocessing members listed above.
 
 ## Observability And Redaction
 


### PR DESCRIPTION
## Summary
- add focused `sifr.ipc` missing-member fail fixtures for `Queue`, `Pipe`, `Pool`, `fork`, `forkserver`, and `shared_memory`
- update the M6 typed IPC design evidence row and phase execution ledger
- include reviewer pass artifact

## Validation
- direct `cargo run -q -p sifr -- check ...` for all six new fixtures -> expected `SIFR-NAME-0004`
- `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture` -> PASS, 461 fail tests
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` -> PASS, 125 e2e pass fixtures, report signature `50edc954137c87b4`
- reviewer pass 1 -> PASS
