### PR TITLE
Add M7 concurrency runtime public docs

### DIFF
--- a/docs/concurrency_runtime.md
+++ b/docs/concurrency_runtime.md
@@ -1,0 +1,275 @@
+# Concurrency And Runtime
+
+Sifr's production concurrency model uses native `sifr.*` modules instead of CPython compatibility veneers. The public surface is structured, typed, cancellation-aware, and compiled to Rust without exposing Tokio, Rayon, OS process handles, or tracing/metrics types in Sifr source.
+
+Use explicit imports from the accepted modules:
+
+```python
+from sifr.task import TaskGroup, sleep, timeout
+from sifr.sync import channel
+from sifr.runtime import spawn_cpu
+from sifr.parallel import map
+from sifr.process import Command
+from sifr.signal import shutdown_stream
+from sifr.resource import nullcontext
+from sifr.ipc import require_serializable
+```
+
+Bare CPython concurrency imports such as `asyncio`, `queue`, `threading`, `subprocess`, `concurrent.futures`, `multiprocessing`, `signal`, `contextlib`, and `warnings` are not aliases for Sifr production APIs. Use the native `sifr.*` modules directly.
+
+## `sifr.task`
+
+`sifr.task` is the public async work model. Tasks are scoped and owned: a child task must be spawned under a live `TaskGroup`, observed exactly once, and prevented from escaping its owner.
+
+Core surfaces:
+
+- `TaskHandle[T, E]`: affine observation handle for a child task result.
+- `TaskGroup[E]`: structured owner for homogeneous child error type `E`.
+- `spawn_scoped(...)`: spawn under the active structured owner.
+- `sleep`, `timeout`, `deadline`, and `cancel_scope`: suspension and cancellation helpers.
+- `join_all`, `race`, and `select`: structured multi-task observation helpers with loser-cancellation evidence.
+- `Context`, `ContextKey[T]`, `empty_context()`, and `current_context()`: explicit task context values.
+
+```python
+from sifr.task import TaskGroup, sleep
+
+async def worker(value: int) -> int:
+    await sleep(0.01)
+    return value + 1
+
+async def main() -> int:
+    async with TaskGroup[Error]() as group:
+        handle = group.spawn(worker(41))
+        return await handle
+```
+
+Task context is explicit and immutable at the task boundary. Sifr does not provide Python `contextvars` dynamic copy-on-spawn behavior in this phase.
+
+Unsupported CPython-shaped surfaces:
+
+- event loops, loop policies, transports, protocols, and callbacks,
+- detached unowned tasks,
+- ambient mutable task-local state,
+- coroutine objects used without `await`.
+
+## `sifr.sync`
+
+`sifr.sync` owns same-process coordination. The primary data path is channels with bounded backpressure and deterministic close/drain behavior.
+
+Core surfaces:
+
+- `Channel[T]`, `ChannelSender[T]`, and `ChannelReceiver[T]`.
+- `channel[T]()` and `bounded_channel[T](capacity)`.
+- `Lock`, `RwLock`, async lock forms, semaphores, and events where fixtures pin the current accepted behavior.
+- `ClosedError` for closed-and-drained channel observation.
+
+```python
+from sifr.sync import bounded_channel
+
+async def pipeline() -> int:
+    sender, receiver = bounded_channel[int](2)
+    await sender.send(1)
+    await sender.send(2)
+    sender.close()
+
+    total = 0
+    async for item in receiver:
+        total += item
+    return total
+```
+
+Sendability and shareability are compile-time ownership facts. Non-send values, process handles, task handles, and synchronization endpoints cannot cross task, channel, IPC, or worker boundaries unless an accepted wrapper proves the boundary safe.
+
+Unsupported CPython-shaped surfaces:
+
+- `queue.Queue` task accounting such as `task_done()` and `join()`,
+- raw `threading.Thread`,
+- implicit global locks or condition variables that hide predicate discipline.
+
+## `sifr.runtime`
+
+`sifr.runtime` exposes structured offload and runtime diagnostics without exposing runtime implementation types.
+
+Core surfaces:
+
+- `spawn_blocking(...)`: run a known blocking-I/O synchronous worker outside the async runtime worker.
+- `spawn_cpu(...)`: run a known CPU-heavy synchronous worker under typed worker error evidence.
+- `JoinSet[T, E]`: homogeneous dynamically-growable task/offload collection.
+- `DiagnosticLevel`, `DiagnosticEvent`, `DiagnosticError`, `diagnostic_event(...)`, and `emit_diagnostic(...)`.
+
+Blocking and CPU-heavy annotations are declaration-site workload facts. Sifr rejects direct calls to known blocking or CPU-heavy functions from async code unless the call goes through an accepted async API, `spawn_blocking`, `spawn_cpu`, or `sifr.parallel`.
+
+```python
+from sifr.runtime import spawn_cpu
+
+@cpu_heavy
+def checksum(data: bytes) -> int:
+    total = 0
+    for byte in data:
+        total += int(byte)
+    return total
+
+async def main(data: bytes) -> int:
+    handle = spawn_cpu(checksum, data)
+    return await handle
+```
+
+Runtime diagnostics lower to fixed-schema tracing events and metrics counters when used. Sifr does not install a process-global subscriber, recorder, exporter, or Python warning filter.
+
+## `sifr.parallel`
+
+`sifr.parallel` is the synchronous CPU parallelism API. It uses private Rayon pools and never configures Rayon's global pool.
+
+Core surfaces:
+
+- `map(worker, items)`: ordered parallel map.
+- `try_map(worker, items)`: ordered parallel map with typed user errors.
+- `Pool` and `PoolConfig`: configured private pools.
+
+```python
+from sifr.parallel import map
+
+@cpu_heavy
+def square(value: int) -> int:
+    return value * value
+
+def main() -> list[int]:
+    return map(square, [1, 2, 3, 4])
+```
+
+Worker panics are caught at the generated boundary and converted into typed worker runtime errors. Direct `sifr.parallel` calls from async code are rejected; use `sifr.runtime.spawn_cpu` or a scoped offload form instead.
+
+## `sifr.process`
+
+`sifr.process` is the production process substrate. It owns child process creation, supervision, status observation, owned pipes, timeout behavior, cancellation, and shell execution effects.
+
+Core surfaces:
+
+- `Command`: typed command builder.
+- `Child`: owned child process and pipe access.
+- `ProcessHandle`: scoped child supervision handle.
+- Sync and async run/output/wait/spawn forms.
+- Owned pipe readers and writers.
+
+```python
+from sifr.process import Command
+
+def main() -> str:
+    result = Command("printf").arg("hello").output_text(encoding="utf-8")
+    return result.stdout
+```
+
+Text process output requires explicit encoding. Shell execution is an explicit effect; Sifr does not silently route command strings through a shell. Timeouts and cancellation map to typed process evidence, and generated code must clean up process groups where the accepted host contract requires it.
+
+Unsupported CPython-shaped surfaces:
+
+- bare `subprocess` imports,
+- unstructured process handles crossing task/offload/channel boundaries,
+- public process pools in this phase.
+
+## `sifr.signal`
+
+`sifr.signal` is structured shutdown signaling. Portable value helpers are host-independent; actual signal delivery is host-limited where the host contract requires it.
+
+Core surfaces:
+
+- `Signal`, `SignalError`.
+- `sigint()`, `sigterm()`, `SIGINT`, `SIGTERM`.
+- `strsignal(signal)`.
+- `ctrl_c()`, `terminate()`, and `shutdown_stream().next()` for structured shutdown waits.
+
+```python
+from sifr.signal import shutdown_stream
+
+async def main() -> str:
+    signal = await shutdown_stream().next()
+    return signal.name
+```
+
+Unix Ctrl-C and SIGTERM delivery are covered by deterministic fixture evidence. Non-Unix delivery remains host-limited until a deterministic host runner can deliver real console-control events.
+
+Unsupported CPython-shaped surfaces:
+
+- arbitrary `signal.signal(...)` handlers,
+- process-global warning/signal mutation,
+- raw signal masks unless a future host-specific API is explicitly designed.
+
+## `sifr.resource`
+
+`sifr.resource` owns small deterministic resource helpers. Language-level `try/finally` cleanup already runs under task cancellation.
+
+Core supported surface:
+
+- `nullcontext()`
+- `nullcontext(value)`
+
+```python
+from sifr.resource import nullcontext
+
+def main() -> int:
+    with nullcontext(3) as value:
+        return value
+```
+
+Unsupported in this phase:
+
+- `ExitStack`
+- `AsyncExitStack`
+- `closing`
+- `aclosing`
+- `contextmanager`
+- `asynccontextmanager`
+- `redirect_stdout`, `redirect_stderr`, `chdir`, and `suppress`
+
+Cleanup stacks and owned closing helpers need future typed cleanup-error aggregation and owned-close protocols before they can be production APIs.
+
+## `sifr.ipc`
+
+`sifr.ipc` is the typed IPC substrate for future Sifr-native process workers. It is not a public process pool and not a pickle-compatible multiprocessing adapter.
+
+Core surfaces and evidence:
+
+- `SchemaId`, `ProtocolVersion`, `FrameKind`, and `BackpressurePolicy` value model.
+- Length-prefixed Postcard frame helpers inside `sifr_stdlib`.
+- Request tracking, bounded in-flight backpressure, cancellation, shutdown, and malformed-frame evidence.
+- Bootstrap and connection-state negotiation over an accepted process-pipe transport.
+- `require_serializable(value)`: compiler-erased marker for representative compile-time payload eligibility diagnostics.
+
+```python
+from sifr.ipc import require_serializable
+
+class Message:
+    value: int
+
+def main(message: Message) -> None:
+    require_serializable(message)
+```
+
+Accepted payload families include concrete scalar/container/record shapes proven by the compiler. Process handles, task handles, synchronization endpoints, callables, raw host resources, and arbitrary object graphs are rejected as IPC payloads.
+
+Public worker pools and generated worker integration are `deferred-to-phase-X`. Windows process-pipe fixture evidence remains host-limited until a deterministic Windows fixture is accepted.
+
+Unsupported CPython-shaped surfaces:
+
+- `multiprocessing.Process`
+- `multiprocessing.Queue`
+- `multiprocessing.Pipe`
+- `multiprocessing.Pool`
+- `concurrent.futures.ProcessPoolExecutor`
+- `fork`, `forkserver`, and `shared_memory` under a CPython-shaped namespace
+
+## Intentional Divergence Index
+
+| CPython-shaped surface | Sifr production replacement | Phase state |
+| --- | --- | --- |
+| `asyncio` | `sifr.task` and `sifr.sync` | unsupported-with-diagnostic |
+| `queue` | `sifr.sync` channels | unsupported-with-diagnostic |
+| `threading` | `sifr.sync`, `sifr.runtime`, `sifr.parallel` | unsupported-with-diagnostic |
+| `subprocess` | `sifr.process` | unsupported-with-diagnostic |
+| `concurrent.futures` | `sifr.runtime` and `sifr.parallel` | unsupported-with-diagnostic |
+| `multiprocessing` | `sifr.process` plus `sifr.ipc` substrate | rejected / deferred worker API |
+| Python `signal` globals | `sifr.signal` structured shutdown | unsupported-with-diagnostic or host-limited |
+| Python `contextlib` helpers | `sifr.resource` plus language cleanup | unsupported-with-diagnostic except `nullcontext` |
+| Python `warnings` globals | `sifr.runtime` diagnostics/tracing | rejected |
+
+Future compatibility adapters must be reviewed separately. They must wrap the native Sifr substrate without process-global mutation, hidden unstructured ownership, or panic-prone generated runtime paths.

--- a/docs/stdlib_imports.md
+++ b/docs/stdlib_imports.md
@@ -32,3 +32,5 @@ from sifr.json import dumps
 `import sifr.math` is also unsupported for now because Sifr does not yet support module-object imports. Import the symbols you need from the module instead.
 
 Text, Unicode, encoding, and i18n surfaces are documented in [text_i18n.md](./text_i18n.md).
+
+Concurrency and runtime surfaces are documented in [concurrency_runtime.md](./concurrency_runtime.md).

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -474,6 +474,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M6 typed IPC closeout classification: https://github.com/sifr-lang/sifr/pull/2467
 - M6: complete.
 - M7 traceability scaffold: https://github.com/sifr-lang/sifr/pull/2469
+- M7 public concurrency/runtime docs: pending PR.
 - M7: in progress.
 
 ## Validation Evidence
@@ -1426,6 +1427,22 @@ M7 traceability scaffold merge ledger:
 M7 traceability scaffold merge-ledger review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m7-traceability-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged timestamp, docs-only scope, validation claim, and M7 in-progress status without phase-completion overclaim.
+
+M7 public concurrency/runtime docs implementation:
+
+- Added `docs/concurrency_runtime.md` as the public documentation surface for `sifr.task`, `sifr.sync`, `sifr.runtime`, `sifr.parallel`, `sifr.process`, `sifr.signal`, `sifr.resource`, and `sifr.ipc`.
+- Documented the intentional CPython-shaped divergences for `asyncio`, `queue`, `threading`, `subprocess`, `concurrent.futures`, `multiprocessing`, Python `signal`, Python `contextlib`, and Python `warnings`.
+- Linked the new public doc from `docs/stdlib_imports.md`.
+- Updated the M7 traceability artifact to mark the public-docs rows covered by this PR while leaving architecture, demos, generated dependency snapshots, generated-code quality coverage, validation lane audit, inventory closure, and final review open.
+
+M7 public concurrency/runtime docs targeted local validation:
+
+- `git diff --check` and `python3 scripts/check_file_size_guardrails.py` -> PASS.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; report `target/validation_lane_reports/create-pr.latest.json`; no advisories (`116.33s`, warm target `<=2m`). Included guardrails, diagnostic contracts, frontend/syntax guardrails, developer tooling, performance budgets, verification hardening, generated-code quality, crate tests, platform golden (`pass=6`, `skip=1`), and create-pr e2e pass suite (`125 passed`, `0 failed`, `cache_hits=37/37`, `report_signature=50edc954137c87b4`; slowest step `crate_tests` `33938ms`).
+
+M7 public concurrency/runtime docs review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-2.md`: `PASS`; reviewer verified the public docs cover all eight required `sifr.*` namespaces, divergence wording is honest, unsupported/deferred/host-limited surfaces are not overclaimed, validation evidence is recorded, and M7 remains in progress.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-2.md
@@ -1,0 +1,36 @@
+VERDICT: PASS
+
+## Public docs coverage of required namespaces
+
+All eight required `sifr.*` namespaces are documented in `docs/concurrency_runtime.md` with surfaces, an example, and an unsupported/deferred boundary:
+
+- `sifr.task` (lines 20–54): `TaskHandle`, `TaskGroup`, `spawn_scoped`, sleep/timeout/deadline/cancel_scope, join_all/race/select, Context/ContextKey, plus unsupported event-loop surfaces and detached tasks.
+- `sifr.sync` (lines 56–87): channels (`channel`, `bounded_channel`), `Lock`/`RwLock`/semaphore/event, `ClosedError`, sendability/shareability boundary, queue/threading unsupported surfaces.
+- `sifr.runtime` (lines 89–117): `spawn_blocking`, `spawn_cpu`, `JoinSet`, structured `DiagnosticEvent`/`emit_diagnostic`, blocking/CPU annotation policy, no global subscriber.
+- `sifr.parallel` (lines 119–140): `map`, `try_map`, `Pool`/`PoolConfig`, private Rayon pools, panic→typed worker error, async direct-call rejection.
+- `sifr.process` (lines 142–168): `Command`, `Child`, `ProcessHandle`, sync/async forms, owned pipes, explicit text encoding, explicit shell effect, timeout/cancel evidence, unsupported `subprocess` parity.
+- `sifr.signal` (lines 170–195): `Signal`/`SignalError`, `sigint`/`sigterm`, `strsignal`, `ctrl_c`/`terminate`/`shutdown_stream`, Unix delivery covered, non-Unix host-limited, rejected global handlers.
+- `sifr.resource` (lines 197–224): `nullcontext` (only supported surface), explicit list of unsupported helpers, language `try/finally` cancellation note.
+- `sifr.ipc` (lines 226–259): `SchemaId`/`ProtocolVersion`/`FrameKind`/`BackpressurePolicy`, Postcard frames, request tracking/backpressure, bootstrap negotiation, `require_serializable`, rejected payload classes, unsupported `multiprocessing.*` names.
+
+## Divergence wording is honest, no overclaim
+
+- `docs/concurrency_runtime.md:228` explicitly states `sifr.ipc` "is not a public process pool and not a pickle-compatible multiprocessing adapter."
+- `docs/concurrency_runtime.md:250` and `:261` keep worker pools and generated worker integration `deferred-to-phase-X`, and Windows process-pipe fixture as host-limited.
+- `docs/concurrency_runtime.md:189` flags non-Unix signal delivery as host-limited.
+- `docs/concurrency_runtime.md:117` is careful not to claim a process-global subscriber/exporter is installed.
+- Divergence index (lines 263–273) correctly tags each CPython-shaped family as `unsupported-with-diagnostic`, `rejected`, or `host-limited` rather than parity.
+- `docs/stdlib_imports.md:36` adds the cross-reference without elevating the slice past docs scope.
+
+## Validation evidence recorded
+
+`issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:1431–1445` records the docs implementation entry, the docs link from `stdlib_imports.md`, and the targeted local validation (`git diff --check` + `check_file_size_guardrails.py` PASS, `run_all_tests.sh --profile create-pr` PASS `116.33s` no advisories, platform golden `pass=6 skip=1`, e2e `125 passed 0 failed`, `cache_hits=37/37`, `report_signature=50edc954137c87b4`, slowest `crate_tests 33938ms`). Values match the context supplied.
+
+## M7 remains in progress
+
+- `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md:5` keeps `Status: Open` and explicitly states the artifact "does not mark the phase complete."
+- Public-docs gate rows (lines 11–18) flipped from `open` → `covered by this PR` only; architecture, demos, generated dep snapshots, panic scan, validation lane audit, inventory closure, and final external review (lines 19–25) remain `partial`/`open`.
+- Required-PR-slice table: only the Public documentation slice moved `pending` → `in progress` (line 44); all other slices stay `pending`.
+- Issue ledger (line 477–478) records the docs slice as `pending PR` and leaves `M7: in progress.` — no phase-completion claim.
+
+No blockers identified for the public-docs slice.

--- a/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
@@ -8,14 +8,14 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 
 | Gate | State | Evidence or required closure |
 | --- | --- | --- |
-| Public docs for `sifr.task` | open | Add public docs covering `TaskHandle`, `TaskGroup`, scoped spawn, timeout/deadline/cancel helpers, join/race/select, explicit task context, cancellation evidence, and unsupported event-loop compatibility boundaries. |
-| Public docs for `sifr.sync` | open | Add public docs covering channels, backpressure, close/drain, cancellation behavior, locks, semaphores, events, sendability/shareability, and unsupported queue/threading parity boundaries. |
-| Public docs for `sifr.runtime` | open | Add public docs covering blocking/CPU offload helpers, `JoinSet`, structured diagnostic events, workload annotations, and direct-call diagnostics. |
-| Public docs for `sifr.parallel` | open | Add public docs covering ordered `map`/`try_map`, private default/configured pools, typed worker errors, panic-to-error behavior, and async direct-call rejection. |
-| Public docs for `sifr.process` | open | Add public docs covering sync/async command execution, owned pipes, process handles, timeout/cancel/kill/terminate behavior, shell execution effects, text encoding, and task-boundary ownership diagnostics. |
-| Public docs for `sifr.signal` | open | Add public docs covering portable signal values, structured shutdown streams, Unix delivery evidence, non-Unix host-limited behavior, `strsignal`, and rejected global handler APIs. |
-| Public docs for `sifr.resource` | open | Add public docs covering `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
-| Public docs for `sifr.ipc` | open | Add public docs covering typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
+| Public docs for `sifr.task` | covered by this PR | `docs/concurrency_runtime.md` documents `TaskHandle`, `TaskGroup`, scoped spawn, timeout/deadline/cancel helpers, join/race/select, explicit task context, cancellation evidence, and unsupported event-loop compatibility boundaries. |
+| Public docs for `sifr.sync` | covered by this PR | `docs/concurrency_runtime.md` documents channels, backpressure, close/drain, cancellation behavior, locks, semaphores, events, sendability/shareability, and unsupported queue/threading parity boundaries. |
+| Public docs for `sifr.runtime` | covered by this PR | `docs/concurrency_runtime.md` documents blocking/CPU offload helpers, `JoinSet`, structured diagnostic events, workload annotations, and direct-call diagnostics. |
+| Public docs for `sifr.parallel` | covered by this PR | `docs/concurrency_runtime.md` documents ordered `map`/`try_map`, private default/configured pools, typed worker errors, panic-to-error behavior, and async direct-call rejection. |
+| Public docs for `sifr.process` | covered by this PR | `docs/concurrency_runtime.md` documents sync/async command execution, owned pipes, process handles, timeout/cancel/kill/terminate behavior, shell execution effects, text encoding, and task-boundary ownership diagnostics. |
+| Public docs for `sifr.signal` | covered by this PR | `docs/concurrency_runtime.md` documents portable signal values, structured shutdown streams, Unix delivery evidence, non-Unix host-limited behavior, `strsignal`, and rejected global handler APIs. |
+| Public docs for `sifr.resource` | covered by this PR | `docs/concurrency_runtime.md` documents `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
+| Public docs for `sifr.ipc` | covered by this PR | `docs/concurrency_runtime.md` documents typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
 | Internal architecture docs | partial | `internal_docs/structured_runtime_work_model.md`, `internal_docs/async_concurrency_model.md`, and `internal_docs/architecture.md` already contain substantial model material. M7 must audit and update task/process/channel/offload/runtime boundaries, typed IPC policy, blocking/offload policy, sendability/shareability, task/request context, diagnostics/signal global-state policy, and the rejected CPython-shaped surface index. |
 | Required demos | partial | Existing demos include `demos/task_core_demo/main.sifr`, `demos/sync_channel_demo/main.sifr`, `demos/blocking_offload_demo/main.sifr`, `demos/structured_concurrency_demo/main.sifr`, and `demos/subprocess/main.sifr`. M7 must add or validate all required demos: structured task group, producer/consumer channel pipeline, blocking offload, CPU parallel map, async subprocess pipeline, structured shutdown, and cleanup under cancellation. |
 | Generated Cargo dependency snapshots | open | Add generated-project dependency evidence for the accepted feature combinations that pull runtime dependencies such as Tokio, Rayon, tracing, metrics, process support, signal support, and IPC serialization. |
@@ -41,7 +41,7 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 | Slice | Required output | Status |
 | --- | --- | --- |
 | Traceability scaffold | Create this artifact and record the M7 audit plan in the execution ledger. | in progress |
-| Public documentation | Add docs for all accepted production APIs and intentional divergences. | pending |
+| Public documentation | Add docs for all accepted production APIs and intentional divergences. | in progress |
 | Internal architecture audit | Update architecture docs and rejected-surface index. | pending |
 | Demo closure | Add or validate the seven required demos and record commands. | pending |
 | Generated dependency and panic-scan evidence | Add generated Cargo dependency snapshots and generated-code quality coverage for concurrency paths. | pending |


### PR DESCRIPTION
## Summary

- add public concurrency/runtime docs for sifr.task, sifr.sync, sifr.runtime, sifr.parallel, sifr.process, sifr.signal, sifr.resource, and sifr.ipc
- document CPython-shaped divergence states and unsupported/deferred/host-limited boundaries
- link the new docs from stdlib imports and update M7 traceability for the public-docs slice

## Validation

- git diff --check
- python3 scripts/check_file_size_guardrails.py
  - PASS (2269 files, limit 900 lines)
- scripts/run_all_tests.sh --profile create-pr
  - PASS, report target/validation_lane_reports/create-pr.latest.json
  - wall_time=116.33s, no advisories
  - platform golden pass=6 skip=1
  - create-pr e2e pass suite: 125 passed, 0 failed, cache_hits=37/37, report_signature=50edc954137c87b4

## Review

- reviews/ad-hoc-production-concurrency-runtime-m7-public-docs-review-pass-2.md: PASS
