### PR TITLE
Add M7 concurrency runtime demo closure

### DIFF
--- a/demos/parallel_map_demo/main.sifr
+++ b/demos/parallel_map_demo/main.sifr
@@ -1,0 +1,12 @@
+from sifr.parallel import WorkerRuntimeError, map
+
+
+def score(value: int) -> int:
+    return value + value
+
+
+def main() -> None:
+    values: list[int] = [1, 2, 3, 4]
+    scores: Result[list[int], WorkerRuntimeError] = map(values, score)
+    assert str(scores) == "Ok([2, 4, 6, 8])"
+    return None

--- a/demos/process_shutdown_cleanup_demo/main.sifr
+++ b/demos/process_shutdown_cleanup_demo/main.sifr
@@ -1,0 +1,90 @@
+from sifr.io import exists, write_text
+from sifr.os import getpid, remove_file
+from sifr.process import AsyncChild, AsyncPipeReader, AsyncPipeWriter, Command, ProcessError, Status, Stdio, async_spawn
+from sifr.signal import SIGINT, SIGTERM, Signal, SignalError, ctrl_c, shutdown_stream, strsignal, terminate
+
+
+def marker_path() -> str:
+    return "/tmp/sifr_process_shutdown_cleanup_demo_" + str(getpid()) + ".txt"
+
+
+def command_echo_pipeline() -> Command:
+    pipe: Stdio = Stdio("pipe")
+    command: Command = Command("sh")
+    command.arg("-c")
+    command.arg("cat; printf done >&2")
+    command.stdin(pipe)
+    command.stdout(pipe)
+    command.stderr(pipe)
+    return command
+
+
+def shutdown_shape_demo() -> None:
+    interrupt: Signal = SIGINT
+    termination: Signal = SIGTERM
+    assert strsignal(interrupt) == "SIGINT"
+    assert strsignal(termination) == "SIGTERM"
+
+    _ctrl_c_wait: Awaitable[Result[Signal, SignalError]] = ctrl_c()
+    _terminate_wait: Awaitable[Result[Signal, SignalError]] = terminate()
+    _shutdown_wait: Awaitable[Result[Signal, SignalError]] = shutdown_stream().next()
+    return None
+
+
+async def async_process_pipeline_demo() -> None:
+    try:
+        child: AsyncChild = await async_spawn(command_echo_pipeline())
+        stdin: AsyncPipeWriter = child.stdin()
+        stdout: AsyncPipeReader = child.stdout()
+        stderr: AsyncPipeReader = child.stderr()
+
+        _write: None = await stdin.write_all(b"runtime")
+        _closed: None = stdin.close()
+
+        stdout_bytes: bytes = await stdout.read_all()
+        stderr_bytes: bytes = await stderr.read_all()
+        assert stdout_bytes == b"runtime"
+        assert stderr_bytes == b"done"
+
+        status: Status = await child.wait()
+        assert status.success
+    except ProcessError as e:
+        assert False
+    return None
+
+
+async def cleanup_under_cancellation_demo() -> Result[None, Error]:
+    path: str = marker_path()
+    if exists(path):
+        try:
+            _removed_existing: None = remove_file(path)
+        except IOError as e:
+            _cleanup_message: str = str(e.message)
+
+    try:
+        async with task.timeout(0.0):
+            try:
+                await task.sleep(10.0)
+            finally:
+                try:
+                    _written: None = write_text(path, "cleanup")
+                except IOError as e:
+                    _write_message: str = str(e.message)
+    except TimeoutError:
+        _timed_out: bool = True
+
+    assert exists(path)
+
+    try:
+        _removed: None = remove_file(path)
+    except IOError as e:
+        _remove_message: str = str(e.message)
+    return None
+
+
+async def main() -> Result[None, Error]:
+    shutdown_shape_demo()
+    await async_process_pipeline_demo()
+    cleanup: Result[None, Error] = await cleanup_under_cancellation_demo()
+    assert str(cleanup) == "Ok(())"
+    return None

--- a/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md
@@ -477,6 +477,7 @@ Current M2 wave: synchronization, channels, and backpressure closure.
 - M7 traceability scaffold: https://github.com/sifr-lang/sifr/pull/2469
 - M7 public documentation: https://github.com/sifr-lang/sifr/pull/2473
 - M7 internal architecture audit: https://github.com/sifr-lang/sifr/pull/2476
+- M7 demo closure: pending PR.
 - M7: in progress.
 
 ## Validation Evidence
@@ -1512,6 +1513,35 @@ M7 internal architecture audit merge ledger:
 M7 internal architecture audit merge-ledger review loop:
 
 - `reviews/ad-hoc-production-concurrency-runtime-m7-architecture-ledger-review-pass-1.md`: `PASS`; reviewer verified the PR URL, merge commit, merged timestamp, docs-only scope, validation claim, architecture gate closed, remaining gates still open/partial/pending, and no M7 completion overclaim.
+
+M7 demo closure implementation:
+
+- Added `demos/parallel_map_demo/main.sifr` to demonstrate `sifr.parallel.map` and typed `WorkerRuntimeError` result observation.
+- Added `demos/process_shutdown_cleanup_demo/main.sifr` to demonstrate async process pipe ownership, async child wait, structured shutdown stream/value shape, and cleanup running under timeout cancellation.
+- Revalidated existing required/supporting demos: `demos/task_core_demo/main.sifr`, `demos/sync_channel_demo/main.sifr`, `demos/blocking_offload_demo/main.sifr`, `demos/structured_concurrency_demo/main.sifr`, and `demos/subprocess/main.sifr`.
+- Updated `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md` so the required demo gate and demo-closure slice are `pending-pr` while generated dependency snapshots, panic-scan coverage, validation/inventory closure, and final external review remain open or pending.
+
+M7 demo closure targeted local validation:
+
+- `cargo run -q -p sifr -- run demos/parallel_map_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/process_shutdown_cleanup_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/task_core_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/sync_channel_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/blocking_offload_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/structured_concurrency_demo/main.sifr` -> PASS.
+- `cargo run -q -p sifr -- run demos/subprocess/main.sifr` -> PASS.
+- `git diff --check` -> PASS.
+- `python3 scripts/check_file_size_guardrails.py` -> PASS; `2271` files checked, `900` line limit.
+- `cargo fmt --check` -> PASS.
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS.
+- `cargo test -p sifr -- --skip test_e2e_pass` -> PASS; CLI unit tests `95 passed`; e2e harness tests `36 passed`, `1 filtered out`; validation-contract test ignored as expected.
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS; `wall_time=417.71s`, `budget_ok=no` due warm wall-time advisory; `max_rss=518.6MiB`, `swaps=0`; platform golden `pass=6 skip=1`; e2e `125 passed`, `0 failed`, `cache_hits=0/37`, `report_signature=50edc954137c87b4`; slowest step `e2e_pass_suite 279192ms`; report `target/validation_lane_reports/create-pr.latest.json`.
+- `cargo clippy --workspace -- -D warnings` -> FAIL on inherited non-demo code in `crates/sifr_codegen/src/intrinsics/registry/runtime.rs`, `crates/sifr_codegen/src/preamble/process_async_child_runtime.rs`, and `crates/sifr_codegen/src/preamble/process_async_runtime.rs`; this demo slice does not touch those files, and the M7 generated dependency/panic-scan quality slice retains final clippy cleanup before phase closeout.
+
+M7 demo closure review loop:
+
+- `reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-1.md`: `PASS`; reviewer verified all seven required M7 demo topics, production API usage, no CPython-shaped compatibility surfaces, no signal-delivery overclaim, M7 still open/in progress, remaining generated-dependency/panic-scan/validation-inventory/final-review gates still open or pending, and traceability scaffold completion. Reviewer requested broader validation evidence before PR; the validation block above records the follow-up commands.
+- `reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-2.md`: `PASS`; reviewer verified the pass-1 validation gap is resolved, the inherited clippy failure is honestly scoped outside the demo slice while retained for final M7 cleanup, `git diff --check` and file-size guardrail claims are accurate, demo closure remains pending PR, M7 remains open/in progress, and remaining non-demo M7 gates stay open or pending.
 
 M5 signal `strsignal` value-helper implementation:
 

--- a/reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-1.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-1.md
@@ -1,0 +1,55 @@
+VERDICT: PASS
+
+## Findings
+
+### Topic coverage (req 1) — ✅
+All seven required M7 demo topics are covered:
+- Structured task group → `demos/structured_concurrency_demo/main.sifr:51-61` (`task.scope`, `task.gather`, `task.select`, `task.TaskGroup`).
+- Producer/consumer channel pipeline → `demos/sync_channel_demo/main.sifr:65-75` (`bounded_channel` + `drain_two` consumer).
+- Blocking offload → `demos/blocking_offload_demo/main.sifr` (`task.spawn_blocking` + `@cpu_heavy`/`@blocking_io`).
+- CPU parallel map → `demos/parallel_map_demo/main.sifr` (new — `sifr.parallel.map` + `WorkerRuntimeError`).
+- Async subprocess pipeline → `demos/process_shutdown_cleanup_demo/main.sifr:34-53` (`async_spawn`, owned `AsyncPipeReader`/`Writer`, `child.wait`).
+- Structured shutdown → `demos/process_shutdown_cleanup_demo/main.sifr:22-31`.
+- Cleanup under cancellation → `demos/process_shutdown_cleanup_demo/main.sifr:56-82`.
+
+### Production-API and no-overclaim (req 2) — ✅
+- Imports come from `sifr.parallel`, `sifr.process`, `sifr.signal`, `sifr.io`, `sifr.os` — production surfaces, no CPython-shaped names.
+- `shutdown_shape_demo` constructs `Awaitable[Result[Signal, SignalError]]` from `ctrl_c()`, `terminate()`, and `shutdown_stream().next()` but never awaits them; combined with `strsignal(...)` shape assertions, this validates only the typed shape and avoids claiming actual signal delivery. Variable names are `_`-prefixed to signal intentionally-unused. Verified against `lib/sifr/signal.sifr` (the signal module's `Signal`/`SignalError`/`shutdown_stream` shape matches).
+- `parallel_map_demo` matches the existing pass fixture shape (`crates/sifr/tests/e2e/pass/parallel_map_basic.sifr`).
+
+### Ledger / no completion claim (req 3) — ✅
+`issues/...execution.md:480-481` reads:
+```
+- M7 demo closure: pending PR.
+- M7: in progress.
+```
+No M7 completion claim. The ledger lists exact commands (7 demo runs + `git diff --check` + `python3 scripts/check_file_size_guardrails.py`). I re-ran each: all PASS (also `cargo run -q -p sifr -- check` on both new demos = "no errors found"; `git diff --check` clean; file-size guardrail: 2271 files, limit 900).
+
+### Traceability gate states (req 4) — ✅
+`verification/stdlib/concurrency_runtime_m7_closeout_traceability.md`:
+- "Required demos" gate (line 20): `pending-pr` — correct.
+- Generated dep snapshots (line 21): `open` — correct.
+- Panic-scan & emitted-code quality (line 22): `open` — correct.
+- Validation lane manifests (line 23): `partial` — correct.
+- Inventory closure (line 24): `open` — correct.
+- Final external review (line 25): `open` — correct.
+- Slice table (line 43-49): scaffold complete, docs complete, architecture complete, demo closure `pending PR`, dep+panic-scan `pending`, validation/inventory `pending`, final review+merge gate `pending`.
+
+### Scaffold "complete" appropriate (req 5) — ✅
+Traceability scaffold PR #2469 already merged (`issues/...execution.md:477`); flipping the slice from "in progress" to "complete" is correct. The slice/gate split prevents this from implying M7 phase completion — the M7 closeout text on line 5 still reads "Status: Open."
+
+### Validation evidence sufficiency (req 6) — Soft gap
+The ledger does **not** record the project's authoritative PR gate. Per `AGENTS.md` ("Before considering any task done, run local validation on your changes: `scripts/run_all_tests.sh --profile create-pr`") and the validation plan in the traceability scaffold itself (lines 55-65), each PR must record exact local validation. The current evidence only covers per-demo runs + `git diff --check` + the file-size guardrail.
+
+Recommended additional commands to record in the ledger before opening the PR:
+- `cargo fmt --check`
+- `cargo clippy --workspace -- -D warnings`
+- `python3 scripts/check_hir_maintainability_guardrails.py`
+- `cargo test -p sifr -- --skip test_e2e_pass`
+- `scripts/run_all_tests.sh --profile create-pr` (covers the e2e pass corpus and lane manifest, which is the primary regression net since the new demos aren't in the e2e auto-discovery corpus)
+
+These don't change the scope of the slice but are needed to satisfy the project gate and the traceability's own validation plan.
+
+### Minor / non-blocking
+- Status terminology inconsistency: "pending-pr" in the gate row (line 20) vs "pending PR" in the slice row (line 46). Pick one and apply consistently.
+- `reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-1.md` is 0 bytes (committed empty placeholder). The ledger flags the review loop as "Pending" which is consistent, but an empty file in the diff is unusual — either remove it from the working tree or populate it as part of the review loop.

--- a/reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-2.md
+++ b/reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-2.md
@@ -1,0 +1,51 @@
+VERDICT: PASS
+
+## Findings
+
+### Validation evidence (pass-1 soft gap) — ✅
+The ledger (`issues/ad-hoc-production-concurrency-runtime-platform-substrate-execution.md:1524-1539`) now records the additional validation commands flagged in pass-1:
+
+- `cargo fmt --check` -> PASS
+- `python3 scripts/check_hir_maintainability_guardrails.py` -> PASS
+- `cargo test -p sifr -- --skip test_e2e_pass` -> PASS (CLI unit `95 passed`; e2e harness `36 passed`, `1 filtered out`)
+- `scripts/run_all_tests.sh --profile create-pr` -> PASS with exact metrics: `wall_time=417.71s`, `budget_ok=no` (warm wall-time advisory), `max_rss=518.6MiB`, `swaps=0`, platform golden `pass=6 skip=1`, e2e `125 passed`, `0 failed`, `cache_hits=0/37`, `report_signature=50edc954137c87b4`, slowest step `e2e_pass_suite 279192ms`, report `target/validation_lane_reports/create-pr.latest.json`.
+
+These cover the project's authoritative create-pr gate and the traceability validation plan.
+
+### Inherited clippy failure — ✅ recorded honestly
+Line 1539: `cargo clippy --workspace -- -D warnings` -> FAIL on `crates/sifr_codegen/src/intrinsics/registry/runtime.rs`, `crates/sifr_codegen/src/preamble/process_async_child_runtime.rs`, `crates/sifr_codegen/src/preamble/process_async_runtime.rs`. I reproduced clippy and confirmed errors at exactly those file paths:
+
+- `crates/sifr_codegen/src/intrinsics/registry/runtime.rs:14:26` (uninlined-format-args)
+- `crates/sifr_codegen/src/preamble/process_async_child_runtime.rs:57:1` (fn_params_excessive_bools)
+- `crates/sifr_codegen/src/preamble/process_async_runtime.rs:231:1` (too_many_arguments + fn_params_excessive_bools)
+
+`git log` confirms these files were last touched by M5 work (`a13950d34`, `134963a2b`, `df95159dd`), not by this demo slice. The ledger explicitly notes "this demo slice does not touch those files, and the M7 generated dependency/panic-scan quality slice retains final clippy cleanup before phase closeout" — the failure is scoped outside the demo PR without hiding that M7 phase closeout must fix it.
+
+### git diff --check and file-size guardrail (req 3) — ✅ accurate
+Re-ran both: `git diff --check` PASS; `python3 scripts/check_file_size_guardrails.py` -> PASS, `2271 files`, `900` line limit. Ledger matches.
+
+### Gate states (req 4) — ✅
+- `issues/...execution.md:480-481`: `- M7 demo closure: pending PR.` / `- M7: in progress.`
+- `verification/stdlib/concurrency_runtime_m7_closeout_traceability.md:20-25`: Required demos `pending PR`; Generated Cargo dependency snapshots `open`; Panic scan and emitted-code quality coverage `open`; Validation lane manifests `partial`; Inventory closure `open`; Final external review `open`.
+- Slice rows (lines 43-49): scaffold/docs/architecture `complete`; Demo closure `pending PR`; Generated dependency and panic-scan `pending`; Validation lane and inventory closure `pending`; Final review and merge gate `pending`.
+
+Pass-1 minor terminology inconsistency (`pending-pr` vs `pending PR`) is resolved — both gate and slice rows now use `pending PR`.
+
+### Demo topic coverage and no-overclaim (req 5) — ✅
+All seven required M7 demo topics still covered without CPython-shaped compatibility surfaces:
+
+- Structured task group: `demos/structured_concurrency_demo/main.sifr` (`task.scope`, `task.gather`, `task.select`, `task.TaskGroup`).
+- Producer/consumer channel pipeline: `demos/sync_channel_demo/main.sifr` (`bounded_channel` + drain consumer).
+- Blocking offload: `demos/blocking_offload_demo/main.sifr` (`task.spawn_blocking`, `@cpu_heavy`, `@blocking_io`).
+- CPU parallel map: `demos/parallel_map_demo/main.sifr` (`sifr.parallel.map` + `WorkerRuntimeError`).
+- Async subprocess pipeline: `demos/process_shutdown_cleanup_demo/main.sifr:34-53` (`async_spawn`, owned `AsyncPipeReader`/`AsyncPipeWriter`, `child.wait`).
+- Structured shutdown shape: `demos/process_shutdown_cleanup_demo/main.sifr:22-31` (annotates `Awaitable[Result[Signal, SignalError]]` from `ctrl_c()`/`terminate()`/`shutdown_stream().next()` without awaiting; `_`-prefixed bindings; `strsignal` value-shape only — no actual signal-delivery claim).
+- Cleanup under cancellation: `demos/process_shutdown_cleanup_demo/main.sifr:56-82` (`task.timeout(0.0)` + `try/finally` writing a PID-scoped marker, then asserting cleanup ran).
+
+Imports are all production surfaces (`sifr.parallel`, `sifr.process`, `sifr.signal`, `sifr.io`, `sifr.os`) — no CPython-shaped names. Re-ran both new demos: PASS.
+
+### No new blockers
+No CPython-shaped surfaces introduced; no signal-delivery overclaim; demo closure remains pending PR; M7 remains open/in progress; remaining gates remain open or pending; honest, scope-bounded record of the inherited clippy debt.
+
+## Conclusion
+The pass-1 soft gap is resolved. The slice is ready to open as a PR with the recorded validation block.

--- a/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
+++ b/verification/stdlib/concurrency_runtime_m7_closeout_traceability.md
@@ -17,7 +17,7 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 | Public docs for `sifr.resource` | closed | `docs/concurrency_runtime.md` documents `nullcontext(...)`, language cleanup under cancellation, and unsupported cleanup-stack/owned-closing helpers. |
 | Public docs for `sifr.ipc` | closed | `docs/concurrency_runtime.md` documents typed schema/frame substrate, payload eligibility diagnostics, version negotiation, process-pipe layering, unsupported CPython multiprocessing names, and `deferred-to-phase-X` worker APIs. |
 | Internal architecture docs | closed | `internal_docs/structured_runtime_work_model.md#m7-production-closure-audit` records the terminal M7 audit for task/process/channel/offload/runtime boundaries, typed IPC policy, blocking/offload policy, sendability/shareability, task/request context, diagnostics/signal global-state policy, and the rejected CPython-shaped surface index; `internal_docs/architecture.md` links to that audit from the concurrency safety contract. |
-| Required demos | partial | Existing demos include `demos/task_core_demo/main.sifr`, `demos/sync_channel_demo/main.sifr`, `demos/blocking_offload_demo/main.sifr`, `demos/structured_concurrency_demo/main.sifr`, and `demos/subprocess/main.sifr`. M7 must add or validate all required demos: structured task group, producer/consumer channel pipeline, blocking offload, CPU parallel map, async subprocess pipeline, structured shutdown, and cleanup under cancellation. |
+| Required demos | pending PR | Demo closure covers the required M7 demo topics: structured task group in `demos/structured_concurrency_demo/main.sifr`, producer/consumer channel pipeline in `demos/sync_channel_demo/main.sifr`, blocking offload in `demos/blocking_offload_demo/main.sifr`, CPU parallel map in `demos/parallel_map_demo/main.sifr`, and async subprocess pipeline, structured shutdown shape, and cleanup under cancellation in `demos/process_shutdown_cleanup_demo/main.sifr`. Existing `demos/task_core_demo/main.sifr` and `demos/subprocess/main.sifr` were revalidated as supporting coverage. |
 | Generated Cargo dependency snapshots | open | Add generated-project dependency evidence for the accepted feature combinations that pull runtime dependencies such as Tokio, Rayon, tracing, metrics, process support, signal support, and IPC serialization. |
 | Panic scan and emitted-code quality coverage | open | Extend or document generated-code quality coverage for task/channel/process/runtime paths. The existing Phase 34 gate and `verification/generated_code_quality/manifest.json` are active but do not yet record M7-specific closeout coverage for all concurrency paths. |
 | Validation lane manifests | partial | `verification/validation_lanes/create_pr_e2e_manifest.json` and `merge_e2e_manifest.json` already include representative task, sync, offload, process, signal, resource, runtime diagnostic, and IPC fixtures. M7 must audit coverage against every required demo and closeout gate. |
@@ -40,10 +40,10 @@ Status: Open. This M7 artifact is the closeout audit surface for docs, demos, va
 
 | Slice | Required output | Status |
 | --- | --- | --- |
-| Traceability scaffold | Create this artifact and record the M7 audit plan in the execution ledger. | in progress |
+| Traceability scaffold | Create this artifact and record the M7 audit plan in the execution ledger. | complete |
 | Public documentation | Add docs for all accepted production APIs and intentional divergences. | complete |
 | Internal architecture audit | Update architecture docs and rejected-surface index. | complete |
-| Demo closure | Add or validate the seven required demos and record commands. | pending |
+| Demo closure | Add or validate the seven required demos and record commands. | pending PR |
 | Generated dependency and panic-scan evidence | Add generated Cargo dependency snapshots and generated-code quality coverage for concurrency paths. | pending |
 | Validation lane and inventory closure | Audit manifests, platform golden entries, waivers, host-limited rows, workload database, CPython evidence matrix, and inventory. | pending |
 | Final review and merge gate | Run external review rounds until satisfied, then run `scripts/run_all_tests.sh` and close the phase. | pending |


### PR DESCRIPTION
## Summary
- Add M7 demo coverage for CPU parallel map and async process/shutdown/cleanup behavior.
- Revalidate existing task, channel, offload, structured-concurrency, and subprocess demos.
- Update M7 traceability and execution ledger with demo mapping, validation evidence, and two Opus PASS review rounds.

## Validation
- cargo run -q -p sifr -- run demos/parallel_map_demo/main.sifr
- cargo run -q -p sifr -- run demos/process_shutdown_cleanup_demo/main.sifr
- cargo run -q -p sifr -- run demos/task_core_demo/main.sifr
- cargo run -q -p sifr -- run demos/sync_channel_demo/main.sifr
- cargo run -q -p sifr -- run demos/blocking_offload_demo/main.sifr
- cargo run -q -p sifr -- run demos/structured_concurrency_demo/main.sifr
- cargo run -q -p sifr -- run demos/subprocess/main.sifr
- git diff --check
- python3 scripts/check_file_size_guardrails.py
- cargo fmt --check
- python3 scripts/check_hir_maintainability_guardrails.py
- cargo test -p sifr -- --skip test_e2e_pass
- scripts/run_all_tests.sh --profile create-pr (PASS; warm wall-time advisory; report_signature=50edc954137c87b4)

Known inherited validation debt:
- cargo clippy --workspace -- -D warnings fails on pre-existing sifr_codegen lints outside this demo slice; recorded in the execution ledger for the M7 quality cleanup slice.

## Review
- reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-1.md: PASS
- reviews/ad-hoc-production-concurrency-runtime-m7-demo-closure-review-pass-2.md: PASS
