### PR TITLE
Record M6 closeout merge ledger

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -471,7 +471,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M6 typed IPC payload diagnostics: https://github.com/sifr-lang/sifr/pull/2460
 - M6 typed IPC CPython-shaped multiprocessing diagnostics: https://github.com/sifr-lang/sifr/pull/2462
 - M6 typed IPC compiler-internal schema extraction: https://github.com/sifr-lang/sifr/pull/2464
-- M6 closeout: pending PR.
+- M6 typed IPC closeout classification: https://github.com/sifr-lang/sifr/pull/2467
 - M6: complete.
 - M7: pending.
 
@@ -1386,6 +1386,18 @@ M6 closeout classification review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-closeout-readiness-review-pass-1.md`: `FAIL`; reviewer found the substantive M6 DoD met but identified docs-only blockers in stale design/host wording that still claimed generated worker integration was M6 implementation work. This closeout slice addresses those blockers.
 - `reviews/ad-hoc-production-concurrency-runtime-m6-closeout-review-pass-1.md`: `PASS`; reviewer verified the stale M6 design and host-matrix blockers are resolved, generated worker/public worker APIs are consistently `deferred-to-phase-X`, Windows process-pipe fixture evidence remains host-limited, validation evidence is recorded, M6 can be considered closed, and M7 remains pending.
+
+M6 typed IPC closeout classification merge ledger:
+
+- PR: https://github.com/sifr-lang/sifr/pull/2467
+- Merge commit: `1606e5d0817af1cb6c0f05b56bf4e5636dfd7775`
+- Merged at: `2026-06-09T04:11:16Z`
+- Scope: docs-only M6 closeout classification, stale generated-worker wording cleanup, host-matrix classification update, roadmap/phase issue status update, validation evidence, and Opus closeout review artifacts.
+- Merge-ledger validation: docs-only ledger update; `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+
+M6 typed IPC closeout classification merge-ledger review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m6-closeout-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged timestamp with expected one-second GitHub/commit timestamp skew, docs-only scope, validation claim, and M6 complete/M7 pending status.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m6-closeout-ledger-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m6-closeout-ledger-review-pass-1.md
@@ -1,0 +1,13 @@
+VERDICT: PASS
+
+Verification details:
+
+- **PR URL** (`https://github.com/sifr-lang/sifr/pull/2467`): confirmed — merge commit subject is `Close M6 typed IPC substrate / Merge PR #2467`, and the diff line 474 records the same URL.
+- **Merge commit** (`1606e5d0817af1cb6c0f05b56bf4e5636dfd7775`): confirmed via `git log -1`.
+- **Merged at** (`2026-06-09T04:11:16Z`): git committer timestamp is `2026-06-09T04:11:15Z` (one second earlier). This is a normal/expected ≤1s skew between GitHub's `merged_at` field (recorded when the merge action completes server-side) and the commit timestamp; not a blocker.
+- **Docs-only scope**: confirmed — the merge touches only `internal_docs/roadmap.md`, `issues/...-platform-substrate-execution.md`, `internal_docs/phases/...-platform-substrate.md`, two `reviews/` markdowns, `verification/platform/supported_host_matrix.md`, and `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md`. No code/Cargo/snapshot files. Ledger's scope description (closeout classification + generated-worker wording cleanup + host-matrix update + roadmap/phase status + review artifacts) matches the merge contents.
+- **Validation claim**: `git diff --check` re-run → clean (PASS). `python3 scripts/check_file_size_guardrails.py` re-run → `PASS (2269 files, limit 900 lines)` — matches the claimed `2269 files`.
+- **M6/M7 status not overclaimed**: lines 475–476 still read `M6: complete.` / `M7: pending.` — unchanged, no upgrade of M7 or downgrade of M6.
+- **Pending reviewer marker**: ledger correctly records `Pending reviewer verification` rather than asserting a PASS for this very review.
+
+No blockers.


### PR DESCRIPTION
## Summary

- record the merged M6 closeout classification PR #2467 with merge commit and timestamp
- replace the pending M6 closeout PR marker with the merged PR URL
- add the Opus merge-ledger PASS artifact

## Validation

- git diff --check
- python3 scripts/check_file_size_guardrails.py
  - PASS (2269 files, limit 900 lines)

## Review

- reviews/ad-hoc-production-concurrency-runtime-m6-closeout-ledger-review-pass-1.md: PASS
