### PR TITLE
Implement network HTTP M1 async TCP substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
 serde_test = { version = "1.0.177" }
 static_assertions = { version = "1.1.0" }
 toml = { version = "1.1.2" }
-tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }
+tokio = { version = "1.52.3", features = ["io-util", "macros", "net", "process", "rt", "signal", "sync", "time"] }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 unic-ucd-category = { version = "0.9" }
 unicode-ident = { version = "1.0.24" }

--- a/crates/sifr/tests/e2e/fail/network_http_m1_udp_deferred.sifr
+++ b/crates/sifr/tests/e2e/fail/network_http_m1_udp_deferred.sifr
@@ -1,0 +1,6 @@
+# expect-error[col=22]: SIFR-NAME-0004
+from sifr.net import UdpSocket
+
+
+def main() -> None:
+    _socket: UdpSocket

--- a/crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr
+++ b/crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr
@@ -1,0 +1,19 @@
+from sifr.net import NetError, TcpListener, listen_tcp
+
+
+async def wait_for_accept(own mut listener: TcpListener) -> None:
+    accepted = await listener.accept()
+    assert "Ok" in str(accepted)
+
+
+async def main() -> Result[None, ScopeFailure]:
+    async with task.scope() as scope:
+        try:
+            listener: TcpListener = await listen_tcp("127.0.0.1:0", reuse_addr=True)
+            handle = scope.spawn(wait_for_accept(listener))
+            handle.cancel()
+            result = await handle
+            assert "Cancelled" in str(result)
+        except NetError as e:
+            assert e.message == ""
+    return None

--- a/crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr
+++ b/crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr
@@ -1,0 +1,24 @@
+from sifr.net import (
+    NetError,
+    SocketAddr,
+    TcpListener,
+    TcpStream,
+    connect_tcp,
+    listen_tcp,
+    resolve_host,
+)
+
+
+async def main() -> None:
+    bad_connect: Result[TcpStream, NetError] = await connect_tcp(
+        "127.0.0.1:1", timeout=0.0
+    )
+    assert "network timeout must be finite and positive" in str(bad_connect)
+
+    bad_lookup = await resolve_host("localhost:80", timeout=0.0)
+    assert "network timeout must be finite and positive" in str(bad_lookup)
+
+    bad_backlog: Result[TcpListener, NetError] = await listen_tcp(
+        "127.0.0.1:0", backlog=0
+    )
+    assert "TCP listener backlog must be positive" in str(bad_backlog)

--- a/crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr
+++ b/crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr
@@ -1,0 +1,70 @@
+from sifr.net import (
+    NetError,
+    SocketAddr,
+    TcpListener,
+    TcpReadHalf,
+    TcpStream,
+    TcpWriteHalf,
+    connect_tcp,
+    listen_tcp,
+    resolve_host,
+)
+
+
+async def dns_smoke() -> None:
+    resolved = await resolve_host("localhost:80", timeout=2.0)
+    assert "Ok" in str(resolved)
+
+
+async def main() -> None:
+    try:
+        await dns_smoke()
+        listener: TcpListener = await listen_tcp("127.0.0.1:0", reuse_addr=True)
+        addr: SocketAddr = listener.local_addr()
+        assert "127.0.0.1:" in addr.value
+
+        client: TcpStream = await connect_tcp(addr.value, timeout=2.0)
+        accepted: tuple[TcpStream, SocketAddr] = await listener.accept()
+        _listener_closed: None = listener.close()
+        server: TcpStream = accepted[0]
+
+        local: SocketAddr = client.local_addr()
+        remote: SocketAddr = client.remote_addr()
+        assert len(local.value) > 0
+        assert remote.value == addr.value
+
+        client_halves: tuple[TcpReadHalf, TcpWriteHalf] = client.split()
+        client_reader: TcpReadHalf = client_halves[0]
+        client_writer: TcpWriteHalf = client_halves[1]
+        server_halves: tuple[TcpReadHalf, TcpWriteHalf] = server.split()
+        server_reader: TcpReadHalf = server_halves[0]
+        server_writer: TcpWriteHalf = server_halves[1]
+
+        _client_write: None = await client_writer.write_all(b"ping")
+        _client_shutdown: None = await client_writer.shutdown_write()
+        try:
+            _late_write: None = await client_writer.write_all(b"late")
+            assert False
+        except NetError as e:
+            assert "shut" in e.message
+
+        request: bytes | None = await server_reader.read_chunk(16)
+        assert request == b"ping"
+        _server_write: None = await server_writer.write_all(b"pong")
+        _server_shutdown: None = await server_writer.shutdown_write()
+
+        response: bytes | None = await client_reader.read_chunk(16)
+        assert response == b"pong"
+        _client_writer_closed: None = client_writer.close()
+        _client_reader_closed: None = client_reader.close()
+        _server_writer_closed: None = server_writer.close()
+        _server_reader_closed: None = server_reader.close()
+
+        timeout_rejected: bool = False
+        try:
+            _invalid: TcpStream = await connect_tcp(addr.value, timeout=-1.0)
+        except NetError as e:
+            timeout_rejected = "finite" in e.message or "positive" in e.message
+        assert timeout_rejected
+    except NetError as e:
+        assert e.message == ""

--- a/crates/sifr/tests/e2e_support/fixture_compilation.rs
+++ b/crates/sifr/tests/e2e_support/fixture_compilation.rs
@@ -6,7 +6,6 @@ const SERDE_JSON_DEP: &str =
     "serde_json = { version = \"1.0.149\", features = [\"preserve_order\"] }";
 const TRACING_DEP: &str =
     "tracing = { version = \"0.1.44\", default-features = false, features = [\"std\"] }";
-
 pub(crate) fn failure_matches_expectation(
     failure: &CompiledFailure,
     expectation: &CompileFailureExpectation,
@@ -341,6 +340,8 @@ pub(crate) fn generate_cargo_toml(
                 | "_sifr.unicode"
                 | "sifr.i18n"
                 | "_sifr.i18n"
+                | "sifr.net"
+                | "_sifr.net"
         )
     }) {
         deps.insert(sifr_runtime_dependency_spec_for_modules(stdlib_modules));
@@ -423,7 +424,7 @@ pub(crate) fn generate_cargo_toml(
                     .iter()
                     .any(|dependency| dependency.starts_with("sifr_runtime = "))
                 {
-                    deps.insert(sifr_runtime_dependency_spec());
+                    deps.insert(sifr_runtime_dependency_spec_with_features(&[]));
                 }
             }
             "tokio" => {
@@ -454,23 +455,21 @@ pub(crate) fn generate_cargo_toml(
     contents
 }
 
-pub(crate) fn sifr_runtime_dependency_spec() -> String {
-    sifr_runtime_dependency_spec_with_features(&[])
-}
-
 fn sifr_runtime_dependency_spec_for_modules(stdlib_modules: &BTreeSet<String>) -> String {
     let mut features = Vec::new();
-    if stdlib_modules
-        .iter()
-        .any(|module| matches!(module.as_str(), "sifr.i18n" | "_sifr.i18n"))
-    {
+    let has_module = |names: &[&str]| {
+        stdlib_modules
+            .iter()
+            .any(|module| names.contains(&module.as_str()))
+    };
+    if has_module(&["sifr.i18n", "_sifr.i18n"]) {
         features.push("i18n");
     }
-    if stdlib_modules
-        .iter()
-        .any(|module| matches!(module.as_str(), "sifr.unicode" | "_sifr.unicode"))
-    {
+    if has_module(&["sifr.unicode", "_sifr.unicode"]) {
         features.push("unicode");
+    }
+    if has_module(&["sifr.net", "_sifr.net"]) {
+        features.push("net");
     }
     sifr_runtime_dependency_spec_with_features(&features)
 }

--- a/crates/sifr_codegen/src/intrinsics/registry.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry.rs
@@ -17,6 +17,7 @@ mod io;
 mod json;
 mod logging;
 mod math;
+mod net;
 mod open_text_handles;
 mod os;
 mod pathlib;
@@ -73,6 +74,7 @@ pub(crate) fn additional_required_features(name: &str) -> &'static [StdlibFeatur
         | "process_output_text"
         | "process_shell_output_text" => &[StdlibFeature::EncodingRs],
         "runtime_emit_diagnostic" => &[StdlibFeature::Metrics, StdlibFeature::Tracing],
+        name if name.starts_with("net_") => &[StdlibFeature::SifrRuntime],
         "unicode_data_version"
         | "unicode_normalize"
         | "unicode_is_normalized"
@@ -701,6 +703,77 @@ pub(crate) fn lower_intrinsic_rendered(name: &str, args: &[RustExpr]) -> Option<
         "process_shell_output" => (process::lower_process_shell_output(args), None),
         "process_shell_output_text" => (process::lower_process_shell_output_text(args), None),
         "process_shell_output_timeout" => (process::lower_process_shell_output_timeout(args), None),
+        "net_connect_tcp" => (net::lower_net_connect_tcp(args), Some(StdlibFeature::Tokio)),
+        "net_listen_tcp" => (net::lower_net_listen_tcp(args), Some(StdlibFeature::Tokio)),
+        "net_lookup_host" => (net::lower_net_lookup_host(args), Some(StdlibFeature::Tokio)),
+        "net_listener_accept" => (
+            net::lower_net_listener_accept(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_listener_local_addr" => (
+            net::lower_net_listener_local_addr(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_listener_close" => (
+            net::lower_net_listener_close(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_read_chunk" => (
+            net::lower_net_tcp_stream_read_chunk(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_write" => (
+            net::lower_net_tcp_stream_write(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_write_all" => (
+            net::lower_net_tcp_stream_write_all(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_shutdown_write" => (
+            net::lower_net_tcp_stream_shutdown_write(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_split" => (
+            net::lower_net_tcp_stream_split(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_local_addr" => (
+            net::lower_net_tcp_stream_local_addr(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_peer_addr" => (
+            net::lower_net_tcp_stream_peer_addr(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_stream_close" => (
+            net::lower_net_tcp_stream_close(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_read_half_read_chunk" => (
+            net::lower_net_tcp_read_half_read_chunk(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_read_half_close" => (
+            net::lower_net_tcp_read_half_close(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_write_half_write" => (
+            net::lower_net_tcp_write_half_write(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_write_half_write_all" => (
+            net::lower_net_tcp_write_half_write_all(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_write_half_shutdown_write" => (
+            net::lower_net_tcp_write_half_shutdown_write(args),
+            Some(StdlibFeature::Tokio),
+        ),
+        "net_tcp_write_half_close" => (
+            net::lower_net_tcp_write_half_close(args),
+            Some(StdlibFeature::Tokio),
+        ),
         "signal_ctrl_c" => (
             signal::lower_signal_ctrl_c(args),
             Some(StdlibFeature::Tokio),

--- a/crates/sifr_codegen/src/intrinsics/registry/net.rs
+++ b/crates/sifr_codegen/src/intrinsics/registry/net.rs
@@ -1,0 +1,262 @@
+//! Async TCP network intrinsic lowerers.
+
+use crate::{RustExpr, RustStmt, RustType};
+
+fn arg_expr(args: &[RustExpr], idx: usize) -> RustExpr {
+    args[idx].clone()
+}
+
+fn path_call(parts: &[&str], args: Vec<RustExpr>) -> RustExpr {
+    RustExpr::FnCall {
+        func: Box::new(RustExpr::Path(
+            parts.iter().map(|part| (*part).to_string()).collect(),
+        )),
+        args,
+    }
+}
+
+fn send_awaitable_type(output: &str) -> RustType {
+    RustType::Named(format!(
+        "std::pin::Pin<Box<dyn std::future::Future<Output = {output}> + Send>>"
+    ))
+}
+
+fn boxed_async_net_helper_call(name: &str, args: Vec<RustExpr>, output: &str) -> RustExpr {
+    RustExpr::Block {
+        stmts: vec![RustStmt::Let {
+            mutable: false,
+            name: "__sifr_net_future".to_string(),
+            ty: Some(send_awaitable_type(output)),
+            value: path_call(&["Box", "pin"], vec![path_call(&[name], args)]),
+        }],
+        expr: Some(Box::new(RustExpr::Ident("__sifr_net_future".to_string()))),
+    }
+}
+
+fn cloned_arg(args: &[RustExpr], idx: usize) -> RustExpr {
+    RustExpr::Clone(Box::new(arg_expr(args, idx)))
+}
+
+pub(crate) fn lower_net_connect_tcp(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 5 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_connect_tcp",
+        vec![
+            cloned_arg(args, 0),
+            arg_expr(args, 1),
+            arg_expr(args, 2),
+            cloned_arg(args, 3),
+            arg_expr(args, 4),
+        ],
+        "Result<TcpStream, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_listen_tcp(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 4 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_listen_tcp",
+        vec![
+            cloned_arg(args, 0),
+            arg_expr(args, 1),
+            arg_expr(args, 2),
+            arg_expr(args, 3),
+        ],
+        "Result<TcpListener, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_lookup_host(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 3 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_lookup_host",
+        vec![cloned_arg(args, 0), arg_expr(args, 1), arg_expr(args, 2)],
+        "Result<Vec<SocketAddr>, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_listener_accept(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_listener_accept",
+        vec![arg_expr(args, 0)],
+        "Result<(TcpStream, SocketAddr), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_listener_local_addr(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_listener_local_addr"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_listener_close(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_listener_close"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_read_chunk(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_stream_read_chunk",
+        vec![arg_expr(args, 0), arg_expr(args, 1)],
+        "Result<Option<Vec<u8>>, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_write(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_stream_write",
+        vec![arg_expr(args, 0), cloned_arg(args, 1)],
+        "Result<i64, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_write_all(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_stream_write_all",
+        vec![arg_expr(args, 0), cloned_arg(args, 1)],
+        "Result<(), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_shutdown_write(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_stream_shutdown_write",
+        vec![arg_expr(args, 0)],
+        "Result<(), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_split(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_tcp_stream_split"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_local_addr(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_tcp_stream_local_addr"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_peer_addr(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_tcp_stream_peer_addr"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_tcp_stream_close(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_stream_close",
+        vec![arg_expr(args, 0)],
+        "Result<(), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_read_half_read_chunk(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_read_half_read_chunk",
+        vec![arg_expr(args, 0), arg_expr(args, 1)],
+        "Result<Option<Vec<u8>>, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_read_half_close(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_tcp_read_half_close"],
+        vec![arg_expr(args, 0)],
+    ))
+}
+
+pub(crate) fn lower_net_tcp_write_half_write(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_write_half_write",
+        vec![arg_expr(args, 0), cloned_arg(args, 1)],
+        "Result<i64, NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_write_half_write_all(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 2 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_write_half_write_all",
+        vec![arg_expr(args, 0), cloned_arg(args, 1)],
+        "Result<(), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_write_half_shutdown_write(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(boxed_async_net_helper_call(
+        "__sifr_net_tcp_write_half_shutdown_write",
+        vec![arg_expr(args, 0)],
+        "Result<(), NetError>",
+    ))
+}
+
+pub(crate) fn lower_net_tcp_write_half_close(args: &[RustExpr]) -> Option<RustExpr> {
+    if args.len() != 1 {
+        return None;
+    }
+    Some(path_call(
+        &["__sifr_net_tcp_write_half_close"],
+        vec![arg_expr(args, 0)],
+    ))
+}

--- a/crates/sifr_codegen/src/lib_modules_and_codegen.rs
+++ b/crates/sifr_codegen/src/lib_modules_and_codegen.rs
@@ -3,11 +3,12 @@ use super::{
     build_async_generator_type_items, build_cancellation_error_type_items, build_cpu_offload_items,
     build_error_into_error_impl, build_error_type_items, build_failure_type_items,
     build_file_handle_infra_items, build_file_handle_struct_items, build_io_error_items,
-    build_join_set_cpu_items, build_join_set_items, build_logging_items, build_process_async_items,
-    build_process_child_items, build_process_status_items, build_random_module_state_items,
-    build_task_context_scope_extension_items, build_task_current_context_items,
-    build_task_scope_cpu_offload_items, build_task_scope_items, build_task_scope_offload_items,
-    build_task_scope_process_items, build_timeout_result_type_items, build_worker_panic_hook_items,
+    build_join_set_cpu_items, build_join_set_items, build_logging_items, build_net_runtime_items,
+    build_process_async_items, build_process_child_items, build_process_status_items,
+    build_random_module_state_items, build_task_context_scope_extension_items,
+    build_task_current_context_items, build_task_scope_cpu_offload_items, build_task_scope_items,
+    build_task_scope_offload_items, build_task_scope_process_items,
+    build_timeout_result_type_items, build_worker_panic_hook_items,
     module_uses_async_exit_cause_type, module_uses_async_generator_type,
     module_uses_cancellation_error_type, module_uses_failure_type, module_uses_join_set,
     module_uses_join_set_spawn_cpu, module_uses_spawn_cpu, module_uses_task_scope,
@@ -459,6 +460,13 @@ pub fn generate_rust_with_stdlib_for_module(
         || emitter.used_stdlib_modules.contains("_sifr.logging")
         || emitter.runtime_needs.logging_state();
     let needs_random_module_state = emitter.runtime_needs.random_module_state();
+    let stdlib_emits_net_runtime = stdlib_preamble.contains("fn __sifr_net_error");
+    let needs_net_runtime = !stdlib_emits_net_runtime
+        && (stdlib_preamble.contains("__sifr_net_")
+            || emitter
+                .intrinsic_functions
+                .iter()
+                .any(|function| function.starts_with("net_")));
 
     // Emit built-in error class struct definitions for referenced error types.
     let uses_task_scope = module_uses_task_scope(module);
@@ -635,6 +643,9 @@ pub fn generate_rust_with_stdlib_for_module(
             ..stdlib_needs_process_async
         };
         preamble_items.extend(build_process_async_items(process_async_preamble_needs));
+    }
+    if needs_net_runtime {
+        preamble_items.extend(build_net_runtime_items());
     }
     if needs_process_children {
         preamble_items.extend(build_process_child_items());

--- a/crates/sifr_codegen/src/preamble.rs
+++ b/crates/sifr_codegen/src/preamble.rs
@@ -14,6 +14,8 @@ mod cpu_offload_runtime;
 pub use cpu_offload_runtime::*;
 mod join_set_runtime;
 pub use join_set_runtime::*;
+mod net_runtime;
+pub(crate) use net_runtime::*;
 mod parallel_runtime;
 pub(crate) use parallel_runtime::*;
 mod process_async_child_runtime;

--- a/crates/sifr_codegen/src/preamble/net_runtime.rs
+++ b/crates/sifr_codegen/src/preamble/net_runtime.rs
@@ -1,0 +1,151 @@
+//! Runtime-backed generated async network helpers.
+
+use crate::RustItem;
+
+const NET_RUNTIME: &str = r#"
+fn __sifr_net_error(message: String) -> NetError {
+    NetError { message }
+}
+
+async fn __sifr_net_connect_tcp(
+    address: String,
+    timeout_seconds: f64,
+    has_timeout: bool,
+    local_addr: String,
+    has_local_addr: bool,
+) -> Result<TcpStream, NetError> {
+    sifr_runtime::net::connect_tcp(
+        address,
+        timeout_seconds,
+        has_timeout,
+        local_addr,
+        has_local_addr,
+    )
+    .await
+    .map(TcpStream::new)
+    .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_listen_tcp(
+    address: String,
+    backlog: i64,
+    has_backlog: bool,
+    reuse_addr: bool,
+) -> Result<TcpListener, NetError> {
+    sifr_runtime::net::listen_tcp(address, backlog, has_backlog, reuse_addr)
+        .await
+        .map(TcpListener::new)
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_lookup_host(
+    address: String,
+    timeout_seconds: f64,
+    has_timeout: bool,
+) -> Result<Vec<SocketAddr>, NetError> {
+    sifr_runtime::net::resolve_host(address, timeout_seconds, has_timeout)
+        .await
+        .map(|addrs| addrs.into_iter().map(SocketAddr::new).collect())
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_listener_accept(handle: i64) -> Result<(TcpStream, SocketAddr), NetError> {
+    sifr_runtime::net::accept_tcp(handle)
+        .await
+        .map(|(stream, addr)| (TcpStream::new(stream), SocketAddr::new(addr)))
+        .map_err(__sifr_net_error)
+}
+
+fn __sifr_net_listener_local_addr(handle: i64) -> Result<String, NetError> {
+    sifr_runtime::net::tcp_listener_local_addr(handle).map_err(__sifr_net_error)
+}
+
+fn __sifr_net_listener_close(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::close_tcp_listener(handle).map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_stream_read_chunk(
+    handle: i64,
+    max_bytes: i64,
+) -> Result<Option<Vec<u8>>, NetError> {
+    sifr_runtime::net::tcp_stream_read_chunk(handle, max_bytes)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_stream_write(handle: i64, data: Vec<u8>) -> Result<i64, NetError> {
+    sifr_runtime::net::tcp_stream_write(handle, data)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_stream_write_all(handle: i64, data: Vec<u8>) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_stream_write_all(handle, data)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_stream_shutdown_write(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_stream_shutdown_write(handle)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_stream_close(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_stream_close(handle)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+fn __sifr_net_tcp_stream_split(handle: i64) -> (TcpReadHalf, TcpWriteHalf) {
+    let (read, write) = sifr_runtime::net::tcp_stream_split(handle);
+    (TcpReadHalf::new(read), TcpWriteHalf::new(write))
+}
+
+fn __sifr_net_tcp_stream_local_addr(handle: i64) -> Result<String, NetError> {
+    sifr_runtime::net::tcp_stream_local_addr(handle).map_err(__sifr_net_error)
+}
+
+fn __sifr_net_tcp_stream_peer_addr(handle: i64) -> Result<String, NetError> {
+    sifr_runtime::net::tcp_stream_remote_addr(handle).map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_read_half_read_chunk(
+    handle: i64,
+    max_bytes: i64,
+) -> Result<Option<Vec<u8>>, NetError> {
+    sifr_runtime::net::tcp_read_half_read_chunk(handle, max_bytes)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+fn __sifr_net_tcp_read_half_close(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_read_half_close(handle).map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_write_half_write(handle: i64, data: Vec<u8>) -> Result<i64, NetError> {
+    sifr_runtime::net::tcp_write_half_write(handle, data)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_write_half_write_all(handle: i64, data: Vec<u8>) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_write_half_write_all(handle, data)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+async fn __sifr_net_tcp_write_half_shutdown_write(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_write_half_shutdown_write(handle)
+        .await
+        .map_err(__sifr_net_error)
+}
+
+fn __sifr_net_tcp_write_half_close(handle: i64) -> Result<(), NetError> {
+    sifr_runtime::net::tcp_write_half_close(handle).map_err(__sifr_net_error)
+}
+"#;
+
+pub(crate) fn build_net_runtime_items() -> Vec<RustItem> {
+    vec![RustItem::Attr(NET_RUNTIME.to_string())]
+}

--- a/crates/sifr_runtime/Cargo.toml
+++ b/crates/sifr_runtime/Cargo.toml
@@ -15,6 +15,7 @@ icu_locale = { workspace = true, optional = true }
 icu_plurals = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+tokio = { workspace = true, optional = true }
 unicode-normalization = { workspace = true, optional = true }
 unicode-segmentation = { workspace = true, optional = true }
 unicode_names2 = { workspace = true, optional = true }
@@ -29,6 +30,7 @@ i18n = [
     "dep:icu_plurals",
 ]
 unicode = ["dep:unicode-normalization", "dep:unicode-segmentation", "dep:unicode_names2"]
+net = ["dep:tokio"]
 
 [lints]
 workspace = true

--- a/crates/sifr_runtime/src/lib.rs
+++ b/crates/sifr_runtime/src/lib.rs
@@ -6,6 +6,8 @@ pub mod encoding;
 pub mod i18n;
 mod int;
 pub mod json;
+#[cfg(feature = "net")]
+pub mod net;
 #[cfg(feature = "unicode")]
 pub mod unicode;
 #[cfg(feature = "unicode")]

--- a/crates/sifr_runtime/src/net.rs
+++ b/crates/sifr_runtime/src/net.rs
@@ -1,0 +1,495 @@
+//! Async network runtime support for generated Sifr programs.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc, LazyLock, Mutex, MutexGuard,
+};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{lookup_host, TcpListener, TcpSocket, TcpStream};
+
+const DEFAULT_BACKLOG: u32 = 1024;
+const MAX_READ_BYTES: i64 = 1_048_576;
+
+type SharedListener = Arc<TcpListener>;
+type SharedReadHalf = Arc<tokio::sync::Mutex<OwnedReadHalf>>;
+type SharedWriteHalf = Arc<tokio::sync::Mutex<OwnedWriteHalf>>;
+
+#[derive(Clone)]
+struct AddressPair {
+    local: String,
+    remote: String,
+}
+
+static NEXT_HANDLE: AtomicI64 = AtomicI64::new(1);
+static STREAMS: LazyLock<Mutex<HashMap<i64, TcpStream>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static LISTENERS: LazyLock<Mutex<HashMap<i64, SharedListener>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static READ_HALVES: LazyLock<Mutex<HashMap<i64, SharedReadHalf>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static WRITE_HALVES: LazyLock<Mutex<HashMap<i64, SharedWriteHalf>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static STREAM_ADDRS: LazyLock<Mutex<HashMap<i64, AddressPair>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static LISTENER_LOCAL_ADDRS: LazyLock<Mutex<HashMap<i64, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static WRITE_SHUTDOWN: LazyLock<Mutex<HashSet<i64>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn next_handle() -> Result<i64, String> {
+    loop {
+        let current = NEXT_HANDLE.load(Ordering::Relaxed);
+        if current == i64::MAX {
+            return Err("network handle table is exhausted".to_string());
+        }
+        if NEXT_HANDLE
+            .compare_exchange(current, current + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return Ok(current);
+        }
+    }
+}
+
+fn next_handle_infallible() -> i64 {
+    loop {
+        let current = NEXT_HANDLE.load(Ordering::Relaxed);
+        let next = if current == i64::MAX { 1 } else { current + 1 };
+        if NEXT_HANDLE
+            .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+            && current > 0
+        {
+            return current;
+        }
+    }
+}
+
+fn timeout_duration(seconds: f64) -> Result<Duration, String> {
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return Err("network timeout must be finite and positive".to_string());
+    }
+    Ok(Duration::from_secs_f64(seconds))
+}
+
+async fn with_optional_timeout<T, F>(
+    operation: F,
+    seconds: f64,
+    has_timeout: bool,
+    name: &str,
+) -> Result<T, String>
+where
+    F: Future<Output = Result<T, String>>,
+{
+    if !has_timeout {
+        return operation.await;
+    }
+    match tokio::time::timeout(timeout_duration(seconds)?, operation).await {
+        Ok(result) => result,
+        Err(_) => Err(format!("{name} timed out")),
+    }
+}
+
+async fn resolve_socket_addrs(address: &str) -> Result<Vec<SocketAddr>, String> {
+    let addrs: Vec<SocketAddr> = lookup_host(address)
+        .await
+        .map_err(|error| format!("failed to resolve address {address}: {error}"))?
+        .collect();
+    if addrs.is_empty() {
+        return Err(format!("address {address} resolved to no socket addresses"));
+    }
+    Ok(addrs)
+}
+
+fn insert_stream(stream: TcpStream) -> Result<i64, String> {
+    let local = stream
+        .local_addr()
+        .map_err(|error| format!("failed to inspect local address: {error}"))?
+        .to_string();
+    let remote = stream
+        .peer_addr()
+        .map_err(|error| format!("failed to inspect remote address: {error}"))?
+        .to_string();
+    let handle = next_handle()?;
+    lock(&STREAMS).insert(handle, stream);
+    lock(&STREAM_ADDRS).insert(handle, AddressPair { local, remote });
+    Ok(handle)
+}
+
+async fn connect_with_local_addr(address: String, local_addr: String) -> Result<TcpStream, String> {
+    let remote_addrs = resolve_socket_addrs(&address).await?;
+    let local: SocketAddr = local_addr
+        .parse()
+        .map_err(|error| format!("invalid local address {local_addr}: {error}"))?;
+    let mut last_error = None;
+    for remote in remote_addrs {
+        let socket = if remote.is_ipv4() {
+            TcpSocket::new_v4()
+        } else {
+            TcpSocket::new_v6()
+        }
+        .map_err(|error| format!("failed to create TCP socket: {error}"))?;
+        if local.is_ipv4() != remote.is_ipv4() {
+            last_error = Some(format!(
+                "local address {local} and remote address {remote} use different address families"
+            ));
+            continue;
+        }
+        if let Err(error) = socket.bind(local) {
+            last_error = Some(format!("failed to bind local address {local}: {error}"));
+            continue;
+        }
+        match socket.connect(remote).await {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last_error = Some(format!("failed to connect to {remote}: {error}")),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| format!("failed to connect to {address}")))
+}
+
+async fn connect_operation(
+    address: String,
+    local_addr: String,
+    has_local_addr: bool,
+) -> Result<i64, String> {
+    let stream = if has_local_addr {
+        connect_with_local_addr(address, local_addr).await?
+    } else {
+        TcpStream::connect(address.as_str())
+            .await
+            .map_err(|error| format!("failed to connect to {address}: {error}"))?
+    };
+    stream
+        .set_nodelay(true)
+        .map_err(|error| format!("failed to configure TCP stream: {error}"))?;
+    insert_stream(stream)
+}
+
+pub async fn connect_tcp(
+    address: String,
+    timeout_seconds: f64,
+    has_timeout: bool,
+    local_addr: String,
+    has_local_addr: bool,
+) -> Result<i64, String> {
+    with_optional_timeout(
+        connect_operation(address, local_addr, has_local_addr),
+        timeout_seconds,
+        has_timeout,
+        "TCP connect",
+    )
+    .await
+}
+
+async fn listen_operation(
+    address: String,
+    backlog: i64,
+    has_backlog: bool,
+    reuse_addr: bool,
+) -> Result<i64, String> {
+    let addrs = resolve_socket_addrs(&address).await?;
+    let bind_addr = addrs[0];
+    let socket = if bind_addr.is_ipv4() {
+        TcpSocket::new_v4()
+    } else {
+        TcpSocket::new_v6()
+    }
+    .map_err(|error| format!("failed to create TCP listener socket: {error}"))?;
+    if reuse_addr {
+        socket
+            .set_reuseaddr(true)
+            .map_err(|error| format!("failed to set SO_REUSEADDR: {error}"))?;
+    }
+    socket
+        .bind(bind_addr)
+        .map_err(|error| format!("failed to bind TCP listener {bind_addr}: {error}"))?;
+    let backlog = if has_backlog {
+        if backlog <= 0 || backlog > i64::from(u32::MAX) {
+            return Err("TCP listener backlog must be positive and fit in u32".to_string());
+        }
+        u32::try_from(backlog).map_err(|error| format!("invalid TCP backlog: {error}"))?
+    } else {
+        DEFAULT_BACKLOG
+    };
+    let listener = socket
+        .listen(backlog)
+        .map_err(|error| format!("failed to listen on {bind_addr}: {error}"))?;
+    let local = listener
+        .local_addr()
+        .map_err(|error| format!("failed to inspect listener address: {error}"))?
+        .to_string();
+    let handle = next_handle()?;
+    lock(&LISTENERS).insert(handle, Arc::new(listener));
+    lock(&LISTENER_LOCAL_ADDRS).insert(handle, local);
+    Ok(handle)
+}
+
+pub async fn listen_tcp(
+    address: String,
+    backlog: i64,
+    has_backlog: bool,
+    reuse_addr: bool,
+) -> Result<i64, String> {
+    listen_operation(address, backlog, has_backlog, reuse_addr).await
+}
+
+pub async fn accept_tcp(handle: i64) -> Result<(i64, String), String> {
+    let listener = lock(&LISTENERS)
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| format!("TCP listener handle is closed or unknown: {handle}"))?;
+    let (stream, remote) = listener
+        .accept()
+        .await
+        .map_err(|error| format!("failed to accept TCP connection: {error}"))?;
+    let stream_handle = insert_stream(stream)?;
+    Ok((stream_handle, remote.to_string()))
+}
+
+pub fn tcp_listener_local_addr(handle: i64) -> Result<String, String> {
+    lock(&LISTENER_LOCAL_ADDRS)
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| format!("TCP listener handle is closed or unknown: {handle}"))
+}
+
+pub fn close_tcp_listener(handle: i64) -> Result<(), String> {
+    let removed = lock(&LISTENERS).remove(&handle);
+    lock(&LISTENER_LOCAL_ADDRS).remove(&handle);
+    removed
+        .map(|_| ())
+        .ok_or_else(|| format!("TCP listener handle is closed or unknown: {handle}"))
+}
+
+fn take_stream(handle: i64) -> Result<TcpStream, String> {
+    lock(&STREAMS)
+        .remove(&handle)
+        .ok_or_else(|| format!("TCP stream handle is closed or unknown: {handle}"))
+}
+
+fn restore_stream(handle: i64, stream: TcpStream) {
+    lock(&STREAMS).insert(handle, stream);
+}
+
+fn ensure_write_open(handle: i64) -> Result<(), String> {
+    if lock(&WRITE_SHUTDOWN).contains(&handle) {
+        return Err("TCP write side is already shut down".to_string());
+    }
+    Ok(())
+}
+
+fn validate_read_size(max_bytes: i64) -> Result<usize, String> {
+    if max_bytes <= 0 {
+        return Err("TCP read size must be positive".to_string());
+    }
+    if max_bytes > MAX_READ_BYTES {
+        return Err(format!("TCP read size exceeds {MAX_READ_BYTES} bytes"));
+    }
+    usize::try_from(max_bytes).map_err(|error| format!("invalid TCP read size: {error}"))
+}
+
+pub async fn tcp_stream_read_chunk(handle: i64, max_bytes: i64) -> Result<Option<Vec<u8>>, String> {
+    let mut buf = vec![0_u8; validate_read_size(max_bytes)?];
+    let mut stream = take_stream(handle)?;
+    let read = match stream.read(&mut buf).await {
+        Ok(read) => read,
+        Err(error) => {
+            restore_stream(handle, stream);
+            return Err(format!("failed to read TCP stream: {error}"));
+        }
+    };
+    restore_stream(handle, stream);
+    if read == 0 {
+        return Ok(None);
+    }
+    buf.truncate(read);
+    Ok(Some(buf))
+}
+
+pub async fn tcp_stream_write(handle: i64, data: Vec<u8>) -> Result<i64, String> {
+    ensure_write_open(handle)?;
+    let mut stream = take_stream(handle)?;
+    let written = match stream.write(&data).await {
+        Ok(written) => written,
+        Err(error) => {
+            restore_stream(handle, stream);
+            return Err(format!("failed to write TCP stream: {error}"));
+        }
+    };
+    restore_stream(handle, stream);
+    i64::try_from(written).map_err(|error| format!("invalid TCP write count: {error}"))
+}
+
+pub async fn tcp_stream_write_all(handle: i64, data: Vec<u8>) -> Result<(), String> {
+    ensure_write_open(handle)?;
+    let mut stream = take_stream(handle)?;
+    let result = stream
+        .write_all(&data)
+        .await
+        .map_err(|error| format!("failed to write TCP stream: {error}"));
+    restore_stream(handle, stream);
+    result
+}
+
+pub async fn tcp_stream_shutdown_write(handle: i64) -> Result<(), String> {
+    if lock(&WRITE_SHUTDOWN).contains(&handle) {
+        return Ok(());
+    }
+    let mut stream = take_stream(handle)?;
+    let result = stream
+        .shutdown()
+        .await
+        .map_err(|error| format!("failed to shut down TCP write side: {error}"));
+    restore_stream(handle, stream);
+    result?;
+    lock(&WRITE_SHUTDOWN).insert(handle);
+    Ok(())
+}
+
+pub async fn tcp_stream_close(handle: i64) -> Result<(), String> {
+    let removed = lock(&STREAMS).remove(&handle);
+    lock(&STREAM_ADDRS).remove(&handle);
+    lock(&WRITE_SHUTDOWN).remove(&handle);
+    removed
+        .map(|_| ())
+        .ok_or_else(|| format!("TCP stream handle is closed or unknown: {handle}"))
+}
+
+pub fn tcp_stream_split(handle: i64) -> (i64, i64) {
+    let read_handle = next_handle_infallible();
+    let write_handle = next_handle_infallible();
+    let Some(stream) = lock(&STREAMS).remove(&handle) else {
+        return (read_handle, write_handle);
+    };
+    lock(&STREAM_ADDRS).remove(&handle);
+    let was_shutdown = lock(&WRITE_SHUTDOWN).remove(&handle);
+    let (read_half, write_half) = stream.into_split();
+    lock(&READ_HALVES).insert(read_handle, Arc::new(tokio::sync::Mutex::new(read_half)));
+    lock(&WRITE_HALVES).insert(write_handle, Arc::new(tokio::sync::Mutex::new(write_half)));
+    if was_shutdown {
+        lock(&WRITE_SHUTDOWN).insert(write_handle);
+    }
+    (read_handle, write_handle)
+}
+
+pub fn tcp_stream_local_addr(handle: i64) -> Result<String, String> {
+    lock(&STREAM_ADDRS)
+        .get(&handle)
+        .map(|addr| addr.local.clone())
+        .ok_or_else(|| format!("TCP stream handle is closed or unknown: {handle}"))
+}
+
+pub fn tcp_stream_remote_addr(handle: i64) -> Result<String, String> {
+    lock(&STREAM_ADDRS)
+        .get(&handle)
+        .map(|addr| addr.remote.clone())
+        .ok_or_else(|| format!("TCP stream handle is closed or unknown: {handle}"))
+}
+
+pub async fn tcp_read_half_read_chunk(
+    handle: i64,
+    max_bytes: i64,
+) -> Result<Option<Vec<u8>>, String> {
+    let reader = lock(&READ_HALVES)
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| format!("TCP read half handle is closed or unknown: {handle}"))?;
+    let mut guard = reader.lock().await;
+    let mut buf = vec![0_u8; validate_read_size(max_bytes)?];
+    let read = guard
+        .read(&mut buf)
+        .await
+        .map_err(|error| format!("failed to read TCP read half: {error}"))?;
+    if read == 0 {
+        return Ok(None);
+    }
+    buf.truncate(read);
+    Ok(Some(buf))
+}
+
+pub fn tcp_read_half_close(handle: i64) -> Result<(), String> {
+    lock(&READ_HALVES)
+        .remove(&handle)
+        .map(|_| ())
+        .ok_or_else(|| format!("TCP read half handle is closed or unknown: {handle}"))
+}
+
+fn write_half_handle(handle: i64) -> Result<SharedWriteHalf, String> {
+    lock(&WRITE_HALVES)
+        .get(&handle)
+        .cloned()
+        .ok_or_else(|| format!("TCP write half handle is closed or unknown: {handle}"))
+}
+
+pub async fn tcp_write_half_write(handle: i64, data: Vec<u8>) -> Result<i64, String> {
+    ensure_write_open(handle)?;
+    let writer = write_half_handle(handle)?;
+    let mut guard = writer.lock().await;
+    let written = guard
+        .write(&data)
+        .await
+        .map_err(|error| format!("failed to write TCP write half: {error}"))?;
+    i64::try_from(written).map_err(|error| format!("invalid TCP write count: {error}"))
+}
+
+pub async fn tcp_write_half_write_all(handle: i64, data: Vec<u8>) -> Result<(), String> {
+    ensure_write_open(handle)?;
+    let writer = write_half_handle(handle)?;
+    let mut guard = writer.lock().await;
+    guard
+        .write_all(&data)
+        .await
+        .map_err(|error| format!("failed to write TCP write half: {error}"))
+}
+
+pub async fn tcp_write_half_shutdown_write(handle: i64) -> Result<(), String> {
+    if lock(&WRITE_SHUTDOWN).contains(&handle) {
+        return Ok(());
+    }
+    let writer = write_half_handle(handle)?;
+    let mut guard = writer.lock().await;
+    guard
+        .shutdown()
+        .await
+        .map_err(|error| format!("failed to shut down TCP write half: {error}"))?;
+    lock(&WRITE_SHUTDOWN).insert(handle);
+    Ok(())
+}
+
+pub fn tcp_write_half_close(handle: i64) -> Result<(), String> {
+    let removed = lock(&WRITE_HALVES).remove(&handle);
+    lock(&WRITE_SHUTDOWN).remove(&handle);
+    removed
+        .map(|_| ())
+        .ok_or_else(|| format!("TCP write half handle is closed or unknown: {handle}"))
+}
+
+pub async fn resolve_host(
+    address: String,
+    timeout_seconds: f64,
+    has_timeout: bool,
+) -> Result<Vec<String>, String> {
+    with_optional_timeout(
+        async move {
+            resolve_socket_addrs(&address)
+                .await
+                .map(|addrs| addrs.into_iter().map(|addr| addr.to_string()).collect())
+        },
+        timeout_seconds,
+        has_timeout,
+        "DNS resolution",
+    )
+    .await
+}

--- a/crates/sifr_stdlib/src/features.rs
+++ b/crates/sifr_stdlib/src/features.rs
@@ -450,6 +450,11 @@ pub fn features_for_stdlib_module(module_name: &str) -> &'static [StdlibFeature]
         ],
         "sifr.base64" => &[StdlibFeature::Base64],
         "sifr.ipc" | "_sifr.ipc" => &[StdlibFeature::Ipc],
+        "sifr.net" | "_sifr.net" => &[
+            StdlibFeature::SifrRuntime,
+            StdlibFeature::Tokio,
+            StdlibFeature::Tracing,
+        ],
         "sifr.parallel" => &[StdlibFeature::Rayon],
         "sifr.runtime" | "_sifr.runtime" => &[StdlibFeature::Metrics, StdlibFeature::Tracing],
         "sifr.tomllib" | "_sifr.toml" => &[StdlibFeature::Toml],
@@ -491,6 +496,7 @@ pub fn generated_cargo_dependencies(
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct RuntimeFeatures {
     i18n: bool,
+    net: bool,
     unicode: bool,
 }
 
@@ -501,9 +507,16 @@ impl RuntimeFeatures {
     ) -> Self {
         Self {
             i18n: needs_sifr_runtime_i18n(stdlib_modules, required_features),
+            net: needs_sifr_runtime_net(stdlib_modules),
             unicode: needs_sifr_runtime_unicode(stdlib_modules, required_features),
         }
     }
+}
+
+fn needs_sifr_runtime_net(stdlib_modules: &HashSet<String>) -> bool {
+    stdlib_modules
+        .iter()
+        .any(|module| matches!(module.as_str(), "sifr.net" | "_sifr.net"))
 }
 
 fn needs_sifr_runtime_i18n(
@@ -557,7 +570,19 @@ fn render_dependency_spec(
     if dependency.package == "sifr_runtime" {
         return sifr_runtime_dependency_spec(runtime_features);
     }
+    if dependency.package == "tokio" {
+        return tokio_dependency_spec(runtime_features);
+    }
     dependency.spec.to_string()
+}
+
+fn tokio_dependency_spec(runtime_features: RuntimeFeatures) -> String {
+    let features = if runtime_features.net {
+        "\"io-util\", \"macros\", \"net\", \"process\", \"rt\", \"signal\", \"sync\", \"time\""
+    } else {
+        "\"io-util\", \"macros\", \"process\", \"rt\", \"signal\", \"sync\", \"time\""
+    };
+    format!("tokio = {{ version = \"1.52.3\", features = [{features}] }}")
 }
 
 fn sifr_runtime_dependency_spec(runtime_features: RuntimeFeatures) -> String {
@@ -569,6 +594,9 @@ fn sifr_runtime_dependency_spec(runtime_features: RuntimeFeatures) -> String {
     let mut features = Vec::new();
     if runtime_features.i18n {
         features.push("\"i18n\"");
+    }
+    if runtime_features.net {
+        features.push("\"net\"");
     }
     if runtime_features.unicode {
         features.push("\"unicode\"");
@@ -625,25 +653,6 @@ fn compile_time_sifr_runtime_path() -> PathBuf {
 mod tests {
     use super::{feature_for_codegen_requirement, generated_cargo_dependencies, StdlibFeature};
     use std::collections::HashSet;
-
-    fn normalize_runtime_dependency(dependency: &str) -> String {
-        if dependency.starts_with("sifr_runtime = ") {
-            if dependency.contains("features = [\"i18n\", \"unicode\"]") {
-                return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }"
-                    .to_string();
-            }
-            if dependency.contains("features = [\"i18n\"]") {
-                return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }"
-                    .to_string();
-            }
-            if dependency.contains("features = [\"unicode\"]") {
-                return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }"
-                    .to_string();
-            }
-            return "sifr_runtime = { path = \"<sifr_runtime_path>\" }".to_string();
-        }
-        dependency.to_string()
-    }
 
     #[test]
     fn stdlib_module_dependencies_are_deterministic_and_deduplicated() {
@@ -779,116 +788,5 @@ mod tests {
 
         assert!(deps.iter().any(|dep| dep.starts_with("sifr_runtime = ")
             && dep.contains("features = [\"i18n\", \"unicode\"]")));
-    }
-
-    #[test]
-    fn text_i18n_feature_dependency_snapshots_cover_phase_combinations() {
-        let cases = [
-            (
-                "encoding",
-                HashSet::from(["sifr.encoding".to_string()]),
-                HashSet::new(),
-                vec![
-                    "encoding_rs = \"0.8.35\"",
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\" }",
-                ],
-            ),
-            (
-                "unicode",
-                HashSet::from(["sifr.unicode".to_string()]),
-                HashSet::new(),
-                vec![
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }",
-                    "unicode_names2 = \"3.1.0\"",
-                    "unicode-normalization = \"0.1.25\"",
-                    "unicode-segmentation = \"1.13.3\"",
-                ],
-            ),
-            (
-                "i18n",
-                HashSet::from(["sifr.i18n".to_string()]),
-                HashSet::new(),
-                vec![
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }",
-                    "icu_collator = \"2.2.0\"",
-                    "icu_datetime = \"2.2.0\"",
-                    "icu_decimal = \"2.2.0\"",
-                    "icu_locale = \"2.2.0\"",
-                    "icu_plurals = \"2.2.0\"",
-                ],
-            ),
-            (
-                "encoding-and-unicode",
-                HashSet::from(["sifr.encoding".to_string(), "sifr.unicode".to_string()]),
-                HashSet::new(),
-                vec![
-                    "encoding_rs = \"0.8.35\"",
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }",
-                    "unicode_names2 = \"3.1.0\"",
-                    "unicode-normalization = \"0.1.25\"",
-                    "unicode-segmentation = \"1.13.3\"",
-                ],
-            ),
-            (
-                "encoding-and-i18n",
-                HashSet::from(["sifr.encoding".to_string(), "sifr.i18n".to_string()]),
-                HashSet::new(),
-                vec![
-                    "encoding_rs = \"0.8.35\"",
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }",
-                    "icu_collator = \"2.2.0\"",
-                    "icu_datetime = \"2.2.0\"",
-                    "icu_decimal = \"2.2.0\"",
-                    "icu_locale = \"2.2.0\"",
-                    "icu_plurals = \"2.2.0\"",
-                ],
-            ),
-            (
-                "unicode-and-i18n",
-                HashSet::from(["sifr.unicode".to_string(), "sifr.i18n".to_string()]),
-                HashSet::new(),
-                vec![
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }",
-                    "icu_collator = \"2.2.0\"",
-                    "icu_datetime = \"2.2.0\"",
-                    "icu_decimal = \"2.2.0\"",
-                    "icu_locale = \"2.2.0\"",
-                    "icu_plurals = \"2.2.0\"",
-                    "unicode_names2 = \"3.1.0\"",
-                    "unicode-normalization = \"0.1.25\"",
-                    "unicode-segmentation = \"1.13.3\"",
-                ],
-            ),
-            (
-                "encoding-unicode-and-i18n",
-                HashSet::from([
-                    "sifr.encoding".to_string(),
-                    "sifr.i18n".to_string(),
-                    "sifr.unicode".to_string(),
-                ]),
-                HashSet::new(),
-                vec![
-                    "encoding_rs = \"0.8.35\"",
-                    "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }",
-                    "icu_collator = \"2.2.0\"",
-                    "icu_datetime = \"2.2.0\"",
-                    "icu_decimal = \"2.2.0\"",
-                    "icu_locale = \"2.2.0\"",
-                    "icu_plurals = \"2.2.0\"",
-                    "unicode_names2 = \"3.1.0\"",
-                    "unicode-normalization = \"0.1.25\"",
-                    "unicode-segmentation = \"1.13.3\"",
-                ],
-            ),
-        ];
-
-        for (name, modules, required_features, expected) in cases {
-            let deps = generated_cargo_dependencies(&modules, &required_features)
-                .iter()
-                .map(|dependency| normalize_runtime_dependency(dependency))
-                .collect::<Vec<_>>();
-
-            assert_eq!(deps, expected, "{name}");
-        }
     }
 }

--- a/crates/sifr_stdlib/src/lib.rs
+++ b/crates/sifr_stdlib/src/lib.rs
@@ -19,6 +19,7 @@ mod ipc_request_tracker;
 mod ipc_schema;
 mod ipc_transport;
 mod math_test;
+mod net;
 mod platform_misc;
 mod process;
 mod runtime;
@@ -54,6 +55,7 @@ pub use ipc_schema::{
 };
 pub use ipc_transport::{read_frame, write_frame, IpcTransportError};
 use math_test::{intrinsic_math, intrinsic_test};
+use net::intrinsic_net;
 use platform_misc::{
     intrinsic_calendar, intrinsic_compress, intrinsic_datetime, intrinsic_html, intrinsic_logging,
     intrinsic_platform, intrinsic_toml,
@@ -128,6 +130,7 @@ pub fn get_intrinsic_module(module_name: &str) -> Option<IntrinsicModule> {
         "_sifr.regex" => Some(intrinsic_regex()),
         "_sifr.uuid" => Some(intrinsic_uuid()),
         "_sifr.platform" => Some(intrinsic_platform()),
+        "_sifr.net" => Some(intrinsic_net()),
         "_sifr.process" => Some(intrinsic_process()),
         "_sifr.signal" => Some(intrinsic_signal()),
         "_sifr.runtime" => Some(intrinsic_runtime()),

--- a/crates/sifr_stdlib/src/net.rs
+++ b/crates/sifr_stdlib/src/net.rs
@@ -1,0 +1,251 @@
+use super::{result_ty, IntrinsicModule};
+use sifr_type_system::{FunctionType, Type};
+use std::collections::HashMap;
+
+fn net_error_result(ok: Type) -> Type {
+    result_ty(ok, "NetError")
+}
+
+fn socket_addr_class() -> Type {
+    Type::Class {
+        name: "SocketAddr".to_string(),
+        fields: vec![("value".to_string(), Type::Str)],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn tcp_stream_class() -> Type {
+    Type::Class {
+        name: "TcpStream".to_string(),
+        fields: vec![
+            ("_handle".to_string(), Type::Int),
+            ("_closed".to_string(), Type::Bool),
+        ],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn tcp_listener_class() -> Type {
+    Type::Class {
+        name: "TcpListener".to_string(),
+        fields: vec![
+            ("_handle".to_string(), Type::Int),
+            ("_closed".to_string(), Type::Bool),
+        ],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn tcp_read_half_class() -> Type {
+    Type::Class {
+        name: "TcpReadHalf".to_string(),
+        fields: vec![
+            ("_handle".to_string(), Type::Int),
+            ("_closed".to_string(), Type::Bool),
+        ],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn tcp_write_half_class() -> Type {
+    Type::Class {
+        name: "TcpWriteHalf".to_string(),
+        fields: vec![
+            ("_handle".to_string(), Type::Int),
+            ("_closed".to_string(), Type::Bool),
+        ],
+        methods: vec![],
+        parent_class: None,
+    }
+}
+
+fn await_net_result(ok: Type) -> Type {
+    Type::Awaitable(Box::new(net_error_result(ok)))
+}
+
+pub(super) fn intrinsic_net() -> IntrinsicModule {
+    let mut functions = HashMap::new();
+
+    functions.insert(
+        "net_connect_tcp".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("address".to_string(), Type::Str),
+                ("timeout_seconds".to_string(), Type::Float),
+                ("has_timeout".to_string(), Type::Bool),
+                ("local_addr".to_string(), Type::Str),
+                ("has_local_addr".to_string(), Type::Bool),
+            ],
+            await_net_result(tcp_stream_class()),
+        ),
+    );
+    functions.insert(
+        "net_listen_tcp".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("address".to_string(), Type::Str),
+                ("backlog".to_string(), Type::Int),
+                ("has_backlog".to_string(), Type::Bool),
+                ("reuse_addr".to_string(), Type::Bool),
+            ],
+            await_net_result(tcp_listener_class()),
+        ),
+    );
+    functions.insert(
+        "net_listener_accept".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            await_net_result(Type::Tuple(vec![tcp_stream_class(), socket_addr_class()])),
+        ),
+    );
+    functions.insert(
+        "net_listener_local_addr".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::Str),
+        ),
+    );
+    functions.insert(
+        "net_listener_close".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_read_chunk".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("max_bytes".to_string(), Type::Int),
+            ],
+            await_net_result(Type::Union(vec![Type::Bytes, Type::None])),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_write".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("data".to_string(), Type::Bytes),
+            ],
+            await_net_result(Type::Int),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_write_all".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("data".to_string(), Type::Bytes),
+            ],
+            await_net_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_shutdown_write".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            await_net_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_close".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            await_net_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_split".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            Type::Tuple(vec![tcp_read_half_class(), tcp_write_half_class()]),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_local_addr".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::Str),
+        ),
+    );
+    functions.insert(
+        "net_tcp_stream_peer_addr".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::Str),
+        ),
+    );
+    functions.insert(
+        "net_tcp_read_half_read_chunk".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("max_bytes".to_string(), Type::Int),
+            ],
+            await_net_result(Type::Union(vec![Type::Bytes, Type::None])),
+        ),
+    );
+    functions.insert(
+        "net_tcp_read_half_close".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_write_half_write".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("data".to_string(), Type::Bytes),
+            ],
+            await_net_result(Type::Int),
+        ),
+    );
+    functions.insert(
+        "net_tcp_write_half_write_all".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("handle".to_string(), Type::Int),
+                ("data".to_string(), Type::Bytes),
+            ],
+            await_net_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_write_half_shutdown_write".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            await_net_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_tcp_write_half_close".to_string(),
+        FunctionType::all_borrow(
+            vec![("handle".to_string(), Type::Int)],
+            net_error_result(Type::None),
+        ),
+    );
+    functions.insert(
+        "net_lookup_host".to_string(),
+        FunctionType::all_borrow(
+            vec![
+                ("address".to_string(), Type::Str),
+                ("timeout_seconds".to_string(), Type::Float),
+                ("has_timeout".to_string(), Type::Bool),
+            ],
+            await_net_result(Type::List(Box::new(socket_addr_class()))),
+        ),
+    );
+
+    IntrinsicModule {
+        functions,
+        constants: HashMap::new(),
+    }
+}

--- a/crates/sifr_stdlib/src/sources.rs
+++ b/crates/sifr_stdlib/src/sources.rs
@@ -87,6 +87,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("../../../lib/sifr/process.sifr"),
     },
     StdlibSource {
+        module: "sifr.net",
+        source: include_str!("../../../lib/sifr/net.sifr"),
+    },
+    StdlibSource {
         module: "sifr.resource",
         source: include_str!("../../../lib/sifr/resource.sifr"),
     },

--- a/crates/sifr_stdlib/tests/network_http_dependency_snapshots.rs
+++ b/crates/sifr_stdlib/tests/network_http_dependency_snapshots.rs
@@ -1,4 +1,6 @@
 use serde_json::Value;
+use sifr_stdlib::{generated_cargo_dependencies, StdlibFeature};
+use std::collections::HashSet;
 
 const SNAPSHOT_JSON: &str =
     include_str!("../../../verification/stdlib/network_http_dependency_snapshots.json");
@@ -55,4 +57,37 @@ fn network_http_m0_dependency_snapshots_exclude_ring5_from_production() {
     sorted_ids.sort();
     sorted_ids.dedup();
     assert_eq!(ids.len(), sorted_ids.len(), "snapshot ids must be unique");
+}
+
+#[test]
+fn network_http_m1_net_module_emits_locked_runtime_dependencies() {
+    let deps = generated_cargo_dependencies(
+        &HashSet::from(["sifr.net".to_string()]),
+        &HashSet::new(),
+    )
+    .into_iter()
+    .map(|dependency| {
+        if dependency.starts_with("sifr_runtime = ") {
+            if dependency.contains("features = [\"net\"]") {
+                return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"net\"] }"
+                    .to_string();
+            }
+            return "sifr_runtime = { path = \"<sifr_runtime_path>\" }".to_string();
+        }
+        dependency
+    })
+    .collect::<Vec<_>>();
+
+    assert_eq!(
+        deps,
+        vec![
+            "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"net\"] }",
+            "tokio = { version = \"1.52.3\", features = [\"io-util\", \"macros\", \"net\", \"process\", \"rt\", \"signal\", \"sync\", \"time\"] }",
+            "tracing = { version = \"0.1.44\", default-features = false, features = [\"std\"] }",
+        ]
+    );
+    assert_eq!(
+        sifr_stdlib::feature_for_codegen_requirement("tokio"),
+        Some(StdlibFeature::Tokio)
+    );
 }

--- a/crates/sifr_stdlib/tests/text_i18n_dependency_snapshots.rs
+++ b/crates/sifr_stdlib/tests/text_i18n_dependency_snapshots.rs
@@ -1,0 +1,125 @@
+use sifr_stdlib::generated_cargo_dependencies;
+use std::collections::HashSet;
+
+fn normalize_runtime_dependency(dependency: &str) -> String {
+    if dependency.starts_with("sifr_runtime = ") {
+        if dependency.contains("features = [\"i18n\", \"unicode\"]") {
+            return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }"
+                .to_string();
+        }
+        if dependency.contains("features = [\"i18n\"]") {
+            return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }"
+                .to_string();
+        }
+        if dependency.contains("features = [\"unicode\"]") {
+            return "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }"
+                .to_string();
+        }
+        return "sifr_runtime = { path = \"<sifr_runtime_path>\" }".to_string();
+    }
+    dependency.to_string()
+}
+
+#[test]
+fn text_i18n_feature_dependency_snapshots_cover_phase_combinations() {
+    let cases = [
+        (
+            "encoding",
+            HashSet::from(["sifr.encoding".to_string()]),
+            vec![
+                "encoding_rs = \"0.8.35\"",
+                "sifr_runtime = { path = \"<sifr_runtime_path>\" }",
+            ],
+        ),
+        (
+            "unicode",
+            HashSet::from(["sifr.unicode".to_string()]),
+            vec![
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }",
+                "unicode_names2 = \"3.1.0\"",
+                "unicode-normalization = \"0.1.25\"",
+                "unicode-segmentation = \"1.13.3\"",
+            ],
+        ),
+        (
+            "i18n",
+            HashSet::from(["sifr.i18n".to_string()]),
+            vec![
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }",
+                "icu_collator = \"2.2.0\"",
+                "icu_datetime = \"2.2.0\"",
+                "icu_decimal = \"2.2.0\"",
+                "icu_locale = \"2.2.0\"",
+                "icu_plurals = \"2.2.0\"",
+            ],
+        ),
+        (
+            "encoding-and-unicode",
+            HashSet::from(["sifr.encoding".to_string(), "sifr.unicode".to_string()]),
+            vec![
+                "encoding_rs = \"0.8.35\"",
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"unicode\"] }",
+                "unicode_names2 = \"3.1.0\"",
+                "unicode-normalization = \"0.1.25\"",
+                "unicode-segmentation = \"1.13.3\"",
+            ],
+        ),
+        (
+            "encoding-and-i18n",
+            HashSet::from(["sifr.encoding".to_string(), "sifr.i18n".to_string()]),
+            vec![
+                "encoding_rs = \"0.8.35\"",
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\"] }",
+                "icu_collator = \"2.2.0\"",
+                "icu_datetime = \"2.2.0\"",
+                "icu_decimal = \"2.2.0\"",
+                "icu_locale = \"2.2.0\"",
+                "icu_plurals = \"2.2.0\"",
+            ],
+        ),
+        (
+            "unicode-and-i18n",
+            HashSet::from(["sifr.unicode".to_string(), "sifr.i18n".to_string()]),
+            vec![
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }",
+                "icu_collator = \"2.2.0\"",
+                "icu_datetime = \"2.2.0\"",
+                "icu_decimal = \"2.2.0\"",
+                "icu_locale = \"2.2.0\"",
+                "icu_plurals = \"2.2.0\"",
+                "unicode_names2 = \"3.1.0\"",
+                "unicode-normalization = \"0.1.25\"",
+                "unicode-segmentation = \"1.13.3\"",
+            ],
+        ),
+        (
+            "encoding-unicode-and-i18n",
+            HashSet::from([
+                "sifr.encoding".to_string(),
+                "sifr.i18n".to_string(),
+                "sifr.unicode".to_string(),
+            ]),
+            vec![
+                "encoding_rs = \"0.8.35\"",
+                "sifr_runtime = { path = \"<sifr_runtime_path>\", features = [\"i18n\", \"unicode\"] }",
+                "icu_collator = \"2.2.0\"",
+                "icu_datetime = \"2.2.0\"",
+                "icu_decimal = \"2.2.0\"",
+                "icu_locale = \"2.2.0\"",
+                "icu_plurals = \"2.2.0\"",
+                "unicode_names2 = \"3.1.0\"",
+                "unicode-normalization = \"0.1.25\"",
+                "unicode-segmentation = \"1.13.3\"",
+            ],
+        ),
+    ];
+
+    for (name, modules, expected) in cases {
+        let deps = generated_cargo_dependencies(&modules, &HashSet::new())
+            .iter()
+            .map(|dependency| normalize_runtime_dependency(dependency))
+            .collect::<Vec<_>>();
+
+        assert_eq!(deps, expected, "{name}");
+    }
+}

--- a/crates/sifr_type_system/src/types/type_queries.rs
+++ b/crates/sifr_type_system/src/types/type_queries.rs
@@ -412,7 +412,7 @@ impl Type {
             }
             Self::Coroutine(ok, err) => {
                 format!(
-                    "std::pin::Pin<Box<dyn std::future::Future<Output = Result<{}, {}>>>>",
+                    "std::pin::Pin<Box<dyn std::future::Future<Output = Result<{}, {}>> + Send>>",
                     ok.rust_type(),
                     err.rust_type()
                 )
@@ -437,7 +437,7 @@ impl Type {
                 format!("__SifrJoinSet<{}, {}>", ok.rust_type(), err.rust_type())
             }
             Self::Awaitable(result) => format!(
-                "std::pin::Pin<Box<dyn std::future::Future<Output = {}>>>",
+                "std::pin::Pin<Box<dyn std::future::Future<Output = {}> + Send>>",
                 result.rust_type()
             ),
             Self::AsyncIterator(item, err) => {

--- a/issues/ad-hoc-production-network-http-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-network-http-platform-substrate-execution.md
@@ -2,7 +2,7 @@
 
 Phase contract: [ad-hoc-production-network-http-platform-substrate.md](./ad-hoc-production-network-http-platform-substrate.md)
 
-Status: in progress; M0 merged; M1 implemented locally with Opus pass 1 blockers remediated, pending rerun review/PR
+Status: in progress; M0 merged; M1 PR open with Opus implementation review PASS and local merge-gate validation PASS, pending merge
 
 ## Scope Split
 
@@ -152,6 +152,13 @@ CPython-shaped public networking/web modules are no longer this phase's objectiv
 - Claude Opus M0 implementation review pass 2:
   - `reviews/ad-hoc-production-network-http-m0-opus-review-pass-2.md`
   - Result: `PASS`; all pass-1 blocking findings B1-B11 and non-blocking follow-ups were verified as remediated. Reviewer stated the M0 PR is safe to open and merge, and M1 can safely start after validation evidence is recorded.
+- Claude Opus M1 implementation review pass 1:
+  - `reviews/ad-hoc-production-network-http-m1-opus-review-pass-1.md`
+  - Result: `FAIL`; reviewer blocked on global `+ Send` validation, infallible affine `TcpStream.split()`, and cancellation fixture coverage.
+  - Remediations: reran create-pr validation after the global sendability change, made `TcpStream.split()` infallible end-to-end with public `TcpStream.close(own self)`, added in-flight `accept()` cancellation coverage, removed unused M1 dependency emission, and documented M1 runtime behavior.
+- Claude Opus M1 implementation review pass 2:
+  - `reviews/ad-hoc-production-network-http-m1-opus-review-pass-2.md`
+  - Result: `PASS`; reviewer accepted the M1 PR for opening after remediation, with the full merge gate required before closure.
 - M0 implementation merge ledger:
   - PR: https://github.com/sifr-lang/sifr/pull/2494
   - Merge commit: `c426d01e26257c5b72e3ecd50e6884c86292a14b`
@@ -221,7 +228,7 @@ CPython-shaped public networking/web modules are no longer this phase's objectiv
 ## Implementation PRs
 
 - M0: https://github.com/sifr-lang/sifr/pull/2494 merged at `c426d01e26257c5b72e3ecd50e6884c86292a14b`.
-- M1: pending.
+- M1: https://github.com/sifr-lang/sifr/pull/2495 open draft pending merge.
 - M2: pending.
 - M3: pending.
 - M4: pending.
@@ -269,11 +276,14 @@ M1 validation:
 | `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
 | `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. |
 | `scripts/run_e2e_pass.sh` | PASS | Merge-manifest e2e pass suite completed 138 pass tests, 0 failed. |
+| `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; all lane steps passed. Advisories: warm wall-time budget exceeded and high group skew. |
+| `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; all merge-lane steps passed. Advisories: warm wall-time budget exceeded and high group skew. |
 
 M1 broad pass-suite note:
 
 - An exploratory `cargo test -p sifr --test e2e e2e_pass -- network_http_m1 --nocapture` invocation ran the full pass corpus rather than filtering only M1 fixtures. It completed 636 pass fixtures and exposed pre-existing non-network failures: IO context-manager generated mutability in `cpython_io_subset`/`stdlib_io_consolidated` and `open_*` fixtures, plus `bytes_conversion_errors` expecting `latin-1` encode/decode rejection. The M1-specific fixtures pass through the selected manifest above.
 - The clean `scripts/run_all_tests.sh --profile create-pr` rerun passed after clearing detached stale validation jobs from earlier interrupted runs. The only advisory was warm wall-time budget exceeded.
+- The full `scripts/run_all_tests.sh` merge gate passed before PR merge. Advisory-only output reported warm wall-time budget exceeded and high group skew.
 
 Required baseline commands:
 

--- a/issues/ad-hoc-production-network-http-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-network-http-platform-substrate-execution.md
@@ -276,14 +276,13 @@ M1 validation:
 | `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
 | `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. |
 | `scripts/run_e2e_pass.sh` | PASS | Merge-manifest e2e pass suite completed 138 pass tests, 0 failed. |
-| `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; all lane steps passed. Advisories: warm wall-time budget exceeded and high group skew. |
 | `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; all merge-lane steps passed. Advisories: warm wall-time budget exceeded and high group skew. |
 
 M1 broad pass-suite note:
 
 - An exploratory `cargo test -p sifr --test e2e e2e_pass -- network_http_m1 --nocapture` invocation ran the full pass corpus rather than filtering only M1 fixtures. It completed 636 pass fixtures and exposed pre-existing non-network failures: IO context-manager generated mutability in `cpython_io_subset`/`stdlib_io_consolidated` and `open_*` fixtures, plus `bytes_conversion_errors` expecting `latin-1` encode/decode rejection. The M1-specific fixtures pass through the selected manifest above.
 - The clean `scripts/run_all_tests.sh --profile create-pr` rerun passed after clearing detached stale validation jobs from earlier interrupted runs. The only advisory was warm wall-time budget exceeded.
-- The full `scripts/run_all_tests.sh` merge gate passed before PR merge. Advisory-only output reported warm wall-time budget exceeded and high group skew.
+- The full `scripts/run_all_tests.sh` merge gate passed before M1 PR prep. Advisory-only output reported warm wall-time budget exceeded and high group skew.
 
 Required baseline commands:
 

--- a/issues/ad-hoc-production-network-http-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-network-http-platform-substrate-execution.md
@@ -2,7 +2,7 @@
 
 Phase contract: [ad-hoc-production-network-http-platform-substrate.md](./ad-hoc-production-network-http-platform-substrate.md)
 
-Status: draft
+Status: in progress; M0 merged
 
 ## Scope Split
 
@@ -18,7 +18,7 @@ CPython-shaped public networking/web modules are no longer this phase's objectiv
 
 ## Milestone Checklist
 
-- [ ] `milestone_network_http_0`: Product Boundary And Architecture
+- [x] `milestone_network_http_0`: Product Boundary And Architecture
 - [ ] `milestone_network_http_1`: Async Network Runtime
 - [ ] `milestone_network_http_2`: TLS Runtime
 - [ ] `milestone_network_http_3`: URL, Header, And Cookie Primitives
@@ -152,6 +152,11 @@ CPython-shaped public networking/web modules are no longer this phase's objectiv
 - Claude Opus M0 implementation review pass 2:
   - `reviews/ad-hoc-production-network-http-m0-opus-review-pass-2.md`
   - Result: `PASS`; all pass-1 blocking findings B1-B11 and non-blocking follow-ups were verified as remediated. Reviewer stated the M0 PR is safe to open and merge, and M1 can safely start after validation evidence is recorded.
+- M0 implementation merge ledger:
+  - PR: https://github.com/sifr-lang/sifr/pull/2494
+  - Merge commit: `c426d01e26257c5b72e3ecd50e6884c86292a14b`
+  - Scope: added the M0 substrate inventory, dependency audit and snapshots, CPython evidence matrix, workload database, platform golden fixtures, unsupported network/HTTP import diagnostics, negative e2e coverage, per-milestone traceability files, and the serving-scale follow-up issue.
+  - Merge-gate validation: `scripts/run_all_tests.sh` passed on rerun for head `30b098eedeec52af8d6234d5af990b86a611ec67`; first merge-gate run had one transient `check-project-004-project-graph` performance p95 outlier, targeted representative performance rerun passed, and the full merge-gate rerun passed with wall-time/batching advisories only.
 - Implementation-readiness merge ledger:
   - PR: https://github.com/sifr-lang/sifr/pull/2490
   - Merge commit: `f30e31f9e`
@@ -215,7 +220,7 @@ CPython-shaped public networking/web modules are no longer this phase's objectiv
 
 ## Implementation PRs
 
-- M0: https://github.com/sifr-lang/sifr/pull/2494 pending merge-gate validation and review/merge.
+- M0: https://github.com/sifr-lang/sifr/pull/2494 merged at `c426d01e26257c5b72e3ecd50e6884c86292a14b`.
 - M1: pending.
 - M2: pending.
 - M3: pending.
@@ -239,6 +244,7 @@ M0 validation:
 | `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
 | `cargo clippy --workspace -- -D warnings` | PASS | Finished dev profile in 2m16s. |
 | `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded, no test failure. |
+| `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; first run failed on one transient performance p95 outlier, targeted representative performance rerun and full merge-gate rerun passed. Advisories: warm wall-time budget exceeded and high group skew. |
 
 Required baseline commands:
 

--- a/issues/ad-hoc-production-network-http-platform-substrate-execution.md
+++ b/issues/ad-hoc-production-network-http-platform-substrate-execution.md
@@ -2,7 +2,7 @@
 
 Phase contract: [ad-hoc-production-network-http-platform-substrate.md](./ad-hoc-production-network-http-platform-substrate.md)
 
-Status: in progress; M0 merged
+Status: in progress; M0 merged; M1 implemented locally with Opus pass 1 blockers remediated, pending rerun review/PR
 
 ## Scope Split
 
@@ -245,6 +245,35 @@ M0 validation:
 | `cargo clippy --workspace -- -D warnings` | PASS | Finished dev profile in 2m16s. |
 | `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded, no test failure. |
 | `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; first run failed on one transient performance p95 outlier, targeted representative performance rerun and full merge-gate rerun passed. Advisories: warm wall-time budget exceeded and high group skew. |
+
+M1 validation:
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `cargo build -p sifr --bin sifr` | PASS | Rebuilt CLI after `sifr.net` stdlib/runtime/codegen changes. |
+| `cargo check -p sifr_runtime --features net` | PASS | Runtime crate builds with optional `net` feature enabled. |
+| `cargo test -p sifr_runtime --features net --lib net -- --nocapture` | PASS | Runtime crate builds and test harness completes; `sifr_runtime::net` currently has no unit tests, so behavior is covered by generated Sifr fixtures. |
+| `cargo test -p sifr_stdlib --test concurrency_runtime_dependency_snapshots -- --nocapture` | PASS | Verifies existing concurrency/Tokio dependency snapshot remains unchanged without `sifr.net`. |
+| `cargo test -p sifr_stdlib --test network_http_dependency_snapshots -- --nocapture` | PASS | Covers M0 Ring 5 dependency absence and the M1 `sifr.net` generated dependency snapshot with `sifr_runtime/net`, Tokio `net`, tracing, and no unused `bytes`/`socket2`/`tokio-util` emission. |
+| `cargo test -p sifr_stdlib --test text_i18n_dependency_snapshots -- --nocapture` | PASS | Verifies moved text/i18n dependency snapshot coverage remains intact after feature-registry edits. |
+| `target/debug/sifr check crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr` | PASS | Public `sifr.net` TCP loopback fixture type-checks. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr` | PASS | Deterministic loopback connect/listen/accept/split/half-close fixture runs without external network dependency. |
+| `target/debug/sifr check crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr` | PASS | Deterministic typed error fixture type-checks. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr` | PASS | Invalid timeout and invalid backlog return typed `NetError` results without external network dependency. |
+| `target/debug/sifr check crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr` | PASS | Provider cancellation fixture type-checks. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr` | PASS | Cancels an in-flight listener `accept()` through a scoped task handle and observes `Cancelled` evidence. |
+| `SIFR_E2E_FIXTURE_MANIFEST=<tmp manifest> SIFR_E2E_DISABLE_CACHE=1 cargo test -p sifr --test e2e test_e2e_pass -- --nocapture` | PASS | Selected fixtures `network_http_m1_tcp_cancel_accept`, `network_http_m1_tcp_errors`, and `network_http_m1_tcp_loopback_split`; 3 pass tests completed. |
+| `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture` | PASS | Full fail corpus completed; validates `network_http_m1_udp_deferred.sifr` expected `SIFR-NAME-0004` and existing unsupported import diagnostics. Existing fail-harness internal CFG panic messages are caught by the negative harness and test exits successfully. |
+| `cargo fmt --check` | PASS | Clean after M1 edits. |
+| `python3 scripts/check_file_size_guardrails.py` | PASS | 2302 files, limit 900 lines. |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
+| `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. |
+| `scripts/run_e2e_pass.sh` | PASS | Merge-manifest e2e pass suite completed 138 pass tests, 0 failed. |
+
+M1 broad pass-suite note:
+
+- An exploratory `cargo test -p sifr --test e2e e2e_pass -- network_http_m1 --nocapture` invocation ran the full pass corpus rather than filtering only M1 fixtures. It completed 636 pass fixtures and exposed pre-existing non-network failures: IO context-manager generated mutability in `cpython_io_subset`/`stdlib_io_consolidated` and `open_*` fixtures, plus `bytes_conversion_errors` expecting `latin-1` encode/decode rejection. The M1-specific fixtures pass through the selected manifest above.
+- The clean `scripts/run_all_tests.sh --profile create-pr` rerun passed after clearing detached stale validation jobs from earlier interrupted runs. The only advisory was warm wall-time budget exceeded.
 
 Required baseline commands:
 

--- a/lib/sifr/net.sifr
+++ b/lib/sifr/net.sifr
@@ -1,0 +1,239 @@
+# sifr.net — Async TCP networking substrate
+from _sifr.net import (
+    net_connect_tcp,
+    net_listener_accept,
+    net_listener_close,
+    net_listener_local_addr,
+    net_listen_tcp,
+    net_lookup_host,
+    net_tcp_read_half_close,
+    net_tcp_read_half_read_chunk,
+    net_tcp_stream_close,
+    net_tcp_stream_local_addr,
+    net_tcp_stream_peer_addr,
+    net_tcp_stream_read_chunk,
+    net_tcp_stream_shutdown_write,
+    net_tcp_stream_split,
+    net_tcp_stream_write,
+    net_tcp_stream_write_all,
+    net_tcp_write_half_close,
+    net_tcp_write_half_shutdown_write,
+    net_tcp_write_half_write,
+    net_tcp_write_half_write_all,
+)
+
+
+class NetError(Error):
+    message: str
+
+
+class SocketAddr:
+    value: str
+
+    def __init__(self, value: str):
+        self.value = value
+
+
+class TcpStream:
+    _handle: int
+    _closed: bool
+
+    def __init__(self, handle: int):
+        self._handle = handle
+        self._closed = False
+
+    def read_chunk(self, max_bytes: int) -> Awaitable[Result[bytes | None, NetError]]:
+        return net_tcp_stream_read_chunk(self._handle, max_bytes)
+
+    def write(self, data: bytes) -> Awaitable[Result[int, NetError]]:
+        return net_tcp_stream_write(self._handle, data)
+
+    def write_all(self, data: bytes) -> Awaitable[Result[None, NetError]]:
+        return net_tcp_stream_write_all(self._handle, data)
+
+    def shutdown_write(self) -> Awaitable[Result[None, NetError]]:
+        return net_tcp_stream_shutdown_write(self._handle)
+
+    def close(own self) -> Awaitable[Result[None, NetError]]:
+        self._closed = True
+        return net_tcp_stream_close(self._handle)
+
+    def split(own self) -> tuple[TcpReadHalf, TcpWriteHalf]:
+        self._closed = True
+        return net_tcp_stream_split(self._handle)
+
+    def local_addr(self) -> Result[SocketAddr, NetError]:
+        try:
+            value: str = net_tcp_stream_local_addr(self._handle)
+            return SocketAddr(value)
+        except NetError as e:
+            raise e
+
+    def remote_addr(self) -> Result[SocketAddr, NetError]:
+        try:
+            value: str = net_tcp_stream_peer_addr(self._handle)
+            return SocketAddr(value)
+        except NetError as e:
+            raise e
+
+
+class TcpReadHalf:
+    _handle: int
+    _closed: bool
+
+    def __init__(self, handle: int):
+        self._handle = handle
+        self._closed = False
+
+    def read_chunk(self, max_bytes: int) -> Awaitable[Result[bytes | None, NetError]]:
+        return net_tcp_read_half_read_chunk(self._handle, max_bytes)
+
+    def close(self) -> Result[None, NetError]:
+        if self._closed:
+            raise NetError("TCP read half is already closed")
+        self._closed = True
+        return net_tcp_read_half_close(self._handle)
+
+
+class TcpWriteHalf:
+    _handle: int
+    _closed: bool
+
+    def __init__(self, handle: int):
+        self._handle = handle
+        self._closed = False
+
+    def write(self, data: bytes) -> Awaitable[Result[int, NetError]]:
+        return net_tcp_write_half_write(self._handle, data)
+
+    def write_all(self, data: bytes) -> Awaitable[Result[None, NetError]]:
+        return net_tcp_write_half_write_all(self._handle, data)
+
+    def shutdown_write(self) -> Awaitable[Result[None, NetError]]:
+        return net_tcp_write_half_shutdown_write(self._handle)
+
+    def close(self) -> Result[None, NetError]:
+        if self._closed:
+            raise NetError("TCP write half is already closed")
+        self._closed = True
+        return net_tcp_write_half_close(self._handle)
+
+
+class TcpListener:
+    _handle: int
+    _closed: bool
+
+    def __init__(self, handle: int):
+        self._handle = handle
+        self._closed = False
+
+    def accept(self) -> Awaitable[Result[tuple[TcpStream, SocketAddr], NetError]]:
+        return _accept_tcp_listener(self._handle)
+
+    def local_addr(self) -> Result[SocketAddr, NetError]:
+        try:
+            value: str = net_listener_local_addr(self._handle)
+            return SocketAddr(value)
+        except NetError as e:
+            raise e
+
+    def close(self) -> Result[None, NetError]:
+        if self._closed:
+            raise NetError("TCP listener is already closed")
+        self._closed = True
+        return net_listener_close(self._handle)
+
+
+def connect_tcp(
+    address: str,
+    timeout: float | None = None,
+    local_addr: str | None = None,
+) -> Awaitable[Result[TcpStream, NetError]]:
+    if timeout is None:
+        if local_addr is None:
+            return _connect_tcp(address, 0.0, False, "", False)
+        return _connect_tcp(address, 0.0, False, local_addr, True)
+    if local_addr is None:
+        return _connect_tcp(address, timeout, True, "", False)
+    return _connect_tcp(address, timeout, True, local_addr, True)
+
+
+def listen_tcp(
+    address: str,
+    backlog: int | None = None,
+    reuse_addr: bool = False,
+) -> Awaitable[Result[TcpListener, NetError]]:
+    if backlog is None:
+        return _listen_tcp(address, 0, False, reuse_addr)
+    return _listen_tcp(address, backlog, True, reuse_addr)
+
+
+def resolve_host(
+    address: str,
+    timeout: float | None = None,
+) -> Awaitable[Result[list[SocketAddr], NetError]]:
+    if timeout is None:
+        return _resolve_host(address, 0.0, False)
+    return _resolve_host(address, timeout, True)
+
+
+def _connect_tcp(
+    address: str,
+    timeout_seconds: float,
+    has_timeout: bool,
+    local_addr: str,
+    has_local_addr: bool,
+) -> Awaitable[Result[TcpStream, NetError]]:
+    return _wrap_connect_tcp(address, timeout_seconds, has_timeout, local_addr, has_local_addr)
+
+
+def _listen_tcp(
+    address: str,
+    backlog: int,
+    has_backlog: bool,
+    reuse_addr: bool,
+) -> Awaitable[Result[TcpListener, NetError]]:
+    return _wrap_listen_tcp(address, backlog, has_backlog, reuse_addr)
+
+
+def _accept_tcp_listener(handle: int) -> Awaitable[Result[tuple[TcpStream, SocketAddr], NetError]]:
+    return _wrap_accept_tcp(handle)
+
+
+def _resolve_host(
+    address: str,
+    timeout_seconds: float,
+    has_timeout: bool,
+) -> Awaitable[Result[list[SocketAddr], NetError]]:
+    return _wrap_resolve_host(address, timeout_seconds, has_timeout)
+
+
+def _wrap_connect_tcp(
+    address: str,
+    timeout_seconds: float,
+    has_timeout: bool,
+    local_addr: str,
+    has_local_addr: bool,
+) -> Awaitable[Result[TcpStream, NetError]]:
+    return net_connect_tcp(address, timeout_seconds, has_timeout, local_addr, has_local_addr)
+
+
+def _wrap_listen_tcp(
+    address: str,
+    backlog: int,
+    has_backlog: bool,
+    reuse_addr: bool,
+) -> Awaitable[Result[TcpListener, NetError]]:
+    return net_listen_tcp(address, backlog, has_backlog, reuse_addr)
+
+
+def _wrap_accept_tcp(handle: int) -> Awaitable[Result[tuple[TcpStream, SocketAddr], NetError]]:
+    return net_listener_accept(handle)
+
+
+def _wrap_resolve_host(
+    address: str,
+    timeout_seconds: float,
+    has_timeout: bool,
+) -> Awaitable[Result[list[SocketAddr], NetError]]:
+    return net_lookup_host(address, timeout_seconds, has_timeout)

--- a/reviews/ad-hoc-production-network-http-m1-opus-review-pass-1.md
+++ b/reviews/ad-hoc-production-network-http-m1-opus-review-pass-1.md
@@ -1,0 +1,49 @@
+I have enough. Here's my review.
+
+## FAIL — do not open the M1 PR yet
+
+Three blocking findings against the M0 contract / DoD, plus several non-blocking items that should land in the same PR or be acknowledged in the traceability.
+
+### Blocking
+
+**B1. `+ Send` bound applied to ALL Awaitable/Coroutine futures was not validated by the full e2e suite.**
+`crates/sifr_type_system/src/types/type_queries.rs:415,440` adds `+ Send` to every emitted `Pin<Box<dyn Future<…>>>`, not just net. This is a cross-cutting change that affects every async pass fixture (e.g., `async_basic`, `async_generator_*`, `async_for_*`, `join_set_*`, `process_async_*`, `async_with_*`, ~30 in `crates/sifr/tests/e2e/pass/`). The validation list only ran `cargo test -p sifr --test e2e test_e2e_pass` with `SIFR_E2E_FIXTURE_MANIFEST` restricting to the two M1 net fixtures. `scripts/run_e2e_pass.sh` and `scripts/run_all_tests.sh --profile create-pr` (the project-mandated authoritative gate) were skipped.
+**Required fix:** Run `scripts/run_e2e_pass.sh` and `scripts/run_all_tests.sh --profile create-pr` (followed by `scripts/run_all_tests.sh`) on this branch. If any existing async fixture or stdlib feature breaks, either scope the `+ Send` change to net-specific awaitables (e.g., type the net intrinsics with a dedicated Send-bounded variant, leaving general `Type::Awaitable` unchanged — `intrinsics/registry/net.rs:18-22` already constructs its own `send_awaitable_type`) or fix the regressions. Record the new validation rows in `verification/stdlib/network_http_m1_async_network_traceability.md`. AGENTS.md and the M0 phase doc make running the local merge gate a non-negotiable pre-PR step.
+
+**B2. `TcpStream.split()` is fallible, but M0 contract requires it to be infallible.**
+Phase doc lines 478-484 lock the contract: *"`split()` consumes a live `TcpStream` and is infallible; closed or moved streams cannot be split because the affine handle is no longer available"*. Current implementation:
+- `lib/sifr/net.sifr:61` declares `def split(own self) -> Result[tuple[TcpReadHalf, TcpWriteHalf], NetError]` and raises `NetError` if `self._closed`.
+- `crates/sifr_codegen/src/intrinsics/registry/net.rs:159-172` registers `net_tcp_stream_split` as `net_error_result(Type::Tuple(...))`, i.e., `Result[..., NetError]`.
+- `crates/sifr_runtime/src/net.rs:346-371` returns `Result` and can return `Err("TCP stream cannot be split while an operation is active")` when `Arc::try_unwrap` fails.
+
+`own self` already enforces affine consumption at the Sifr layer, so the `_closed` check and the `Arc::try_unwrap` defensive recovery are redundant against the M0 contract.
+**Required fix:** Make split infallible at all three layers. Drop the `_closed` raise in `lib/sifr/net.sifr` (rely on `own self`); change the intrinsic registry return type to plain `Type::Tuple(...)` instead of `net_error_result(...)`; in the runtime, ensure the affine handle invariant guarantees the Arc count is 1 at `split()` time and replace `Arc::try_unwrap` with a direct ownership transfer (e.g., drop the Arc/Mutex layer for unsplit `TcpStream` storage, or pass the `tokio::net::TcpStream` directly through the handle table without `Arc<Mutex<…>>` indirection — the alternative is a panic, which M0 also forbids). If the impedance with handle-table storage genuinely can't be reconciled, that needs a formal M0 contract amendment before M1 ships, not a silent divergence.
+
+**B3. Cancellation behavior is asserted in M0 DoD but not covered by any M1 fixture.**
+M0 DoD (M1 milestone): *"Timeout and cancellation behavior is deterministic, typed, and panic-free."* The two M1 e2e fixtures only exercise input-validation typed errors (`timeout=0.0`, `timeout=-1.0`, `backlog=0`). Nothing exercises provider task-scope cancellation propagating into an in-flight `accept()`/`read_chunk()`/`write_all()`. M0 explicitly forbids a parallel cancellation token and requires consumption of `sifr.task`'s deadline/cancellation model; without an active fixture, the integration claim in `network_http_m1_async_network_traceability.md` is unverified.
+**Required fix:** Add a loopback fixture that spawns a server task into `task.scope(...)`, blocks an `accept()` or `read_chunk()`, cancels the scope, and asserts a typed `NetError`/`CancelledError` (whichever the M0 error mapping designates) with deterministic partial-progress evidence. Record the new fixture row in the M1 traceability.
+
+### Non-blocking but should be resolved before PR
+
+**N1. Write-after-shutdown is not a stable typed variant.** `crates/sifr_runtime/src/net.rs:271-274` returns a single `NetError { message: "TCP write side is already shut down" }`, and `network_http_m1_tcp_loopback_split.sifr:49` substring-matches `"shut"`. M0 phase doc requires "a stable typed write-after-shutdown error". Either expose a distinct error variant (preferred) or document in M1 traceability that the message string is the M1 stable contract until the full taxonomy lands.
+
+**N2. Tokio workspace features exceed the M1 locked set.** `Cargo.toml:97` now enables `process, signal` in addition to M1's `macros, rt, sync, time, net, io-util`. M0 ecosystem decisions (network feature row) lock the set to `macros, rt, sync, time, net, io-util` and explicitly reject `process`/`signal` for the network feature (rejected-features row, lines 388-390). If these are needed for other workspace crates (sifr_runtime tests, concurrency/runtime provider), document the justification in M1 traceability or scope this change to the provider PR — don't smuggle it under M1.
+
+**N3. `StdlibFeature::Bytes`, `Socket2`, `TokioUtil` declared but unused.** `crates/sifr_stdlib/src/features.rs` registers all three and `features_for_stdlib_module("sifr.net")` pulls `Bytes` into every generated network program, but `sifr.net.sifr` and `sifr_runtime::net` use `Vec<u8>`. Generated programs will compile `bytes` for no functional reason. Either start using `bytes::Bytes` for body chunks internally (matches M0 ecosystem row) or drop `Bytes` from `features_for_stdlib_module("sifr.net")`. `Socket2`/`TokioUtil` are unwired entirely — keep them out of `features.rs` until the M2/M4 PRs that actually need them, otherwise the locked-decision audit slips.
+
+**N4. Hardcoded `set_nodelay(true)` on every connect is an undocumented policy choice.** `crates/sifr_runtime/src/net.rs:162`. M0 lists `TCP_NODELAY` as an accepted `socket2` option but doesn't mandate it as a default for `connect_tcp`. Either document the default in the M1 traceability or expose a knob.
+
+**N5. Inventory artifacts not updated.** Working tree only touches `verification/stdlib/network_http_m1_async_network_traceability.md` and the execution ledger; `verification/stdlib/network_http_substrate_inventory.{md,json}` still mark `sifr.net` surfaces as `open`. Technically allowed during M1, but if reviewers expect surfaces to flip to `production-public` on M1 PR, do it now to avoid carrying the gap to M5.
+
+**N6. Runtime `MAX_READ_BYTES = 1_048_576` is hardcoded and unconfigurable.** `crates/sifr_runtime/src/net.rs:17`. M0 phase doc requires *"explicit configured limits"* on every reader. Hardcoding a per-call cap satisfies "explicit" but not "configured". Acceptable as a substrate default for M1; flag in M1 traceability so M4/M5 can layer configuration.
+
+### What is good
+
+- TCP loopback (connect / listen / accept / read / write / shutdown_write / split / close) is functionally complete and panic-free in the surveyed paths.
+- Typed-error mapping out of the runtime via `__sifr_net_error` is consistent; runtime functions only return `Result<_, String>` and never panic on user data.
+- `net_*` intrinsics are properly gated behind `StdlibFeature::SifrRuntime` and `StdlibFeature::Tokio`; the runtime crate hides `tokio::net::TcpStream` behind opaque `i64` handles, so no Tokio type or raw fd leaks to the Sifr surface.
+- Generated Cargo feature set for `sifr.net` (snapshot test at `crates/sifr_stdlib/tests/network_http_dependency_snapshots.rs:62-94`) matches the M0 locked ring decisions for the net feature.
+- UDP is properly deferred via the `SIFR-NAME-0004` fail fixture; no partial public API ships.
+- `shutdown_write()` correctly preserves the read side (idempotent on the bitset, read path unaffected), matching the M0 half-close contract.
+
+Once B1-B3 are fixed and the full local validation gate is rerun, this is close to PR-ready.

--- a/reviews/ad-hoc-production-network-http-m1-opus-review-pass-2.md
+++ b/reviews/ad-hoc-production-network-http-m1-opus-review-pass-2.md
@@ -1,0 +1,50 @@
+I have enough. Here's my review.
+
+## PASS — safe to open the M1 PR
+
+Pass-1 blockers B1–B3 are remediated; the M0/M1 contract is satisfied at the Sifr surface, intrinsic registry, codegen lowerer, generated preamble, and Rust runtime. The non-blocking items are either resolved in code or explicitly documented in the M1 traceability with acceptable follow-up disposition. One residual validation note is recorded below — it does not block opening the PR but should close before the merge step.
+
+### Blocker verification
+
+**B1 — Global `+ Send` validation on Awaitable/Coroutine. RESOLVED for PR open.**
+`crates/sifr_type_system/src/types/type_queries.rs:413-419` and `:439-442` still emit `Send`-bounded `Pin<Box<dyn Future<…> + Send>>` for every `Coroutine`/`Awaitable`, i.e., the change remains workspace-wide rather than net-scoped. The remediation closed the *validation* gap rather than the *scope*: `scripts/run_all_tests.sh --profile create-pr` (the AGENTS.md PR-opening lane) is recorded `PASS` in `verification/stdlib/network_http_m1_async_network_traceability.md:37` and `issues/ad-hoc-production-network-http-platform-substrate-execution.md:270`. The create-pr fixture manifest (`verification/validation_lanes/create_pr_e2e_manifest.json`) explicitly exercises the previously-uncovered async surfaces — `async_with_basic`, `async_with_nested_cleanup_order`, `async_with_return_cleanup`, `async_for_*`, `async_generator_*`, `process_async_*`, `cheap_sync_helper_in_async_allowed`, plus the three new M1 net fixtures — so the cross-cutting `+ Send` bound is now empirically validated against the async corpus the create-pr lane is meant to cover. The broad exploratory `cargo test … e2e_pass -- network_http_m1` run that exposed `cpython_io_subset` / `stdlib_io_consolidated` / `open_*` / `bytes_conversion_errors` failures is classified as pre-existing by the traceability; the working tree confirms it (none of those fixtures use `async`/`await`, the diff vs `main` touches only network/type-system/feature-registry code, and the I/O subsystem they depend on is untouched), so the failures are not regressions introduced by `+ Send`.
+
+Residual note (not blocking PR open): the original pass-1 fix list also asked for `scripts/run_all_tests.sh` (the merge gate). Only `--profile create-pr` is recorded. AGENTS.md treats `--profile create-pr` as the PR-opening lane and the bare `run_all_tests.sh` as the merge gate; the merge-gate run should be recorded in `validation_evidence` before flipping the M1 checklist to merged, but is not required to open the PR.
+
+**B2 — `TcpStream.split()` is infallible end-to-end. RESOLVED.**
+The contract from `issues/ad-hoc-production-network-http-platform-substrate.md:480` is now satisfied at every layer with no `Result` and no panic:
+
+- Sifr surface: `lib/sifr/net.sifr:61-63` declares `def split(own self) -> tuple[TcpReadHalf, TcpWriteHalf]` and the `_closed` raise is gone — affinity is enforced by `own self` alone.
+- Intrinsic type registry: `crates/sifr_stdlib/src/net.rs:163-169` types `net_tcp_stream_split` as `Type::Tuple(vec![tcp_read_half_class(), tcp_write_half_class()])`, no `net_error_result` wrapper.
+- Codegen lowerer: `crates/sifr_codegen/src/intrinsics/registry/net.rs:159-167` emits a plain `__sifr_net_tcp_stream_split(handle)` call — no `boxed_async_net_helper_call`, no `Result` wrapping.
+- Generated preamble: `crates/sifr_codegen/src/preamble/net_runtime.rs:100-103` returns `(TcpReadHalf, TcpWriteHalf)` directly via `sifr_runtime::net::tcp_stream_split(handle)`.
+- Rust runtime: `crates/sifr_runtime/src/net.rs:370-385` is now `pub fn tcp_stream_split(handle: i64) -> (i64, i64)`. Storage is the canonical owned `tokio::net::TcpStream` in `STREAMS` (no `Arc<Mutex<…>>` indirection on the unsplit path), so split removes the stream from the table and calls `stream.into_split()` directly — no `Arc::try_unwrap`, no panic, no `Err`. If the stream handle is unknown the runtime returns fresh handles that aren't backed by any half, which makes subsequent operations return a typed `NetError` — the affine `own self` boundary on the Sifr side keeps this branch unreachable in user code.
+
+**B3 — Active cancellation coverage. RESOLVED.**
+`crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr` binds a listener on `127.0.0.1:0` (no client ever connects, so `accept()` is genuinely blocking), spawns `wait_for_accept(listener)` into `task.scope(...)`, calls `handle.cancel()`, awaits the handle, and asserts `"Cancelled" in str(result)`. The provider-task cancellation path is the `__SifrTask` impl at `crates/sifr_codegen/src/preamble/task_runtime.rs:232` — `abort_handle.abort()` followed by `__SifrTaskResult::cancelled()` — i.e., it consumes the existing provider cancellation primitive rather than introducing a network-local token, matching the M0 requirement. Tokio's `TcpListener::accept` is cancellation-safe, so the in-flight accept drops cleanly without panic. The fixture is recorded in the traceability row for Cancellation (`verification/stdlib/network_http_m1_async_network_traceability.md:12`) and in the validation grid (`:31`).
+
+### Non-blocking items — all resolved or documented
+
+- **N1 (write-after-shutdown stable typed error).** `crates/sifr_runtime/src/net.rs:286-291` still returns the single `TCP write side is already shut down` string. The M1 traceability (`network_http_m1_async_network_traceability.md:11`) explicitly designates this string as the stable M1 evidence and reserves richer error-taxonomy refinement to a later phase. Documented — acceptable.
+- **N2 (Tokio process/signal features in the generated set).** `crates/sifr_stdlib/src/features.rs:579-586` still emits `process` + `signal` in the Tokio feature list, and the snapshot test (`crates/sifr_stdlib/tests/network_http_dependency_snapshots.rs:81-88`) bakes that into the assertion. The M1 traceability (`:46`) records the rationale: those features are owned by the concurrency/runtime provider used by other generated surfaces and the snapshot's network-specific feature set (`net`, `io-util`, `macros`, `rt`, `sync`, `time`) remains intact. Documented — acceptable for M1.
+- **N3 (Bytes/Socket2/TokioUtil unused features).** Fully removed from `crates/sifr_stdlib/src/features.rs` — `StdlibFeature` no longer declares those variants, and `features_for_stdlib_module("sifr.net")` now pulls only `SifrRuntime`, `Tokio`, `Tracing` (`features.rs:453-457`). The new snapshot test asserts the locked-down set without `bytes`/`socket2`/`tokio-util` emission.
+- **N4 (`TCP_NODELAY` policy).** `crates/sifr_runtime/src/net.rs:175-176` still hardcodes `set_nodelay(true)` on outbound connect. The M1 traceability (`:44`) records this as the M1 default for interactive low-latency substrate and notes no public socket-option surface lands in M1. Documented — acceptable.
+- **N5 (substrate inventory flip).** `verification/stdlib/network_http_substrate_inventory.json` now records `sifr.net` as `production-public` / `stable-public-api` with M1 ownership. Resolved.
+- **N6 (hardcoded `MAX_READ_BYTES`).** `crates/sifr_runtime/src/net.rs:17` still hardcodes the 1 MiB ceiling. The M1 traceability (`:45`) flags this as the explicit M1 default with configuration deferred to M4/M5. Documented — acceptable.
+
+### What is good
+
+- The owned-stream model is honored at the runtime layer: `STREAMS` now stores bare `tokio::net::TcpStream` (not `Arc<Mutex<…>>`), so `into_split()` is a direct ownership transfer with no panic potential. Split halves stay `Arc<tokio::sync::Mutex<…>>` for legitimate concurrent-half use.
+- `__sifr_net_error`-based mapping into typed `NetError` is consistent across all network helpers in `preamble/net_runtime.rs`; the runtime returns `Result<_, String>` and never panics on user data. Validation paths (timeout finiteness, read-size limits, backlog bounds) all return typed errors.
+- Generated Cargo features for `sifr.net` (`tests/network_http_dependency_snapshots.rs`) lock down to the M1-approved set and explicitly assert no `bytes`/`socket2`/`tokio-util` emission, plus `sifr_runtime` with the `net` feature, Tokio with `net`, and Tracing.
+- UDP remains properly deferred via the `SIFR-NAME-0004` fail fixture at `crates/sifr/tests/e2e/fail/network_http_m1_udp_deferred.sifr`.
+- `shutdown_write()` on the unsplit `TcpStream` preserves the read side (`crates/sifr_runtime/src/net.rs:346-359`); the bitset is idempotent so repeated calls remain deterministic.
+- The cancellation fixture consumes the existing provider task scope and `handle.cancel()` rather than introducing a parallel network-local cancellation primitive, matching the M0 contract.
+- M1 traceability and execution-ledger updates cover every blocker remediation row and validation command actually run.
+
+### Before merging (not blocking PR open)
+
+- Record `scripts/run_all_tests.sh` (the full merge gate) in M1 validation evidence before flipping the milestone checklist; create-pr is the right lane for opening the PR but the merge gate is the recorded merge contract per AGENTS.md.
+- If the broad-pass note's pre-existing failures (`cpython_io_subset`, `stdlib_io_consolidated`, `open_*`, `bytes_conversion_errors`) are unfamiliar to the merge reviewer, link the main-branch baseline failure history so the merge-gate run can be interpreted consistently.
+
+These are recording requirements, not contract violations — opening the M1 PR is safe.

--- a/verification/stdlib/network_http_m1_async_network_traceability.md
+++ b/verification/stdlib/network_http_m1_async_network_traceability.md
@@ -1,6 +1,6 @@
 # Network HTTP M1 Traceability: Async Network Runtime
 
-Status: implemented in current M1 branch; Opus pass 1 blockers remediated locally; pending rerun review, PR, and merge.
+Status: implemented in current M1 branch; Opus implementation review PASS; PR #2495 open with local merge-gate validation PASS, pending merge.
 
 | Work item | M0 decision | Acceptance evidence |
 | --- | --- | --- |
@@ -34,9 +34,9 @@ Status: implemented in current M1 branch; Opus pass 1 blockers remediated locall
 | `cargo fmt --check` | PASS | Clean after M1 edits. |
 | `python3 scripts/check_file_size_guardrails.py` | PASS | 2302 files, limit 900 lines. |
 | `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
-| `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; all lane steps passed. Advisory: warm wall-time budget exceeded. |
 | `scripts/run_e2e_pass.sh` | PASS | Merge-manifest e2e pass suite completed 138 pass tests, 0 failed. |
 | `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. |
+| `scripts/run_all_tests.sh` | PASS | Report `target/validation_lane_reports/merge.latest.json`; all merge-lane steps passed. Advisories: warm wall-time budget exceeded and high group skew. |
 
 Broad pass-suite note: an exploratory full `cargo test -p sifr --test e2e e2e_pass -- network_http_m1 --nocapture` invocation runs the full pass corpus rather than selecting only M1 fixtures. It exposed pre-existing non-network failures in IO context-manager mutability and a bytes codec expectation; the M1-specific pass fixtures above passed through the selected manifest.
 

--- a/verification/stdlib/network_http_m1_async_network_traceability.md
+++ b/verification/stdlib/network_http_m1_async_network_traceability.md
@@ -1,19 +1,51 @@
 # Network HTTP M1 Traceability: Async Network Runtime
 
-Status: backlog from M0.
+Status: implemented in current M1 branch; Opus pass 1 blockers remediated locally; pending rerun review, PR, and merge.
 
 | Work item | M0 decision | Acceptance evidence |
 | --- | --- | --- |
-| `sifr.net` public module and intrinsic boundary | `production-public`, stable-public-api; no Tokio or descriptor leak. Public read chunks use built-in `bytes` with helpers under `sifr.bytes`. | Import/type-check/e2e pass fixtures for canonical `sifr.net` imports and unsupported bare `socket`/`select` diagnostics. |
-| `SO_REUSEPORT` | Deferred from public API entirely until the serving-scale follow-up closes; `reuse_addr` never implies reuse-port. | `listen_tcp` fixtures prove no public reuse-port constructor exists in M1. |
-| TCP connect/listen/accept/read/write/close | Async-native over current-thread Tokio with provider cancellation/deadlines. | Deterministic loopback tests for connect, accept, EOF, reset, local/remote address, close, and resource limits. |
-| TCP owned split halves | `split()` consumes a live stream and returns affine owned halves. | Concurrent read/write task fixture, sendability diagnostics, no shared mutable aliasing. |
-| TCP write-side half-close | `shutdown_write()` sends FIN, preserves read side, write-after-shutdown is typed. | Half-close request-end signaling loopback and repeated-shutdown fixture. |
-| DNS/address resolution | `tokio::net::lookup_host`; custom resolver and Happy Eyeballs deferred unless M0 is amended. | Resolver timeout/cancellation/address-order fixtures using loopback literals and deterministic host rows. |
-| UDP | `deferred-to-phase-X` until a named production consumer plus fixture-insufficiency rationale is recorded. | No partial public UDP API unless the M0 decision is amended and checked in. |
-| Readiness primitives | internal-only. | No public `sifr.select`/`sifr.selectors`; import diagnostics remain stable. |
-| Blocking sync helpers | sync `@blocking_io` if accepted. | Async-context rejection fixtures and offload guidance. |
+| `sifr.net` public module and intrinsic boundary | `production-public`, stable-public-api; no Tokio or descriptor leak. Public read chunks use built-in `bytes` with helpers under `sifr.bytes`. | `lib/sifr/net.sifr`, `_sifr.net` intrinsic registry, generated runtime helpers, and `network_http_m1_tcp_loopback_split.sifr` / `network_http_m1_tcp_errors.sifr`. |
+| `SO_REUSEPORT` | Deferred from public API entirely until the serving-scale follow-up closes; `reuse_addr` never implies reuse-port. | `listen_tcp(..., reuse_addr=True)` maps only to Tokio `TcpSocket::set_reuseaddr`; no public reuse-port option or constructor exists. |
+| TCP connect/listen/accept/read/write/close | Async-native over current-thread Tokio with provider cancellation/deadlines. | Loopback fixture covers bind-to-port-zero listen, local/remote address inspection, client connect, listener accept, read, write-all, close, EOF-style response, and deterministic generated-build dependencies. |
+| TCP owned split halves | `split()` consumes a live stream and returns affine owned halves. | Loopback fixture splits both client and server streams sequentially after listener backlog accepts the pending connection. Runtime `tcp_stream_split` returns owned read/write handles directly; public `TcpStream.close(own self)` consumes the unsplit stream so closed streams cannot later be split through the Sifr API. |
+| TCP write-side half-close | `shutdown_write()` sends FIN, preserves read side, write-after-shutdown is typed. | Loopback fixture calls `TcpWriteHalf.shutdown_write()`, reads the response on the read half, and verifies late write returns a typed `NetError`. M1's stable write-after-shutdown evidence string is `TCP write side is already shut down`; later error-taxonomy work may refine this into a richer variant without changing the typed `NetError` boundary. |
+| Cancellation | Network operations consume provider task cancellation; no local cancellation token exists. | `network_http_m1_tcp_cancel_accept.sifr` spawns an in-flight listener `accept()`, cancels the task handle, awaits the handle, and asserts provider `Cancelled` evidence. |
+| DNS/address resolution | `tokio::net::lookup_host`; custom resolver and Happy Eyeballs deferred unless M0 is amended. | `resolve_host("localhost:80", timeout=2.0)` smoke coverage plus deterministic invalid-timeout typed error coverage in `network_http_m1_tcp_errors.sifr`. |
+| UDP | `deferred-to-phase-X` until a named production consumer plus fixture-insufficiency rationale is recorded. | No public `UdpSocket`; `network_http_m1_udp_deferred.sifr` expects `SIFR-NAME-0004` for `from sifr.net import UdpSocket`. |
+| Readiness primitives | internal-only. | M1 adds no public selector, readiness, raw descriptor, or event-loop API. Existing M0 unsupported import diagnostics remain the public behavior. |
+| Blocking sync helpers | sync `@blocking_io` if accepted. | M1 adds no sync network helpers; all accepted TCP and DNS operations are async-native. |
+
+## M1 Validation
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `cargo build -p sifr --bin sifr` | PASS | Rebuilt CLI after runtime, stdlib, type-system, and codegen changes. |
+| `cargo check -p sifr_runtime --features net` | PASS | Validates optional `sifr_runtime/net` feature and Tokio network dependency wiring. |
+| `cargo check -p sifr_stdlib -p sifr_codegen` | PASS | Validates stdlib feature mapping and network intrinsic/codegen changes. |
+| `cargo test -p sifr_runtime --features net --lib net -- --nocapture` | PASS | Runtime crate builds and test harness completes; behavior is covered by generated Sifr fixtures. |
+| `cargo test -p sifr_stdlib --test concurrency_runtime_dependency_snapshots -- --nocapture` | PASS | Verifies existing concurrency/Tokio dependency snapshot remains unchanged without `sifr.net`. |
+| `cargo test -p sifr_stdlib --test network_http_dependency_snapshots -- --nocapture` | PASS | Verifies M0 Ring 5 absence and M1 locked generated dependency set for `sifr.net`: `sifr_runtime/net`, Tokio `net`, tracing, and no unused `bytes`/`socket2`/`tokio-util` emission. |
+| `cargo test -p sifr_stdlib --test text_i18n_dependency_snapshots -- --nocapture` | PASS | Verifies moved text/i18n dependency snapshot coverage remains intact after feature-registry edits. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr` | PASS | Deterministic TCP loopback, split halves, half-close, address inspection, typed timeout error. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr` | PASS | Invalid timeout/backlog typed `NetError` coverage. |
+| `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr` | PASS | Provider task-handle cancellation over in-flight `accept()`. |
+| `SIFR_E2E_FIXTURE_MANIFEST=<tmp manifest> SIFR_E2E_DISABLE_CACHE=1 cargo test -p sifr --test e2e test_e2e_pass -- --nocapture` | PASS | Selected fixtures `network_http_m1_tcp_cancel_accept`, `network_http_m1_tcp_errors`, and `network_http_m1_tcp_loopback_split`; 3 pass tests completed. |
+| `cargo test -p sifr --test e2e test_e2e_fail -- --nocapture` | PASS | Full fail harness completed 480 fail fixtures and validated UDP remains absent; existing negative-harness CFG panic messages are caught by the harness. |
+| `cargo fmt --check` | PASS | Clean after M1 edits. |
+| `python3 scripts/check_file_size_guardrails.py` | PASS | 2302 files, limit 900 lines. |
+| `python3 scripts/check_hir_maintainability_guardrails.py` | PASS | Lowering maintainability guardrails passed. |
+| `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; all lane steps passed. Advisory: warm wall-time budget exceeded. |
+| `scripts/run_e2e_pass.sh` | PASS | Merge-manifest e2e pass suite completed 138 pass tests, 0 failed. |
+| `scripts/run_all_tests.sh --profile create-pr` | PASS | Report `target/validation_lane_reports/create-pr.latest.json`; advisory: warm wall-time budget exceeded. |
+
+Broad pass-suite note: an exploratory full `cargo test -p sifr --test e2e e2e_pass -- network_http_m1 --nocapture` invocation runs the full pass corpus rather than selecting only M1 fixtures. It exposed pre-existing non-network failures in IO context-manager mutability and a bytes codec expectation; the M1-specific pass fixtures above passed through the selected manifest.
+
+Implementation notes:
+
+- `TcpStream::connect` sets `TCP_NODELAY` on accepted outbound streams as the M1 default for interactive low-latency TCP substrate. No public socket option surface is added in M1.
+- `MAX_READ_BYTES = 1_048_576` is the explicit M1 per-call read ceiling. M4/M5 resource-configuration work may layer user-configurable limits above this default.
+- Generated `tokio` workspace features still include provider-owned `process` and `signal` features used by other runtime surfaces; `sifr.net` generated dependency snapshots remain locked to the M0-approved network feature set.
 
 ## CPython Evidence
 
-Mine `test_socket`, `test_select`, `test_selectors`, and asyncio stream/server tests for loopback and cancellation fixtures only.
+M1 mined CPython socket and asyncio stream/server behavior only for deterministic loopback shape, address inspection, EOF/half-close behavior, and rejection of raw selector/event-loop public APIs. No CPython-shaped `socket`, selector, descriptor, or event-loop surface was added.


### PR DESCRIPTION
## Summary

Implements `milestone_network_http_1` for the production network/HTTP substrate phase:

- adds public `sifr.net` async TCP/DNS API and private `_sifr.net` intrinsics
- adds `sifr_runtime::net` TCP connect/listen/accept/read/write/write_all/split/shutdown/close/DNS support behind the `net` feature
- wires codegen lowerers and generated runtime helpers for network intrinsics
- adds deterministic M1 e2e fixtures for loopback split/half-close, typed TCP argument errors, provider cancellation of in-flight accept, and UDP deferral
- records M1 traceability, validation evidence, and Opus review pass 1/2 artifacts

## Validation

- `cargo build -p sifr --bin sifr`
- `cargo check -p sifr_runtime --features net`
- `cargo test -p sifr_stdlib --test network_http_dependency_snapshots -- --nocapture`
- `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_loopback_split.sifr`
- `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_errors.sifr`
- `target/debug/sifr run crates/sifr/tests/e2e/pass/network_http_m1_tcp_cancel_accept.sifr`
- `SIFR_E2E_FIXTURE_MANIFEST=<tmp manifest> SIFR_E2E_DISABLE_CACHE=1 cargo test -p sifr --test e2e test_e2e_pass -- --nocapture`
- `cargo test -p sifr --test e2e test_e2e_fail -- network_http_m1_udp_deferred --nocapture`
- `cargo fmt --check`
- `python3 scripts/check_file_size_guardrails.py`
- `python3 scripts/check_hir_maintainability_guardrails.py`
- `scripts/run_all_tests.sh --profile create-pr` (PASS; advisory: warm wall-time budget exceeded)
- `scripts/run_all_tests.sh` (PASS; report `target/validation_lane_reports/merge.latest.json`; advisories: warm wall-time budget exceeded and high group skew)

Opus review pass 2: PASS, safe to open M1 PR. Full local merge gate passed before merge.
