### PR TITLE
Add M7 closeout traceability scaffold

### DIFF
--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -473,7 +473,8 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M6 typed IPC compiler-internal schema extraction: https://github.com/sifr-lang/sifr/pull/2464
 - M6 typed IPC closeout classification: https://github.com/sifr-lang/sifr/pull/2467
 - M6: complete.
-- M7: pending.
+- M7 traceability scaffold: pending PR.
+- M7: in progress.
 
 ## Validation Evidence
 
@@ -1398,6 +1399,21 @@ M6 typed IPC closeout classification merge ledger:
 M6 typed IPC closeout classification merge-ledger review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m6-closeout-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged timestamp with expected one-second GitHub/commit timestamp skew, docs-only scope, validation claim, and M6 complete/M7 pending status.
+
+M7 traceability scaffold implementation:
+
+- Created `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` as the required M7 milestone traceability artifact.
+- Recorded M7 closeout gates for public docs, internal architecture docs, demos, generated Cargo dependency snapshots, generated-code panic/emitted-quality coverage, validation lane manifests, inventory closure, and final external review.
+- Preserved M7 as in-progress rather than complete; this scaffold records the remaining closeout PR slices and does not satisfy the final phase gate.
+
+M7 traceability scaffold targeted local validation:
+
+- `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded (`222.51s`, warm target `<=2m`) after package-cache lock waits. Included guardrails, diagnostic contracts, frontend/syntax guardrails, developer tooling, performance budgets, verification hardening, generated-code quality, crate tests, platform golden (`pass=6`, `skip=1`), and create-pr e2e pass suite (`125 passed`, `0 failed`, `cache_hits=37/37`, `report_signature=50edc954137c87b4`; slowest step `crate_tests` `72699ms`).
+
+M7 traceability scaffold review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m7-traceability-review-pass-1.md`: `PASS`; reviewer verified the required M7 traceability artifact exists, M7 remains in progress rather than complete, open gates are tracked with correct state semantics, validation evidence is recorded, and the scaffold does not overclaim phase completion.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m7-traceability-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m7-traceability-review-pass-1.md
@@ -1,0 +1,30 @@
+VERDICT: PASS
+
+Verification:
+
+**Required M7 artifact exists** — `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` is created (65 lines, status "Open", milestone `milestone_concurrency_runtime_7`). Note: currently untracked in `git status`; must be `git add`ed before PR submission since `git diff --stat` only shows the 1-file ledger change.
+
+**M7 remains in progress / not complete** — confirmed in three places:
+- `issues/...execution.md:477` — "M7: in progress."
+- `verification/.../m7_closeout_traceability.md:5` — "Status: Open. … It does not mark the phase complete"
+- Ledger entry line 1407 — "Preserved M7 as in-progress rather than complete; this scaffold … does not satisfy the final phase gate."
+
+**Open gates accurately tracked** — all eight required gates present with correct state semantics:
+- Public docs (8 modules: `sifr.task`, `sync`, `runtime`, `parallel`, `process`, `signal`, `resource`, `ipc`) — open
+- Internal architecture docs — partial (correctly cites existing `structured_runtime_work_model.md` / `async_concurrency_model.md` / `architecture.md`)
+- Required demos — partial (correctly cites existing `task_core_demo`, `sync_channel_demo`, `blocking_offload_demo`, `structured_concurrency_demo`, `subprocess` demos and lists the seven required demos)
+- Generated Cargo dependency snapshots — open
+- Panic scan / emitted-code quality coverage — open
+- Validation lane manifests — partial (correctly cites `create_pr_e2e_manifest.json` / `merge_e2e_manifest.json`)
+- Inventory closure — open
+- Final external review — open
+
+M0–M6 closure inputs row accurately marks M6 closed via `concurrency_runtime_m6_typed_ipc_design.md`, consistent with the `M6: complete.` ledger marker.
+
+**Validation evidence recorded** — ledger line 1411–1412 records `git diff --check` PASS, `check_file_size_guardrails.py` PASS, and `run_all_tests.sh --profile create-pr` PASS with the exact numbers from the task context (`wall_time=222.51s`, `platform golden pass=6 skip=1`, `125 passed 0 failed`, `cache_hits=37/37`, `report_signature=50edc954137c87b4`, slowest step `crate_tests 72699ms`, advisory warm wall-time budget exceeded after package-cache lock waits).
+
+**No phase-completion overclaim** — scaffold slice marked "in progress" while all six downstream slices (public docs, internal architecture audit, demo closure, dep/panic evidence, lane/inventory closure, final review and merge gate) marked "pending". Review loop entry correctly says "Pending reviewer verification."
+
+Non-blocking observations (for the PR submitter, not blockers for this review):
+1. `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` is untracked — must be `git add`ed so it lands in the PR diff; otherwise the ledger references an artifact the PR doesn't deliver.
+2. `reviews/ad-hoc-production-concurrency-runtime-m7-traceability-review-pass-1.md` exists as a 0-byte file. Either populate it with this review pass result before commit, or remove it so the working tree is clean.

--- a/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
@@ -1,0 +1,65 @@
+# Concurrency Runtime M7 Closeout Traceability
+
+Milestone: `milestone_concurrency_runtime_7`
+
+Status: Open. This M7 artifact is the closeout audit surface for docs, demos, validation lanes, panic scans, generated dependency snapshots, inventory closure, and final external review. It does not mark the phase complete; it records the remaining gates that must close before `milestone_concurrency_runtime_7` can be checked off.
+
+## Closeout Gates
+
+| Gate | State | Evidence or required closure |
+| --- | --- | --- |
+| Public docs for `sifr.task` | open | Add public docs covering `TaskHandle`, `TaskGroup`, scoped spawn, timeout/deadline/cancel helpers, join/race/select, explicit task context, cancellation evidence, and unsupported event-loop compatibility boundaries. |
+| Public docs for `sifr.sync` | open | Add public docs covering channels, backpressure, close/drain, cancellation behavior, locks, semaphores, events, sendability/shareability, and unsupported queue/threading parity boundaries. |
+| Public docs for `sifr.runtime` | open | Add public docs covering blocking/CPU offload helpers, `JoinSet`, structured diagnostic events, workload annotations, and direct-call diagnostics. |
+| Public docs for `sifr.parallel` | open | Add public docs covering ordered `map`/`try_map`, private default/configured pools, typed worker errors, panic-to-error behavior, and async direct-call rejection. |
+| Public docs for `sifr.process` | open | Add public docs covering sync/async command execution, owned pipes, process handles, timeout/cancel/kill/terminate behavior, shell execution effects, text encoding, and task-boundary ownership diagnostics. |
+| Public docs for `sifr.signal` | open | Add public docs covering portable signal values, structured shutdown streams, Unix delivery evidence, non-Unix host-limited behavior, `strsignal`, and rejected global handler APIs. |
+| Public docs for `sifr.resource` | open | Add public docs covering `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
+| Public docs for `sifr.ipc` | open | Add public docs covering typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
+| Internal architecture docs | partial | `internal_docs/structured_runtime_work_model.md`, `internal_docs/async_concurrency_model.md`, and `internal_docs/architecture.md` already contain substantial model material. M7 must audit and update task/process/channel/offload/runtime boundaries, typed IPC policy, blocking/offload policy, sendability/shareability, task/request context, diagnostics/signal global-state policy, and the rejected CPython-shaped surface index. |
+| Required demos | partial | Existing demos include `demos/task_core_demo/main.sifr`, `demos/sync_channel_demo/main.sifr`, `demos/blocking_offload_demo/main.sifr`, `demos/structured_concurrency_demo/main.sifr`, and `demos/subprocess/main.sifr`. M7 must add or validate all required demos: structured task group, producer/consumer channel pipeline, blocking offload, CPU parallel map, async subprocess pipeline, structured shutdown, and cleanup under cancellation. |
+| Generated Cargo dependency snapshots | open | Add generated-project dependency evidence for the accepted feature combinations that pull runtime dependencies such as Tokio, Rayon, tracing, metrics, process support, signal support, and IPC serialization. |
+| Panic scan and emitted-code quality coverage | open | Extend or document generated-code quality coverage for task/channel/process/runtime paths. The existing Phase 34 gate and `verification/generated_code_quality/manifest.json` are active but do not yet record M7-specific closeout coverage for all concurrency paths. |
+| Validation lane manifests | partial | `verification/validation_lanes/create_pr_e2e_manifest.json` and `merge_e2e_manifest.json` already include representative task, sync, offload, process, signal, resource, runtime diagnostic, and IPC fixtures. M7 must audit coverage against every required demo and closeout gate. |
+| Inventory closure | open | `verification/stdlib/concurrency_runtime_substrate_inventory.md`, `concurrency_runtime_substrate_inventory.json`, `concurrency_runtime_cpython_evidence_matrix.md`, `concurrency_runtime_workload_database.md`, platform contract artifacts, supported-host matrix, and platform golden manifest must have no unclassified public surfaces, CPython families, waivers without revisit rules, or host-limited rows without a matrix entry. |
+| Final external review | open | Final phase completion requires a reviewer `PASS` on the closed inventory and implementation, or the documented five-working-day fallback procedure with no unresolved blocking questions. |
+
+## M0-M6 Closure Inputs
+
+| Milestone | Artifact | Closure state |
+| --- | --- | --- |
+| M0a | `concurrency_runtime_m0a_legacy_surface_traceability.md` | Closed by legacy-surface diagnostics and native surface boundary selection. |
+| M1 | `concurrency_runtime_m1_traceability.md` | Closed by structured task ownership, scoped spawn, timeout/cancellation, race/select, and task handle evidence. |
+| M2 | `concurrency_runtime_m2_sync_traceability.md` | Closed by channels, backpressure, close/drain, cancellation, locks, semaphores, events, and sendability/shareability diagnostics. |
+| M3 | `concurrency_runtime_m3_offload_traceability.md` | Closed by blocking/CPU offload, `JoinSet`, `sifr.parallel`, typed worker errors, and panic-boundary evidence. |
+| M4 | `concurrency_runtime_m4_process_traceability.md` | Closed by sync/async process supervision, owned pipes, text mode, shell effect, timeout, cancellation, kill/terminate, and scoped process ownership evidence. |
+| M5 | `concurrency_runtime_m5_shutdown_traceability.md` | Closed by signal values/streams, cleanup cancellation, `nullcontext`, task context propagation, diagnostics/tracing, and rejected global-state surfaces. |
+| M6 | `concurrency_runtime_m6_typed_ipc_design.md` | Closed by typed IPC schema/frame substrate, request tracking, connection negotiation, payload diagnostics, Unix process-pipe evidence, and `deferred-to-phase-X` worker boundaries. |
+
+## Required M7 PR Slices
+
+| Slice | Required output | Status |
+| --- | --- | --- |
+| Traceability scaffold | Create this artifact and record the M7 audit plan in the execution ledger. | in progress |
+| Public documentation | Add docs for all accepted production APIs and intentional divergences. | pending |
+| Internal architecture audit | Update architecture docs and rejected-surface index. | pending |
+| Demo closure | Add or validate the seven required demos and record commands. | pending |
+| Generated dependency and panic-scan evidence | Add generated Cargo dependency snapshots and generated-code quality coverage for concurrency paths. | pending |
+| Validation lane and inventory closure | Audit manifests, platform golden entries, waivers, host-limited rows, workload database, CPython evidence matrix, and inventory. | pending |
+| Final review and merge gate | Run external review rounds until satisfied, then run `scripts/run_all_tests.sh` and close the phase. | pending |
+
+## Validation Plan
+
+M7 final validation must include:
+
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `python3 scripts/check_file_size_guardrails.py`
+- `cargo test -p sifr_stdlib`
+- `cargo test -p sifr -- stdlib`
+- `scripts/run_e2e_pass.sh`
+- `scripts/run_all_tests.sh --profile create-pr`
+- `scripts/run_all_tests.sh`
+
+Intermediate M7 PRs may run narrower validation when they are docs-only, but each PR must record its exact local validation in the execution ledger and the final phase closeout must run the full merge gate.


### PR DESCRIPTION
## Summary

- create the required M7 closeout traceability artifact
- record M7 as in progress while keeping the milestone checkbox open
- enumerate open M7 closeout gates and planned PR slices without claiming phase completion

## Validation

- git diff --check
- python3 scripts/check_file_size_guardrails.py
  - PASS (2269 files, limit 900 lines)
- scripts/run_all_tests.sh --profile create-pr
  - PASS, report target/validation_lane_reports/create-pr.latest.json
  - wall_time=222.51s, advisory: warm wall-time budget exceeded after package-cache lock waits
  - platform golden pass=6 skip=1
  - create-pr e2e pass suite: 125 passed, 0 failed, cache_hits=37/37, report_signature=50edc954137c87b4

## Review

- reviews/ad-hoc-production-concurrency-runtime-m7-traceability-review-pass-1.md: PASS
