### PR TITLE
Add M7 concurrency runtime public docs

### DIFF
--- a/docs/concurrency_runtime.md
+++ b/docs/concurrency_runtime.md
@@ -1,0 +1,240 @@
+# Concurrency Runtime
+
+Sifr's concurrency runtime is a native structured-concurrency substrate, not a CPython event-loop or multiprocessing clone. The accepted public modules are:
+
+- `sifr.task`
+- `sifr.sync`
+- `sifr.runtime`
+- `sifr.parallel`
+- `sifr.process`
+- `sifr.signal`
+- `sifr.resource`
+- `sifr.ipc`
+
+The common rule across these modules is that concurrency boundaries are statically typed and ownership checked. Values that cross task, thread, process, or IPC boundaries must be owned and must satisfy the boundary's sendability, shareability, or `IpcSerializable` requirements. Unsupported CPython-shaped APIs are rejected with diagnostics instead of being silently emulated.
+
+## `sifr.task`
+
+`sifr.task` is the structured task and task-context surface.
+
+Public value APIs:
+
+- `Context`
+- `ContextKey[T]`
+- `empty_context() -> Context`
+- `current_context() -> Context`
+
+Compiler-recognized task APIs are lowered as structured runtime operations:
+
+- `task.scope(...)`
+- `TaskGroup`
+- `TaskHandle[T, E]`
+- scoped spawn
+- timeout and deadline helpers
+- task cancellation helpers
+- `join`, `race`, and `select`
+
+Task handles are linear ownership values. Awaiting or joining a handle consumes the handle; using it again is a compile-time ownership diagnostic. Scoped spawn requires an active owner, and values captured by a spawned task must be sendable across the task boundary. Lock guards, semaphore permits, borrowed values that could escape the lexical scope, process handles, and other non-send resources are rejected at the boundary.
+
+`Context` and `ContextKey[T]` are Sifr-owned task context values. Explicit context propagation is supported through the accepted task APIs; implicit CPython `contextvars` behavior is not exposed as global mutable task state.
+
+Intentional divergences:
+
+- No public CPython `asyncio` event-loop object is exposed.
+- Event-loop policy, loop replacement, callback scheduling, and global task registries are unsupported.
+- Detached fire-and-forget tasks are not accepted; work belongs to a scope or an explicit owner.
+
+## `sifr.sync`
+
+`sifr.sync` provides same-process synchronization and communication primitives.
+
+Public APIs:
+
+- `Shared[T]`
+- `channel[T]() -> tuple[ChannelSender[T], ChannelReceiver[T]]`
+- `bounded_channel[T](capacity: int) -> tuple[ChannelSender[T], ChannelReceiver[T]]`
+- `ChannelSender[T].send(...)`
+- `ChannelSender[T].close()`
+- `ChannelReceiver[T].receive()`
+- `Lock[T]`, `LockGuard[T]`
+- `RwLock[T]`, `RwLockReadGuard[T]`, `RwLockWriteGuard[T]`
+- `Semaphore`, `SemaphorePermit`
+- `Notify`
+- `WouldBlockError`
+- `ClosedError`
+
+Channels are typed. Sending transfers ownership of the value to the channel. Receiving transfers ownership back to the receiver. Closing a sender makes the close state explicit; closed receives and sends return typed `ClosedError` evidence. Bounded channels are the accepted backpressure surface.
+
+Locks, read/write locks, semaphores, and notifications are same-process primitives. Guards and permits are scoped resources and may not cross task, thread, process, or IPC boundaries. Holding such a guard across an await or returning it from an invalid scope is rejected by ownership diagnostics.
+
+Intentional divergences:
+
+- CPython `queue.Queue`, `asyncio.Queue`, `threading.Lock`, and multiprocessing queue/pipe names are not aliases for `sifr.sync`.
+- Same-process channels are not process IPC. Use `sifr.process` for raw subprocess I/O and `sifr.ipc` for typed future worker protocols.
+
+## `sifr.runtime`
+
+`sifr.runtime` exposes structured diagnostic events for runtime surfaces.
+
+Public APIs:
+
+- `DiagnosticLevel`
+- `DiagnosticEvent`
+- `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`
+- `diagnostic_event(...)`
+- `emit_diagnostic(event)`
+- `DiagnosticError`
+
+Runtime diagnostic events carry a level, target, name, and message. They are intended for structured runtime observability around task, sync, process, signal, offload, and IPC surfaces. Diagnostic emission returns `Result[None, DiagnosticError]`; it is not an exception-style logging side channel.
+
+Intentional divergences:
+
+- Runtime diagnostics are not CPython `warnings` or `logging` global handler mutation.
+- Payload bytes, process command lines, environment values, and decoded IPC payloads must not be used as metric labels or diagnostic messages unless an explicit redaction rule covers that field.
+
+## `sifr.parallel`
+
+`sifr.parallel` is the CPU parallel map surface backed by native worker pools.
+
+Public APIs:
+
+- `map(items, func)`
+- `try_map(items, func)`
+- `PoolConfig`
+- `Pool`
+- `Pool.map(...)`
+- `Pool.try_map(...)`
+- `WorkerRuntimeError`
+- `WorkerError`
+
+`map` preserves output order for successful items. `try_map` returns a typed worker error when an item fails. Captured values and return values must satisfy worker-boundary ownership and sendability requirements. Worker panics are converted to typed worker errors instead of surfacing as user-triggerable runtime panics.
+
+Blocking or CPU-heavy work should be explicit. Directly calling blocking helpers from async code is rejected by diagnostics; use accepted blocking/offload surfaces so the runtime can isolate the work.
+
+Intentional divergences:
+
+- `concurrent.futures.ThreadPoolExecutor` and `ProcessPoolExecutor` are not public aliases.
+- Public process worker pools are deferred to a future phase over `sifr.ipc`; M7 does not ship a public process-worker API.
+
+## `sifr.process`
+
+`sifr.process` is the native subprocess surface.
+
+Public APIs include:
+
+- `run(...)`
+- `run_timeout(...)`
+- `output(...)`
+- `output_text(...)`
+- `output_timeout(...)`
+- `spawn(...)`
+- `run_shell(...)`
+- `output_shell(...)`
+- `output_shell_text(...)`
+- `output_shell_timeout(...)`
+- async variants such as `async_run`, `async_spawn`, `async_wait`, `async_output`, `async_run_shell`, and `async_output_shell`
+- `Command`
+- `Child`
+- `AsyncChild`
+- `ProcessHandle`
+- `PipeReader`
+- `PipeWriter`
+- `AsyncPipeReader`
+- `AsyncPipeWriter`
+- `Status`
+- `Output`
+- `Stdio`, `PIPE`, `INHERIT`, `NULL`
+- `ProcessError`
+
+Process handles and pipes are owned resources. Waiting on a child consumes the wait capability; duplicate wait or use-after-close is rejected or returns typed `ProcessError` evidence. Pipe readers and writers must be closed or consumed through the accepted APIs. Timeout, cancellation, `kill`, and `terminate` return structured status or error evidence.
+
+`output_text` and shell text helpers use explicit text behavior recorded by the platform contract. Raw byte output remains available through `Output.stdout` and `Output.stderr`.
+
+Intentional divergences:
+
+- `subprocess.Popen` is not a direct public alias.
+- Shell helpers are explicit effectful APIs; they are not the default command execution path.
+- Process groups, descendant supervision, and host-specific signal semantics are supported only where recorded by the host matrix.
+
+## `sifr.signal`
+
+`sifr.signal` provides structured shutdown and signal values.
+
+Public APIs:
+
+- `Signal`
+- `SIGINT`, `SIGTERM`
+- `sigint()`
+- `sigterm()`
+- `strsignal(signal)`
+- `ctrl_c()`
+- `terminate()`
+- `shutdown_stream()`
+- `ShutdownStream.next()`
+- `SignalError`
+
+Portable signal values and `strsignal` are host-independent. `ctrl_c` and `shutdown_stream` expose structured awaitable signal evidence. Unix SIGTERM delivery is host-limited and recorded in the supported-host matrix; non-Unix SIGTERM behavior returns typed unsupported evidence where the host cannot provide equivalent semantics.
+
+Intentional divergences:
+
+- Global signal handler mutation is rejected.
+- CPython `signal.signal`, `set_wakeup_fd`, and arbitrary handler registration are not public Sifr runtime APIs.
+- Signal delivery behavior must be represented as typed values or errors, not process-global mutation.
+
+## `sifr.resource`
+
+`sifr.resource` contains deterministic cleanup helpers.
+
+Public APIs:
+
+- `NullContext[T]`
+- `nullcontext[T](value=None)`
+
+`nullcontext` is an owned value context manager. Language-level cleanup under cancellation is part of the structured runtime contract: cleanup runs before timeout or cancellation evidence is observed.
+
+Intentional divergences:
+
+- `ExitStack`, `AsyncExitStack`, `closing`, and `aclosing` are unsupported until cleanup-error aggregation and owned close protocols are accepted.
+- Cleanup helpers do not provide a hidden dynamic stack of arbitrary callbacks.
+
+## `sifr.ipc`
+
+`sifr.ipc` is the typed IPC substrate for future Sifr-native process workers.
+
+Public value APIs:
+
+- `SchemaId`
+- `schema_id(name, version, hash)`
+- `ProtocolVersion`
+- `protocol_version(minimum, maximum)`
+- `FrameKind`
+- frame-family constants such as `HELLO`, `READY`, `RUN`, `COMPLETED`, `FAILED`, `CANCEL`, `SHUTDOWN`, and `TERMINATING`
+- `BackpressurePolicy`
+- `default_backpressure()`
+- `schemas_match(left, right)`
+- `require_serializable(value)`
+- `IpcError`
+
+The runtime substrate uses deterministic schema identity, protocol-version negotiation, length-prefixed Postcard frames, bounded request tracking, explicit close/cancel frames, and typed malformed-frame evidence. The compiler can extract accepted payload schema shapes and reject unsupported process-local resources, sync endpoints, task handles, functions, borrowed values, and other non-serializable values.
+
+`require_serializable(...)` is a compiler-erased marker used to force representative payload eligibility diagnostics at compile time. It is not a runtime encoder and does not make unsupported values serializable.
+
+Intentional divergences:
+
+- CPython `multiprocessing.Queue`, `Pipe`, `Pool`, `Process`, `fork`, `forkserver`, and `shared_memory` names under `sifr.ipc` are rejected or unsupported with diagnostics.
+- M7 does not ship a public process-worker pool or public `ipc.Connection` API.
+- Windows process-pipe typed IPC fixture support remains host-limited until a deterministic Windows fixture is accepted.
+
+## Validation And Host Support
+
+The supported-host matrix records whether a surface is host-independent, Unix/macOS/Linux supported, Windows supported, or host-limited. Public documentation should be read with that matrix for platform-specific process and signal behavior.
+
+Representative validation lives in:
+
+- `verification/stdlib/concurrency_runtime_m1_traceability.md`
+- `verification/stdlib/concurrency_runtime_m2_sync_traceability.md`
+- `verification/stdlib/concurrency_runtime_m3_offload_traceability.md`
+- `verification/stdlib/concurrency_runtime_m4_process_traceability.md`
+- `verification/stdlib/concurrency_runtime_m5_shutdown_traceability.md`
+- `verification/stdlib/concurrency_runtime_m6_typed_ipc_design.md`
+- `verification/platform/supported_host_matrix.md`

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -475,6 +475,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M6 typed IPC closeout classification: https://github.com/sifr-lang/sifr/pull/2467
 - M6: complete.
 - M7 traceability scaffold: https://github.com/sifr-lang/sifr/pull/2469
+- M7 public documentation: pending PR.
 - M7: in progress.
 
 ## Validation Evidence
@@ -1456,6 +1457,21 @@ M7 traceability scaffold merge ledger:
 M7 traceability scaffold merge-ledger review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m7-traceability-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged timestamp, docs-only scope, validation claim, and M7 in-progress status without phase-completion overclaim.
+
+M7 public documentation implementation:
+
+- Added `docs/concurrency_runtime.md` as the public M7 docs entry for `sifr.task`, `sifr.sync`, `sifr.runtime`, `sifr.parallel`, `sifr.process`, `sifr.signal`, `sifr.resource`, and `sifr.ipc`.
+- Documented accepted API families, ownership/sendability/shareability boundaries, typed error surfaces, process/signal host limits, IPC schema/frame substrate boundaries, and intentional divergences from CPython event-loop, queue/threading, subprocess, signal-handler, cleanup-stack, multiprocessing, and process-pool APIs.
+- Updated `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` so every public-doc gate points at the new public docs artifact as `pending-pr` while preserving M7 as open/in-progress until the remaining internal architecture, demos, generated dependency/panic-scan, validation inventory, and final review gates close.
+
+M7 public documentation targeted local validation:
+
+- `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- Touched file line counts: `docs/concurrency_runtime.md` `240`, `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` `65`, and this ledger `2444`.
+
+M7 public documentation review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-1.md`: `PASS`; reviewer verified public docs coverage for all eight modules, intentional CPython divergence and public API boundaries, M7 in-progress status, non-public-doc gates left open, validation claims, and touched-file line counts.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-1.md
@@ -1,0 +1,32 @@
+## VERDICT: PASS
+
+### Validation re-run (confirmed locally)
+- `git diff --check` → PASS
+- `python3 scripts/check_file_size_guardrails.py` → PASS (2268 files, limit 900 lines)
+- Line counts confirmed exactly: `docs/concurrency_runtime.md` 240, `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` 65, execution ledger 2444
+
+### Public docs coverage (all 8 modules present in `docs/concurrency_runtime.md`)
+
+| Module | API surface covered | Intentional CPython divergence stated |
+| --- | --- | --- |
+| `sifr.task` | `Context`, `ContextKey[T]`, `task.scope`, `TaskGroup`, `TaskHandle[T,E]`, scoped spawn, timeout/deadline/cancel, `join`/`race`/`select`, linear handle ownership, sendability boundary | No `asyncio` event-loop object, no loop policy/replacement/global registry, no detached fire-and-forget |
+| `sifr.sync` | `Shared[T]`, typed `channel`/`bounded_channel`, `ChannelSender`/`ChannelReceiver`, `Lock`/`RwLock`/`Semaphore`/`Notify`, `WouldBlockError`, `ClosedError`, guard non-crossing rule | `queue.Queue`, `asyncio.Queue`, `threading.Lock`, multiprocessing queues are not aliases |
+| `sifr.runtime` | `DiagnosticLevel`, `DiagnosticEvent`, level constants, `diagnostic_event`/`emit_diagnostic`, `DiagnosticError`, redaction rule | Not CPython `warnings`/`logging` global handler mutation |
+| `sifr.parallel` | `map`/`try_map`, `PoolConfig`, `Pool`, `WorkerRuntimeError`, `WorkerError`, ordered output, panic-to-error, async direct-call rejection | `ThreadPoolExecutor`/`ProcessPoolExecutor` not aliased; public process worker deferred |
+| `sifr.process` | `run`/`run_timeout`/`output`/`output_text`/`spawn`/shell variants/async variants, `Command`, `Child`, `AsyncChild`, `ProcessHandle`, pipe readers/writers, `Stdio`/`PIPE`/`INHERIT`/`NULL`, `Status`, `Output`, `ProcessError`, owned-resource diagnostics | `subprocess.Popen` not aliased; shell is explicit effect; process-group/descendant semantics gated on host matrix |
+| `sifr.signal` | `Signal`, `SIGINT`/`SIGTERM`, `sigint`/`sigterm`, `strsignal`, `ctrl_c`, `terminate`, `shutdown_stream`/`ShutdownStream.next`, `SignalError`, Unix host-limited evidence | `signal.signal`, `set_wakeup_fd`, global handler registration rejected |
+| `sifr.resource` | `NullContext[T]`, `nullcontext`, cleanup-under-cancellation contract | `ExitStack`/`AsyncExitStack`/`closing`/`aclosing` unsupported |
+| `sifr.ipc` | `SchemaId`, `schema_id`, `ProtocolVersion`, `protocol_version`, `FrameKind` + frame constants (`HELLO`/`READY`/`RUN`/`COMPLETED`/`FAILED`/`CANCEL`/`SHUTDOWN`/`TERMINATING`), `BackpressurePolicy`, `default_backpressure`, `schemas_match`, `require_serializable`, `IpcError` | `multiprocessing.Queue`/`Pipe`/`Pool`/`Process`/`fork`/`forkserver`/`shared_memory` rejected; no public process-worker pool / `ipc.Connection`; Windows fixture host-limited |
+
+### M7 status and non-public-doc gates (correctly left open)
+- Execution ledger line 481: `M7: in progress.` retained; new line 478 only marks `M7 public documentation: pending PR.`
+- Traceability artifact preserves `Status: Open` and the 8 public-doc rows flipped only to `pending-pr` (not `closed`).
+- Internal architecture docs `partial`, Required demos `partial`, Generated Cargo dependency snapshots `open`, Panic scan `open`, Validation lane manifests `partial`, Inventory closure `open`, Final external review `open` — all unchanged.
+- PR-slice table: only the Public documentation row flipped to `pending PR`; Internal architecture audit / Demo closure / Generated dependency and panic-scan / Validation lane and inventory / Final review remain `pending`.
+
+### Scope and reviewability
+- Diff is docs-only (no code or generated artifacts touched).
+- Execution-ledger entries cover implementation, validation, and a review-loop placeholder, matching the prior M7 traceability-scaffold ledger pattern.
+- No phase-completion overclaim; `pending-pr` semantics are appropriate for a still-open review.
+
+No blockers found.

--- a/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
@@ -8,14 +8,14 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 
 | Gate | State | Evidence or required closure |
 | --- | --- | --- |
-| Public docs for `sifr.task` | open | Add public docs covering `TaskHandle`, `TaskGroup`, scoped spawn, timeout/deadline/cancel helpers, join/race/select, explicit task context, cancellation evidence, and unsupported event-loop compatibility boundaries. |
-| Public docs for `sifr.sync` | open | Add public docs covering channels, backpressure, close/drain, cancellation behavior, locks, semaphores, events, sendability/shareability, and unsupported queue/threading parity boundaries. |
-| Public docs for `sifr.runtime` | open | Add public docs covering blocking/CPU offload helpers, `JoinSet`, structured diagnostic events, workload annotations, and direct-call diagnostics. |
-| Public docs for `sifr.parallel` | open | Add public docs covering ordered `map`/`try_map`, private default/configured pools, typed worker errors, panic-to-error behavior, and async direct-call rejection. |
-| Public docs for `sifr.process` | open | Add public docs covering sync/async command execution, owned pipes, process handles, timeout/cancel/kill/terminate behavior, shell execution effects, text encoding, and task-boundary ownership diagnostics. |
-| Public docs for `sifr.signal` | open | Add public docs covering portable signal values, structured shutdown streams, Unix delivery evidence, non-Unix host-limited behavior, `strsignal`, and rejected global handler APIs. |
-| Public docs for `sifr.resource` | open | Add public docs covering `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
-| Public docs for `sifr.ipc` | open | Add public docs covering typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
+| Public docs for `sifr.task` | pending-pr | `docs/concurrency_runtime.md` documents task handles, task groups, scoped spawn, timeout/deadline/cancel helpers, join/race/select, explicit task context, cancellation evidence, and unsupported event-loop compatibility boundaries. |
+| Public docs for `sifr.sync` | pending-pr | `docs/concurrency_runtime.md` documents typed channels, backpressure, close/drain, cancellation behavior, locks, semaphores, notifications, sendability/shareability, and unsupported queue/threading parity boundaries. |
+| Public docs for `sifr.runtime` | pending-pr | `docs/concurrency_runtime.md` documents structured diagnostic events, levels, emission, redaction policy, and global warnings/logging divergence. |
+| Public docs for `sifr.parallel` | pending-pr | `docs/concurrency_runtime.md` documents ordered `map`/`try_map`, configured pools, typed worker errors, panic-to-error behavior, worker-boundary sendability, and async direct-call rejection. |
+| Public docs for `sifr.process` | pending-pr | `docs/concurrency_runtime.md` documents sync/async command execution, owned pipes, process handles, timeout/cancel/kill/terminate behavior, shell execution effects, text output, and task-boundary ownership diagnostics. |
+| Public docs for `sifr.signal` | pending-pr | `docs/concurrency_runtime.md` documents portable signal values, structured shutdown streams, Unix delivery evidence, non-Unix host-limited behavior, `strsignal`, and rejected global handler APIs. |
+| Public docs for `sifr.resource` | pending-pr | `docs/concurrency_runtime.md` documents `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
+| Public docs for `sifr.ipc` | pending-pr | `docs/concurrency_runtime.md` documents typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
 | Internal architecture docs | partial | `internal_docs/structured_runtime_work_model.md`, `internal_docs/async_concurrency_model.md`, and `internal_docs/architecture.md` already contain substantial model material. M7 must audit and update task/process/channel/offload/runtime boundaries, typed IPC policy, blocking/offload policy, sendability/shareability, task/request context, diagnostics/signal global-state policy, and the rejected CPython-shaped surface index. |
 | Required demos | partial | Existing demos include `demos/task_core_demo/main.sifr`, `demos/sync_channel_demo/main.sifr`, `demos/blocking_offload_demo/main.sifr`, `demos/structured_concurrency_demo/main.sifr`, and `demos/subprocess/main.sifr`. M7 must add or validate all required demos: structured task group, producer/consumer channel pipeline, blocking offload, CPU parallel map, async subprocess pipeline, structured shutdown, and cleanup under cancellation. |
 | Generated Cargo dependency snapshots | open | Add generated-project dependency evidence for the accepted feature combinations that pull runtime dependencies such as Tokio, Rayon, tracing, metrics, process support, signal support, and IPC serialization. |
@@ -41,7 +41,7 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 | Slice | Required output | Status |
 | --- | --- | --- |
 | Traceability scaffold | Create this artifact and record the M7 audit plan in the execution ledger. | in progress |
-| Public documentation | Add docs for all accepted production APIs and intentional divergences. | pending |
+| Public documentation | Add docs for all accepted production APIs and intentional divergences. | pending PR |
 | Internal architecture audit | Update architecture docs and rejected-surface index. | pending |
 | Demo closure | Add or validate the seven required demos and record commands. | pending |
 | Generated dependency and panic-scan evidence | Add generated Cargo dependency snapshots and generated-code quality coverage for concurrency paths. | pending |


### PR DESCRIPTION
## Summary

- add `docs/concurrency_runtime.md` covering the public concurrency runtime modules and accepted boundaries
- document intentional CPython divergences and deferred public process-worker/IPC APIs
- update M7 traceability public-doc gates to point at the new docs as pending PR work while keeping M7 open
- record validation and reviewer evidence

## Validation

- `git diff --check`
- `python3 scripts/check_file_size_guardrails.py`

## Review

- `reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-1.md`: PASS
